### PR TITLE
data: generate subject-vocab for 25 states (incl. CA & TX)

### DIFF
--- a/data/ak/subject-vocab.json
+++ b/data/ak/subject-vocab.json
@@ -1,0 +1,703 @@
+{
+  "state": "ak",
+  "generated_at": "2026-06-06T15:41:39.314Z",
+  "subjects": [
+    {
+      "prefix": "SAFE",
+      "name": "SAFE",
+      "course_count": 8,
+      "section_count": 63,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "40-Hour HAZWOPER",
+        "8-Hour HAZWOPER, Ann",
+        "Basic Life Support",
+        "Blood Borne Pathogen",
+        "Hunter Education"
+      ]
+    },
+    {
+      "prefix": "DE",
+      "name": "Drivers",
+      "course_count": 6,
+      "section_count": 47,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Basic Drivers Educat",
+        "Behind the Wheel Dri",
+        "Behind the Wheel Pro",
+        "Driver's Ed Test Pre",
+        "Driver's Refresher:"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 22,
+      "section_count": 32,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Applied Business Com",
+        "Business English",
+        "Business Math",
+        "Contemporary Managem",
+        "Customer Service"
+      ]
+    },
+    {
+      "prefix": "INU",
+      "name": "INU",
+      "course_count": 20,
+      "section_count": 30,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Alaska Native Claims",
+        "Cultural Knowledge",
+        "Elementary Inupiaq 2",
+        "Elementary Inupiaq I",
+        "Foundations of Inupi"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "IT",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Compter Presentation",
+        "Computer Presentatio",
+        "Computer Word-Proces",
+        "Internet Use and Sec",
+        "Introduction to Micr"
+      ]
+    },
+    {
+      "prefix": "WFDB",
+      "name": "WFDB",
+      "course_count": 17,
+      "section_count": 25,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Commincation Skills",
+        "Conflict Resolution",
+        "Customer Service",
+        "Effective Teamwork",
+        "Financial Literacy"
+      ]
+    },
+    {
+      "prefix": "DHAT",
+      "name": "DHAT",
+      "course_count": 21,
+      "section_count": 21,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Advanced Dental Ther",
+        "AdvDiag&Treat Plan",
+        "Anatomy, Physiology",
+        "Behavorial Science",
+        "C. Clinicial Rota 2"
+      ]
+    },
+    {
+      "prefix": "HEO",
+      "name": "HEO",
+      "course_count": 6,
+      "section_count": 21,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "CDL Behind the Wheel",
+        "CDL: General Knowled",
+        "Commercial Driver's",
+        "Entry Level Operatio",
+        "Equipment Specific T"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Applied Math, Mod A",
+        "Applied Math, Mod B",
+        "Beg Alb, Mod A",
+        "Beginning Algebra, M",
+        "College Algebra"
+      ]
+    },
+    {
+      "prefix": "WFDI",
+      "name": "WFDI",
+      "course_count": 4,
+      "section_count": 21,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Basic Small Engine",
+        "Indigenous Sentinels",
+        "Intro to 3D Printing",
+        "Water Examine Procto"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "ED",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Best Practices for P",
+        "Early Child Develop",
+        "Explorations in the",
+        "Family and Community",
+        "Guidance in Early Ch"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Academic Writing",
+        "Academic Writing abo",
+        "Creative Writing Wor",
+        "Integrated Rdg&Wrtg",
+        "Introduction to Acad"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Biol",
+        "General Biology II",
+        "Human Anatomy & Phys",
+        "Human Antmy & Phys 2",
+        "Human Biology"
+      ]
+    },
+    {
+      "prefix": "DATA",
+      "name": "Computer",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Computer Spreadsheet",
+        "Database Design Fund",
+        "Introduction to Prog",
+        "Presenting Data Effe"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Computerized Accting",
+        "Fundamentals of Non-",
+        "Managerial Acc",
+        "Payroll Accounting",
+        "Principles of Acct 1"
+      ]
+    },
+    {
+      "prefix": "CTT",
+      "name": "CTT",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Communication for th",
+        "Fundamentals of Crew",
+        "Introduction to Cons",
+        "Project Management",
+        "Project Supervision"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Allied Health Camp",
+        "Allied Health Intern",
+        "Intro to Health Prof",
+        "Intro to Pharma",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "WFDH",
+      "name": "Mandt",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "MANDT"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Advanced Blueprints",
+        "Commercial Writing",
+        "Electric 1, Skill La",
+        "Electrical Blueprint",
+        "Electrical, Level I"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Alaska Land & Its Pe",
+        "Modern World History",
+        "Native American Hist",
+        "U.S. History to 1865",
+        "U.S. History, 1865 t"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "Carpentry",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Carpentry I, Skills",
+        "Carpentry Level 2",
+        "Carpentry Skill",
+        "Carpentry, Level I"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Basic General Chemis",
+        "General Chemistry I",
+        "Intro Organic & Bio"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Macroeconomics",
+        "Microeconomics",
+        "Political Economy *B"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "HUMS",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Becoming a Behaviora",
+        "Ethics in Human Svc",
+        "Introduction to Addi",
+        "Substance Abuse Coun"
+      ]
+    },
+    {
+      "prefix": "LS",
+      "name": "Library",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Library Information"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Introduction to Psyc",
+        "Lifespan Development"
+      ]
+    },
+    {
+      "prefix": "WMT",
+      "name": "Welding",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Welding, Level I Mod",
+        "Welding, Level II"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Individual",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Individual, Society",
+        "Native Cultures of A"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Aesthetic Appreciati",
+        "Beginning Drawing",
+        "Introduction to Pain"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Oral"
+      ]
+    },
+    {
+      "prefix": "GEOS",
+      "name": "Climate",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Arctic STEM (NREL)",
+        "Climate Change and t"
+      ]
+    },
+    {
+      "prefix": "MTHT",
+      "name": "Construction",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Applied Construction"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "History",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "History of American"
+      ]
+    },
+    {
+      "prefix": "WFD",
+      "name": "Hunter",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Hunter Education",
+        "Swimming Lesson Inst"
+      ]
+    },
+    {
+      "prefix": "ANS",
+      "name": "Alaska",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Alaska Natives in Fi",
+        "Native American/Alas"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Emergency Trauma"
+      ]
+    },
+    {
+      "prefix": "ESBM",
+      "name": "Entrepreneurship",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurship",
+        "Small Business"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "CPD-4 Coding",
+        "ICD-10-CM Coding"
+      ]
+    },
+    {
+      "prefix": "TEM",
+      "name": "Tribal",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Incident Command Str",
+        "Intro to Tribal Emer"
+      ]
+    },
+    {
+      "prefix": "CCS",
+      "name": "Tools",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Tools for Success"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Unity in the Arts *B"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Introduction to Logi"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "College Physics II"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "Political",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Political Economy"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Probabili",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Elementary Probabili"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Social Work in Human"
+      ]
+    },
+    {
+      "prefix": "UNA",
+      "name": "Unangam",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Intro to Unangam Tun"
+      ]
+    },
+    {
+      "prefix": "WFDM",
+      "name": "Lifeguarding",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ilisagvik-college"
+      ],
+      "sample_titles": [
+        "Lifeguarding"
+      ]
+    }
+  ],
+  "program_titles": [
+    "Accounting Technician I",
+    "Accounting Technician II",
+    "Allied Health",
+    "Business Specialist I",
+    "Business Specialist II",
+    "Construction Technology II",
+    "Data Analysis I",
+    "Data Analysis II",
+    "Education I",
+    "Education II",
+    "Entrepreneurship and Small Business Management Specialist I",
+    "Entrepreneurship and Small Business Management Specialist II",
+    "Indigenous Human Services",
+    "Information Technology Support Specialist I",
+    "Information Technology Support Specialist II",
+    "Iñupiaq Culture and Language I",
+    "Liberal Arts",
+    "Medical Coding Specialist",
+    "Medical Office Management I",
+    "Medical Office Management II",
+    "Office Management I",
+    "Office Management II",
+    "Pre-Nursing",
+    "Tribal Emergency Management"
+  ]
+}

--- a/data/ar/subject-vocab.json
+++ b/data/ar/subject-vocab.json
@@ -1,0 +1,4373 @@
+{
+  "state": "ar",
+  "generated_at": "2026-06-06T15:41:39.339Z",
+  "subjects": [
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 33,
+      "section_count": 386,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Accelerated Reading/Writing",
+        "American Lit I",
+        "APPLIED TECHNICAL WRITING",
+        "Basic Writing I",
+        "Basic Writing Lab I"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 68,
+      "section_count": 378,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Applied Math (Quantitative Reasoning) Concurrent",
+        "Applied Math Lab",
+        "APPLIED TECHNICAL MATH",
+        "Cal I Concurrent",
+        "Calculus I"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 57,
+      "section_count": 331,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "A/P I Lab",
+        "A/P II Lab",
+        "Anat & Physiol II",
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology I Lab"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 31,
+      "section_count": 211,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Arkansas History",
+        "Arkansas History Concurrent",
+        "History of American People since 1877",
+        "History of Arkansas",
+        "History of the American People to 1877"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 18,
+      "section_count": 181,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Abnormal Psychology Concurrent",
+        "Addiction and the Human Experience",
+        "An Introduction to Substance Use and Abuse",
+        "Applied Human Services"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 36,
+      "section_count": 119,
+      "colleges": [
+        "east-arkansas-community-college",
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "3D Design",
+        "Advanced Graph Design I",
+        "Art Appreciation",
+        "Art History I",
+        "Basic Design 2D"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 41,
+      "section_count": 109,
+      "colleges": [
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Care for Pt Acute, Chr, Unst",
+        "Care for Pt With Chr, St Con.",
+        "Dosage Calculation",
+        "Family-Centered Pediatric Nursing",
+        "Family-Centered Pediatric Nursing Practicum"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 10,
+      "section_count": 87,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Basic Economics: Theory & Practice",
+        "Business Statistics I",
+        "Introduction to Macroeconomics",
+        "Introduction to Microeconomics",
+        "Macroeconomics"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 29,
+      "section_count": 82,
+      "colleges": [
+        "black-river-technical-college",
+        "national-park-college",
+        "north-arkansas-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Command Line Scripting",
+        "Comp Accounting",
+        "Computer Architecture",
+        "Computer Forensics I",
+        "Computer Information Systems"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 25,
+      "section_count": 78,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Chemistry I and Lab",
+        "Chemistry I for Majors",
+        "Chemistry II for Majors",
+        "Chemistry Modern World",
+        "College Chemistry I"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 8,
+      "section_count": 69,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Analytic Geometry & Calc II",
+        "Careers Math",
+        "College Algebra",
+        "Introduction to Statistics",
+        "Number Systems Elem Teachers I"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 25,
+      "section_count": 68,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "ozarka-college",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "AC TIG/GTAW",
+        "API 1104",
+        "ARC Welding",
+        "Basic Welding",
+        "BASIC WELDING"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 13,
+      "section_count": 65,
+      "colleges": [
+        "black-river-technical-college",
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "American Lit I",
+        "American Lit II",
+        "Composition I",
+        "Composition II",
+        "English I"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 13,
+      "section_count": 59,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Accounting I",
+        "Accounting Principles I Concurrent",
+        "Accounting Principles II Concurrent",
+        "COMPUTERIZED ACCOUNTING",
+        "Computerized Accounting with Payroll"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "COSM",
+      "course_count": 42,
+      "section_count": 59,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Advanced Aesthetics Laboratory",
+        "Advanced Nail Techniques",
+        "Aesthetics III",
+        "Aesthetics Lab II",
+        "Aesthetics with Lab"
+      ]
+    },
+    {
+      "prefix": "PLSC",
+      "name": "Government",
+      "course_count": 4,
+      "section_count": 59,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "American Government Concurrent",
+        "American National Government",
+        "Introduction to International Relations, Honors",
+        "State and Local Government"
+      ]
+    },
+    {
+      "prefix": "FDST",
+      "name": "FDST",
+      "course_count": 30,
+      "section_count": 56,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Breads",
+        "Advanced Cakes",
+        "Applied Farming",
+        "Baking",
+        "Beverage Management"
+      ]
+    },
+    {
+      "prefix": "MUAP",
+      "name": "Private",
+      "course_count": 24,
+      "section_count": 54,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Major Private Brass II",
+        "Major Private Instrument/Voice I",
+        "Major Private Instrument/Voice II",
+        "Major Private Percussion II",
+        "Major Private Piano I"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 6,
+      "section_count": 52,
+      "colleges": [
+        "northwest-arkansas-community-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Communications",
+        "Film Arts",
+        "Interpersonal Communications",
+        "Public Speaking (H1)",
+        "Public Speaking, Honors (H1)"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Speaking",
+      "course_count": 3,
+      "section_count": 51,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "north-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Fund/Public Speaking",
+        "INTRODUCTION TO ORAL COMMUNICATION",
+        "Public Speaking"
+      ]
+    },
+    {
+      "prefix": "AMST",
+      "name": "AMST",
+      "course_count": 30,
+      "section_count": 50,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "AUTOMATED SYSTEMS AND ROBOTICS",
+        "Basic Electricity",
+        "Blueprint Basics",
+        "CNC Machinery",
+        "Comp Aided Drafting/Design"
+      ]
+    },
+    {
+      "prefix": "BA",
+      "name": "Business",
+      "course_count": 12,
+      "section_count": 49,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Accounting Information Systems",
+        "Accounting Principles I",
+        "Accounting Principles II",
+        "Business & Professional Ethics",
+        "Business Administration Intern"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 9,
+      "section_count": 48,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "AI Ethics",
+        "Intro To Philosophy",
+        "Introduction to Ethics",
+        "Introduction to Logic",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "CPSI",
+      "name": "CPSI",
+      "course_count": 15,
+      "section_count": 47,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Coding in Java/Java Script",
+        "Computer Ethics",
+        "Computer Tech Capstone",
+        "Database Design and Programming I",
+        "Fundamentals of Programming"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "Sociology",
+      "course_count": 7,
+      "section_count": 46,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Intro to Sociology",
+        "Introduction to Sociology",
+        "Introduction to Sociology Concurrent",
+        "Marriage and Family in Society",
+        "MARRIAGE AND THE FAMILY (HYB)"
+      ]
+    },
+    {
+      "prefix": "ALHE",
+      "name": "ALHE",
+      "course_count": 11,
+      "section_count": 45,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Basic Human Anatomy and Physiology Concurrent",
+        "CERTIFIED MEDICATION ASSISTANT",
+        "Health Skills I",
+        "Intro to Health Professions",
+        "Medical Math Concurrent"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Science",
+      "course_count": 9,
+      "section_count": 44,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "Fund. of Physical Science",
+        "Introduction to Astronomy",
+        "Introduction to Physical Science",
+        "Phy. Science Lab"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "PNUR",
+      "course_count": 33,
+      "section_count": 41,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "BASIC NURSING",
+        "Basic Nursing Principles and Skills",
+        "Body Structure and Function",
+        "CLINICAL PRACTICUM I",
+        "CLINICAL PRACTICUM II"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 8,
+      "section_count": 40,
+      "colleges": [
+        "black-river-technical-college",
+        "national-park-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Cultural Competency",
+        "Interviewing Skills/Practice",
+        "Intro to Addiction Studies",
+        "Intro to Social Work",
+        "Intro To Sociology"
+      ]
+    },
+    {
+      "prefix": "CISQ",
+      "name": "Computer",
+      "course_count": 3,
+      "section_count": 38,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Information Systems",
+        "Business Statistics",
+        "Intro to Computer Information"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 17,
+      "section_count": 38,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college",
+        "ozarka-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Child Growth & Dev",
+        "Child Growth & Development",
+        "Child Growth & Learning",
+        "Core Praxis/ACT Prep Class",
+        "Curr Strategies for Teachers"
+      ]
+    },
+    {
+      "prefix": "LAD",
+      "name": "Review",
+      "course_count": 7,
+      "section_count": 38,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "College Algebra Review 1",
+        "College Algebra Review 2",
+        "Integrated Reading and Writing",
+        "Math Essentials",
+        "Math Reasoning Review 1"
+      ]
+    },
+    {
+      "prefix": "EMTA",
+      "name": "Emergency",
+      "course_count": 9,
+      "section_count": 37,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Cardiac Dysrhythmias",
+        "Emergency Medical Responder Lab (4G)",
+        "Emergency Medical Responder Lecture (4G)",
+        "Emergency Medical Tech II Clinical (1G)",
+        "Emergency Medical Tech II Lecture (1G)"
+      ]
+    },
+    {
+      "prefix": "ARHS",
+      "name": "History",
+      "course_count": 6,
+      "section_count": 36,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "northwest-arkansas-community-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Art Appreciation (H1)",
+        "Art Appreciation, Honors (H1)",
+        "Art History I",
+        "Art History II",
+        "History of Photography and Graphic Design"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 24,
+      "section_count": 36,
+      "colleges": [
+        "black-river-technical-college",
+        "east-arkansas-community-college",
+        "national-park-college",
+        "north-arkansas-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Auto Elec Systems",
+        "Auto Transmission",
+        "Automatic Transmissions",
+        "Automotive Electrical",
+        "Automotive Electronics II"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "BUSI",
+      "course_count": 19,
+      "section_count": 35,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Advanced MS Office Appl",
+        "BUSINESS COMMUNICATION I",
+        "Business Mathematics",
+        "Business Statistics",
+        "Computer Software Applications"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 21,
+      "section_count": 35,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Aerobics",
+        "Beginning Walking & Jogging",
+        "Coaching Methods",
+        "Core Abs and Stretching",
+        "E- Sports"
+      ]
+    },
+    {
+      "prefix": "PHTA",
+      "name": "PHTA",
+      "course_count": 18,
+      "section_count": 35,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Basic Principles of Physical Therapy",
+        "Basic Principles of Physical Therapy Lab",
+        "Basic PT Tests & Measures",
+        "Basic PT Tests & Measures-Lab",
+        "Clinical Experience I"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 12,
+      "section_count": 34,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Internship I",
+        "Disease Pathology",
+        "Electronic Health Records",
+        "Health Data Analytics",
+        "Health Data Content"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 24,
+      "section_count": 32,
+      "colleges": [
+        "northwest-arkansas-community-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Aural Skills II",
+        "Basic Musicianship",
+        "Beginning Guitar Class",
+        "Beginning Piano Class",
+        "Chamber Singers I"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "TECH",
+      "course_count": 11,
+      "section_count": 31,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "north-arkansas-college",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Industrial Safety",
+        "Intern Work Experience I",
+        "Intro to Computer Aided Design",
+        "Introduction to Craft Skills",
+        "OSHA 10HR CONSTRUCTION INDUSTRY"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 18,
+      "section_count": 31,
+      "colleges": [
+        "black-river-technical-college",
+        "national-park-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Blueprint Reading for Welding",
+        "Cert Welding Lab",
+        "Fabrication Welding",
+        "Gas Shie Arc Wldg"
+      ]
+    },
+    {
+      "prefix": "EMTP",
+      "name": "EMTP",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "12 Lead EKG",
+        "Emergency Cardiac Care Lab (1G)",
+        "Emergency Cardiac Care Lecture (1G)",
+        "Emergency Respiratory Care",
+        "EMS Environment I"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 10,
+      "section_count": 29,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "national-park-college",
+        "northwest-arkansas-community-college",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Beg Spanish I",
+        "Beg Spanish II",
+        "Elementary Spanish I",
+        "Elementary Spanish I AV DQ",
+        "Elementary Spanish II"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 19,
+      "section_count": 28,
+      "colleges": [
+        "black-river-technical-college",
+        "north-arkansas-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville"
+      ],
+      "sample_titles": [
+        "Agricultural Mechanics and Equipment",
+        "Agricultural Operations I",
+        "Agricultural Operations II",
+        "Agriculture Internship",
+        "Agriculture Technology"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "RESP",
+      "course_count": 25,
+      "section_count": 27,
+      "colleges": [
+        "national-park-college",
+        "northwest-arkansas-community-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Adv. Pharmacology",
+        "Applications of Respiratory Ca",
+        "Basic Assess/Diag",
+        "Cardiac Rhythms",
+        "Cardio-Pulmo A & P I"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Child Development",
+        "Child Growth & Development",
+        "Child Growth and Development",
+        "Child Guidance",
+        "CURRICULM AND ASSESSMENT FOR INFANTS AND TODDLERS"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-batesville"
+      ],
+      "sample_titles": [
+        "Advanced College Physics I",
+        "Advanced College Physics II",
+        "College Physics I, Honors (1H)",
+        "College Physics II",
+        "General Physics I and Lab"
+      ]
+    },
+    {
+      "prefix": "BLAW",
+      "name": "Legal",
+      "course_count": 2,
+      "section_count": 25,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "northwest-arkansas-community-college",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Legal Environment of Business",
+        "Legal Environment of Business Concurrent"
+      ]
+    },
+    {
+      "prefix": "BUTR",
+      "name": "BUTR",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Data Analysis and Interpretation",
+        "Foundations of Business Analytics",
+        "Intro to Supply Chain Mgmt",
+        "Managing People & Organization"
+      ]
+    },
+    {
+      "prefix": "ENGA",
+      "name": "Academic",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Academic Literacy Writing/Reading (10P)",
+        "Reading and Writing Studio (15P)"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 10,
+      "section_count": 23,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Advanced Network Security",
+        "CIT Internship",
+        "Cloud Technologies Fund",
+        "Cybersecurity Fundamentals",
+        "Introduction to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "CP",
+      "name": "CP",
+      "course_count": 6,
+      "section_count": 23,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "College Algebra Enhancement",
+        "Foundations of Math",
+        "Fundamentals of Language",
+        "Intro to Language",
+        "Quantitative Reasoning Enhance"
+      ]
+    },
+    {
+      "prefix": "CRJU",
+      "name": "CRJU",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Adv. Law Enforcement",
+        "CJI Internship",
+        "Correction Systems and Prac.",
+        "Corrections",
+        "Intro to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 16,
+      "section_count": 23,
+      "colleges": [
+        "north-arkansas-college",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "AC & HEATING SYSTEMS I",
+        "AC & HEATING SYSTEMS III",
+        "AIR CONDITION & HEATING SYSTEMS II",
+        "COMMERCIAL HVAC",
+        "Commercial HVAC/R Fundament"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 17,
+      "section_count": 22,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Basic Immunology",
+        "Clin Hematol & Body Fluid Prac",
+        "Clin Serology/Immunohemat Prac",
+        "Clinical Chemistry",
+        "Clinical Chemistry Practicum"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 3,
+      "section_count": 21,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "College Concert Choir I",
+        "Music Appreciation"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "Nursing",
+      "course_count": 18,
+      "section_count": 21,
+      "colleges": [
+        "black-river-technical-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Basic Nursing Princ & Skills",
+        "Clinical I",
+        "Clinical II",
+        "Clinical III",
+        "Clinical Pract I"
+      ]
+    },
+    {
+      "prefix": "COLL",
+      "name": "Student",
+      "course_count": 3,
+      "section_count": 20,
+      "colleges": [
+        "black-river-technical-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Freshman Seminar",
+        "Student Success"
+      ]
+    },
+    {
+      "prefix": "EDHP",
+      "name": "EDHP",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Child Growth and Development Concurrent",
+        "DEVELOPMENT AND LEARNING THEORIES",
+        "Engaging All Learners",
+        "INTG CURRICULUM ASSESSMENT PLANNING",
+        "Intro to Special Ed Concurrent"
+      ]
+    },
+    {
+      "prefix": "MEDL",
+      "name": "Medical",
+      "course_count": 7,
+      "section_count": 19,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Foundations of Human A & P",
+        "Intro Health Care Issues",
+        "Medical Coding II",
+        "Medical Coding III",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "PEAC",
+      "name": "Fitness",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "northwest-arkansas-community-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Fitness Concepts",
+        "FITNESS WALKING AND RUNNING",
+        "Judo",
+        "Lifetime Fitness",
+        "Lifetime Fitness II"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "College Reading",
+        "College Reading Strategies",
+        "Intro to College Reading Skill",
+        "Reading",
+        "Reading Lab I"
+      ]
+    },
+    {
+      "prefix": "AJ",
+      "name": "Criminal",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Criminal Evidence & Procedure",
+        "Intro to Criminal Justice",
+        "Intro to Juvenile Delinquency",
+        "Introduction to Corrections"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "national-park-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Bus Communications",
+        "Business Calculus",
+        "Business Communications",
+        "Business Law",
+        "Business Principles"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "north-arkansas-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "First Aid",
+        "Personal Health & Safety",
+        "Physical Conditioning Act I",
+        "Physical Conditioning Act II",
+        "Theory & Prac of Basketball II"
+      ]
+    },
+    {
+      "prefix": "ORT",
+      "name": "First",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "national-park-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "College Seminar",
+        "First Year Experience",
+        "New Student Orientation",
+        "Northark First Year Experience",
+        "Title Ix Training"
+      ]
+    },
+    {
+      "prefix": "CISM",
+      "name": "CISM",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Photoshop",
+        "Advanced Spreadsheet Analysis",
+        "Business Information Systems",
+        "Database Management (ACCESS)",
+        "Photoshop"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "DRFT",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "AutoCAD Civil 3D",
+        "AutoCAD I",
+        "BIM - Revit Building Systems",
+        "Building Information Modeling I",
+        "Building Information Modeling II"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 16,
+      "section_count": 17,
+      "colleges": [
+        "black-river-technical-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Emergency Med Tech",
+        "Emergency Medical Tech Practic",
+        "Emergency Medical Technician",
+        "Field Internship",
+        "Intro to Clinical Areas"
+      ]
+    },
+    {
+      "prefix": "NA",
+      "name": "NA",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "black-river-technical-college",
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum",
+        "Community CNA",
+        "Introduction,ethics, & Legal",
+        "Nursing Arts",
+        "Restorative Care"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "ozarka-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Advance Weight Training I",
+        "Advanced Team Sports II",
+        "Advanced Weight Training II",
+        "Basketball",
+        "Beginning Weight Training I"
+      ]
+    },
+    {
+      "prefix": "CMJS",
+      "name": "CMJS",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Corrections",
+        "Crime Scene Investigation",
+        "Criminal Law",
+        "Digital Forensics",
+        "Intro/Terrorism: Perspectives"
+      ]
+    },
+    {
+      "prefix": "CTTE",
+      "name": "CTTE",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "CARPENTRY",
+        "Compact Track Excavator Oper.",
+        "Compact Track Loader Oper.",
+        "CONSTRUCTION FUNDAMENTALS",
+        "Construction II"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 3,
+      "section_count": 15,
+      "colleges": [
+        "national-park-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Essentials of Earth Science and Lab",
+        "General Geology I",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "HEAL",
+      "name": "HEAL",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Basic Coding & Classification",
+        "Disease Processes",
+        "Intermediate Med/Cod Prins",
+        "Intro to Phlebotomy",
+        "Medical Billing"
+      ]
+    },
+    {
+      "prefix": "RNSG",
+      "name": "Nursing",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "black-river-technical-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "NCLEX-RN Preparation",
+        "Nurs Practicum III",
+        "Nursing Practicum II",
+        "Nursing Practicum III",
+        "Nursing Process II"
+      ]
+    },
+    {
+      "prefix": "UNIV",
+      "name": "Success",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "FIRST YEAR EXPERIENCE",
+        "READING",
+        "Student Success for Medical Education Concurrent",
+        "Success Strategies Concurrent"
+      ]
+    },
+    {
+      "prefix": "BADM",
+      "name": "BADM",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Business Organization and Mgmt",
+        "Internship Experience",
+        "Pro Selling & Marketing",
+        "Supervision"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Electronic Circuits",
+        "Industrial Electrical Systems",
+        "Intro to Robotics & Prog I",
+        "Robot Programming II"
+      ]
+    },
+    {
+      "prefix": "FL",
+      "name": "Spanish",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Beginning Spanish I",
+        "Beginning Spanish II",
+        "Intermediate Spanish I"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "Health",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Nutrition in Health",
+        "Personal Health and Safety",
+        "Wellness Concepts"
+      ]
+    },
+    {
+      "prefix": "HP",
+      "name": "HP",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Cardiac Arrhythmia",
+        "Caree Dev for Health Profess",
+        "Medical Term and Communication",
+        "Medical Terminology",
+        "Pharmacology"
+      ]
+    },
+    {
+      "prefix": "BIKE",
+      "name": "Bicycle",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Ball Bearing Systems",
+        "Basic Bicycle Mechanics",
+        "Bicycle Braking Systems",
+        "Bicycle Drivetrain Systems",
+        "Bicycle Suspension Systems"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "Commercial",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "black-river-technical-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Commercial Driver Training",
+        "Commercial Driver Vehicle Oper",
+        "Road Regulations & Rules",
+        "Truck Maint & Road Safety"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Construction Codes & Regs",
+        "Construction Internship",
+        "Construction Methods I",
+        "Construction Methods II",
+        "Estimating"
+      ]
+    },
+    {
+      "prefix": "ISYS",
+      "name": "ISYS",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Advanced Linux Operating Systems",
+        "Computer & Networking Lab",
+        "Concepts of Operating Systems",
+        "Ethical Hacking/Network Defens",
+        "Intro to Cloud Computing"
+      ]
+    },
+    {
+      "prefix": "MBIO",
+      "name": "Microbiology",
+      "course_count": 1,
+      "section_count": 13,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Microbiology"
+      ]
+    },
+    {
+      "prefix": "SKTR",
+      "name": "SKTR",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Basic Electric Circuits with Lab",
+        "Basic Plumbing with Lab",
+        "Introduction to Construction with Lab",
+        "Introduction to HVAC with Lab",
+        "Introduction to Skilled Trades"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "black-river-technical-college",
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Intro Anthropology",
+        "Intro to Biological Anthropology Lab",
+        "Intro to Cultural Anthropology",
+        "Introduction to Biological Anthropology"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "CRIM",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "black-river-technical-college",
+        "ozarka-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Careers in Criminal Justice",
+        "Constitutional Law",
+        "Crim Investigation",
+        "Criminal Evidence and Procedure",
+        "Criminology"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Crim Just Internship",
+        "Crim Proc & Evidence",
+        "Crime Scene Documentation",
+        "Criminal Law",
+        "Criminalistics"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "national-park-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Coding Principles",
+        "Computer Applications for Healthcare Professionals",
+        "Computers/Healthcare",
+        "Fund/Medical Science",
+        "Health Data Content"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "LEGL",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Civil Litigation",
+        "Computers in the Law",
+        "Family Law",
+        "Immigration Law",
+        "Introduction to Law & Legal Assistance"
+      ]
+    },
+    {
+      "prefix": "LPNE",
+      "name": "Nursing",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Nursing Clinical Experience I",
+        "Nursing Clinical Experience II",
+        "Nursing Clinical Experience III",
+        "Nursing Process I",
+        "Nursing Process II"
+      ]
+    },
+    {
+      "prefix": "MM",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Hospitality Management",
+        "Human Relations",
+        "Principles of Management",
+        "Principles of Marketing",
+        "Supply Chain Management"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "Intro to Fine Arts MUSIC Concurrent",
+        "Music Appreciation"
+      ]
+    },
+    {
+      "prefix": "TRAL",
+      "name": "Trails",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Heavy Equipment Operations for Trails",
+        "Introduction to Sustainable Trails",
+        "Small Engine Repair for Trails",
+        "Trail Construction",
+        "Trail Maintenance and Management"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Survey of the Universe (H1)",
+        "Survey of the Universe, Honors (H1)"
+      ]
+    },
+    {
+      "prefix": "DRAM",
+      "name": "Acting",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Advanced Acting",
+        "Beginning Acting I",
+        "Beginning Acting II",
+        "Drama in Healthcare Sim",
+        "Improv for Theatre"
+      ]
+    },
+    {
+      "prefix": "MLSC",
+      "name": "MLSC",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Clinical Chem Lab",
+        "Clinical Chemistry",
+        "Fundamental Lab",
+        "Instr, Urinalysis and Body Flu",
+        "Medical Lab Sci Fund"
+      ]
+    },
+    {
+      "prefix": "SCWK",
+      "name": "Social",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "north-arkansas-college",
+        "northwest-arkansas-community-college",
+        "university-of-arkansas-community-college-batesville"
+      ],
+      "sample_titles": [
+        "Child Abuse Response and Prevention",
+        "Human Diversity & Social Work",
+        "Introduction to Social Work",
+        "Social Institutions",
+        "Social Work"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Directing I",
+        "Drama Practicum",
+        "History of Theatre I",
+        "Introduction to the Theatre (H2)"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "Accounting",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Basic Accounting",
+        "Cost Accounting",
+        "Prin/Accounting I",
+        "Prin/Accounting II"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Science",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "black-river-technical-college",
+        "cossatot-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Equine Science Concurrent",
+        "Intro Animal Science",
+        "Intro Animal Science Lab",
+        "Intro to Animal Science with Lab Concurrent",
+        "Small Ruminant Management Concurrent"
+      ]
+    },
+    {
+      "prefix": "ASTE",
+      "name": "Automotive",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "AUTOMOTIVE ELECTRICAL SYSTEMS",
+        "AUTOMOTIVE ELECTRONICS",
+        "AUTOMOTIVE TRIM",
+        "BRAKES",
+        "CHASSIS AND STEERING"
+      ]
+    },
+    {
+      "prefix": "CHED",
+      "name": "CHED",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Child Growth and Development",
+        "Creative Experiences",
+        "Environment for Young Children",
+        "Field Experience I",
+        "Foundations of Early Childhood"
+      ]
+    },
+    {
+      "prefix": "DIEL",
+      "name": "DIEL",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "CAREER READINESS",
+        "DIESEL BRAKES",
+        "DIESEL DRIVE TRAINS SUSPENSION AND STEERING",
+        "Electrical Systems",
+        "Engine Performance"
+      ]
+    },
+    {
+      "prefix": "ENSC",
+      "name": "Environmental",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Environmental Science Lab",
+        "Environmental Special Problems",
+        "Internship in Environmental Sciences",
+        "Undergraduate Research I"
+      ]
+    },
+    {
+      "prefix": "HBHE",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Behav. Health Issues",
+        "Health Care Del.",
+        "Prac. Seminar BH",
+        "Practicum BH"
+      ]
+    },
+    {
+      "prefix": "RADI",
+      "name": "RADI",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Imaging Equipment",
+        "Intro to Rad Tech",
+        "Rad Pathology",
+        "Rad Physics",
+        "Rad Practicum I"
+      ]
+    },
+    {
+      "prefix": "ALH",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Medical Terminology",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "CECE",
+      "name": "Fitness",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Introduction to Fitness"
+      ]
+    },
+    {
+      "prefix": "EMSC",
+      "name": "Emergency",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville",
+        "university-of-arkansas-community-college-morrilton",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Basic Emergency Medical Tech",
+        "Emergency Medical Technician",
+        "EMERGENCY MEDICAL TECHNICIAN",
+        "EMT Basic",
+        "Paramedic I"
+      ]
+    },
+    {
+      "prefix": "ET",
+      "name": "Industrial",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Industrial Control Systems",
+        "Industrial Electricity/Motors",
+        "Intro Industrial Technology",
+        "Intro Robotics & Indust Proc",
+        "Intro to Electronics"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "northwest-arkansas-community-college",
+        "ozarka-college",
+        "phillips-community-college-of-the-university-of-arkansas",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Human Geography",
+        "Intro. Geography",
+        "Introduction to Geography",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "MDIA",
+      "name": "Creative",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Creative Media Internship",
+        "Desktop Publishing (InDesign)",
+        "Introduction to Creative Media",
+        "Video Editing"
+      ]
+    },
+    {
+      "prefix": "PROG",
+      "name": "Programming",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Programming Foundations I (H1)",
+        "Programming Foundations I, Honors (H1)",
+        "Programming III",
+        "Programming Logic I (H1)",
+        "Programming Logic I, Honors (H1)"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Clinical Education I",
+        "Clinical Education III",
+        "Clinical Education IV",
+        "Image Qlty and Acquisition I",
+        "Intro/Radiography"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Clinical Practice III",
+        "Clinical Practice V",
+        "Intro to Radiologic Technology",
+        "Patient Care"
+      ]
+    },
+    {
+      "prefix": "RES",
+      "name": "RES",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Cardio Eval",
+        "Clinical Pract II",
+        "Clinical Pract III",
+        "Internal Medicine II",
+        "Mechanical Vent I"
+      ]
+    },
+    {
+      "prefix": "SPTC",
+      "name": "Topic",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Special Topic"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "SURG",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "ozarka-college",
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum II",
+        "Introduction to Surgical Technology",
+        "Lab Practicum I",
+        "Patient Care Concepts",
+        "Perioperative Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ABR",
+      "name": "Painting",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "east-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Application Lab I",
+        "Application Lab II",
+        "Basic Metal Repair I",
+        "Color Matching",
+        "Painting and Estimating I"
+      ]
+    },
+    {
+      "prefix": "AFLS",
+      "name": "Careers",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "northwest-arkansas-community-college",
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Careers in Agri",
+        "Careers in Agriculture, Food, and Life Sciences",
+        "Intro Plant Science",
+        "Prin. Hort. Lab",
+        "Prin. of Horticulture"
+      ]
+    },
+    {
+      "prefix": "ALLI",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Nursing Asst/Home Care Aide"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Basic Food Service & Nutrition",
+        "Culinary Arts Internship",
+        "Culinary Math",
+        "Introduction to Baking",
+        "Introduction to Food Production"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "black-river-technical-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Intro K-12 Educ Tech",
+        "Introduction to Education",
+        "Introduction to K-12 Technology"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Advertising Design",
+        "Digital Illustration",
+        "Intro to Graphic Design",
+        "Publication Design"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "Exploring",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Exploring The Humanities (H1)",
+        "Exploring the Humanities, Honors (H1)"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "black-river-technical-college",
+        "northwest-arkansas-community-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurship in Action",
+        "Intro to Business",
+        "Management",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "SUCC",
+      "name": "Success",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Prin of Workplace Success",
+        "Principles of Academic Success"
+      ]
+    },
+    {
+      "prefix": "XCDL",
+      "name": "Refresher",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "CDL 3-day Refresher",
+        "CDL 5-day Refresher",
+        "CDL Class B",
+        "CDL Full Training"
+      ]
+    },
+    {
+      "prefix": "XMRK",
+      "name": "Retail",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Retail Analytical Techniques",
+        "Retail Industry Foundations",
+        "Retail Link Data Management",
+        "Retail Strategic Analysis",
+        "Retail Tools Integration"
+      ]
+    },
+    {
+      "prefix": "XPLM",
+      "name": "Plumbing",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Plumbing I",
+        "Plumbing II",
+        "Plumbing III",
+        "Plumbing IV"
+      ]
+    },
+    {
+      "prefix": "AVIA",
+      "name": "AVIA",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Aviation Weather",
+        "Commercial Pilot Practicum III",
+        "Fundamentals of Aeronautics I & II",
+        "Fundamentals of Aeronautics IV",
+        "Human Factors and Aviation Safety"
+      ]
+    },
+    {
+      "prefix": "CNET",
+      "name": "CNET",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Intro to CNET",
+        "Intro to Linux",
+        "Network Management",
+        "Networking Tech Sup",
+        "Windows Op System"
+      ]
+    },
+    {
+      "prefix": "GSP",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Earth Science & Lab",
+        "Physical Sc & Lab"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "Computer",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "COMPUTER HARDWARE AND SOFTWARE I",
+        "COMPUTER HARDWARE AND SOFTWARE II",
+        "DESKTOP OPERATING SYSTEMS",
+        "INTRODUCTION TO COMPUTER PROGRAMMING LOGIC AND LANGUAGE",
+        "INTRODUCTION TO NETWORK ADMINISTRATION"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Bas Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "NTWK",
+      "name": "NTWK",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Computer Forensics",
+        "Microcomputer Software Support",
+        "Network Administration-Windows",
+        "Network Security",
+        "Networking & Info Systems"
+      ]
+    },
+    {
+      "prefix": "OTAP",
+      "name": "OTAP",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Intro to OTA",
+        "Mental Health L1 FW A",
+        "Pediatrics in Occupational Therapy",
+        "Special Procedures"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "SUR",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Adv Surgical Proced",
+        "Clinical Pract II",
+        "Clinical Pract III",
+        "Intro to Surg Tech",
+        "Lab Practicum II"
+      ]
+    },
+    {
+      "prefix": "SURV",
+      "name": "Surveying",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "BOUNDARY SURVEYING",
+        "CONSTRUCTION AND ROUTE SURVEYING",
+        "GLOBAL POSITIONING SYSTEMS",
+        "INTRODUCTION TO CAD AND SURVEYING SOFTWARE",
+        "PLANE SURVEYING"
+      ]
+    },
+    {
+      "prefix": "ADMS",
+      "name": "ADMS",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Business Communicat",
+        "Keyboarding/Prof I",
+        "Professional Develop",
+        "Word/Information Pro"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Heritage",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Heritage and Values of USAF",
+        "Heritage and Values USAF Lab",
+        "Team and Leadership Fundamentals Lab",
+        "Team and Leadership Fundmental"
+      ]
+    },
+    {
+      "prefix": "CIED",
+      "name": "Teaching",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Intro. To Education",
+        "Teaching Exceptional Learners"
+      ]
+    },
+    {
+      "prefix": "CMLT",
+      "name": "Clinical",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Hematology & Hemostasis",
+        "Clinical Immunohematology",
+        "Clinical Microbiology I",
+        "Clinical Practicum III",
+        "Clinical Urinalysis & Body Fluids"
+      ]
+    },
+    {
+      "prefix": "DNTA",
+      "name": "Dental",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Dentistry",
+        "Dental Assisting Procedures I",
+        "Dental Materials I",
+        "Dental Radiography I",
+        "Dental Science I"
+      ]
+    },
+    {
+      "prefix": "ECDT",
+      "name": "ECDT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Child Nutrition/Health",
+        "Early Child Ed Prac",
+        "Early Childhood Field Exp",
+        "Essen Ele/Child Care",
+        "Soc Stud/Math/Sci PS"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "AC-DC Fundamentals",
+        "Industrial Motor Controls",
+        "Instrumentation & Control I",
+        "Principles of Technology",
+        "Prog. Logic Controllers II"
+      ]
+    },
+    {
+      "prefix": "GUNS",
+      "name": "GUNS",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Firearm Safety &Maint.",
+        "Firearms Repair I",
+        "Gunsmithing Theory I",
+        "Metal Finishing I",
+        "Riflesmithing"
+      ]
+    },
+    {
+      "prefix": "HEC",
+      "name": "Food",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Field Experience",
+        "Food Science",
+        "Food Sys Management",
+        "Intro to Nutrition and Menu",
+        "Quant. Food Prod"
+      ]
+    },
+    {
+      "prefix": "HIMT",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Essentials of Management Practice",
+        "Intro Medical Coding",
+        "Med Office Intern",
+        "Medical Terminology II"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Media and Society",
+        "Media Writing",
+        "News Reporting",
+        "Newspaper Layout and Design",
+        "Special Topics in Journalism"
+      ]
+    },
+    {
+      "prefix": "MAR",
+      "name": "Marketing",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Drives",
+        "Electrical Syst I",
+        "Electrical Syst II",
+        "Introduction to Marine Repair",
+        "Marine Electronic Fuel Injecti"
+      ]
+    },
+    {
+      "prefix": "MILS",
+      "name": "Leadership",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Basic Outdoor Skills and Leadership Intro",
+        "Basic Outdoor Skills and Leadership Lab",
+        "Leadership Development I",
+        "Leadership Development I Lab"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Basic Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "PCEN",
+      "name": "Composition",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Composition Principles Lab",
+        "English Composition I Supplemental Instruction Lab"
+      ]
+    },
+    {
+      "prefix": "PCMA",
+      "name": "Foundations",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Foundations of College Algebra",
+        "Foundations of Mathematics",
+        "Foundations of Quantitative Literacy"
+      ]
+    },
+    {
+      "prefix": "RNUR",
+      "name": "Clinical",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Nursing Concepts I",
+        "Nursing Concepts II",
+        "Nursing Concepts III",
+        "RN Clinical Practicum I",
+        "RN Clinical Practicum II"
+      ]
+    },
+    {
+      "prefix": "XHVC",
+      "name": "Hvac",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "HVAC Level I",
+        "HVAC Level II",
+        "HVAC Level III"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Computer Concepts"
+      ]
+    },
+    {
+      "prefix": "DFTG",
+      "name": "Drafting",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "AUTOCAD",
+        "BEGINNING DRAFTING",
+        "MECHANICAL DRAFTING",
+        "RESIDENTIAL DRAFTING",
+        "SPATIAL PLANNING"
+      ]
+    },
+    {
+      "prefix": "ECD",
+      "name": "Practicum",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Child Development",
+        "Fundamentals of Early Childhood Education",
+        "Healthy, Safe Learning Environment",
+        "Practicum I",
+        "Practicum II"
+      ]
+    },
+    {
+      "prefix": "OSIM",
+      "name": "Management",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Management",
+        "Business Communications",
+        "Business Presentations",
+        "Computer Support and Project Management"
+      ]
+    },
+    {
+      "prefix": "PTAP",
+      "name": "PTAP",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Clinical Practicum I",
+        "Concepts of PT Profession Concurrent",
+        "Neurorehabilitation",
+        "Pathophysiology"
+      ]
+    },
+    {
+      "prefix": "SCOM",
+      "name": "Oral",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Oral Communications"
+      ]
+    },
+    {
+      "prefix": "XELC",
+      "name": "Electrical",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Electrical I",
+        "Electrical II",
+        "Electrical III",
+        "Electrical IV"
+      ]
+    },
+    {
+      "prefix": "AB",
+      "name": "AB",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Estimating",
+        "Non-Struct Repair",
+        "Preparation/Refinish",
+        "Welding and Cutting"
+      ]
+    },
+    {
+      "prefix": "AHSC",
+      "name": "Cnapca",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "CNA-PCA",
+        "Phlebotomy"
+      ]
+    },
+    {
+      "prefix": "AIRC",
+      "name": "Refrigeration",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Basic Refrigeration",
+        "Commercial Refrigeration",
+        "Controls A/C Refrig",
+        "Elec for A/C Refrigeration"
+      ]
+    },
+    {
+      "prefix": "BINS",
+      "name": "Electronic",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "BUSINESS PROCEDURES",
+        "ELECTRONIC CALCULATORS",
+        "ELECTRONIC SPREADSHEET",
+        "PROFESSIONAL DEVELOPMENT"
+      ]
+    },
+    {
+      "prefix": "CEO",
+      "name": "Oper",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Compact Equiq & Environ Safety",
+        "Equipment Fund & Oper Prin",
+        "Heavy Equip Oper: Comp Equip",
+        "Soil Types & Characteristics"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "Computers",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Intro to Computers"
+      ]
+    },
+    {
+      "prefix": "CRT",
+      "name": "Repair",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Body and Frame Alignment",
+        "Collision Repair Fundamentals",
+        "Non-Structural Repair",
+        "Plastics, Adhesives, & Sealers"
+      ]
+    },
+    {
+      "prefix": "CRTE",
+      "name": "CRTE",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "AUTO BODY FUNDAMENTALS",
+        "COLOR THEORY",
+        "ELECTRICAL AND MECHANICAL SYSTEMS",
+        "MATERIALS AND PROCESSES"
+      ]
+    },
+    {
+      "prefix": "ECTC",
+      "name": "Early",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Child Guidance",
+        "Literacy and Language Arts for Early Childhood",
+        "Math & Science Early Childhood",
+        "Preschool Curriculum"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Build Science & Weath Prin",
+        "Energy Auditing",
+        "Intro to Energy Management",
+        "Solar Pv Sys & Renewable Eng I"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "Educational",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Educational Technology"
+      ]
+    },
+    {
+      "prefix": "FAT",
+      "name": "Fine",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Fine Arts Theatre"
+      ]
+    },
+    {
+      "prefix": "GDES",
+      "name": "Digital",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Digital Image Production I",
+        "Digital Photography",
+        "Graph Art/Design I",
+        "Two Dimensional Design"
+      ]
+    },
+    {
+      "prefix": "GNEG",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "north-arkansas-college",
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Engineering"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "Hospitality",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Cafe Practicum",
+        "Cafe Practicum II",
+        "Hospitality Operations & Supervisor Management",
+        "Hospitality Purchasing"
+      ]
+    },
+    {
+      "prefix": "LOGM",
+      "name": "Logistics",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Intro to Logistics"
+      ]
+    },
+    {
+      "prefix": "MEH",
+      "name": "MEH",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Blueprint Reading",
+        "Basic Mill Operation",
+        "Intro/Mach Processes"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Math for Health Care"
+      ]
+    },
+    {
+      "prefix": "NUPN",
+      "name": "Nursing",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Medical Surgical for Practical Nursing I",
+        "Medical Surgical for Practical Nursing II",
+        "Mental Health Nursing",
+        "Transition to Practice"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking Apps I",
+        "Nursing Process I",
+        "Nursing Process III",
+        "Nursing Process IV"
+      ]
+    },
+    {
+      "prefix": "PSSC",
+      "name": "Plant",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Intro Plant Sci Lab",
+        "Intro Plant Science",
+        "Intro to Soils",
+        "Intro to Soils Lab"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Developmental Psy",
+        "Intro to Psychology"
+      ]
+    },
+    {
+      "prefix": "SM",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Intro to Sports Management"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "UAS",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Aviation Weather",
+        "Mob Drone Pwer Econ",
+        "Multi-Rotor Operations",
+        "Safety & Maintenance"
+      ]
+    },
+    {
+      "prefix": "AGEC",
+      "name": "Agriculture",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville"
+      ],
+      "sample_titles": [
+        "Agriculture Economics",
+        "Intro. To Agri. Business"
+      ]
+    },
+    {
+      "prefix": "AI",
+      "name": "Artificial",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "App in Artificial Intelligence",
+        "Fund in AI Communications"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Art Seminar",
+        "Drawing",
+        "Free Hand Drawing"
+      ]
+    },
+    {
+      "prefix": "BFIN",
+      "name": "Banking",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Investing",
+        "Principles of Banking"
+      ]
+    },
+    {
+      "prefix": "BUAD",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Business Ethics",
+        "Intro to Business"
+      ]
+    },
+    {
+      "prefix": "CT",
+      "name": "Construction",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Construction Fundamentals",
+        "Construction Methods",
+        "Plumbing and Electrical System"
+      ]
+    },
+    {
+      "prefix": "DASC",
+      "name": "Data",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Data Science in Today's World",
+        "Introduction to Data Science",
+        "Programming for Data Science"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Dynamics",
+        "Electrical Circuits I",
+        "Introduction to Engineering"
+      ]
+    },
+    {
+      "prefix": "ESCI",
+      "name": "Earth",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Earth Science"
+      ]
+    },
+    {
+      "prefix": "FAMU",
+      "name": "Fine",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Fine Arts Music"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Fire Fighter I",
+        "Fire Fighter II",
+        "Fire Service Special Operations"
+      ]
+    },
+    {
+      "prefix": "FORE",
+      "name": "Forestry",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Forestry Concurrent"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Basic Health Skills"
+      ]
+    },
+    {
+      "prefix": "HONS",
+      "name": "HONS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Honors Internship",
+        "Honors Seminar II",
+        "Intro to Honors Seminar"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "INDT",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Industrial Fundamentals",
+        "Welding for Maintenance Techs"
+      ]
+    },
+    {
+      "prefix": "INEG",
+      "name": "Safetysanitation",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Ind. Safety/Sanitation"
+      ]
+    },
+    {
+      "prefix": "INET",
+      "name": "Prog",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Adv Database Cncpts",
+        "Adv Web Prog",
+        "Intro to Web Prog"
+      ]
+    },
+    {
+      "prefix": "IST",
+      "name": "Essentials",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "A+ Essentials",
+        "Introduction to Servers",
+        "Networking Essentials I"
+      ]
+    },
+    {
+      "prefix": "MSTE",
+      "name": "Forklift",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas",
+        "university-of-arkansas-community-college-batesville"
+      ],
+      "sample_titles": [
+        "Basic Machining",
+        "Forklift Certification"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "Control",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Computer Numerical Control",
+        "Manufacturing Processes I",
+        "Quality Control"
+      ]
+    },
+    {
+      "prefix": "PMT",
+      "name": "Manual",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Blueprints, Measurement and Safety",
+        "Manual Machining"
+      ]
+    },
+    {
+      "prefix": "PNP",
+      "name": "PNP",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology",
+        "Fundamentals of Nursing",
+        "Mental Health Nursng"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "American Natl Govt",
+        "State & Local Govt"
+      ]
+    },
+    {
+      "prefix": "SPEE",
+      "name": "Oral",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Oral Communication"
+      ]
+    },
+    {
+      "prefix": "TRLG",
+      "name": "Management",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Inventory Management",
+        "Supply Chain Mgmt for A.A.S.",
+        "Transportation Management"
+      ]
+    },
+    {
+      "prefix": "WFRB",
+      "name": "Robotics",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Robotics I - Introduction to Robotics"
+      ]
+    },
+    {
+      "prefix": "ACCO",
+      "name": "Prinaccounting",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Prin/Accounting I",
+        "Prin/Accounting II"
+      ]
+    },
+    {
+      "prefix": "BOTY",
+      "name": "Biology",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Biology",
+        "Plant Biology"
+      ]
+    },
+    {
+      "prefix": "BSYS",
+      "name": "Buspro",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Bus/Pro Presentation",
+        "Sprdsht/Man.Decis"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Career Communication"
+      ]
+    },
+    {
+      "prefix": "CSES",
+      "name": "Soil",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Soil Science"
+      ]
+    },
+    {
+      "prefix": "CYSC",
+      "name": "Cybercrime",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Digital Forensics",
+        "Intro to Cybercrime"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "national-park-college",
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Basic Emergency Med. Tech.",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "ENGC",
+      "name": "Vocabulary",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "College Reading & Vocabulary (C1)",
+        "Comp Review & Vocabulary (C2)"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Entrepreneurship",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "E-Commerce",
+        "Introduction to Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "FA",
+      "name": "Film",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Film Classics I"
+      ]
+    },
+    {
+      "prefix": "INFO",
+      "name": "Computer",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Computer Prog I",
+        "Java Programming"
+      ]
+    },
+    {
+      "prefix": "ISHP",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Nursing Assistant Clinical",
+        "Nursing Assistant Theory"
+      ]
+    },
+    {
+      "prefix": "LANG",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "Elementary Spanish II"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "Legal",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Legal Env Business"
+      ]
+    },
+    {
+      "prefix": "LPN",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Nursing Clinical Experience II",
+        "Nursing Process II"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "Electromechanical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading/Measurements",
+        "Electro-Mechanical Device Syst"
+      ]
+    },
+    {
+      "prefix": "MEEG",
+      "name": "Statics",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Statics",
+        "Thermodynamics"
+      ]
+    },
+    {
+      "prefix": "NREM",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cossatot-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Natural Resources and Conservation Concurrent"
+      ]
+    },
+    {
+      "prefix": "POLI",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "State & Local Governments"
+      ]
+    },
+    {
+      "prefix": "XCMP",
+      "name": "Office",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Excel & Database Mgmt. Retail",
+        "MS Office 365"
+      ]
+    },
+    {
+      "prefix": "XCUL",
+      "name": "Baking",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Cost Control",
+        "Intro to Baking"
+      ]
+    },
+    {
+      "prefix": "XRTL",
+      "name": "Shelf",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Adv Shelf Mgmt/Plan-ProSpace",
+        "Intro Shelf Mgmt/Plan-ProSpace"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Aviat",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Aviat Maint Tech GP 1"
+      ]
+    },
+    {
+      "prefix": "CESC",
+      "name": "Cybersecurity",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "university-of-arkansas-community-college-batesville"
+      ],
+      "sample_titles": [
+        "Introduction to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "CSEC",
+      "name": "Cybersecurity",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Intro to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "DVSC",
+      "name": "Data",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-arkansas-college"
+      ],
+      "sample_titles": [
+        "Introduction to Data Science"
+      ]
+    },
+    {
+      "prefix": "ECH",
+      "name": "Child",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Child Development"
+      ]
+    },
+    {
+      "prefix": "EMSP",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Adv Emergency Medical Tech"
+      ]
+    },
+    {
+      "prefix": "ESCO",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "phillips-community-college-of-the-university-of-arkansas"
+      ],
+      "sample_titles": [
+        "Emergency Services Communication I"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "Exercise",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "university-of-arkansas-community-college-rich-mountain"
+      ],
+      "sample_titles": [
+        "Introduction to Exercise Science"
+      ]
+    },
+    {
+      "prefix": "FAM",
+      "name": "Fine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Fine Arts Musical"
+      ]
+    },
+    {
+      "prefix": "FATH",
+      "name": "Fine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ozarka-college"
+      ],
+      "sample_titles": [
+        "Fine Arts Theater"
+      ]
+    },
+    {
+      "prefix": "FAV",
+      "name": "Fine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Fine Arts Visual"
+      ]
+    },
+    {
+      "prefix": "FINN",
+      "name": "Personal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "university-of-arkansas-community-college-morrilton"
+      ],
+      "sample_titles": [
+        "PERSONAL FINANCE"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Elementary French I"
+      ]
+    },
+    {
+      "prefix": "FS",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "EM Med First Responder"
+      ]
+    },
+    {
+      "prefix": "GEOS",
+      "name": "Geographic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Geographic Information Sciences I"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Elementary German I"
+      ]
+    },
+    {
+      "prefix": "GLST",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Global Practicum"
+      ]
+    },
+    {
+      "prefix": "HOME",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-arkansas-college"
+      ],
+      "sample_titles": [
+        "Basic Nutrition"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "Horticulture",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Horticulture"
+      ]
+    },
+    {
+      "prefix": "IMT",
+      "name": "Hydraulics",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Hydraulics"
+      ]
+    },
+    {
+      "prefix": "INTB",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Global Management"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Medical Assisting"
+      ]
+    },
+    {
+      "prefix": "MPAX",
+      "name": "Technology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Technology & Design in STEM"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "Video",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Video Production"
+      ]
+    },
+    {
+      "prefix": "PHTC",
+      "name": "Pharmacy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Pharmacy Technician"
+      ]
+    },
+    {
+      "prefix": "POSC",
+      "name": "Government",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "US Government"
+      ]
+    },
+    {
+      "prefix": "QM",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Business Statistics"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "black-river-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Social Work"
+      ]
+    },
+    {
+      "prefix": "TECM",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "national-park-college"
+      ],
+      "sample_titles": [
+        "Technical Math I"
+      ]
+    },
+    {
+      "prefix": "WFAI",
+      "name": "Survey",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-arkansas-community-college"
+      ],
+      "sample_titles": [
+        "Survey of Artificial Intelligence"
+      ]
+    }
+  ],
+  "program_titles": [
+    "Accounting",
+    "Accounting Technician, TC",
+    "Addiction Studies, AS-LAS for Transfer to UCA BS in Addiction Studies",
+    "Administrative Medical Assistant",
+    "Advanced Manufacturing Technology, TC",
+    "Agriculture",
+    "Allied Health, TC",
+    "Associate of Applied Science in Early Childhood",
+    "Associate of Applied Science in Radiologic Technology",
+    "Associate of Applied Science in Respiratory Care",
+    "Associate of Applied Science in Surgical Technology",
+    "Associate of Arts",
+    "Associate of Arts in Teaching",
+    "Associate of General Studies",
+    "Associate of Liberal Studies",
+    "Athletic Training, CP",
+    "Automation and Systems Integration (Emphasis in Electronics Technology)",
+    "Automation and Systems Integration (Emphasis in Manufacturing Technology)",
+    "Automotive Brake Specialist, CP",
+    "Automotive Engine Performance Specialist, CP",
+    "Automotive Front-End Specialist, CP",
+    "Automotive Service Technology",
+    "Automotive Service Technology, AAS",
+    "Automotive Service Technology, TC",
+    "Automotive Service/Maintenance, CP",
+    "Automotive Transmissions, CP",
+    "Automotive Tune-Up Specialist, CP",
+    "Aviation Maintenance",
+    "Banking and Finance",
+    "Basic Business Law, CP",
+    "Basic Business Management, CP",
+    "Basic Business Principles, CP",
+    "Business",
+    "Business Administration - General Business, AS for Transfer to UAM at NPC BA - General Business",
+    "Business Analytics, AAS",
+    "Business Entrepreneurship, CP",
+    "Business Management: Accounting, AAS",
+    "Business Management: Management/Marketing, AAS",
+    "Business, AS for Transfer",
+    "Business, AS for Transfer to UAFS BBA",
+    "Certificate of General Studies",
+    "Certificate of Proficiency in Air Conditioning and Refrigeration Technology",
+    "Certificate of Proficiency in Business Analytics",
+    "Certificate of Proficiency in Commercial Driving License",
+    "Certificate of Proficiency in Communications",
+    "Certificate of Proficiency in Computer Network Technology",
+    "Certificate of Proficiency in Criminal Justice",
+    "Certificate of Proficiency in Early Childhood",
+    "Certificate of Proficiency in Gaming and Interactive Media Design",
+    "Certificate of Proficiency in Hydraulics/Pneumatics",
+    "Certificate of Proficiency in Industrial Motor Controls",
+    "Certificate of Proficiency in Mechanical Devices",
+    "Certificate of Proficiency in Medical Coding",
+    "Certificate of Proficiency in Phlebotomy Technology",
+    "Certificate of Proficiency in Security/Forensics",
+    "Certificate of Proficiency in Welding - Metal Inert Gas (MIG)",
+    "Certificate of Proficiency in Welding - Shielded Metal ARC Welding (SMAW)",
+    "Certificate of Proficiency in Welding - Tungsten Inert Gas (TIG)",
+    "Certification Welding",
+    "Certified Clinical Medical Assistant",
+    "Certified Teaching Assistant, CP",
+    "Chemistry, AS",
+    "CJI Crime Scene Investigation, AAS",
+    "CJI Crime Scene Investigation, CP",
+    "CJI Crime Scene Investigation, TC",
+    "CJI Law Enforcement Administration, AAS",
+    "CJI Law Enforcement Administration, CP",
+    "CJI Law Enforcement Administration, TC",
+    "Climate Control Manual Drive Trains Technology",
+    "Collision Repair Technology",
+    "Community Nutrition, AS-LAS for Transfer to UCA BS in Community Nutrition",
+    "Computer Information Systems - Programming & Information Security, AS-STEM for Transfer to UAM Computer Information Systems - Programming & Information Security, BS for Completion at NPC",
+    "Computer Information Systems Technology, AAS",
+    "Computer Network Technology, AAS",
+    "Computer Science, CP",
+    "Construction Equipment Operation",
+    "Construction Finishes (Pending ADHE/HLC Approval)",
+    "Construction Technology",
+    "Construction Technology, CP",
+    "Creative Media",
+    "Criminal Justice",
+    "Criminal Justice Technology, AAS",
+    "Criminal Justice, AAS",
+    "Criminal Justice, AAS for Transfer to UAFS BS in Criminal Justice",
+    "Criminal Justice, CP",
+    "Criminal Justice, TC",
+    "Cybersecurity",
+    "Cybersecurity Management Technology, AAS",
+    "Data Analytics",
+    "Data Science",
+    "Dietetics, AS-LAS for Transfer to UCA BS in Dietetics",
+    "Digital & Media Arts, AAS",
+    "Digital & Media Arts, CP",
+    "Digital & Media Arts, TC",
+    "Digital Media",
+    "Education",
+    "Electronics Technology",
+    "Elementary Education, AS for Transfer to HSU BSE in Elementary Education K-6",
+    "Elementary Education, AS for Transfer to UAM at NPC BA in Elementary Education K-6",
+    "Emergency Medical Services - Paramedic, AAS",
+    "Emergency Medical Services - Paramedic, TC",
+    "Emergency Medical Technician",
+    "Emergency Medical Technician, CP",
+    "Energy Management",
+    "Exercise Science, AS-STEM for Transfer to UAM BS in Exercise Science",
+    "Facilities Maintenance",
+    "Foundations in Outdoor Recreation, CP",
+    "Funeral Service Education NPC/UAHT, AAS",
+    "Gas Engine Repair and Brake Technology",
+    "Gas Metal Arc Welding (GMAW) Technology",
+    "General Studies",
+    "General Studies Certificate",
+    "General Technology",
+    "General Technology, AAS",
+    "General Technology, Individualized Technical Option, AAS",
+    "Health & PE - Coaching, AS-LAS for Transfer to UAM BS in Health & PE-Coaching (non-licensure)",
+    "Health & PE - Sports Administration, AS-LAS for Transfer to UAM BS in Health & PE-Sports Administration (non-licensure)",
+    "Health Information Technology, AAS",
+    "Healthcare Administration - Business, AS-LAS for Transfer to UCA BS Healthcare Administration - Business",
+    "Healthcare Administration - Pre-Occupational Therapy, AS-LAS for Transfer to UCA BS Healthcare Administration - Pre-Occupational Therapy",
+    "Healthcare Administration - Pre-Physical Therapy, AS-LAS for Transfer to UCA BS Healthcare Administration - Pre-Physical Therapy",
+    "Heating, Ventilation, Air Conditioning & Refrigeration Technology",
+    "Heating, Ventilation, and Air Conditioning",
+    "Hospitality Management",
+    "Industrial Controls, CP",
+    "Information Technologies",
+    "Logistics & Supply Chain",
+    "Logistics and Supply Chain Management",
+    "Management",
+    "Manufacturing Technology",
+    "Marine Engine Fundamentals, CP",
+    "Marine Engine Maintenance Fundamentals, CP",
+    "Marine Repair Technology, TC",
+    "Marketing, CP",
+    "Mechanical Systems, CP",
+    "Medical Assistant-Clinical and Administrative",
+    "Medical Laboratory Technology",
+    "Medical Laboratory Technology, AAS",
+    "Middle Level Education, AS",
+    "Mountain Biking and Trail Maintenance, CP",
+    "Music, AS-LAS for Transfer to HSU BA in Music",
+    "Networking & Cybersecurity, AAS",
+    "Networking & Cybersecurity, TC",
+    "Nursing Assistant",
+    "Office Management",
+    "Outdoor Maintenance, CP",
+    "Outdoor Power Equipment",
+    "Outdoor Power Equipment (pending ADHE / HLC approval)",
+    "Outdoor Power Equipment Fuel and Chassis Systems (pending ADHE / HLC approval)",
+    "Outdoor Power Equipment Powertrain System (pending ADHE / HLC approval)",
+    "Outdoor Recreation Activities, CP",
+    "Outdoor Recreation Management, CP",
+    "Outdoor Recreation, AAS",
+    "Outdoor Recreation, TC",
+    "Paramedic (Associate of Applied Science)",
+    "Paramedic (Technical Certificate)",
+    "Phlebotomy Technician",
+    "Pipe Welding, CP",
+    "Practical Nursing",
+    "Practical Nursing, TC",
+    "Pre-Allied Health",
+    "Pre-Engineering, AS",
+    "Pre-Nursing, TC",
+    "Programming",
+    "Programming (Pending ADHE/HLC Approval)",
+    "Psychology, AS-LAS for Transfer to UCA BS in Psychology",
+    "Radiologic Technology",
+    "Radiologic Technology, AAS",
+    "Registered Nursing",
+    "Registered Nursing, AS",
+    "Registered Nursing, AS - LPN to RN",
+    "Respiratory Care, AAS",
+    "Retail Management, CP",
+    "RN Bridge",
+    "Science, Engineering and Math",
+    "Shielded Metal Arc Welding (SMAW) Technology",
+    "Small Business Management",
+    "Social Work, AS-LAS for Transfer to UALR BSW",
+    "Sociology, AS-LAS for Transfer to UCA BS in Sociology",
+    "Sports Management",
+    "Sports Management, CP",
+    "Sports Turf Management",
+    "Studio Arts",
+    "Supply Chain Management Technology, AAS",
+    "Surgical Technology",
+    "Technical Certificate in Air Conditioning and Refrigeration Technology",
+    "Technical Certificate in Business Analytics",
+    "Technical Certificate in Computer Information Systems Technology",
+    "Technical Certificate in Computer Network Technology",
+    "Technical Certificate in Computer Programming (Cybersecurity Emphasis)",
+    "Technical Certificate in Practical Nursing",
+    "Technical Certificate in Programmable Logic Controllers",
+    "Technical Certificate in Supply Chain Transportation",
+    "Technical Certificate in Surgical Technology",
+    "Technical Certificate in Teaching",
+    "Technical Certificate in Welding Technology",
+    "Tourism and Hospitality, CP",
+    "Truck Driving",
+    "Turf Management",
+    "UAS and Data Applications (Pending ADHE/HLC Approval)",
+    "Welding Application & Procedures",
+    "Welding Layout & Fabrication, CP",
+    "Welding Technology",
+    "Welding Technology, TC",
+    "Welding/GMAW, CP",
+    "Welding/GTAW, CP",
+    "Welding/SMAW, CP",
+    "Wilderness Safety, CP",
+    "Workforce Technology"
+  ]
+}

--- a/data/az/subject-vocab.json
+++ b/data/az/subject-vocab.json
@@ -1,0 +1,6349 @@
+{
+  "state": "az",
+  "generated_at": "2026-06-06T15:41:39.416Z",
+  "subjects": [
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 77,
+      "section_count": 1707,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# MAT 1142) College Mathematics",
+        "(SUN# MAT 1151) Precalculus Algebra",
+        "(SUN# MAT 1160) Elements of Statistics",
+        "(SUN# MAT 2212) Calculus for Business",
+        "(SUN# MAT 2262) Differential Equations"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 61,
+      "section_count": 1071,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# ENG 1101) English Composition I",
+        "(SUN# ENG 1102) English Composition II",
+        "Advanced Creative Writing",
+        "Advanced Professional Writing in the Workplace",
+        "Basic Manuscript Writing: Fiction"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 71,
+      "section_count": 953,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# BIO 1181) General Biology I (for majors)",
+        "(SUN# BIO 1182) General Biology II",
+        "(SUN# BIO 2201) Human Anatomy and Physiology I",
+        "(SUN# BIO 2202) Human Anatomy and Physiology II",
+        "(SUN# BIO 2205) Microbiology"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 159,
+      "section_count": 919,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "(SUN# CIS 1120) Introduction to Computer Information Systems",
+        "(SUN# CSC2205) Computer Science II",
+        "A+ Certification Preparation I",
+        "A+ Certification Preparation II",
+        "A+ Computer Tech Hardware"
+      ]
+    },
+    {
+      "prefix": "MUP",
+      "name": "Instruction",
+      "course_count": 258,
+      "section_count": 809,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Chamber Music Ensembles",
+        "Chamber Singers",
+        "Class Guitar I",
+        "Class Guitar II",
+        "Class Piano I"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 141,
+      "section_count": 743,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# ART 1101) Survey of World Art: Prehistoric - Gothic",
+        "(SUN# ART 1102) Survey of World Art: Renaissance",
+        "(SUN# ART 1112) Design Fundamentals",
+        "(SUN# ART 1115) Three-Dimensional Design",
+        "Adobe Photoshop I"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 51,
+      "section_count": 660,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# PSY 1101) Introduction to Psychology",
+        "(SUN# PSY 2290) Research Methods",
+        "Abnormal Psychology",
+        "Adv Reading in Psychology",
+        "Applied Research Methods"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 39,
+      "section_count": 549,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# CHM 1130) Fundamental Chemistry",
+        "(SUN# CHM 1151) General Chemistry I",
+        "(SUN# CHM 1152) General Chemistry II",
+        "(SUN# CHM 2235) General Organic Chemistry I",
+        "(SUN# CHM 2236) General Organic Chemistry II"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 70,
+      "section_count": 487,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Adv Flux-Cored Arc Welding",
+        "Adv Shield Metal Arc Welding",
+        "Advanced Gas Metal Arc Welding",
+        "Advanced GTAW - Exotic Metals",
+        "Advanced GTAW - Hard Metals"
+      ]
+    },
+    {
+      "prefix": "AJS",
+      "name": "AJS",
+      "course_count": 62,
+      "section_count": 402,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# AJS 1101) Introduction to Administration of Justice",
+        "Civil Procedures",
+        "Constitutional Law",
+        "Constitutional Law: Civil Liberties and Civil Rights",
+        "Contemporary Iss Criminal Jus"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 109,
+      "section_count": 393,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Art Methods and Curriculum Development for Elementary",
+        "Art Methods and Curriculum Development for Secondary",
+        "Assessment and Eligibility in Special Education",
+        "ASVAB Prep and Improvement",
+        "Bil/ESL Rdg Mth Mgmt Assessmnt"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 20,
+      "section_count": 389,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# COM 1100) Introduction to Communication",
+        "Basic Communication Theory",
+        "Communication Activities",
+        "Communication Analysis",
+        "Communication in Business and Professions"
+      ]
+    },
+    {
+      "prefix": "WRT",
+      "name": "Writing",
+      "course_count": 17,
+      "section_count": 358,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Adv Professional Communication",
+        "Advanced Fiction Writing",
+        "Advanced Poetry Writing",
+        "Basics of Short Story Writing",
+        "Beginning Poetry Writing"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 50,
+      "section_count": 349,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "coconino-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Accounting Information Systems",
+        "Accounting Internship",
+        "Accounting Principles I",
+        "Accounting Principles II",
+        "Accounting Systems & Procedure"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 85,
+      "section_count": 275,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "(SUN# ACC 2201) Financial Accounting",
+        "(SUN# BUS 2201) Business Statistics",
+        "(SUN# BUS2202) Managerial Accounting",
+        "Analytic Methods in Business",
+        "Analytical Methods in Business"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 47,
+      "section_count": 274,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# HIS 1131) History of the United States 1607-1877",
+        "(SUN# HIS 1132) History of the United States Since 1877",
+        "African-American History 1865 to Present",
+        "African-American History to 1865",
+        "American Indian History"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 99,
+      "section_count": 274,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# MUS 2222) Music Theory III",
+        "(SUN# MUS 2223) Music Theory IV",
+        "Adv Music Recording &amp; Prod",
+        "Adv Musical Theater Workshop",
+        "Advanced Integrated Theory I"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 22,
+      "section_count": 266,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# SPA 1101) Elementary Spanish I",
+        "(SUN# SPA 1102) Beginning Spanish II",
+        "(SUN# SPA 2201) Intermediate Spanish I",
+        "(SUN# SPA 2201) Intermediate Spanish II",
+        "Beg Spanish Heritage Learners"
+      ]
+    },
+    {
+      "prefix": "ASD",
+      "name": "ASD",
+      "course_count": 43,
+      "section_count": 260,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Addiction Review Seminar",
+        "Addictions and Substance Use Disorders Practicum",
+        "Addictive and Medical Plants Seminar",
+        "Adolescent Substance Abuse Treatment Seminar",
+        "Adolescent Substance Use Prevention"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 258,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Exploration of College, Career and Personal Success",
+        "Introduction to College, Career and Personal Success"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 64,
+      "section_count": 249,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Placement Nursing Asst",
+        "Advanced Nursing Capstone",
+        "BSN Capstone Project",
+        "Case Management",
+        "Community Health Nursing"
+      ]
+    },
+    {
+      "prefix": "GBS",
+      "name": "Business",
+      "course_count": 17,
+      "section_count": 230,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Business Calculations",
+        "Business Communication",
+        "Business Internship",
+        "Business Statistics",
+        "Consumer Credit"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 27,
+      "section_count": 214,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# SOC 1101) Introduction to Sociology",
+        "(SUN# SOC 2250) Social Problems",
+        "Current Social Problems SUN# SOC2250",
+        "Gender Ident,Interact&amp;Relation",
+        "Human Sexuality"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "Nursing",
+      "course_count": 31,
+      "section_count": 205,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Drug Calculations",
+        "Intro Practical NRS Clinical",
+        "Intro Practical NRS Skills LAB",
+        "Intro to Practical Nursing",
+        "Introduction to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 25,
+      "section_count": 204,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "mesa-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# PHY 1111) General Physics I",
+        "(SUN# PHY 1112) General Physics II",
+        "(SUN# PHY 1121) Physics with Calculus I",
+        "Algebra-based Physics I",
+        "Conceptual Physics"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "ECN",
+      "course_count": 14,
+      "section_count": 190,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# ECN 2201) Principles of Macroeconomics",
+        "(SUN# ECN 2202) Principles of Microeconomics",
+        "An Economics Perspective",
+        "Business Statistical Analysis",
+        "Economics of Sports"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 51,
+      "section_count": 182,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "mohave-community-college",
+        "pima-community-college",
+        "scottsdale-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Culinary Skills",
+        "Advanced Pastry Arts",
+        "Art of Chocolate",
+        "Art of Confections",
+        "Art of Pastry"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 54,
+      "section_count": 177,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Admin of ECE Programs",
+        "Authentic Assess &amp; Curricu Int",
+        "Child Development",
+        "Child Growth and Development",
+        "Child Observation &amp; Assessment"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 29,
+      "section_count": 167,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "African-Americans in Film",
+        "American Arts &amp; Ideas",
+        "Contemporary Cinema",
+        "Contemporary Humanities",
+        "Film Appreciation"
+      ]
+    },
+    {
+      "prefix": "BHS",
+      "name": "BHS",
+      "course_count": 38,
+      "section_count": 161,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "glendale-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Addiction and Treatment",
+        "Addictions, Substance Use Disorders, and Recovery",
+        "Advanced Interview Techniques",
+        "Advanced Supervised Practice in Behavioral Health and Human Services",
+        "Appl Therapeutic Communication"
+      ]
+    },
+    {
+      "prefix": "STU",
+      "name": "STU",
+      "course_count": 9,
+      "section_count": 156,
+      "colleges": [
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Choosing Major/College Sccss",
+        "College Success Skills",
+        "College Success/Career Planng",
+        "Dynamics of Leadership",
+        "Making Career Choices"
+      ]
+    },
+    {
+      "prefix": "DAN",
+      "name": "Dance",
+      "course_count": 61,
+      "section_count": 154,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "eastern-arizona-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "scottsdale-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Ballet I: Community",
+        "Ballet II",
+        "Ballet II: Community",
+        "Ballet III"
+      ]
+    },
+    {
+      "prefix": "POS",
+      "name": "POS",
+      "course_count": 24,
+      "section_count": 152,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# POS 1110) American National Government",
+        "(SUN# POS 1120) World Politics",
+        "(SUN# POS 2204) Comparative Politics",
+        "Amer National Govermt/Politics SUN# POS1110",
+        "American National Government"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 21,
+      "section_count": 147,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# PHI 1101) Introduction to Philosophy",
+        "An Introduction To Logic SUN# PHI1103",
+        "Business Ethics",
+        "Comparative World Religions",
+        "Contemporary Moral Issues"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 35,
+      "section_count": 144,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Business Org &amp; Management",
+        "Business Organization and Management",
+        "Business Plan Development",
+        "Compensation and Benefits"
+      ]
+    },
+    {
+      "prefix": "PAR",
+      "name": "Paralegal",
+      "course_count": 37,
+      "section_count": 141,
+      "colleges": [
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "pima-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Administrative Law for the Paralegal",
+        "Administrative Law: Employment",
+        "Administrative Law:Immigration",
+        "Administrative Law:Soc Securit",
+        "Bankruptcy Law for the Paralegal"
+      ]
+    },
+    {
+      "prefix": "GLG",
+      "name": "Geology",
+      "course_count": 14,
+      "section_count": 137,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# GLG 1101) Introduction to Geology I (Physical)",
+        "(SUN# GLG 1102) Introduction to Geology II (Historical)",
+        "Field Geology of the Southwest",
+        "Geological Disasters and the Environment",
+        "Geological Disasters and the Environment Lab"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "EMT",
+      "course_count": 28,
+      "section_count": 136,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "eastern-arizona-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Care",
+        "Advanced ECG Interpretation",
+        "Advanced Emergency Medical Technician (A-EMT)",
+        "ALS Adv Practicum: Vehicular",
+        "ALS Advanced Foundations"
+      ]
+    },
+    {
+      "prefix": "BCT",
+      "name": "BCT",
+      "course_count": 57,
+      "section_count": 129,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading for Construc",
+        "Blueprint Reading/Estimating",
+        "Building&amp;ConstTechCapstone",
+        "Cabinetmaking I",
+        "Cabinetmaking II"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "HPE",
+      "course_count": 57,
+      "section_count": 126,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "eastern-arizona-college",
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Advanced Cheerleading I",
+        "Advanced Cheerlieading II",
+        "Advanced Golf I",
+        "Advanced Golf II",
+        "Advanced Volleyball I"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 48,
+      "section_count": 119,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Beginning to Low-Intermediate English Grammar",
+        "Beginning to Low-Intermediate English Listening and Speaking",
+        "English as a Second Language I: Grammar",
+        "English as a Second Language I: Listening and Speaking",
+        "English as a Second Language IA"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 22,
+      "section_count": 118,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Computer Literacy",
+        "Computer Organization and Assembly Language",
+        "Computer Science II",
+        "Data Structures and Algorithms",
+        "Digital Design Fundamentals"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "PED",
+      "course_count": 36,
+      "section_count": 114,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Baseball",
+        "Basketball",
+        "Basketball - Intermediate",
+        "Fitness for Life",
+        "Fitness For Life"
+      ]
+    },
+    {
+      "prefix": "CFS",
+      "name": "CFS",
+      "course_count": 23,
+      "section_count": 113,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Child and Family Organizations: Fiscal Management and Grant Writing",
+        "Child and Family Organizations: Management and Administration",
+        "Child and Family Organizations: Project Management",
+        "Child Development",
+        "Cross-Cultural Parenting"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 12,
+      "section_count": 109,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "American Sign Language II W/Lb",
+        "American Sign Language III",
+        "American Sign Language IV",
+        "American Sign Language V",
+        "Beginning American Sign Language I"
+      ]
+    },
+    {
+      "prefix": "FON",
+      "name": "Nutrition",
+      "course_count": 21,
+      "section_count": 107,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Applied Nutrition",
+        "Applied Nutrition Experience for Personal Trainers and Coaches",
+        "Certification in Food Service Safety and Sanitation",
+        "Food and Culture",
+        "Food Service Management Practicum"
+      ]
+    },
+    {
+      "prefix": "AVM",
+      "name": "AVM",
+      "course_count": 22,
+      "section_count": 101,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Blueprint Reading",
+        "Aircraft Composite Repair",
+        "Aircraft Propellers",
+        "Aircraft Sheet Metal Repair",
+        "Airframe Inspections"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 39,
+      "section_count": 96,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Auto Body and Paint Project",
+        "Auto Body Welding and Collision Repair",
+        "Auto Brakes Diagnosis/Repair",
+        "Auto Electrical Accessories",
+        "Auto Engine Diagnosis"
+      ]
+    },
+    {
+      "prefix": "ENH",
+      "name": "Literature",
+      "course_count": 19,
+      "section_count": 94,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "19th Century Women Writers",
+        "American Literature After 1860",
+        "American Literature Before 1860",
+        "Banned Books and Censorship",
+        "Chicano Literature"
+      ]
+    },
+    {
+      "prefix": "PHE",
+      "name": "Fitness",
+      "course_count": 84,
+      "section_count": 93,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Fitness Workshop: Balance &amp; Stretch",
+        "Fitness Workshop: Barre",
+        "Fitness Workshop: Cadio Core",
+        "Fitness Workshop: Cardio Core",
+        "Fitness Workshop: Core &amp; Stretch"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "ANT",
+      "course_count": 23,
+      "section_count": 91,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "dine-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Ancient North American Civiliz",
+        "Animals as Commodities",
+        "Biological Anthropology and Human Origins",
+        "Biological Anthropology and Human Origins Lab",
+        "Bones, Stones, Human Evolution"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 21,
+      "section_count": 91,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Advertising Principles",
+        "Applied Marketing and Social Networking",
+        "Brand Strategy: Tactics &amp; Digital Tools",
+        "Digital Marketing Landscape"
+      ]
+    },
+    {
+      "prefix": "RDG",
+      "name": "Reading",
+      "course_count": 8,
+      "section_count": 90,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Basic Reading",
+        "College Reading",
+        "College Reading Support",
+        "Disciplinary Literacy Lab",
+        "Successful College Reading"
+      ]
+    },
+    {
+      "prefix": "CRE",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 86,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "College Critical Reading and Critical Thinking"
+      ]
+    },
+    {
+      "prefix": "ASB",
+      "name": "ASB",
+      "course_count": 12,
+      "section_count": 84,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "American Indians of the Southwest",
+        "Buried Cities and Lost Tribes: New World",
+        "Buried Cities and Lost Tribes: Old World",
+        "Death and Dying Across Cultures",
+        "Ethnic Relations in the United States"
+      ]
+    },
+    {
+      "prefix": "AVC",
+      "name": "AVC",
+      "course_count": 40,
+      "section_count": 84,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "2D Media Design",
+        "3D Character Animation",
+        "3D Modeling and Animation I",
+        "3D Modeling and Animation II",
+        "Animation and Interactivity"
+      ]
+    },
+    {
+      "prefix": "MHL",
+      "name": "Music",
+      "course_count": 8,
+      "section_count": 83,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "American Jazz and Popular Music",
+        "Hip-Hop Music and Culture",
+        "Mexican Music History",
+        "Music and Culture",
+        "Music in World Cultures"
+      ]
+    },
+    {
+      "prefix": "CRW",
+      "name": "Writing",
+      "course_count": 16,
+      "section_count": 82,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Intermediate Fiction Writing",
+        "Intermediate Screenwriting",
+        "Introduction to Creative Writing",
+        "Introduction to Screenwriting",
+        "Introduction to Writing Fiction"
+      ]
+    },
+    {
+      "prefix": "ARH",
+      "name": "ARH",
+      "course_count": 12,
+      "section_count": 80,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Art from Prehistory Through Middle Ages",
+        "Art from Renaissance to Modernism",
+        "Art of Africa, Oceania, and Americas",
+        "Art of Ancient Egypt",
+        "Art of Asia"
+      ]
+    },
+    {
+      "prefix": "HES",
+      "name": "Health",
+      "course_count": 13,
+      "section_count": 78,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Allied Health Anatomy & Phys",
+        "Basic Pharmacology",
+        "Basic Technical Mathematics",
+        "Cultural Aspects of Health and Illness",
+        "Health Career Occupations"
+      ]
+    },
+    {
+      "prefix": "HLT",
+      "name": "Health",
+      "course_count": 19,
+      "section_count": 78,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "CPR and First Aid",
+        "Dental Assistant",
+        "Dental Assistant - Lab Only",
+        "Dental Assistant-Lab Only",
+        "Dental Clinical Procedures"
+      ]
+    },
+    {
+      "prefix": "ECH",
+      "name": "ECH",
+      "course_count": 21,
+      "section_count": 76,
+      "colleges": [
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Arranging the Environment",
+        "Child Development",
+        "Child Development Associate Preparation Practicum I",
+        "Child Development Associate Preparation Practicum II",
+        "Community Resources and Referral"
+      ]
+    },
+    {
+      "prefix": "CYB",
+      "name": "CYB",
+      "course_count": 15,
+      "section_count": 67,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Applied Cyber Operations",
+        "Basic Operating Systems",
+        "Cybersecurity for Networking",
+        "Digital Forensics/Incident Rsp",
+        "Intermediate Operating Systems"
+      ]
+    },
+    {
+      "prefix": "FSC",
+      "name": "Fire",
+      "course_count": 45,
+      "section_count": 67,
+      "colleges": [
+        "coconino-community-college",
+        "glendale-community-college",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Fire Behavior and Combustion",
+        "Basic Wildland Firefighting",
+        "Bldg Constructn-Fire Protectn",
+        "Build/Construct Fire Service",
+        "Emergency Preparedness"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 15,
+      "section_count": 67,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Adv Health Mngmt Info Systems",
+        "Advanced ICD Coding",
+        "AdvClassSystemsApplications",
+        "CPT Coding",
+        "Health Info Tech Internship"
+      ]
+    },
+    {
+      "prefix": "MUC",
+      "name": "Music",
+      "course_count": 26,
+      "section_count": 67,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Audio Mixing Techniques",
+        "Audio Production Internship",
+        "Computer Literacy for the Music Business",
+        "Digital Audio Workstation I (DAW I)",
+        "Digital Audio Workstation II (DAW II)"
+      ]
+    },
+    {
+      "prefix": "PSA",
+      "name": "Public",
+      "course_count": 14,
+      "section_count": 67,
+      "colleges": [
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "21st Century Public Safety Practices",
+        "Administrative Law for Public Safety Professionals",
+        "Communication Strategies for Public Safety Professionals",
+        "Crime Scene Coordination for Public Safety Professionals",
+        "Critical Incident Management for Public Safety Professionals"
+      ]
+    },
+    {
+      "prefix": "ASE",
+      "name": "Automotive",
+      "course_count": 29,
+      "section_count": 65,
+      "colleges": [
+        "gateway-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Electrical",
+        "Advanced Driver Assistance Systems",
+        "Automatic Transmission and Transaxle",
+        "Automotive Brake Systems",
+        "Automotive Braking Systems"
+      ]
+    },
+    {
+      "prefix": "DHE",
+      "name": "Dental",
+      "course_count": 26,
+      "section_count": 65,
+      "colleges": [
+        "mesa-community-college",
+        "phoenix-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Skills Enhancement I",
+        "Clinical Skills Enhancement II",
+        "Community Oral Health",
+        "Dental Anatomy, Embryology and Histology",
+        "Dental Anesthesia"
+      ]
+    },
+    {
+      "prefix": "EED",
+      "name": "Early",
+      "course_count": 12,
+      "section_count": 65,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Creative and Cognitive Play",
+        "Early Childhood Infant/Toddler Internship",
+        "Early Childhood Preschool Internship",
+        "Early Learning Curriculum and Instruction - Birth to Age Eight",
+        "Early Learning: Health, Safety, Nutrition and Physical Fitness"
+      ]
+    },
+    {
+      "prefix": "HVA",
+      "name": "HVAC",
+      "course_count": 19,
+      "section_count": 62,
+      "colleges": [
+        "gateway-community-college",
+        "mohave-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning",
+        "Air Management",
+        "Basic Electricity for HVAC Technicians",
+        "Boiler, Chiller, Cooling Tower",
+        "Construction Trades: H.V.A.C.r Installation"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 45,
+      "section_count": 62,
+      "colleges": [
+        "eastern-arizona-college",
+        "gateway-community-college",
+        "mohave-community-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Clinical Education I",
+        "Clinical Education IV",
+        "Clinical Practicum III",
+        "Image Analysis I",
+        "Intro to Radiation Biology"
+      ]
+    },
+    {
+      "prefix": "BPC",
+      "name": "Computer",
+      "course_count": 5,
+      "section_count": 61,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "A+ Exam Prep: Computer Hardware Configuration and Support",
+        "A+ Exam Prep: Operating System Configuration and Support",
+        "Computer Keyboarding I",
+        "Computer Usage and Applications",
+        "Recycling Used Computer Technology"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "Hospitality",
+      "course_count": 27,
+      "section_count": 60,
+      "colleges": [
+        "coconino-community-college",
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Beverage Management",
+        "Campground Ops &amp; Property Mgmt",
+        "Commercial Food Production",
+        "Events Management",
+        "Front Office Procedures"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 9,
+      "section_count": 59,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "mohave-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Independent Study in Astronomy",
+        "Intro to Astronomy With Lab",
+        "Introduction to Astronomy",
+        "Introduction to Solar System Astronomy",
+        "Introduction to Stars, Galaxies, and Cosmology"
+      ]
+    },
+    {
+      "prefix": "AIT",
+      "name": "AIT",
+      "course_count": 21,
+      "section_count": 56,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "estrella-mountain-community-college",
+        "mesa-community-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "AIT Capstone",
+        "AIT Internship",
+        "Applied Soldering",
+        "Composites",
+        "Electrical Systems I"
+      ]
+    },
+    {
+      "prefix": "MNT",
+      "name": "MNT",
+      "course_count": 11,
+      "section_count": 56,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Advanced Topics in Light and Lasers",
+        "Careers and Professional Skills in Nanotechnology",
+        "Introduction to Light and Lasers",
+        "Introduction to Microelectromechanical Systems (MEMS)",
+        "Introduction to Vacuum Technology"
+      ]
+    },
+    {
+      "prefix": "AHS",
+      "name": "AHS",
+      "course_count": 18,
+      "section_count": 55,
+      "colleges": [
+        "coconino-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "AHS Practicum: Medical Assistant",
+        "Caregiving I",
+        "Fundamentals of Health Care",
+        "Health Care Ethics &amp; Law",
+        "Human Disease Process"
+      ]
+    },
+    {
+      "prefix": "SGT",
+      "name": "Surgical",
+      "course_count": 26,
+      "section_count": 55,
+      "colleges": [
+        "gateway-community-college",
+        "mohave-community-college",
+        "northland-pioneer-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Basic Surgical Instrumentation for Surgical Services",
+        "Equipment and Supplies for Surgical Services",
+        "Fundamentals of Surgical Services",
+        "Instrument Handling I",
+        "Introduction to Healthcare"
+      ]
+    },
+    {
+      "prefix": "CPD",
+      "name": "CPD",
+      "course_count": 9,
+      "section_count": 54,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "rio-salado-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Career and Personal Development",
+        "Career Exploration",
+        "Connections for Success",
+        "Creating College Success",
+        "Creative Job Hunting"
+      ]
+    },
+    {
+      "prefix": "PFT",
+      "name": "Flight",
+      "course_count": 27,
+      "section_count": 54,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Aircraft Systems",
+        "Aviation Weather",
+        "Commercial Flight I",
+        "Commercial Flight II",
+        "Commercial Flight III"
+      ]
+    },
+    {
+      "prefix": "DAE",
+      "name": "Dental",
+      "course_count": 29,
+      "section_count": 53,
+      "colleges": [
+        "mohave-community-college",
+        "phoenix-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Skills for Clinical Externship",
+        "Biomedical Dental Science",
+        "Clinical Dental Assist Interns",
+        "Clinical Dental Assisting I",
+        "Dental Assisting I"
+      ]
+    },
+    {
+      "prefix": "HCC",
+      "name": "Health",
+      "course_count": 6,
+      "section_count": 53,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Common Medical Terminology for Health Care Professionals",
+        "CPR for Health Care Provider",
+        "Fundamentals in Health Care Delivery",
+        "Medical Terminology for Health Care Professionals",
+        "Medical Terminology for Health Care Professionals I"
+      ]
+    },
+    {
+      "prefix": "NSG",
+      "name": "Nursing",
+      "course_count": 22,
+      "section_count": 51,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Assessment and Health Promotion",
+        "Aging and End of Life",
+        "Development of Nursing Practice I",
+        "Development of Nursing Practice II",
+        "Global Health: Ethics and Human Rights"
+      ]
+    },
+    {
+      "prefix": "TEC",
+      "name": "TEC",
+      "course_count": 31,
+      "section_count": 51,
+      "colleges": [
+        "eastern-arizona-college",
+        "mesa-community-college",
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Advanced Apparel Construction",
+        "Apparel Production Management",
+        "Beginning Apparel Construction",
+        "Color in Fashion",
+        "Computer-Assisted Pattern Making"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 28,
+      "section_count": 50,
+      "colleges": [
+        "coconino-community-college",
+        "mohave-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support Initial Provider in Paramedicine",
+        "Airway and Ventilatory Management in Paramedicine",
+        "Cardiopulmonary Resuscitation for the Health Care Provider",
+        "Critical Care Paramedicine",
+        "Critical Care Practicum"
+      ]
+    },
+    {
+      "prefix": "HRP",
+      "name": "Health",
+      "course_count": 6,
+      "section_count": 50,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Basic Health Professions Skill",
+        "Intro to Health Professions",
+        "Med Term for Health Profess",
+        "PN Introduction Pharmacology",
+        "Success in Health Prof"
+      ]
+    },
+    {
+      "prefix": "CCP",
+      "name": "High",
+      "course_count": 10,
+      "section_count": 48,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Beginning Algebra with Applications",
+        "High School Equivalency Exam Prep ll",
+        "High School Equivalency Prep I",
+        "High School Equivalency Prep: Civics",
+        "High School Equivalency Ready"
+      ]
+    },
+    {
+      "prefix": "ENL",
+      "name": "College",
+      "course_count": 5,
+      "section_count": 48,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Children’s Literature",
+        "College Composition I",
+        "College Composition II",
+        "Creative Writing I",
+        "Women’s Literature"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "CNT",
+      "course_count": 11,
+      "section_count": 47,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "A+ Computer Technician Certification",
+        "Cisco Routing and Switching I",
+        "Cybersecurity Forensics",
+        "Cybersecurity Operations",
+        "Cybersecurity Principles"
+      ]
+    },
+    {
+      "prefix": "EDC",
+      "name": "EDC",
+      "course_count": 27,
+      "section_count": 47,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "21st Century Learning",
+        "Arizona Constitution for Teach",
+        "Class Mgmt: Secondary",
+        "Classroom Mgt: Secondary",
+        "Elem Methods: Math"
+      ]
+    },
+    {
+      "prefix": "EXS",
+      "name": "Exercise",
+      "course_count": 13,
+      "section_count": 47,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Cardiorespiratory and Flexibility Training",
+        "Exercise Science Internship",
+        "Introduction to Evidence-Based Practice",
+        "Introduction to Exercise Physiology",
+        "Introduction to Exercise Science"
+      ]
+    },
+    {
+      "prefix": "HCR",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 47,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Care of the Medically Complex Child",
+        "Clinical Health Care Ethics",
+        "Culture And Health",
+        "Human Pathophysiology",
+        "Introduction to Nursing and Health Care Systems"
+      ]
+    },
+    {
+      "prefix": "MTC",
+      "name": "Perception",
+      "course_count": 15,
+      "section_count": 47,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Aural Perception I",
+        "Aural Perception II",
+        "Aural Perception III",
+        "Aural Perception IV",
+        "Composition"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 11,
+      "section_count": 47,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "coconino-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "American Indian Religions",
+        "Asian Religions",
+        "Comparative Religions",
+        "Introduction to Christianity",
+        "Introduction to World Religions"
+      ]
+    },
+    {
+      "prefix": "BSA",
+      "name": "Business",
+      "course_count": 16,
+      "section_count": 45,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Professional Productivity Solutions",
+        "Business Analytics",
+        "Business Policy and Strategic Planning",
+        "Capstone Project: Business",
+        "Career Search and Success: Skills for Entering and Succeeding in the Workplace"
+      ]
+    },
+    {
+      "prefix": "GPH",
+      "name": "GPH",
+      "course_count": 10,
+      "section_count": 45,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "gateway-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Climate and Weather",
+        "Climate and Weather Laboratory",
+        "Introduction to Meteorology I",
+        "Introduction to Meteorology Laboratory I",
+        "Landform Processes"
+      ]
+    },
+    {
+      "prefix": "REA",
+      "name": "Real",
+      "course_count": 4,
+      "section_count": 45,
+      "colleges": [
+        "glendale-community-college",
+        "pima-community-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Critical Reading",
+        "Reading Improvement",
+        "Real Estate Principles I and II",
+        "Real Estate Seminar: Contract Writing"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 25,
+      "section_count": 41,
+      "colleges": [
+        "glendale-community-college",
+        "mohave-community-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Additive Manufact/3D Printing",
+        "Adv Electro-Mechanical Design",
+        "Adv Parametric Mod: SolidWorks",
+        "Advanced Cad",
+        "Advanced Revit Techniques"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Clinical",
+      "course_count": 32,
+      "section_count": 41,
+      "colleges": [
+        "gateway-community-college",
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography",
+        "Adult Echocardiography",
+        "Adv Adult Echocardiography",
+        "Advanced Vascular & Special Pr",
+        "Advanced Vascular Technology"
+      ]
+    },
+    {
+      "prefix": "ECD",
+      "name": "Early",
+      "course_count": 16,
+      "section_count": 41,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Arts and Aesthetics in Early Education",
+        "Building Relationships with Families",
+        "Culture, Language, and Community",
+        "Early Childhood Capstone-Experiential B-Pre-K",
+        "Early Childhood Capstone: Experiential K-3"
+      ]
+    },
+    {
+      "prefix": "DAR",
+      "name": "DAR",
+      "course_count": 26,
+      "section_count": 40,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Applied Computer Graphics",
+        "Art of Digital Cinematography",
+        "Basic Audio Production",
+        "Color Rendering and Theory",
+        "Comp 2D Anim:AdobeAfterEffects"
+      ]
+    },
+    {
+      "prefix": "FAW",
+      "name": "FAW",
+      "course_count": 12,
+      "section_count": 39,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Ballroom/Latin Dance",
+        "Cardio-Cross Training",
+        "Golf",
+        "Group Fitness Access I",
+        "Group Fitness Access II"
+      ]
+    },
+    {
+      "prefix": "THP",
+      "name": "Production",
+      "course_count": 15,
+      "section_count": 39,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Directing Techniques",
+        "Introduction to Costume Construction for Theatre",
+        "Introduction to Technical Theatre"
+      ]
+    },
+    {
+      "prefix": "BUE",
+      "name": "Business",
+      "course_count": 10,
+      "section_count": 38,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Business English",
+        "Business Ethics",
+        "Business Math",
+        "Business Plan for Entrepreneur",
+        "Financial Mgmt - Entrepreneurs"
+      ]
+    },
+    {
+      "prefix": "FMT",
+      "name": "Film",
+      "course_count": 20,
+      "section_count": 38,
+      "colleges": [
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "16mm Film Workshop: Post-Production",
+        "16mm Film Workshop: Pre-Production",
+        "16mm Film Workshop: Production",
+        "Advanced Film Production Techniques",
+        "AVID Media Composer Editing"
+      ]
+    },
+    {
+      "prefix": "SBS",
+      "name": "Business",
+      "course_count": 9,
+      "section_count": 38,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "rio-salado-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Financial and Tax Management for Small Business",
+        "Hiring and Managing Employees",
+        "Internet Marketing for Small Business",
+        "Planning for a Small Business",
+        "Small Business Customer Relations"
+      ]
+    },
+    {
+      "prefix": "CSA",
+      "name": "CSA",
+      "course_count": 14,
+      "section_count": 37,
+      "colleges": [
+        "northland-pioneer-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Artificial Intelligence",
+        "Advanced Data Science",
+        "Big Data Architecture",
+        "Computer Literacy",
+        "CSA Project"
+      ]
+    },
+    {
+      "prefix": "EEE",
+      "name": "Computer",
+      "course_count": 5,
+      "section_count": 37,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Circuits and Devices",
+        "Computer Organization and Assembly Language",
+        "Digital Design Fundamentals",
+        "Programming for Computer Engineering",
+        "Signals and Systems"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 37,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "northland-pioneer-college",
+        "pima-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Climate Change",
+        "Human Geography",
+        "Intro to Physical Geography",
+        "Introduction to Meteorology",
+        "Introduction to Physical Geography"
+      ]
+    },
+    {
+      "prefix": "ARC",
+      "name": "ARC",
+      "course_count": 21,
+      "section_count": 36,
+      "colleges": [
+        "phoenix-college",
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Revit",
+        "Archaeological Excavation I",
+        "Archaeological Excavation II",
+        "Archaeology Workshop",
+        "Architectural Computer Aided Design I: Introduction"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "Counseling",
+      "course_count": 4,
+      "section_count": 36,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Career and Professional Preparation for the Helping Professions",
+        "Introduction to Counseling",
+        "Introduction to Counseling Skills",
+        "The Counselor in a Multicultural Society"
+      ]
+    },
+    {
+      "prefix": "CMN",
+      "name": "Communication",
+      "course_count": 6,
+      "section_count": 36,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Bus &amp; Prof Communication",
+        "Intercultural Communication",
+        "Interpersonal Communication",
+        "Intro Communication Technology",
+        "Intro to Communication SUN# COM1100"
+      ]
+    },
+    {
+      "prefix": "INT",
+      "name": "Design",
+      "course_count": 16,
+      "section_count": 36,
+      "colleges": [
+        "phoenix-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Kitchen and Bath Design",
+        "Architectural Computer Aided Design I: Introduction",
+        "Architectural Computer Aided Design II: Plans and Elevations",
+        "Color and Design Communication Studio",
+        "Custom Design Studio"
+      ]
+    },
+    {
+      "prefix": "NIS",
+      "name": "Navajo",
+      "course_count": 13,
+      "section_count": 36,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Contemp Ind Affrs & Tribal Govt3 DC Staff",
+        "Dine Education Philosophy I",
+        "Found of Nav Culture",
+        "Intro to Nav Ldrshp & Comm",
+        "Intro to Nav Wholistic Heal"
+      ]
+    },
+    {
+      "prefix": "PME",
+      "name": "Paramedicine",
+      "course_count": 22,
+      "section_count": 36,
+      "colleges": [
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support (ACLS) Initial Provider in Paramedicine",
+        "Advanced Medical Life Support (AMLS) Initial Provider in Paramedicine",
+        "Airway and Ventilatory Management in Paramedicine",
+        "Comprehensive Patient Assessment in Paramedicine",
+        "Critical Care Paramedicine"
+      ]
+    },
+    {
+      "prefix": "ESE",
+      "name": "ESE",
+      "course_count": 17,
+      "section_count": 34,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Class Mgmt:Mild-Mod Disability",
+        "Dev Reading.Inst, Assess,Remed",
+        "Develop Read Intrus Assess",
+        "Diag Assess of Mild Mod Disab",
+        "Diagnosis/Mild-ModDisabilities"
+      ]
+    },
+    {
+      "prefix": "AIS",
+      "name": "AIS",
+      "course_count": 15,
+      "section_count": 33,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "estrella-mountain-community-college",
+        "mesa-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "American Indian History",
+        "American Indian Religions",
+        "Contemp Native Americans of SW",
+        "Electronic Keyboarding I",
+        "History Indians North America"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "Driving",
+      "course_count": 7,
+      "section_count": 32,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Behind the Wheel: School Bus",
+        "Commercial Driving: Behind the Wheel",
+        "Commercial Driving: Behind the Wheel Refresher",
+        "Commercial Driving: Closed Course",
+        "General Driving and Testing"
+      ]
+    },
+    {
+      "prefix": "RES",
+      "name": "Care",
+      "course_count": 28,
+      "section_count": 32,
+      "colleges": [
+        "gateway-community-college",
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Applied Biophysics for Respiratory Care",
+        "CPR for Health Care Provider",
+        "Infection Control for Respiratory Care",
+        "Intro Resp Care & Human Diseas",
+        "Introduction to Mechanical Ventilation"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "(SUN# THE 2220) Principles of Drama (Dramatic Structure)",
+        "Acting I",
+        "Acting II",
+        "Acting: Audition for Theater",
+        "Introduction To Acting I"
+      ]
+    },
+    {
+      "prefix": "VET",
+      "name": "Veterinary",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "mesa-community-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Pathology I",
+        "Clinical Veterinary Pharm Lab",
+        "Introduction to Veterinary Tec",
+        "Pharmacology",
+        "RAD/IMG Techniques Lab"
+      ]
+    },
+    {
+      "prefix": "CTM",
+      "name": "CTM",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical Theory",
+        "Battery-Based Photovoltaic Sys",
+        "Bldg Construction Methods I",
+        "Bldg Construction Methods II",
+        "Blue Print Reading/Estimating"
+      ]
+    },
+    {
+      "prefix": "FRE",
+      "name": "French",
+      "course_count": 7,
+      "section_count": 30,
+      "colleges": [
+        "eastern-arizona-college",
+        "glendale-community-college",
+        "phoenix-college",
+        "pima-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elementary French I SUN# FRE1101",
+        "Elementary French II SUN# FRE1102",
+        "French Conversation and Composition I",
+        "French Conversation and Composition II",
+        "Intermediate French Conversation I"
+      ]
+    },
+    {
+      "prefix": "SWU",
+      "name": "Social",
+      "course_count": 7,
+      "section_count": 29,
+      "colleges": [
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Economics: A Social Issues Perspective",
+        "Foundations of Social Work Practice",
+        "Introduction to Social Work",
+        "Introductory Ethics: A Social Service Perspective",
+        "Mindfulness for Stress Management"
+      ]
+    },
+    {
+      "prefix": "ASM",
+      "name": "Bones",
+      "course_count": 2,
+      "section_count": 28,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Bones, Stones, and Human Evolution",
+        "Forensic Anthropology"
+      ]
+    },
+    {
+      "prefix": "EPS",
+      "name": "Venture",
+      "course_count": 6,
+      "section_count": 28,
+      "colleges": [
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Business Start-Up and Planning",
+        "Introduction to Entrepreneurship",
+        "New Venture Creation",
+        "New Venture Feasibility Analysis",
+        "New Venture Law and Finance"
+      ]
+    },
+    {
+      "prefix": "FOR",
+      "name": "Forensic",
+      "course_count": 2,
+      "section_count": 28,
+      "colleges": [
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Forensic Science: Biological Evidence",
+        "Forensic Science: Physical Evidence"
+      ]
+    },
+    {
+      "prefix": "MNG",
+      "name": "Management",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "paradise-valley-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Accounting for Managers",
+        "Applied Human Resource Management",
+        "Change Management",
+        "Management Capstone",
+        "Management Principles"
+      ]
+    },
+    {
+      "prefix": "NAV",
+      "name": "Navajo",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "coconino-community-college",
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Adv Interm Nav Sec Lang IV",
+        "Interm Nav as Sec Lang III",
+        "Medical Termi of the Navajo",
+        "Navajo as a Sec Lang I",
+        "Navajo as a Sec Lang II"
+      ]
+    },
+    {
+      "prefix": "RTH",
+      "name": "RTH",
+      "course_count": 10,
+      "section_count": 28,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Adv Assessment &amp; Monitor",
+        "App Mechanical Ventilation Lab",
+        "App of Mechanical Ventilation",
+        "Basic Therapeutics",
+        "Cardiopulmonary Diseases I"
+      ]
+    },
+    {
+      "prefix": "MEA",
+      "name": "Medical",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Assisti",
+        "Electronic Medical Records",
+        "Intro to Medical Insurance",
+        "Med Assist Clinical Proc I",
+        "Med Assist Clinical Proc II"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 20,
+      "section_count": 27,
+      "colleges": [
+        "gateway-community-college",
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Biophysical Agents in Physical Therapy",
+        "Clinical Neurology",
+        "Clinical Pathology",
+        "Clinical Practicum I",
+        "Clinical Practicum II"
+      ]
+    },
+    {
+      "prefix": "FSS",
+      "name": "FSS",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Capstone: Cert. Personal Train",
+        "Cardio Assess &amp; Program Design",
+        "Exercise Test and Prescription",
+        "Fitness Profess Internship",
+        "Fundamentals Exercise Science"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "HST",
+      "course_count": 14,
+      "section_count": 26,
+      "colleges": [
+        "dine-college",
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Amer Hist: 1865 to Present",
+        "Amer History: Prehistory to 18653 Marius I Begay",
+        "Cellular Biological and Immunohistochemical Staining",
+        "Chemistry of Fixation",
+        "Hist Nat Am:Precon to Modern 3"
+      ]
+    },
+    {
+      "prefix": "NRA",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 26,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant",
+        "Nursing Assistant Clinical",
+        "Nursing Assistant Skills"
+      ]
+    },
+    {
+      "prefix": "SPE",
+      "name": "Education",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "paradise-valley-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Special Education: Assessment and Eligibility of Exceptional Learners",
+        "Special Education: Classroom Management and Behavioral Analysis",
+        "Special Education: Effective Collaboration and Communication Practices",
+        "Special Education: Language Development and Disorders",
+        "Special Education: Law, Policy, and Practice"
+      ]
+    },
+    {
+      "prefix": "WED",
+      "name": "WED",
+      "course_count": 20,
+      "section_count": 26,
+      "colleges": [
+        "phoenix-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Aromatherapy",
+        "Clinical Practicum: Part II",
+        "Clinical Preceptorship: Part I",
+        "Cupping Therapy",
+        "Establishing A Massage Practice"
+      ]
+    },
+    {
+      "prefix": "HON",
+      "name": "HON",
+      "course_count": 6,
+      "section_count": 25,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "College Honors Advisory Counci",
+        "Honors Ind Study Project",
+        "Introduction to Honors",
+        "Leadership Development Studies",
+        "Leadership Development: Historical and Contemporary Perspectives"
+      ]
+    },
+    {
+      "prefix": "THF",
+      "name": "Cinema",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Cinema",
+        "Introduction to Cinema",
+        "Introduction to Television Arts"
+      ]
+    },
+    {
+      "prefix": "ACU",
+      "name": "Accounting",
+      "course_count": 7,
+      "section_count": 24,
+      "colleges": [
+        "paradise-valley-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Capstone",
+        "Accounting Information Systems",
+        "Advanced Accounting I",
+        "Advanced Accounting II",
+        "Auditing"
+      ]
+    },
+    {
+      "prefix": "AVT",
+      "name": "Pilot",
+      "course_count": 19,
+      "section_count": 24,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Air Traffic Control Tower Procedures",
+        "Commercial Pilot Flight",
+        "Commercial Pilot Ground",
+        "Commercial Pilot Multi-Engine Airplane Flight",
+        "Commercial Pilot Multi-Engine Airplane Ground"
+      ]
+    },
+    {
+      "prefix": "HDE",
+      "name": "College",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "College Readiness I",
+        "College Readiness II",
+        "College Readiness III",
+        "College Readiness IV",
+        "SPECIAL PROBLEMS"
+      ]
+    },
+    {
+      "prefix": "SAC",
+      "name": "SAC",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Assessment",
+        "Counseling Groups/Individuals",
+        "Cultural Diversity",
+        "Disorders Co-Occur Subst Abuse",
+        "Ethics in Subst Abuse Treatmnt"
+      ]
+    },
+    {
+      "prefix": "NUC",
+      "name": "Nuclear",
+      "course_count": 19,
+      "section_count": 23,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Computed Tomography Clinical Practicum I",
+        "Computed Tomography Clinical Preceptorship II",
+        "Essentials of Nuclear Medicine Technology",
+        "Fundamentals of Computed Tomography and Elements of Magnetic Resonance Imaging",
+        "Fundamentals of Research in Nuclear Medicine"
+      ]
+    },
+    {
+      "prefix": "STO",
+      "name": "Storytelling",
+      "course_count": 5,
+      "section_count": 23,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "phoenix-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Creating And Telling Personal Stories",
+        "Multicultural Folktales",
+        "Service-Learning Experience in Storytelling",
+        "Special Projects",
+        "The Art of Storytelling"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "ACT",
+      "course_count": 15,
+      "section_count": 22,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Body Work",
+        "Advanced Refinishing",
+        "Auto Body Terminology",
+        "Auto Collision Estimating",
+        "Auto Plastic Repair/Adhesives"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 21,
+      "section_count": 22,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Agriculture and the Environmnt",
+        "Agroecology",
+        "Animal Science",
+        "Beekeeping",
+        "Conservation Planning"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Systems",
+      "course_count": 12,
+      "section_count": 22,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Aircraft Electrical, Instruments, Communication and Navigation Systems",
+        "Aircraft Hydraulics, Pneumatics, Fuel, Landing Gear, Positioning and Warning Systems",
+        "Aircraft Metallic Structures",
+        "Aircraft Reciprocating Engines",
+        "Aircraft Turbine Engines"
+      ]
+    },
+    {
+      "prefix": "CDT",
+      "name": "Commercial",
+      "course_count": 3,
+      "section_count": 22,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Commercial Behind the Wheel",
+        "Commercial Driver Refresher/Extender",
+        "Commercial License Prep"
+      ]
+    },
+    {
+      "prefix": "CLD",
+      "name": "Cloud",
+      "course_count": 5,
+      "section_count": 22,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "cochise-county-community-college-district",
+        "glendale-community-college",
+        "mesa-community-college",
+        "paradise-valley-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Amazon Web Services Cloud Architect Associate",
+        "Amazon Web Services Cloud Developing",
+        "Amazon Web Services Cloud Foundations",
+        "Amazon Web Services Cloud Operations",
+        "AWS CLOUD SECURITY"
+      ]
+    },
+    {
+      "prefix": "FDC",
+      "name": "Fashion",
+      "course_count": 13,
+      "section_count": 22,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Apparel Design and Construct I",
+        "Apparel Design Construct III",
+        "Apparel Design Construction II",
+        "Digital Fashion Design",
+        "Fashion Drawing"
+      ]
+    },
+    {
+      "prefix": "FSN",
+      "name": "Nutrition",
+      "course_count": 2,
+      "section_count": 22,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Human Nutrition &amp; Biology",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "ITS",
+      "name": "Ethical",
+      "course_count": 5,
+      "section_count": 22,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Forensics",
+        "Computer Forensics Foundations",
+        "Ethical Hacking and Network Defense",
+        "Information Security Fundamentals",
+        "Legal, Ethical and Regulatory Issues"
+      ]
+    },
+    {
+      "prefix": "AES",
+      "name": "Leadership",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "coconino-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "AES Leadership Lab",
+        "AES Physical Training Course",
+        "Air Force Physical Fitness",
+        "Heritage and Values I",
+        "Team &amp; Ldrshp Fundamentals I"
+      ]
+    },
+    {
+      "prefix": "AET",
+      "name": "Flight",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "chandler-gilbert-community-college"
+      ],
+      "sample_titles": [
+        "Aerodynamics and Performance",
+        "Attitude Instruments and Navigation",
+        "Aviation Safety",
+        "Basic Airplane Systems",
+        "Certified Flight Instructor: Airplane, Single Engine Land Flight Lab"
+      ]
+    },
+    {
+      "prefix": "ELC",
+      "name": "ELC",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "gateway-community-college",
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "AC Machinery and DC Machinery",
+        "AC/DC Theory",
+        "Basic Automated Systems Using Programmable Controllers",
+        "Commercial Electrical Wiring and Codes",
+        "Commercial Electricity II"
+      ]
+    },
+    {
+      "prefix": "HCE",
+      "name": "HCE",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Computers in Healthcare",
+        "First Aid and CPR",
+        "Health Care Systems in the U.S. I",
+        "Human Body in Health and Disease",
+        "Human Pathophysiology"
+      ]
+    },
+    {
+      "prefix": "HUS",
+      "name": "HUS",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Assess & Treat of Addictive Di",
+        "Case Mgt & Doc I",
+        "Child Welfare and Family Servi",
+        "Co-Occurring Disorders",
+        "Community Health & Wellness I"
+      ]
+    },
+    {
+      "prefix": "ICE",
+      "name": "ICE",
+      "course_count": 14,
+      "section_count": 21,
+      "colleges": [
+        "gateway-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Imaging Preceptorship",
+        "Bone Densitometry Certification",
+        "Bone Densitometry Clinical Education",
+        "Comprehensive Computed Tomography",
+        "Computed Tomography Certification"
+      ]
+    },
+    {
+      "prefix": "JRN",
+      "name": "JRN",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "(SUN# JRN 2201) Journalism/Newswriting",
+        "Advanced Media Production",
+        "Fld Exp Communic or Media Tech",
+        "Intro Reporting/Media Wrt SUN# JRN2201",
+        "Journalism Internship"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Calculus I",
+        "Calculus II",
+        "Coll Math/Quant Reason",
+        "College Algebra",
+        "Intermediate Algebra"
+      ]
+    },
+    {
+      "prefix": "AIM",
+      "name": "Artificial",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "scottsdale-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Artificial Intelligence Capstone Project",
+        "Artificial Intelligence for Business Solutions",
+        "Artificial Intelligence for Computer Vision",
+        "Introduction to Artificial Intelligence",
+        "Introduction to Data Science"
+      ]
+    },
+    {
+      "prefix": "CBT",
+      "name": "CBT",
+      "course_count": 15,
+      "section_count": 20,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Basic Carpentry I",
+        "Basic Electricity for the Trades",
+        "Basic Residential Plumbing",
+        "Blueprint Reading and Electrical Codes",
+        "Conduits and Raceways"
+      ]
+    },
+    {
+      "prefix": "FA",
+      "name": "FA",
+      "course_count": 16,
+      "section_count": 20,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "2D Design",
+        "3D Design",
+        "Bus Plan and Marketing for th",
+        "Capstone",
+        "Color Theory"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "pima-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elementary German I SUN# GER1101",
+        "Elementary German II SUN# GER1102",
+        "Intermediate German I SUN# GER2201",
+        "Intermediate German II"
+      ]
+    },
+    {
+      "prefix": "HRS",
+      "name": "HRS",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Benefits &amp; Compensation",
+        "Human Resource Law",
+        "Intro Human Resources Mgm",
+        "Job Requirement/Recruitment",
+        "Labor Relations"
+      ]
+    },
+    {
+      "prefix": "INS",
+      "name": "Insurance",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Commercial Insurance",
+        "Insurance Industry Profession",
+        "Personal Insurance",
+        "Principles of Property and Liability Insurance",
+        "Risk in an Evolving World"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "paradise-valley-community-college",
+        "pima-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I SUN# JPN1101",
+        "Elementary Japanese II",
+        "Intermediate Japanese I SUN# JPN2201",
+        "Intermediate Japanese II"
+      ]
+    },
+    {
+      "prefix": "LAS",
+      "name": "LAS",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Business Organizations",
+        "Civil Procedures I",
+        "Civil Procedures II",
+        "Contract Law",
+        "Criminal Trial Procedure"
+      ]
+    },
+    {
+      "prefix": "NAP",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 19,
+      "section_count": 19,
+      "colleges": [
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Advanced Applications of Coding and Reimbursement",
+        "CPT and HCPCS Coding",
+        "Health Data Analytics",
+        "Health Data and Content",
+        "Health Information Management Systems"
+      ]
+    },
+    {
+      "prefix": "LGM",
+      "name": "LGM",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Computerized Logistics",
+        "Contracts and Freight Claims",
+        "Independent Study: LGM MGMT",
+        "International Logistics",
+        "Introduction to Purchasing"
+      ]
+    },
+    {
+      "prefix": "MAC",
+      "name": "MAC",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Applied Metallurgy",
+        "CNC Lathe Programming",
+        "CNC Mill Programming II",
+        "Comp Aided Machines III",
+        "Comp-Aid Machining CAM Prog I"
+      ]
+    },
+    {
+      "prefix": "ALT",
+      "name": "Academic",
+      "course_count": 1,
+      "section_count": 18,
+      "colleges": [
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Academic Literacy Through Integrated Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "BUA",
+      "name": "Business",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Business Capstone",
+        "Business Communications",
+        "Introduction to Business",
+        "Introduction to Project Management",
+        "Legal Environment of Business"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "Navajo",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Adv Nav Moccasin Making",
+        "Advanced Navajo Weaving",
+        "Found of Navajo Silversmith",
+        "Found to Navajo Weaving",
+        "Intro to Navajo Silversmithing"
+      ]
+    },
+    {
+      "prefix": "CAS",
+      "name": "CAS",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Explorations",
+        "Food, People and the Planet",
+        "Sustainable Futures",
+        "Systems, Logic &amp; Sustainabilit"
+      ]
+    },
+    {
+      "prefix": "GTW",
+      "name": "Tradestech",
+      "course_count": 1,
+      "section_count": 18,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Wrt for Trades/Tech Occupation"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "Legal",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "dine-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Legal Writing",
+        "Constitutional Law: Civil Liberties and Civil Rights",
+        "Ethics and the Law",
+        "Evidence",
+        "Family Law"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "Medical",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "phoenix-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Medical Assisting Practicum",
+        "Fundamentals of Administrative Medical Assisting",
+        "Fundamentals of Clinical Medical Assisting",
+        "Introduction to Medical Assisting",
+        "Laboratory Testing in Ambulatory Healthcare Settings"
+      ]
+    },
+    {
+      "prefix": "PAD",
+      "name": "Public",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "21st Century Public Policy and Service",
+        "Public Finance Administration",
+        "Public Sector Human Resources Management",
+        "Public Sector Organizational Behavior"
+      ]
+    },
+    {
+      "prefix": "THO",
+      "name": "Stage",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Combat for Stage and Screen",
+        "Costume Play Group Performance Practicum",
+        "Introduction to Stage Management",
+        "Makeup for Stage and Screen",
+        "Opportunities in Production"
+      ]
+    },
+    {
+      "prefix": "ARB",
+      "name": "Arabic",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "pima-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elem Modern Standard Arabic I",
+        "Elementary Arabic II",
+        "Intermediate Arabic I",
+        "Intermediate Arabic II"
+      ]
+    },
+    {
+      "prefix": "CHI",
+      "name": "Chinese",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "pima-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elementary Chinese (Mandarin) II",
+        "Elementary Chinese I SUN# CHI1101",
+        "Intermediate Chinese I",
+        "Intermediate Chinese II"
+      ]
+    },
+    {
+      "prefix": "DAH",
+      "name": "Dance",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "paradise-valley-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Dance in Popular Culture",
+        "Dance, Culture, and Global Contexts",
+        "Hip Hop: Arts, Aesthetic and Culture",
+        "Introduction to Dance in the United States"
+      ]
+    },
+    {
+      "prefix": "DEH",
+      "name": "Dental",
+      "course_count": 16,
+      "section_count": 17,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Anesthesiology",
+        "Applied Pharmacology",
+        "Community Dental Health",
+        "Dental Anat/Hist-/Embry-Ology",
+        "Dental Hygiene Clinic I"
+      ]
+    },
+    {
+      "prefix": "EPD",
+      "name": "Reading",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elementary Physical Education Methods and Curriculum Development",
+        "Elements of Elementary Content Area Reading and Writing K-8",
+        "Essential Elements of Elementary Reading and Writing Instruction K-8",
+        "Mathematics Classroom Assessment",
+        "Reading Assessment"
+      ]
+    },
+    {
+      "prefix": "FCS",
+      "name": "Young",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Developmentally Appropriate Environments for Young Children",
+        "Family and Consumer Science Internship",
+        "Influences on Young Children's Development",
+        "Portfolio Development and Professional Writing",
+        "Supporting Young Children and Their Families"
+      ]
+    },
+    {
+      "prefix": "FMA",
+      "name": "Media",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Animation Principles",
+        "Cinematography and Lighting",
+        "Directing for Stage and Media",
+        "Film and Media Production",
+        "Fundamentals of Video Editing"
+      ]
+    },
+    {
+      "prefix": "ICS",
+      "name": "Integrated",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Integrated College Skills MAT"
+      ]
+    },
+    {
+      "prefix": "LMO",
+      "name": "LMO",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Communication &amp; Conflict Mgmt",
+        "Data Analysis, Decision Making",
+        "Financial Analysis &amp; Budgeting",
+        "Human Capital &amp; Resource Mgmt",
+        "Indstrl &amp; Organizational Psych"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "PHL",
+      "course_count": 3,
+      "section_count": 17,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Comparative World Religions",
+        "Introduction to Ethics",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "SLP",
+      "name": "Disorders",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "estrella-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Assistive Technology and Augmentative Communication",
+        "Behavior Management",
+        "Introduction to Communication Disorders",
+        "Language Disorders and Rehabilitation",
+        "Low Incidence Disabilities"
+      ]
+    },
+    {
+      "prefix": "SSE",
+      "name": "SSE",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Case Report Writing/Document",
+        "Crisis Interv:REl/FamViolence",
+        "Fndns of Social Work Practice",
+        "Group Work",
+        "Into Ethics: Soc Service Persp"
+      ]
+    },
+    {
+      "prefix": "THC",
+      "name": "Rehearsal",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Introduction to Theatre",
+        "Rehearsal and Production I",
+        "Rehearsal and Production II",
+        "Rehearsal and Production III",
+        "Rehearsal and Production IV"
+      ]
+    },
+    {
+      "prefix": "AGS",
+      "name": "AGS",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "mesa-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Agricultural Mechanics",
+        "Aquaculture Science",
+        "Community Supported Agriculture",
+        "Horticulture Fall Production",
+        "Microcomputers in Agriculture"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "Cosmetology",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Cosmetology I",
+        "Cosmetology II",
+        "Cosmetology III",
+        "Cosmetology IV",
+        "Cosmetology Professional Educator"
+      ]
+    },
+    {
+      "prefix": "CRC",
+      "name": "Clinical",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "paradise-valley-community-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Clin Res Regulatory Compliance",
+        "Clinical Research Design",
+        "Clinical Research Regulations",
+        "Clinical Research Site Management",
+        "CRC Internship"
+      ]
+    },
+    {
+      "prefix": "DMA",
+      "name": "Digital",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Computer Animation I",
+        "Computer Animation II",
+        "Digital Media Arts Capstone",
+        "Digital Media Arts I",
+        "Digital Media Arts II"
+      ]
+    },
+    {
+      "prefix": "LAT",
+      "name": "Latin",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Elementary Latin I",
+        "Elementary Latin II",
+        "Intermediate Latin I",
+        "Intermediate Latin II"
+      ]
+    },
+    {
+      "prefix": "PUH",
+      "name": "Health",
+      "course_count": 14,
+      "section_count": 16,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Comm Hlth Assess & Plan",
+        "Global Indigenous Health",
+        "Health and Human Disease",
+        "Health Disparities",
+        "Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "SBU",
+      "name": "Society",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "gateway-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Society and Business"
+      ]
+    },
+    {
+      "prefix": "CON",
+      "name": "Construction",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "gateway-community-college",
+        "mesa-community-college",
+        "northland-pioneer-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry: Concrete Forms",
+        "Construction Calculations",
+        "Construction Capstone Portfolio",
+        "Construction Drawings Introduction",
+        "Construction Internship"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 3,
+      "section_count": 15,
+      "colleges": [
+        "coconino-community-college",
+        "dine-college",
+        "estrella-mountain-community-college",
+        "mohave-community-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Fund. of ENV: Humans &amp; Environ",
+        "Introduction to Environmental Science",
+        "Vegetative Assessment"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "American Literature",
+        "Introduction to Literature",
+        "Literature And Film",
+        "Literature and Film: Honors",
+        "Literature and the Environment"
+      ]
+    },
+    {
+      "prefix": "SOS",
+      "name": "Sustainable",
+      "course_count": 3,
+      "section_count": 15,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sustainability",
+        "Sustainable Cities",
+        "Sustainable World"
+      ]
+    },
+    {
+      "prefix": "TRM",
+      "name": "Prealgebra",
+      "course_count": 2,
+      "section_count": 15,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Algebra",
+        "Pre-Algebra"
+      ]
+    },
+    {
+      "prefix": "ATO",
+      "name": "ATO",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions",
+        "Automotive Diesel",
+        "Automotive Fundamentals & Basic Service",
+        "Brake Systems",
+        "Electrical I"
+      ]
+    },
+    {
+      "prefix": "CDA",
+      "name": "CDA",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Ages &amp; Stages of Child: Presch",
+        "Ages/Stages: Prenatal--Toddler",
+        "Child Total Learn Environment",
+        "Curriculum Planning/Schedules",
+        "How Children Learn and Develop"
+      ]
+    },
+    {
+      "prefix": "LPN",
+      "name": "Practical",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Development of Practical Nursing",
+        "Application of Practical Nursing I",
+        "Application of Practical Nursing II",
+        "Development of Practical Nursing",
+        "Fundamentals of Practical Nursing Care I"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "Level",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "gateway-community-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Applied Neuroanatomy and Physiology",
+        "Electromagnetic Test Level I",
+        "Electromagnetic Test Level II",
+        "Intermediate Neurodiagnostic Laboratory",
+        "Intro Nondestructive Testing"
+      ]
+    },
+    {
+      "prefix": "WAC",
+      "name": "Writing",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Writing Across the Curriculum"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "ABE",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "ABE Intro - Reading & Writing",
+        "ABE Math",
+        "GED Preparation"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "eastern-arizona-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "AC Electrical Systems",
+        "Basic Electricity: AC &amp; DC",
+        "Communication Systems and Circuits",
+        "DC Electrical Systems",
+        "Digital Circuits"
+      ]
+    },
+    {
+      "prefix": "GD",
+      "name": "GD",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "L GD 110 Lab Course",
+        "L GD 210 Lab Course",
+        "L GD 310 Lab Course",
+        "L GD 314 Lab Course",
+        "L GD 315 Lab Course"
+      ]
+    },
+    {
+      "prefix": "IOS",
+      "name": "IOS",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Analysis of Counterintel I",
+        "Analytical Process/Product II",
+        "Combating Terrorism",
+        "Intel Prep of the Battlefield",
+        "Intel, Surveil and Recon (ISR)"
+      ]
+    },
+    {
+      "prefix": "ITT",
+      "name": "ITT",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Alternative Energy I",
+        "Alternative Energy II",
+        "Craft Core Skills",
+        "Electrical and Instrumentation I",
+        "Electrical, Instrumentation and Mechanical Fundamentals I"
+      ]
+    },
+    {
+      "prefix": "LDR",
+      "name": "Leadership",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Leadership",
+        "Leadership &amp; Innovation",
+        "Leadership and Change Management",
+        "Leadership Application and Development",
+        "Strategic Leadership"
+      ]
+    },
+    {
+      "prefix": "MPT",
+      "name": "MPT",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "gateway-community-college",
+        "mesa-community-college"
+      ],
+      "sample_titles": [
+        "CNC Machine Operator",
+        "CNC Machining Level I",
+        "Computer Aided Manufacturing (CAM) I",
+        "Coordinate Measuring Machines I",
+        "Geometric Dimensioning and Tolerance (GDT)"
+      ]
+    },
+    {
+      "prefix": "PHB",
+      "name": "Phlebotomy",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "mohave-community-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Basic Phlebotomy Techniques",
+        "Intro to Lab and Phlebotomy",
+        "MLA Practicum",
+        "MLA Principles and Procedures",
+        "Phlebotomy Practicum"
+      ]
+    },
+    {
+      "prefix": "REC",
+      "name": "Recreation",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "phoenix-college",
+        "rio-salado-college",
+        "scottsdale-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Leisure and the Quality of Life",
+        "Recreation Leadership",
+        "Recreation Workshop: Staying Alive Outdoors"
+      ]
+    },
+    {
+      "prefix": "SPH",
+      "name": "Hispanic",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Hispanic Heritage in the Southwest",
+        "Spanish and Latin American Film in Translation"
+      ]
+    },
+    {
+      "prefix": "COE",
+      "name": "Cooperative",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education I (Occupational)",
+        "Cooperative Education II (Occupational)",
+        "Cooperative Education III (Occupational)"
+      ]
+    },
+    {
+      "prefix": "CTE",
+      "name": "Career",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Career and Technical Education: Classroom Management and Lab Safety",
+        "Career and Technical Education: Principles, Philosophy and Student Organizations",
+        "Career and Technical Education: Teaching Methods and Curriculum Development"
+      ]
+    },
+    {
+      "prefix": "GST",
+      "name": "Gunsmithing",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "paradise-valley-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Engraving",
+        "Advanced Gunsmithing Practicum",
+        "Basic Engraving",
+        "Firearms Part Design and CNC Simulation",
+        "Games, Culture and Aesthetics"
+      ]
+    },
+    {
+      "prefix": "HPS",
+      "name": "Healthcare",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration in HPS",
+        "Essential Skills in Healthcare",
+        "The Successful Healthcare Prof"
+      ]
+    },
+    {
+      "prefix": "ITD",
+      "name": "Birth",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Cognition and Communication: Birth to Age Three",
+        "Early Attachments, Relationships, and Families: Birth to Age Three",
+        "The Physical Child: Birth to Age Three"
+      ]
+    },
+    {
+      "prefix": "NTR",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "coconino-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Food and Culture",
+        "Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "ELA",
+      "name": "Reading",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "ELA Adv Reading and Writing",
+        "ELA Basic Listening & Speakg",
+        "ELA Basic Reading & Writing",
+        "ELA Int Reading & Writing"
+      ]
+    },
+    {
+      "prefix": "EXW",
+      "name": "EXW",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "ACE Personal Trainer Preparation",
+        "Complementary and Integrative Health Therapies",
+        "Foundations of Mind-Body Exercise",
+        "Integrated and Applied Exercise Sciences",
+        "Performance Nutrition"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "Firefighter",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Field Exp in Fire Science Tech",
+        "Fire Service App Driver/Op",
+        "Firefighter I",
+        "Firefighter II"
+      ]
+    },
+    {
+      "prefix": "IPP",
+      "name": "Interpreting",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "ASL to English Consecutive Interpreting",
+        "Careers in Deaf Studies: Observation",
+        "English to ASL Consecutive Interpreting",
+        "Ethics and Decision Making for ASL/English Interpreters",
+        "Interactive Interpreting I"
+      ]
+    },
+    {
+      "prefix": "MDA",
+      "name": "MDA",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "northland-pioneer-college",
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Admin Proc for Med Assts",
+        "Clinical Coding, Billing,Insur",
+        "Clinical Safety &amp; Procedures",
+        "Med Asst Skills for Success",
+        "Med Term for Med Professionals"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Adv Co-op:Medical Lab Tec",
+        "Clinical Microbiology",
+        "Clinical Microbiology Lab",
+        "Immunohematology and Immunolgy",
+        "Immunohematology-Immunolgy Lab"
+      ]
+    },
+    {
+      "prefix": "YOG",
+      "name": "Yoga",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Yoga",
+        "Intermediate Yoga",
+        "Teaching Yoga: Level I",
+        "Tradition and Practice of Yoga I",
+        "Tradition and Practice of Yoga II"
+      ]
+    },
+    {
+      "prefix": "GCU",
+      "name": "Geography",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "paradise-valley-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Arizona Geography: Landforms, Climate, Water, People, and Culture",
+        "Human Geography: Spatial Relationships Between Humans and Culture with Their Environment",
+        "World Geography: People, Places, and Culture"
+      ]
+    },
+    {
+      "prefix": "GTM",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Applied Technical Math"
+      ]
+    },
+    {
+      "prefix": "THR",
+      "name": "THR",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "coconino-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Directing for Stage and Media",
+        "Introduction to the Theater",
+        "Introduction to Theatre"
+      ]
+    },
+    {
+      "prefix": "WST",
+      "name": "Womens",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "glendale-community-college",
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "19th Century Women Writers",
+        "Intro to Women's & Gen Studies",
+        "Introduction to Women's and Gender Studies",
+        "Women and Films"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "cochise-county-community-college-district",
+        "coconino-community-college",
+        "eastern-arizona-college",
+        "mohave-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "(SUN# EGR 1102) Introduction to Engineering Design",
+        "Engineering Mechanics I - Statics",
+        "Engr Mechanics I: Statics",
+        "Engr Mechanics II: Dynamics",
+        "Intro to Engineering"
+      ]
+    },
+    {
+      "prefix": "EQS",
+      "name": "Equine",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Applied Equine Skills I",
+        "Equine Anatomy and Physiology",
+        "Equine Behavior",
+        "Equine Business and Law",
+        "Equine Health and Disease Management"
+      ]
+    },
+    {
+      "prefix": "PHT",
+      "name": "Pharmacy",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "pima-community-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Accelerated Pharmacy Technology",
+        "Intro to Pharmacy Technology",
+        "Pharmaceutical Calculations",
+        "Pharmacology",
+        "Pharmacy Law and Ethics"
+      ]
+    },
+    {
+      "prefix": "SPT",
+      "name": "SPT",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "gateway-community-college",
+        "glendale-community-college",
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Baseball Theory of Coaching",
+        "Fundamentals of Oral Communications",
+        "History of Television I",
+        "History of Television II",
+        "Introduction to Theatre"
+      ]
+    },
+    {
+      "prefix": "SUS",
+      "name": "Sustainability",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "paradise-valley-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Careers in Sustainability",
+        "Introduction to Sustainability",
+        "Professional Skills in Sustainability Practice",
+        "Sustainable World"
+      ]
+    },
+    {
+      "prefix": "VEN",
+      "name": "Winemaking",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Introduction to Viticulture",
+        "Maintaining a Vinifera Vineyard",
+        "Science of Winemaking I",
+        "Science of Winemaking III",
+        "Sensory Evaluation of Wine"
+      ]
+    },
+    {
+      "prefix": "DES",
+      "name": "Design",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Brand Strategy: Tactics &amp; Digital Tools",
+        "Design Project Research and Production I",
+        "Digital Design Studio",
+        "Experiential Design",
+        "Interaction Design"
+      ]
+    },
+    {
+      "prefix": "DFT",
+      "name": "Autocad",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced AutoCAD",
+        "AutoCAD 3D",
+        "Fundamentals of AutoCAD",
+        "Topics in Drafting"
+      ]
+    },
+    {
+      "prefix": "FIT",
+      "name": "Yoga",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Yoga",
+        "Yoga II"
+      ]
+    },
+    {
+      "prefix": "FRS",
+      "name": "Fire",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Building Construction for Fire Prevention",
+        "Fire Behavior and Combustion",
+        "Fire Prevention",
+        "Fire Protection Systems",
+        "Fire Service Communication"
+      ]
+    },
+    {
+      "prefix": "IFS",
+      "name": "Society",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Digital Information and Access in a Global Society",
+        "Hacking and Open Source Culture",
+        "Information in a Post-Truth World",
+        "Social Media, Society, and Ourselves"
+      ]
+    },
+    {
+      "prefix": "LIS",
+      "name": "LIS",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Hacking &amp;Open Source Culture",
+        "Learning in the Inform Age",
+        "Social Media and Ourselves"
+      ]
+    },
+    {
+      "prefix": "MSP",
+      "name": "Mortuary",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "chandler-gilbert-community-college"
+      ],
+      "sample_titles": [
+        "Chemistry for Mortuary Science",
+        "Embalming",
+        "Embalming Lab",
+        "Microbiology for Mortuary Science",
+        "Mortuary Science, Sociology, and Religion"
+      ]
+    },
+    {
+      "prefix": "NCE",
+      "name": "Skills",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "gateway-community-college",
+        "mesa-community-college",
+        "phoenix-college",
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Mental Health Assessment Skills for Healthcare",
+        "Advanced Placement: Nurse Assisting",
+        "Math/Methods Of Drug Calculation",
+        "Orientation to Nursing Program",
+        "Patient Care Technician Skills"
+      ]
+    },
+    {
+      "prefix": "OPT",
+      "name": "Precision",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Introduction to Precision Optics",
+        "Precision Optics and Mathematical Concepts"
+      ]
+    },
+    {
+      "prefix": "SWO",
+      "name": "Social",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Culture & Diversity:work w/Nat",
+        "Field Experience I",
+        "Field Placement Seminar I",
+        "Human Behvior in Soc Enviro",
+        "Intro to Social Work"
+      ]
+    },
+    {
+      "prefix": "TMP",
+      "name": "TMP",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Body/Mind Therapy",
+        "Business and Communication for Massage Therapy",
+        "Lab A & P with Kinesiology Techniques I",
+        "Lab A & P with Kinesiology Techniques II",
+        "Overview for Alternative and Complementary Medicine"
+      ]
+    },
+    {
+      "prefix": "TQM",
+      "name": "Quality",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Quality Customer Service",
+        "Teamwork Dynamics"
+      ]
+    },
+    {
+      "prefix": "CMP",
+      "name": "CMP",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "CIS Practicum",
+        "Electronic Spreadsheet with Microsoft Excel",
+        "Introduction to Computer Based Systems",
+        "Introduction to Computers"
+      ]
+    },
+    {
+      "prefix": "CW",
+      "name": "CW",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Fiction II",
+        "Intro to Creative Writing",
+        "Introduction to Poetry",
+        "Junior Seminar",
+        "Poetry IV"
+      ]
+    },
+    {
+      "prefix": "DNC",
+      "name": "Dance",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Ballet Folklorico I",
+        "Ballet I",
+        "Ballet II",
+        "Dance Ensemble",
+        "Jazz Dance I"
+      ]
+    },
+    {
+      "prefix": "EEP",
+      "name": "Early",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Early Childhood Curriculum And Methods In Language Arts - Birth To Age Eight",
+        "Early Childhood Curriculum and Methods of Science - Birth to Age Eight",
+        "Early Childhood Curriculum and Methods of Social Studies - Birth to Age Eight"
+      ]
+    },
+    {
+      "prefix": "LAN",
+      "name": "Navajo",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "eastern-arizona-college",
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "INTERACTIVE LANGUAGES LAB",
+        "Navajo I",
+        "Navajo II"
+      ]
+    },
+    {
+      "prefix": "MLS",
+      "name": "Army",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Army Leadership Dynamics I",
+        "Army Physical Training",
+        "Intro To Military Skills I"
+      ]
+    },
+    {
+      "prefix": "MSC",
+      "name": "Leadership",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Leadership",
+        "Army Physical Fitness I",
+        "Army Physical Fitness II",
+        "Basic Military Science I",
+        "Leadership Lab I"
+      ]
+    },
+    {
+      "prefix": "NAS",
+      "name": "NAS",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Archery",
+        "Colonization & Ethnopolitics",
+        "Decolon & Self-Determ",
+        "Indig Animal Relatnships",
+        "Indig Rsrch Methodologies"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "Occupational",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Assistive Technology",
+        "Introduction to Occupational Therapy Assistant Profession",
+        "Occupational Therapy Assistant in Geriatrics",
+        "Occupational Therapy Assistant in Physical Rehabilitation",
+        "Occupational Therapy Assisting Pediatrics II"
+      ]
+    },
+    {
+      "prefix": "PMD",
+      "name": "Paramedicine",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "cochise-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Paramedicine I",
+        "Paramedicine II",
+        "Paramedicine III",
+        "Paramedicine IV",
+        "Paramedicine V"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "Flight",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Introduction to UAS",
+        "Remote Pilot Certification and Flight Operations",
+        "UAS Fixed-Wing Systems",
+        "UAS Flight Operations",
+        "UAS Sensing Systems"
+      ]
+    },
+    {
+      "prefix": "AHU",
+      "name": "Arabic",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "glendale-community-college",
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Arabic Culture and Islam"
+      ]
+    },
+    {
+      "prefix": "ATT",
+      "name": "Systems",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Airframe Instrument Systems",
+        "App Avionics Knowledge",
+        "Avionic Familiriztn Electr Rev",
+        "Avionic Installer",
+        "Communications Systems"
+      ]
+    },
+    {
+      "prefix": "CCS",
+      "name": "Chicana",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Chicana and Chicano Studies"
+      ]
+    },
+    {
+      "prefix": "CNC",
+      "name": "Machine",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Advanced Multi-Axis CNC Machining",
+        "CNC Machine Operator",
+        "CNC Machine Setup",
+        "Computer Aided Programming for CNC"
+      ]
+    },
+    {
+      "prefix": "EDP",
+      "name": "Educational",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Digital Literacy in Higher Education",
+        "Educational Policies, Partnerships, and Ethics",
+        "Introduction to Educational Research",
+        "Psychology of Learning"
+      ]
+    },
+    {
+      "prefix": "LET",
+      "name": "Criminal",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigations Certification",
+        "Search Warrant Preparation"
+      ]
+    },
+    {
+      "prefix": "RPM",
+      "name": "Outdoor",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Outdoor Adventure Skills",
+        "Programming of Recreation Services"
+      ]
+    },
+    {
+      "prefix": "HHP",
+      "name": "Sports",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Personal Health",
+        "Sports Nutrition"
+      ]
+    },
+    {
+      "prefix": "HRC",
+      "name": "Healthcare",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Health Care Regulatory Compliance Program Design",
+        "Healthcare Corporate Compliance Program Design",
+        "Healthcare Industry Regulation",
+        "Overview of Healthcare Compliance"
+      ]
+    },
+    {
+      "prefix": "IPH",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Chronic Disease Management",
+        "Community Health Work Practicum",
+        "Community-Based Health Education in Health and Illness",
+        "Cultural Aspects of Health for Community Health Work",
+        "Introduction to Public Health"
+      ]
+    },
+    {
+      "prefix": "MLA",
+      "name": "MLA",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Heritage and Values of USAF I",
+        "Military Aerospace Phys Trning",
+        "Team/Leadership Fundamentals I"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "Installing",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college",
+        "phoenix-college",
+        "south-mountain-community-college"
+      ],
+      "sample_titles": [
+        "Installing and Configuring Microsoft Windows"
+      ]
+    },
+    {
+      "prefix": "SLC",
+      "name": "Linguistics",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "phoenix-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Introduction to Linguistics"
+      ]
+    },
+    {
+      "prefix": "TRS",
+      "name": "Spanengl",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Interpretation Techniques",
+        "Intro Legal Span/Engl Interpre",
+        "Intro Translation/Interpretati",
+        "Med Span/Engl Interpreting",
+        "Tech Translatin/Interpretation"
+      ]
+    },
+    {
+      "prefix": "CAN",
+      "name": "Cannabis",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "scottsdale-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Cannabis Industry",
+        "Legal and Regulatory Environment in the Cannabis Industry",
+        "Social Equity and Current Issues in the Cannabis Industry",
+        "Supply Chain Management in the Cannabis Industry"
+      ]
+    },
+    {
+      "prefix": "CTT",
+      "name": "Conditioning",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "mesa-community-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning Fundamentals",
+        "Machine Electronics"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Principles of Macroeconomic",
+        "Principles of Microeconomic"
+      ]
+    },
+    {
+      "prefix": "EIT",
+      "name": "Industrial",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Industrial Maintenance Elect & Instrumentation Technician",
+        "Industrial Maintenance Electrical and Instrumentation Technician Level III",
+        "Industrial Maintenance Electrical and Instrumentation Technician Level IV"
+      ]
+    },
+    {
+      "prefix": "EUT",
+      "name": "Linework",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity for Linework",
+        "Energy Industry Fundamentals",
+        "Field Training I (Lineworker)",
+        "Introduction to Linework I"
+      ]
+    },
+    {
+      "prefix": "HCS",
+      "name": "Surgical",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Basic Surgical Instrumentation for Surgical Services",
+        "Equipment and Supplies for Surgical Services",
+        "Fundamentals of Surgical Services"
+      ]
+    },
+    {
+      "prefix": "HEE",
+      "name": "Wellness",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Intro to Wellness",
+        "Personal & Comm Health"
+      ]
+    },
+    {
+      "prefix": "HSM",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Current Issues in Health Services Management",
+        "Ethics and Legalities of Health Services Management",
+        "Health Services Management",
+        "Health Services Supervision"
+      ]
+    },
+    {
+      "prefix": "IBS",
+      "name": "International",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Introduction to International Business"
+      ]
+    },
+    {
+      "prefix": "JPH",
+      "name": "Traditional",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Traditional and Modern Japanese Culture"
+      ]
+    },
+    {
+      "prefix": "MTE",
+      "name": "Math",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "dine-college",
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Math for Elem Tchrs II",
+        "Math for Elem Teachers I",
+        "Methods and Mathematical Practices for K-8 Teaching"
+      ]
+    },
+    {
+      "prefix": "OGL",
+      "name": "OGL",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Analytical Thinking and Problem Solving",
+        "Applied Leadership Theory",
+        "Organizational Behavior",
+        "Project Management"
+      ]
+    },
+    {
+      "prefix": "PUB",
+      "name": "Public Administration",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Adaptive Leadership in Public Safety",
+        "Community Engagement &amp; Crisis Communication",
+        "Current Issues &amp; Trends in Public Safety",
+        "Emergency Operations &amp; Crisis Management"
+      ]
+    },
+    {
+      "prefix": "ACL",
+      "name": "Academic",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Academic and Critical Literacy"
+      ]
+    },
+    {
+      "prefix": "AFM",
+      "name": "AFM",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Auto Electrical Fundmtls &amp; App",
+        "Dealership Work Experience I",
+        "Noise, Vibration and Harshness"
+      ]
+    },
+    {
+      "prefix": "AFR",
+      "name": "Africanamerican",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "chandler-gilbert-community-college",
+        "estrella-mountain-community-college"
+      ],
+      "sample_titles": [
+        "African-American History 1865 to Present",
+        "African-American History to 1865"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "Student",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "College Success Skills",
+        "New Student Orientation"
+      ]
+    },
+    {
+      "prefix": "DRF",
+      "name": "Information",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Dimensioning and Tolerancing",
+        "Geographic Information Systems II",
+        "Lab Giographic Information Stystems II"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Geographic Info System I",
+        "Global Positioning Sys Basics",
+        "Mapping Concepts"
+      ]
+    },
+    {
+      "prefix": "IPD",
+      "name": "Designing",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "northland-pioneer-college"
+      ],
+      "sample_titles": [
+        "Designing Accessible Digital Material",
+        "Instructional Skills Workshop"
+      ]
+    },
+    {
+      "prefix": "NUT",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Human Nut in Health & Disease"
+      ]
+    },
+    {
+      "prefix": "PLB",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy: Basic Skills",
+        "Practicum: Phlebotomy and Specimen Processing",
+        "Specimen Processing and Advanced Techniques in Phlebotomy Procedures"
+      ]
+    },
+    {
+      "prefix": "SSH",
+      "name": "Sustainable",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "paradise-valley-community-college",
+        "rio-salado-college"
+      ],
+      "sample_titles": [
+        "Sustainable Cities"
+      ]
+    },
+    {
+      "prefix": "AFA",
+      "name": "African",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "African American Experience",
+        "The African Diaspora"
+      ]
+    },
+    {
+      "prefix": "AFL",
+      "name": "Heritage",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Heritage and Values",
+        "Leadership Laboratory"
+      ]
+    },
+    {
+      "prefix": "CPS",
+      "name": "Colorado",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "Colorado Plateau Overview"
+      ]
+    },
+    {
+      "prefix": "CSL",
+      "name": "Monster",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Leadership Techniques I",
+        "Monster Bridge I"
+      ]
+    },
+    {
+      "prefix": "GAM",
+      "name": "Game",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Game Design III",
+        "Game Programming I"
+      ]
+    },
+    {
+      "prefix": "GHY",
+      "name": "World",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "GWS",
+      "name": "Feminist",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Feminist Studies",
+        "Sexuality, Gender and Culture"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "Orient",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Orient to Hum Anat/Physiology",
+        "Orientation to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "KOR",
+      "name": "Korean",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Korean I",
+        "Elementary Korean II"
+      ]
+    },
+    {
+      "prefix": "LTP",
+      "name": "Landscape",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Land Sustain/Water Harvest",
+        "Landscape Design"
+      ]
+    },
+    {
+      "prefix": "MDL",
+      "name": "Clinical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Clinical Laboratory Operations",
+        "Practicum: Clinical Microbiology"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Solidworks",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "SolidWorks for Non-Engineers"
+      ]
+    },
+    {
+      "prefix": "MIS",
+      "name": "Army",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "phoenix-college"
+      ],
+      "sample_titles": [
+        "Army Leadership and Decision Making",
+        "Introduction to the United States Army"
+      ]
+    },
+    {
+      "prefix": "NSP",
+      "name": "Naval",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Intro. To Naval Science",
+        "Naval Laboratory I"
+      ]
+    },
+    {
+      "prefix": "PSG",
+      "name": "Polysomnography",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Polysomnography",
+        "Polysomnography (PSG) Clinical Rotation II"
+      ]
+    },
+    {
+      "prefix": "SBM",
+      "name": "Marketing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Marketing",
+        "Supervision"
+      ]
+    },
+    {
+      "prefix": "TDP",
+      "name": "Printing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "3-D Printer Operation and Maintenance",
+        "Introduction to 3-D Printing"
+      ]
+    },
+    {
+      "prefix": "VGD",
+      "name": "Video",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "3D Modeling and Animation",
+        "Video Game Development for Game Engines"
+      ]
+    },
+    {
+      "prefix": "BHA",
+      "name": "Legal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mohave-community-college"
+      ],
+      "sample_titles": [
+        "Legal, Ethical, & Prof Issues"
+      ]
+    },
+    {
+      "prefix": "CHP",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Leadership Development Studies Honors"
+      ]
+    },
+    {
+      "prefix": "EEG",
+      "name": "Electroencephalography",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Electroencephalography (EEG) Clinical Rotation II"
+      ]
+    },
+    {
+      "prefix": "FAC",
+      "name": "Codes",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Codes"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Business Finance"
+      ]
+    },
+    {
+      "prefix": "FNR",
+      "name": "Plants",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "Plants of the Colorado Plateau"
+      ]
+    },
+    {
+      "prefix": "GLS",
+      "name": "Cities",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "pima-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Cities and Global Soc"
+      ]
+    },
+    {
+      "prefix": "IPT",
+      "name": "Machine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "yavapai-college"
+      ],
+      "sample_titles": [
+        "Machine Shop"
+      ]
+    },
+    {
+      "prefix": "LIB",
+      "name": "Found",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "Found for Lib Research"
+      ]
+    },
+    {
+      "prefix": "MDC",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-arizona-college"
+      ],
+      "sample_titles": [
+        "Sports Production I"
+      ]
+    },
+    {
+      "prefix": "OSH",
+      "name": "Construction",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "gateway-community-college"
+      ],
+      "sample_titles": [
+        "Construction Safety"
+      ]
+    },
+    {
+      "prefix": "SPC",
+      "name": "Speech",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "coconino-community-college"
+      ],
+      "sample_titles": [
+        "Fund. of Speech Communication"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dine-college"
+      ],
+      "sample_titles": [
+        "General Social Science"
+      ]
+    }
+  ],
+  "program_titles": [
+    "**Certificate Template",
+    "**Degree Template",
+    "3-D Printing and Manufacturing Certificate",
+    "AAFA - Music Concentration",
+    "AAFA - Performing Arts Concentration",
+    "AAFA - Visual Arts Concentration",
+    "AAS General Education Core Requirements",
+    "Accounting",
+    "Accounting - AAS",
+    "Accounting Assistant Certificate",
+    "Accounting Certificate",
+    "Accounting, AAS",
+    "Accounting, AAS (ACC.AAS)",
+    "Accounting, Bookkeeping Certificate",
+    "Administration of Justice",
+    "Administration of Justice - AAS",
+    "Administration of Justice, AA (AJS.AA)",
+    "Advanced Automotive Technology Certificate (ATA.CT)",
+    "Advanced Bookkeeping Certificate",
+    "Advanced Manufacturing Technology - AAS",
+    "Aerospace Science Airplane Operations AAS",
+    "Agriculture Technology Management - AAS",
+    "Agriculture Technology Management Certificate",
+    "Air Traffic Control Academy Prep Certificate",
+    "Aircraft Airframe and Powerplant Mechanics Certificate",
+    "Aircraft Avionics Technician Certificate",
+    "Aircraft General Mechanics Certificate",
+    "Aircraft Structural Repair Certificate",
+    "Alternative Elementary Teaching Pathway (AETP.ND)",
+    "Alternative Secondary Teaching Pathway (ASTP.ND)",
+    "American Sign Language and Interpreting Studies",
+    "American Sign Language and Interpreting Studies Certificate",
+    "Animal Care and Management Certificate",
+    "Applied Pre-Engineering - AAS",
+    "Arizona General Education Certificate",
+    "Arizona General Education Curriculum",
+    "Arizona General Education Curriculum (AGEC.CC)",
+    "Art, AA (ART.AA)",
+    "Art, Visual Communications, AA (ARTV.AA)",
+    "Artificial Intelligence and Machine Learning Certificate",
+    "Assisted Living Facility Caregiver Certificate",
+    "Associate of Arts",
+    "Associate of Arts in Elementary Education",
+    "Associate of Arts in Fine Arts",
+    "Associate of Business",
+    "Associate of General Studies",
+    "Associate of General Studies, AGS (GS.AGS)",
+    "Associate of Science",
+    "Auto Body Paint and Collision Technology Certificate",
+    "Automated Industrial Technology Certificate",
+    "Automated Industrial Technology Certificate Level II",
+    "Automated Industrial Technology Level I Certificate",
+    "Automated Industrial Technology Level II Certificate",
+    "Automated Industrial Technology, AAS",
+    "Automotive Bodywork Certificate (ABW.CT)",
+    "Automotive Estimating Certificate (AES.CT)",
+    "Automotive Master Technician Certificate",
+    "Automotive Mechanics Certificate",
+    "Automotive Refinishing Certificate (ARF.CT)",
+    "Automotive Technician (MLR) Certificate",
+    "Automotive Technology - AAS",
+    "Automotive Technology Certificate",
+    "Automotive Technology, AAS",
+    "Automotive Trades I",
+    "Automotive Trades II",
+    "Automotive Trades III",
+    "Automotive, Ford ASSET, AAS",
+    "Autonomous Vehicle Driver & Operations Specialist Certificate",
+    "Aviation Technology, AAS",
+    "Bachelor of Applied Science in Business",
+    "Bachelor of Design in Visual Design",
+    "Bachelor of Science in Business",
+    "Bachelor of Science in Computer Science",
+    "Bachelor of Science in Nursing (RN - BSN)",
+    "Bachelors of Applied Science in Public Safety Administration",
+    "BAS in PSA - Administration of Justice Concentration",
+    "BAS in PSA - Fire Science Concentration",
+    "BAS in PSA - Paralegal Studies Concentration",
+    "BAS in PSA - Paramedicine Concentration",
+    "Basic Automotive Technology Certificate (ATB.CT)",
+    "Basic Business Certificate",
+    "Basic Carpentry Certificate",
+    "Basic Detention Academy Certificate",
+    "Basic Residential Trades Certificate",
+    "Basic Tax Certificate",
+    "Behavioral Health Aide (BHA.CT)",
+    "Behavioral Health and Social Work Certificate (BHSW.CT)",
+    "Behavioral Health Technician Certificate",
+    "Biology, BS (BIO.BS)",
+    "Bone Densitometry Certificate",
+    "Bookkeeping Certificate",
+    "BS in Business - Accounting Concentration",
+    "BS in Business - Digital Marketing Concentration",
+    "BS in Business - Entrepreneurship Concentration",
+    "BS in Business - Organizational Management and Leadership Concentration",
+    "Building and Construction Technologies, AAS",
+    "Building Trades I",
+    "Building Trades II - Construction",
+    "Building Trades II - Electrical",
+    "Building Trades II - HVAC",
+    "Building Trades II - Plumbing",
+    "Building Trades III - Construction",
+    "Building Trades III - Electrical",
+    "Building Trades III - HVAC",
+    "Building Trades III - Plumbing",
+    "Business",
+    "Business - Bookkeeping Certificate (BKP.CT)",
+    "Business - Entrepreneurship and e-Marketing Certificate (BUE.CT)",
+    "Business - Organizational Management Certificate (ORGM.CT)",
+    "Business - Retail Management Certificate (RTM.CT)",
+    "Business Administration, ABUS",
+    "Business Administration, ABus (BUS.ABUS)",
+    "Business and Entrepreneurship, AAS (BUE.AAS)",
+    "Business Basics II",
+    "Business Foundations Certificate",
+    "Business, AAS",
+    "Cabinetmaker Certificate",
+    "Carpenter Certificate",
+    "Chemistry, AS (CHM.AS)",
+    "Child Development Associate® Credential™ (CD.ND)",
+    "Cisco Networking Specialist Certificate",
+    "Class A Vehicle Driver Certificate",
+    "Class B Commercial Driver’s License Certificate",
+    "Clinical Research Coordinator, AAS",
+    "Clinical Research Professional, Post Degree Certificate",
+    "Collision Repair Technician",
+    "Commercial Driver Training Certificate",
+    "Commercial/Industrial Electricity (ELCI.CT)",
+    "Computed Tomography Certificate",
+    "Computer Aided Design Certificate (CADE.CT)",
+    "Computer Graphics and Web Design Certificate (WEB.CT)",
+    "Computer Graphics and Web Design, AAS (CGWD.AAS)",
+    "Computer Information Systems Administration, AAS (CISA.AAS)",
+    "Computer Information Systems, ABus (CISB.ABUS)",
+    "Computer Networking Technician Certificate",
+    "Computer Networking: Cybersecurity - AAS",
+    "Computer Numerical Control (CNC) Operator Certificate",
+    "Computer Numerical Controlled (CNC) Machining Certificate",
+    "Computer Programming Certificate",
+    "Computer Science, AS (CS.AS)",
+    "Computer Systems and Applications - AAS",
+    "Computer Technician Certification (CTC.CT)",
+    "Computer Technology",
+    "Computer-Aided Design, AAS",
+    "Computer-Aided Design, Parametric Modeler Certificate",
+    "Computer-Aided Design, Technician Certificate",
+    "Construction and Industry Trades",
+    "Construction Technology",
+    "Construction Technology Certificate",
+    "Contemporary Global/International Awareness or Historical Awareness",
+    "Cosmetology (COS.CT)",
+    "County Corrections Training Academy Certificate",
+    "Critical Care Provider",
+    "CTE - Arts & Humanities",
+    "CTE - Communication",
+    "CTE - Mathematics or Science",
+    "CTE - Options Category",
+    "CTE - Social & Behavioral Science",
+    "CTE Entrepreneurship, AAS (ENTR.AAS)",
+    "CTE Organizational Management, AAS (ORGM.AAS)",
+    "Culinary Arts Certificate (CHSM.CT)",
+    "Culinary Arts Fundamentals Certificate",
+    "Culinary Arts Management, AAS (CHSM.AAS)",
+    "Custom Firearms Design and Manufacturing Certificate",
+    "Cyber Security Certification (CyS.CT)",
+    "Cybersecurity and Network Support, AAS (CSNS.AAS)",
+    "Cybersecurity Specialist Certificate",
+    "Cybersecurity Technician Certificate",
+    "CyberSecurity, AAS",
+    "Dental Assisting Certificate (DAE.CT)",
+    "Dental Assisting Education Certificate",
+    "Dental Hygiene, AAS",
+    "Dental Hygiene, AAS (DAE.AAS)",
+    "Detention Officer Training Academy Certificate",
+    "Diagnostic Medical Sonography Cardiac Pathway, AAS (DMSCP.AAS)",
+    "Diagnostic Medical Sonography Certificate",
+    "Diagnostic Medical Sonography, AAS (DMS.AAS)",
+    "Diesel Technician - AAS",
+    "Diesel Technician Certificate",
+    "Digital Arts, Design Concentration, AAS",
+    "Digital Arts, Web Design Concentration, AAS",
+    "Digital Film Arts and Animation, Digital and Film Arts Concentration, AAS",
+    "Digital Film Arts and Animation, Digital Animation Concentration, AAS",
+    "Early Childhood Assistant Educator Certificate",
+    "Early Childhood Education",
+    "Early Childhood Education Advanced Certificate",
+    "Early Childhood Education Basic Certificate",
+    "Early Childhood Education Certificate",
+    "Early Childhood Education Industry Certificate",
+    "Early Childhood Education, AA (EDEC.AA)",
+    "Early Childhood Studies, AAS",
+    "Early Childhood Studies, Child Development Associate (CDA) Preparation Certificate",
+    "Education, AA (EDU.AA)",
+    "Education, BA",
+    "Education, Elementary Teacher Certification, Post-Baccalaureate Certificate",
+    "Education, Secondary Teacher Certification, Post-Baccalaureate Certificate",
+    "Education, Special Education Endorsement for Certified Teachers Post-Baccalaureate Certificate",
+    "Education, Special Education Mild-Moderate Disabilities Teacher Post-Baccalaureate Certification",
+    "Electric Utility Lineworker Certificate",
+    "Electrical & Instrumentation Technology - AAS",
+    "Electrical Instrumentation Technician Certificate",
+    "Electrical Technology",
+    "Electrician Certificate",
+    "Electronics - Analog Electronics Certificate",
+    "Electronics - Digital Electronics Certificate",
+    "Electronics - Industrial Electronics Certificate",
+    "Electronics Technology Certificate",
+    "Elementary Education, BA (ELED.BA)",
+    "Emergency Medical Technician Certificate",
+    "Emergency Medical Technology",
+    "Emergency Medical Technology — Paramedic, AAS",
+    "Emergency Medical Technology Certificate",
+    "Engineering, AS (ENGR.AS)",
+    "English, AA (ENG.AA)",
+    "Enology Certificate",
+    "Entrepreneurship Certificate",
+    "Environmental Technology: Alternative Energy Advanced Certificate",
+    "Environmental Technology: Alternative Energy Intermediate Certificate",
+    "Environmental Technology: Alternative Energy Technician",
+    "Ethnic/Race/Gender/Class Awareness",
+    "Field Archaeology Certificate",
+    "Fire and Emergency Services Higher Education (FESHE), AAS",
+    "Fire Company Officer Certificate",
+    "Fire Engineer Certificate",
+    "Fire Fighter Certificate (FF.CT)",
+    "Fire Officer Certificate (FOC.CT)",
+    "Fire Science",
+    "Fire Science - AAS",
+    "Fire Science Academy Track Certificate",
+    "Fire Science Advanced Certificate",
+    "Fire Science Intermediate Certificate",
+    "Fire Science Wildfire Suppression Certificate",
+    "Fire Science, AAS (FSC.AAS)",
+    "Fire Service - Advanced Firefighter Certificate",
+    "Fire Service Community Risk Reduction Certificate",
+    "Fire Service Company Officer Certificate",
+    "Fire Service Driver/Operator Certificate",
+    "Fitness Professional Certificate",
+    "Fitness Trainer/Instructor Certificate",
+    "Food Management Certificate (FM.CT)",
+    "Food Preparation Certificate (FP.CT)",
+    "Fundamentals of Agriculture Science Technology Certificate",
+    "General Education List of Approved Courses at CCC",
+    "General Studies, AGS",
+    "Geology, AS (GLG.AS)",
+    "Google IT Support Professional Certificate",
+    "Graphic Design Certificate",
+    "Gunsmithing - AAS",
+    "Gunsmithing Certificate",
+    "Health and Wellness Coach Certificate",
+    "Health Information Technology, AAS",
+    "Health Professions Readiness Certificate",
+    "Heating, Ventilation, Air Conditioning, Refrigeration (HVACr) Level 1 Technician Certificate",
+    "History, AA (HIS.AA)",
+    "Honors Program Certificate",
+    "Hospitality Leadership, AAS",
+    "Hospitality Management, Lodging and Guest Experience Management",
+    "Hospitality Management, Restaurant Emphasis",
+    "Hospitality, Advanced Certificate",
+    "Hospitality, Baking and Pastry Certificate",
+    "Hospitality, Fundamentals Certificate",
+    "Hospitality, Hotel and Restaurant Management Certificate",
+    "Hotel and Restaurant Services Intermediate Certificate",
+    "Hotel and Restaurant Services Introduction Certificate",
+    "Human Resources Certificate",
+    "Human Services, BA (HUS.BA)",
+    "HVAC Installation & Maintenance Technician Certificate",
+    "HVAC Installer Certificate (HVIN.CT)",
+    "HVAC Refrigeration Technician Certificate (HVTR.CT)",
+    "HVAC Service Technician Certificate",
+    "HVAC Technician Certificate (HVTN.CT)",
+    "HVAC-R Technician Certificate",
+    "HVAC/R Technician Certificate (HVT.CT)",
+    "Industrial Maintenance and Mechatronics (INMM.CT)",
+    "Integrative Health (Fitness/Reiki Trainer) - AAS",
+    "Integrative Health (Massage Therapy) - AAS",
+    "Integrative Health (Reflexology) - AAS",
+    "Introduction to Welding Certificate (WIN.CT)",
+    "IT Support Specialist Certificate",
+    "IT Support Technician Certificate",
+    "Justice Professions, Administration of Justice Concentration, AAS",
+    "Justice Professions, Law Enforcement Concentration, AAS",
+    "Justice Studies Certificate",
+    "Law Enforcement Academy Certificate",
+    "Law Enforcement Academy Preparation Certificate (AJS.CT)",
+    "Law Enforcement Certificate",
+    "Law Enforcement Training Academy",
+    "Legal Office Clerk Certificate",
+    "Legal Paraprofessional Certificate",
+    "Liberal Arts, AA",
+    "Liberal Arts, AA (LBA.AA)",
+    "Life Science, AS (LS.AS)",
+    "Limited X-Ray Machine Operator Certificate",
+    "Logistics and Supply Chain Management Certificate",
+    "Logistics and Supply Chain Management, AAS",
+    "Machine Tool Technology, AAS",
+    "Machining Inspection and Quality Assurance Certificate",
+    "Magnetic Resonance Certificate",
+    "Management - AAS",
+    "Management - Entrepreneurship Principles and Practice Certificate",
+    "Management - Foundations of Leadership Certificate",
+    "Management - Strategic Leadership Certificate",
+    "Management Certificate",
+    "Manufacturing Processes and Systems (MFPS.CT)",
+    "Massage Therapy Certificate",
+    "Mathematics",
+    "Mathematics, AA (MATH.AA)",
+    "Media Editing and Post-Production Certificate",
+    "Medical Assistant Certificate",
+    "Medical Assistant Certificate (MDA.CT)",
+    "Medical Billing and Coding Certificate",
+    "Medical Billing and Coding Certificate (INS.CT)",
+    "Medical Laboratory Assistant (MLA.CT)",
+    "Medical Laboratory Technician, AAS",
+    "Medical Office Assistant Certificate",
+    "Medical Office Management",
+    "Medical Records Technician Certificate",
+    "Network Support Certificate (NS.CT)",
+    "Networking/Cyber Defense, AAS",
+    "New Program Template",
+    "Nursing",
+    "Nursing - AAS",
+    "Nursing Assistant Certificate",
+    "Nursing Assistant Program (NA.ND)",
+    "Nursing, AAS (ADN.AAS)",
+    "Paralegal Certificate (PLG.CT)",
+    "Paralegal Studies - AAS",
+    "Paralegal, AAS (PLG.AAS)",
+    "Paramedic Certificate (EMS.CT)",
+    "Paramedic Studies",
+    "Paramedic, AAS (EMS.AAS)",
+    "Paramedicine - AAS",
+    "Paramedicine Certificate",
+    "Pathway to Dental Hygiene (PDAE.AA)",
+    "Pathway to Diagnostic Medical Sonography, AA (PDMS.AGS)",
+    "Pathway to Nursing (PADN.AA)",
+    "Pathway to Paramedic (PEMS.AGS)",
+    "Pathway to Physical Therapist Assistant (PPTA.AA)",
+    "Pathway to Radiologic Technology (PRADT.AGS)",
+    "Pathway to Respiratory Care Practitioner (PRCP.AGS)",
+    "Pathway to Substance Abuse Counseling (PSAC.AA)",
+    "Pathway to Surgical Technology (PSGT.AGS)",
+    "Patisserie and Baking Certificate (CULPB.CT)",
+    "Phlebotomy Certificate (MAPH.CT)",
+    "Phlebotomy Technician Certificate",
+    "Physical Therapist Assistant, AAS (PTA.AAS)",
+    "Pipe Welding and Fabrication Certificate (WPF.CT)",
+    "Plumbing Technician Certificate",
+    "Practical Nursing - LPN Step-out Certificate (PNSO.CT)",
+    "Practical Nursing Fast Track Certificate",
+    "Practical Nursing Transition Certificate",
+    "Pre-Health Careers",
+    "Pre-Health Careers Certificate",
+    "Production Horticulture Certificate",
+    "Production Welding Certificate (WPR.CT)",
+    "Professional Applications Certificate (CISP.CT)",
+    "Programming and Game Development Certificate (PGD.CT)",
+    "Radiologic Technology - AAS",
+    "Radiologic Technology, AAS (RADT.AAS)",
+    "Reflexology Certificate",
+    "Rehabilitation Technician (RT.CT)",
+    "Residential Construction, Certificate",
+    "Residential Wiring Certificate (RESW.CT)",
+    "Respiratory Care Practitioner, AAS (RCP.AAS)",
+    "Robotics Certificate",
+    "Science, AS (SC.AS)",
+    "Script Supervisor Certificate",
+    "Social and Behavioral Science, AA (SOC.AA)",
+    "Stage and Media Production Certificate",
+    "Structural Steel Welding and Fabrication Certificate (WSSF.CT)",
+    "Substance Abuse Counseling Post-Degree Certificate (SACP.CT)",
+    "Substance Abuse Counseling, AA (SAC.AA)",
+    "Surgical Technology, AAS (SGT.AAS)",
+    "Surgical Technology, CST Pathway to AAS (SGTP.AAS)",
+    "Sustainable Green Building",
+    "Technical Theater in Stagecraft Certificate",
+    "Unmanned Aircraft Systems Certificate",
+    "Victim Advocacy Certificate",
+    "Video Game Developer Certificate",
+    "Visual Arts",
+    "Visual Design - AAS",
+    "Viticulture Advanced Certificate",
+    "Viticulture and Enology - AAS",
+    "Viticulture Fundamentals Certificate",
+    "Welding - Gas Metal Arc Welding Certificate",
+    "Welding - Gas Tungsten Arc Welding Certificate",
+    "Welding - Pipe Welding Certificate",
+    "Welding - Structural Welding Certificate",
+    "Women's Health Imaging Certificate",
+    "Writing for the Screen Certificate"
+  ]
+}

--- a/data/ca/subject-vocab.json
+++ b/data/ca/subject-vocab.json
@@ -1,0 +1,30572 @@
+{
+  "state": "ca",
+  "generated_at": "2026-06-06T15:41:39.958Z",
+  "subjects": [
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 627,
+      "section_count": 12905,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Acad Reading &amp; Writing-Honors",
+        "Acad. Read. Writing",
+        "Academic Composition Skills: Paragraph Development, Analysis, &Research",
+        "Academic Composition Skills: Prewriting and Organization",
+        "Academic Composition Skills: Sentence Structure and Proofreading"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 682,
+      "section_count": 8000,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Alg Support for R115",
+        "Algebra & Trigonometry for Cal",
+        "Algebra and Trigonometry for Calculus",
+        "Algebra Support for Finite Mathematics",
+        "Algebra Support for MATH R106"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 220,
+      "section_count": 6188,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Public Speaking",
+        "Argument and Critical Thinking",
+        "Argument and Debate",
+        "Argumentation",
+        "ARGUMENTATION"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 1007,
+      "section_count": 5344,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "19th Through 21st Century Art",
+        "2-D Design",
+        "2-D Design Older Adults",
+        "2-D FOUNDATIONS",
+        "2-D VISUAL DESIGN"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 462,
+      "section_count": 5304,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lassen-community-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "A Survey of Emerging and Re-emerging Infectious Diseases",
+        "Advanced Anatomical Dissect 2",
+        "Advanced Anatomical Dissection",
+        "Anatomy and Physiology",
+        "Anatomy and Physiology Lab"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 414,
+      "section_count": 5122,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Af-Am Hist to 1877",
+        "Afri-American History I",
+        "Afri-American History II",
+        "African America Hist From 1865",
+        "African American Exp to 1877"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 253,
+      "section_count": 4461,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Abnormal Behavior",
+        "Abnormal Psychology",
+        "ABNORMAL PSYCHOLOGY",
+        "Adult Development and Aging",
+        "African American Psychology"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 300,
+      "section_count": 4394,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adventures in Chemistry",
+        "Analytical Instrumentation",
+        "Basic Organic Chemistry &amp; Biochemistry",
+        "Beginning Chemistry",
+        "Biochemistry"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Statistics",
+      "course_count": 55,
+      "section_count": 4066,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Algebra Support for STAT C1000",
+        "Conc. Support Intro Stats",
+        "Corequisite Support for Introduction to Statistics",
+        "ELEM STATISTICS",
+        "Elementary Statistics I For The Social Sciences"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 633,
+      "section_count": 3528,
+      "colleges": [
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "barstow-community-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "mission-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "reedley-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Acad ESL Adv Rdg&GrmmrIV",
+        "Acad ESL Adv Writ and Gram IV",
+        "ACAD ESL II",
+        "Acad ESL Rdg,Wrtng&Grmmr I",
+        "Acad ESL Rdg,Wrtng&Grmmr II"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 453,
+      "section_count": 3241,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "merritt-college",
+        "mission-college",
+        "moorpark-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Accounting Ethics",
+        "Accounting for Small Business",
+        "Accounting Internship",
+        "Accounting With Quickbooks",
+        "Acct Fund for Sm Bus Owners"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 836,
+      "section_count": 2965,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "butte-college",
+        "cabrillo-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "madera-community-college",
+        "mission-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "santa-ana-college",
+        "shasta-college",
+        "sierra-college",
+        "southwestern-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Adv Chamber Music: Brass",
+        "Adv Chamber Music: Woodwinds",
+        "Adv Chamber: Strings/Keyboards",
+        "Adv Contemp Vocal Ensemble",
+        "Adv Opera/Music Theatre Wrkshp"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 227,
+      "section_count": 2591,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "AFRICAN AMERICAN SOCIOLOGY",
+        "ALCOHOL & DRUG ABUSE",
+        "Alcohol, Other Drugs, and Addi",
+        "American Social Issues: Problems and Challenges",
+        "Analysis of Social Problems"
+      ]
+    },
+    {
+      "prefix": "KIN",
+      "name": "KIN",
+      "course_count": 670,
+      "section_count": 2483,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "butte-college",
+        "cabrillo-college",
+        "citrus-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "cypress-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "laney-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "merritt-college",
+        "mission-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "sierra-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "1 - Body Dynamics Skills I",
+        "1 - Boot Camp I",
+        "1 - Self Defense I",
+        "1 - Soccer I",
+        "1 - Softball - I"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 129,
+      "section_count": 2202,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "African American/Black Politic",
+        "American Gov./Politics-Honors",
+        "American Government &amp; Politics",
+        "American Government and Politics",
+        "AMERICAN GOVERNMENT AND POLITICS"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 211,
+      "section_count": 2129,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lemoore-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adv Composition &amp; Grammar",
+        "ADV CONVERSATION",
+        "Adv Grammar and Comp",
+        "Advanced Spanish Conversation",
+        "Advanced Spanish Oral and Written Composition"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 219,
+      "section_count": 2088,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "butte-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "college-of-the-desert",
+        "compton-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "ADVANCED APPLICATIONS OF ARCHAEOLOGICAL FIELD WORK",
+        "ANCIENT MEXICO",
+        "Anth - Magic, Witchcraft, Relg",
+        "Anthro Religion/Magic/Wtchcrft",
+        "Anthro Sex, Gender & Sexuality"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 101,
+      "section_count": 2087,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Applied Business Statistics",
+        "Behavioral Economics",
+        "BUS/ECON STATISTICS",
+        "Concepts in Personal Finance",
+        "Consumer and Family Finance"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 241,
+      "section_count": 1939,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lemoore-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Ancient & Medieval Philosophy",
+        "Ancient and Medieval Philosophy",
+        "ANCIENT PHILOSOPHY",
+        "Asian and Pacific Philosophies",
+        "Bioethics"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 377,
+      "section_count": 1707,
+      "colleges": [
+        "berkeley-city-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "compton-college",
+        "contra-costa-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "grossmont-college",
+        "hartnell-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "merritt-college",
+        "mission-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "shasta-college",
+        "solano-community-college",
+        "southwestern-college",
+        "victor-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "3-D Printing; Basic Model",
+        "3D Print: Basic Model Finish",
+        "3D Rapid Model & Proto",
+        "A+ Cert Hardware",
+        "A+ Cert Prep/Cisco IT Essen I"
+      ]
+    },
+    {
+      "prefix": "ETHN",
+      "name": "ETHN",
+      "course_count": 93,
+      "section_count": 1655,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "cuyamaca-college",
+        "diablo-valley-college",
+        "foothill-college",
+        "gavilan-college",
+        "grossmont-college",
+        "los-medanos-college",
+        "porterville-college",
+        "santa-ana-college",
+        "sierra-college",
+        "solano-community-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Afr Amer Culture",
+        "African American History",
+        "African American History to 1877",
+        "African American Literature",
+        "AFRICAN/AM HISTORY"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 252,
+      "section_count": 1634,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "laney-college",
+        "lassen-community-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Topics in Modern Physics",
+        "Algebra Based Physics 2",
+        "Algebra Based Physics: Mech",
+        "Algebra Based Physics:Elec/Mag",
+        "Algebra-Based Physics 1"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 178,
+      "section_count": 1356,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Geographic Information Systems",
+        "Advanced GIS",
+        "Application of Geospatial Tech",
+        "Beg Geospatial Design",
+        "California Geography"
+      ]
+    },
+    {
+      "prefix": "COUN",
+      "name": "COUN",
+      "course_count": 145,
+      "section_count": 1335,
+      "colleges": [
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "santa-rosa-junior-college",
+        "solano-community-college",
+        "ventura-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Academic and Life Success",
+        "Academic Success (formerly COUN 060 F)",
+        "Adaptive Computer Access",
+        "Adaptive Computer Access - Learning Strategies",
+        "Applied Stress Management"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 295,
+      "section_count": 1279,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "cabrillo-college",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "san-jose-city-college",
+        "solano-community-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adult Health I",
+        "Adult Health II",
+        "Adv Medical Surgical Nursing",
+        "ADVANCED MEDICAL SURGICAL NURSING",
+        "ADVANCED MEDICAL SURGICAL NURSING - LAB/CLINICAL"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "EXSC",
+      "course_count": 190,
+      "section_count": 1242,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Adapted Physical Fitness",
+        "Aerobic Dance I",
+        "Aerobic Dance II",
+        "Aerobic Dance III",
+        "Aerobic Dance IV"
+      ]
+    },
+    {
+      "prefix": "MUSIC",
+      "name": "MUSIC",
+      "course_count": 313,
+      "section_count": 1211,
+      "colleges": [
+        "berkeley-city-college",
+        "chaffey-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "laney-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "merritt-college",
+        "san-jose-city-college",
+        "west-los-angeles-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "1 - Commercial Music Studio Practicum I",
+        "2 - Jazz and Popular Music Piano II",
+        "3 - Intermediate Piano III",
+        "3 - Music Performance Workshop III",
+        "3 - Music Technology Workshop III"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 191,
+      "section_count": 1210,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "butte-college",
+        "cabrillo-college",
+        "citrus-college",
+        "coastline-community-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cypress-college",
+        "de-anza-college",
+        "folsom-lake-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "moorpark-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "santa-ana-college",
+        "shasta-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Accounting Ethics",
+        "Accounting for Payroll",
+        "Accounting for Small Business",
+        "Accounting Fundamentals: Quickbooks",
+        "Accounting Information System"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 338,
+      "section_count": 1172,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "citrus-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "san-diego-city-college",
+        "santa-rosa-junior-college",
+        "solano-community-college",
+        "victor-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "A Survey of World Music",
+        "Advanced Class Piano",
+        "ADVANCED JAZZ KEYBOARD SKILLS",
+        "Advanced Recording, Mixing and Mastering",
+        "AFRICAN AMERICAN MUSIC"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 551,
+      "section_count": 1158,
+      "colleges": [
+        "allan-hancock-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "compton-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "foothill-college",
+        "fullerton-college",
+        "golden-west-college",
+        "grossmont-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Adaptive Dance",
+        "Adv Teaching Practicum-Dance",
+        "Advanced Ballet I",
+        "Advanced Beginning Modern Dance (formerly DANC 108 F)",
+        "Advanced Dance Theatre"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 337,
+      "section_count": 1128,
+      "colleges": [
+        "allan-hancock-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "compton-college",
+        "contra-costa-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "fullerton-college",
+        "golden-west-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "madera-community-college",
+        "reedley-college",
+        "shasta-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Activities-Basketball",
+        "Adapted Bowling",
+        "Adapted Cardiovascular Fitness",
+        "Adapted Fitness",
+        "ADAPTED PE"
+      ]
+    },
+    {
+      "prefix": "KINS",
+      "name": "KINS",
+      "course_count": 223,
+      "section_count": 1114,
+      "colleges": [
+        "bakersfield-college",
+        "evergreen-valley-college",
+        "foothill-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "porterville-college",
+        "san-jose-city-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Academic Skill Development for Intercollegiate Athletes I",
+        "Adaptive Physical Education",
+        "Adult CPR and AED",
+        "Advanced Basketball",
+        "Advanced Marine Diver"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 284,
+      "section_count": 1109,
+      "colleges": [
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "laney-college",
+        "los-medanos-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adv Arc Welding Speciality Lab",
+        "Adv Arc Welding Specialty Lab",
+        "ADV AUTOMATED WELD/CUT",
+        "Adv FCAW (Flux-Core Welding)",
+        "ADV GMAW WELDING"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 339,
+      "section_count": 1004,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "cuyamaca-college",
+        "de-anza-college",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "golden-west-college",
+        "grossmont-college",
+        "los-medanos-college",
+        "monterey-peninsula-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "shasta-college",
+        "sierra-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "ADV AUTO ELEC",
+        "Adv Eng Perf & Emisons Cont",
+        "Adv Engine Perf & Diagnostics",
+        "Advanced Automotive Detailing",
+        "Advanced Automotive Machining"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 133,
+      "section_count": 960,
+      "colleges": [
+        "cabrillo-college",
+        "coalinga-college",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "cuyamaca-college",
+        "gavilan-college",
+        "grossmont-college",
+        "hartnell-college",
+        "lemoore-college",
+        "mission-college",
+        "palo-verde-college",
+        "santa-rosa-junior-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Adv Applied Research in Bio",
+        "Advanced Biotech",
+        "Anat/Phsio People",
+        "Anatomy & Physiology for Allied Health Workers",
+        "ANATOMY AND PHYSIOLOGY"
+      ]
+    },
+    {
+      "prefix": "ES",
+      "name": "ES",
+      "course_count": 138,
+      "section_count": 953,
+      "colleges": [
+        "allan-hancock-college",
+        "cabrillo-college",
+        "coalinga-college",
+        "cuyamaca-college",
+        "de-anza-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Action for Sustainability",
+        "Adv Aerobic Walk-Fitness/Well",
+        "Adv Cardio Fit & Resist Train",
+        "Adv Tech/Strat Wmns Flag Ftbl",
+        "Adv Tech/Strategies of Soccer"
+      ]
+    },
+    {
+      "prefix": "AJ",
+      "name": "AJ",
+      "course_count": 263,
+      "section_count": 943,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "butte-college",
+        "citrus-college",
+        "compton-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "lassen-community-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "san-jose-city-college",
+        "santa-rosa-junior-college",
+        "southwestern-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "1ST AID 4 MED INJ",
+        "1ST AID 4 TRAMATIC INJ",
+        "1ST AID/CPR REFRSHR",
+        "ACO CORE ACADEMY",
+        "Admin of Justice"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 179,
+      "section_count": 887,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "clovis-community-college",
+        "college-of-the-siskiyous",
+        "cosumnes-river-college",
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "hartnell-college",
+        "los-medanos-college",
+        "oxnard-college",
+        "reedley-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "shasta-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adlt Sprvsn & Mntring in ECE",
+        "Adm and Supervis Prog",
+        "Admin & Supervision I",
+        "Admin & Supervision of ECE II",
+        "Admin Child Centers"
+      ]
+    },
+    {
+      "prefix": "BSHS",
+      "name": "BSHS",
+      "course_count": 35,
+      "section_count": 863,
+      "colleges": [
+        "cuesta-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "BSHS English 4",
+        "High School Algebra I",
+        "High School Algebra II",
+        "High School English",
+        "HS Algebra 1"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 411,
+      "section_count": 846,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "citrus-college",
+        "coastline-community-college",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "monterey-peninsula-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "porterville-college",
+        "santa-ana-college",
+        "sierra-college",
+        "solano-community-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Acting 1",
+        "Acting 2",
+        "Acting 3",
+        "Acting 4",
+        "Acting for Film and Television"
+      ]
+    },
+    {
+      "prefix": "PSYCH",
+      "name": "Psychology",
+      "course_count": 103,
+      "section_count": 825,
+      "colleges": [
+        "berkeley-city-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "coalinga-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "laney-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "merritt-college",
+        "san-jose-city-college",
+        "west-los-angeles-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "ADOLESCENT PSYCHOLOGY",
+        "Alcohol/Drug Studies: Prevention And Education",
+        "Bio Psychology Lab",
+        "Biological Psychology"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 234,
+      "section_count": 824,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "butte-college",
+        "cabrillo-college",
+        "citrus-college",
+        "clovis-community-college",
+        "college-of-the-desert",
+        "compton-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "lemoore-college",
+        "madera-community-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "ADJUST COMPUTATIONS",
+        "Advanced 3D Solid Modeling and Simulation",
+        "ADVANCED MANUFACTURING",
+        "Applications of 3D Printing",
+        "AutoCAD I"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "Sociology",
+      "course_count": 73,
+      "section_count": 808,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "butte-college",
+        "clovis-community-college",
+        "college-of-the-desert",
+        "compton-college",
+        "contra-costa-college",
+        "cuyamaca-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "grossmont-college",
+        "madera-community-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "napa-valley-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "shasta-college",
+        "solano-community-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Community and Social Psychology",
+        "Contemporary Social Problems",
+        "Court/Marriage/Divorce",
+        "Crime and Society",
+        "Criminology"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "Sign",
+      "course_count": 102,
+      "section_count": 793,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "fullerton-college",
+        "grossmont-college",
+        "hartnell-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "madera-community-college",
+        "napa-valley-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced ASL Conversation",
+        "Amer Sign Lang 1-Skill Lab",
+        "Amer Sign Lang I",
+        "Amer Sign Lang II",
+        "Amer Sign/Engl Interpret I"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 126,
+      "section_count": 746,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "butte-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "cuyamaca-college",
+        "cypress-college",
+        "fullerton-college",
+        "grossmont-college",
+        "hartnell-college",
+        "mission-college",
+        "moorpark-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "rio-hondo-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "ABNORMAL PSYCHOLOGY",
+        "Applied Psychology",
+        "Beg Stats for Behavioral Sci",
+        "Biological Psychology"
+      ]
+    },
+    {
+      "prefix": "VOC",
+      "name": "VOC",
+      "course_count": 186,
+      "section_count": 731,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "A+ Certification Prep",
+        "Advanced CAD",
+        "Advanced Digital Media",
+        "Advertising and Promotion",
+        "AI for the Workplace"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "Photography",
+      "course_count": 199,
+      "section_count": 723,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "foothill-college",
+        "fullerton-college",
+        "golden-west-college",
+        "grossmont-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "san-diego-city-college",
+        "santa-ana-college",
+        "sierra-college",
+        "solano-community-college",
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Adobe Photoshop I",
+        "Adv Projects Photoshop",
+        "Advanced Alternative Processes",
+        "Advanced Digital Image Editing",
+        "Advanced Digital Photography"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 100,
+      "section_count": 701,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "butte-college",
+        "citrus-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "folsom-lake-college",
+        "foothill-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Astronomical Observing Lab",
+        "Astronomy",
+        "Astronomy Honors",
+        "Astronomy Lab",
+        "Astronomy Laboratory"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 138,
+      "section_count": 687,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "compton-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "laney-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "madera-community-college",
+        "merritt-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced GIS",
+        "Applied Environmental Geology",
+        "Cascade Range Field Study",
+        "Cascade Range/Modoc Plateau",
+        "Dynamic Earth: Intro to Geo. L"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 123,
+      "section_count": 658,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "golden-west-college",
+        "grossmont-college",
+        "hartnell-college",
+        "lemoore-college",
+        "madera-community-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Africa/Oceania/Indig Amer Art",
+        "African Art and the Diaspora",
+        "African-American Art History",
+        "African, Oceanic, Ancient and Indigenous American Art",
+        "American Art History"
+      ]
+    },
+    {
+      "prefix": "BSAD",
+      "name": "BSAD",
+      "course_count": 58,
+      "section_count": 654,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Beginning Keyboarding, Part 1",
+        "Beginning Keyboarding, Part 2",
+        "Beginning Keyboarding, Part 3",
+        "Business Communication",
+        "Business Communications"
+      ]
+    },
+    {
+      "prefix": "CHDV",
+      "name": "CHDV",
+      "course_count": 102,
+      "section_count": 649,
+      "colleges": [
+        "bakersfield-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Admin Childrens Programs I",
+        "Admin of Child Programs II",
+        "Administration I: Programs in Early Childhood Education",
+        "Administration II: Personnel and Leadership in Early Childhood Education",
+        "ADMINISTRATION II: PERSONNEL AND LEADERSHIP IN EARLY CHILDHOOD EDUCATION"
+      ]
+    },
+    {
+      "prefix": "OAP",
+      "name": "OAP",
+      "course_count": 15,
+      "section_count": 640,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Beginning Quilting",
+        "Beginning Watercolor Painting",
+        "Creative Cooking for Older Ad",
+        "Explore World Heritage Sites",
+        "Hand Embroidery"
+      ]
+    },
+    {
+      "prefix": "ATHL",
+      "name": "ATHL",
+      "course_count": 233,
+      "section_count": 626,
+      "colleges": [
+        "barstow-community-college",
+        "coalinga-college",
+        "college-of-alameda",
+        "cuesta-college",
+        "foothill-college",
+        "golden-west-college",
+        "laney-college",
+        "lemoore-college",
+        "merritt-college",
+        "mission-college",
+        "monterey-peninsula-college",
+        "orange-coast-college",
+        "santa-rosa-junior-college",
+        "sierra-college",
+        "solano-community-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Athletic Team Training",
+        "Baseball - Men&#39;s Intercollegiate Off-Season (Fall)",
+        "Baseball Laboratory",
+        "Baseball Men",
+        "Baseball Skills"
+      ]
+    },
+    {
+      "prefix": "CH DEV",
+      "name": "CH DEV",
+      "course_count": 46,
+      "section_count": 616,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "1 - Child Development Literacy Lab I",
+        "2 - Child Development Lab I: Technology For The Early Childhood Educator",
+        "Administration & Supervision Of Early Childhood Programs I",
+        "Administration II: Personnel and Leadership In Early Childhood Education",
+        "Adult Supervision/Early Childhood Mentoring"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 143,
+      "section_count": 605,
+      "colleges": [
+        "cuyamaca-college",
+        "foothill-college",
+        "grossmont-college",
+        "mt-san-antonio-college",
+        "oxnard-college",
+        "rio-hondo-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Acting I",
+        "ACTING I",
+        "Acting II",
+        "Acting III"
+      ]
+    },
+    {
+      "prefix": "OAD",
+      "name": "OAD",
+      "course_count": 17,
+      "section_count": 579,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Brain Health 1 Introduction to Brain Training",
+        "Brain Health 2 Brain Health Topics",
+        "Ceramics for Older Adults",
+        "Drawing-Beginning Through Advanced",
+        "Financial Literacy in Retirement"
+      ]
+    },
+    {
+      "prefix": "ESLN",
+      "name": "ESLN",
+      "course_count": 64,
+      "section_count": 571,
+      "colleges": [
+        "college-of-the-desert",
+        "los-medanos-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Academic Writing - Noncredit ESL",
+        "ADVANCED CONVERSATION",
+        "Advanced Grammar - Noncredit ESL",
+        "ADVANCED GRAMMAR REVIEW",
+        "ADVANCED PRONUNCIATION"
+      ]
+    },
+    {
+      "prefix": "NC",
+      "name": "NC",
+      "course_count": 185,
+      "section_count": 565,
+      "colleges": [
+        "citrus-college",
+        "coalinga-college",
+        "lemoore-college",
+        "orange-coast-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "A Caregiver's Guide to Teens",
+        "Acute Care Nursing Assis",
+        "Acute Care Nursing Assist Lab",
+        "Advanced Communication Skills for Life And Career",
+        "Advanced Reading Writing and Speaking"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 96,
+      "section_count": 556,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "barstow-community-college",
+        "berkeley-city-college",
+        "butte-college",
+        "cabrillo-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "cuesta-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "foothill-college",
+        "fresno-city-college",
+        "golden-west-college",
+        "lemoore-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "solano-community-college",
+        "victor-valley-college",
+        "west-los-angeles-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Tutor Training",
+        "AI for Instructional Designers",
+        "Aspects and Issues in Teaching",
+        "Concepts of Organizational Leadership",
+        "Contemporary Themes in Leadership"
+      ]
+    },
+    {
+      "prefix": "ETHS",
+      "name": "ETHS",
+      "course_count": 77,
+      "section_count": 536,
+      "colleges": [
+        "butte-college",
+        "coastline-community-college",
+        "cypress-college",
+        "fullerton-college",
+        "golden-west-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "African American Studies",
+        "African-American History I",
+        "African-American History II",
+        "American Ethnic Studies",
+        "American Ethnic Studies (formerly ETHS 100 C)"
+      ]
+    },
+    {
+      "prefix": "CNSL",
+      "name": "CNSL",
+      "course_count": 30,
+      "section_count": 526,
+      "colleges": [
+        "foothill-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Career/Life Planning & Persona",
+        "Careers in Teaching",
+        "COLLEGE SUCCESS",
+        "College Success Skills",
+        "Educational & Career Asmt"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 187,
+      "section_count": 518,
+      "colleges": [
+        "barstow-community-college",
+        "compton-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "monterey-peninsula-college",
+        "napa-valley-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Advanced College Choir II",
+        "Advanced Concert Band",
+        "Advanced Concert Band II",
+        "Advanced Jazz Ensemble",
+        "Advanced Piano"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "ARCH",
+      "course_count": 209,
+      "section_count": 510,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "fullerton-college",
+        "laney-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "3-D Modeling: Rhino 1",
+        "3-D Modeling:Rhino 2",
+        "3-D Modeling:SketchUp 1",
+        "3D Architectural Design Mdlg",
+        "Adv Architectural Design I"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 68,
+      "section_count": 510,
+      "colleges": [
+        "bakersfield-college",
+        "cabrillo-college",
+        "cuesta-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "grossmont-college",
+        "hartnell-college",
+        "merritt-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "santa-ana-college",
+        "shasta-college",
+        "solano-community-college",
+        "west-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Appl. of Hlth & Well. Coaching",
+        "Apps of Health/Wellness Coach",
+        "Careers in Nutrition and Foods",
+        "Contemporary Nutrition",
+        "Cultural Aspects of Food"
+      ]
+    },
+    {
+      "prefix": "KINA",
+      "name": "KINA",
+      "course_count": 152,
+      "section_count": 508,
+      "colleges": [
+        "barstow-community-college",
+        "cuesta-college",
+        "evergreen-valley-college",
+        "mt-san-antonio-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "san-jose-city-college",
+        "santa-rosa-junior-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Aquatic Fitness",
+        "ADVANCED BADMINTON",
+        "ADVANCED BASKETBALL",
+        "ADVANCED CYCLING FOR FITNESS - STATIONARY, INDOOR",
+        "ADVANCED FENCING"
+      ]
+    },
+    {
+      "prefix": "BS",
+      "name": "BS",
+      "course_count": 16,
+      "section_count": 505,
+      "colleges": [
+        "lassen-community-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Academic Success",
+        "All Subject Tutoring",
+        "Career Development",
+        "Career Info and Guidance",
+        "Career Life Planning ESL"
+      ]
+    },
+    {
+      "prefix": "CD",
+      "name": "Child Development",
+      "course_count": 144,
+      "section_count": 501,
+      "colleges": [
+        "coalinga-college",
+        "cuyamaca-college",
+        "de-anza-college",
+        "gavilan-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "moorpark-college",
+        "rio-hondo-college",
+        "southwestern-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Admin of CD Programs I",
+        "Admin of CD Programs II",
+        "Admin of Early Childhd Prog",
+        "Administration and Supervision of Children's Programs",
+        "Administration in ECE I"
+      ]
+    },
+    {
+      "prefix": "NBAS",
+      "name": "Part",
+      "course_count": 38,
+      "section_count": 477,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Biology: Living Earth Systems I",
+        "Biology: Living Earth Systems II",
+        "Chemistry I",
+        "Chemistry II"
+      ]
+    },
+    {
+      "prefix": "ETH",
+      "name": "American",
+      "course_count": 52,
+      "section_count": 471,
+      "colleges": [
+        "evergreen-valley-college",
+        "hartnell-college",
+        "mission-college",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "san-jose-city-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "African American Cinema",
+        "African American Culture",
+        "African American History",
+        "African American History - Honors",
+        "AFRICAN AMERICAN HISTORY FROM 1865"
+      ]
+    },
+    {
+      "prefix": "BIOLOGY",
+      "name": "Biology",
+      "course_count": 20,
+      "section_count": 467,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Directed Study - Biology",
+        "General Biology - Genetic Analysis And Biotechnology",
+        "General Biology I",
+        "General Biology II",
+        "Genetic Analysis"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "ESOL",
+      "course_count": 73,
+      "section_count": 467,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college",
+        "merritt-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Acad Conversations",
+        "Accel Acad ESOL I",
+        "Accel Acad ESOL III",
+        "Advanced Listening and Speaking",
+        "Advanced Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 120,
+      "section_count": 459,
+      "colleges": [
+        "cabrillo-college",
+        "chaffey-college",
+        "coastline-community-college",
+        "college-of-the-desert",
+        "cuesta-college",
+        "golden-west-college",
+        "moorpark-college",
+        "santa-ana-college",
+        "solano-community-college",
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Anatomy of a Murder",
+        "Anatomy of Murder",
+        "Bujinkan Fundamentals-Practica",
+        "Career Prep WS for FS",
+        "Civilian Supvsry, Law Enforce"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 169,
+      "section_count": 459,
+      "colleges": [
+        "american-river-college",
+        "bakersfield-college",
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "los-medanos-college",
+        "mt-san-antonio-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "santa-rosa-junior-college",
+        "sierra-college",
+        "solano-community-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "73602 Fire P101 &ndash;50 Principles of Emergency Services",
+        "Advanced Fire Fighter Academy",
+        "AH-330 Taskforce",
+        "All-Risk Com Ops Co Off-CO 2D",
+        "Arson and Fire Investigation"
+      ]
+    },
+    {
+      "prefix": "ACCTG",
+      "name": "Accounting",
+      "course_count": 55,
+      "section_count": 457,
+      "colleges": [
+        "chaffey-college",
+        "clovis-community-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "madera-community-college",
+        "reedley-college",
+        "san-jose-city-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "ACCOUNTING 4 MNGRS",
+        "Accounting Using Quickbooks Pro",
+        "Acctg for Gov/Not-For-Prft Org",
+        "Acctg. for Govt. & Nonprofits",
+        "Advanced Income Tax"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 150,
+      "section_count": 454,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "cabrillo-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "cuesta-college",
+        "cuyamaca-college",
+        "golden-west-college",
+        "grossmont-college",
+        "merritt-college",
+        "moorpark-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "santa-rosa-junior-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "&#39;&#39;C&#39;&#39; Programming Language",
+        "Adobe Illustrator 1",
+        "Adobe InDesign 1",
+        "ADVANCED JAVA PROGRAMMING AND ALGORITHM WITH DATA STRUCTURES",
+        "ADVANCED PYTHON PROGRAMMING AND BASIC DATA STRUCTURES"
+      ]
+    },
+    {
+      "prefix": "HED",
+      "name": "Health",
+      "course_count": 61,
+      "section_count": 450,
+      "colleges": [
+        "allan-hancock-college",
+        "contra-costa-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "grossmont-college",
+        "hartnell-college",
+        "moorpark-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "san-jose-city-college",
+        "sierra-college",
+        "solano-community-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Applied Nutrition",
+        "Drugs, Health, and Society",
+        "DRUGS, HEALTH, AND SOCIETY",
+        "Dynamic Health Concepts",
+        "Education for Healthful Living"
+      ]
+    },
+    {
+      "prefix": "PHOTO",
+      "name": "Photography",
+      "course_count": 115,
+      "section_count": 449,
+      "colleges": [
+        "chaffey-college",
+        "clovis-community-college",
+        "cosumnes-river-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "fresno-city-college",
+        "laney-college",
+        "los-angeles-city-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-valley-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "west-los-angeles-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adobe Lightroom",
+        "ADV BLACK/WHITE",
+        "Adv Digital Photo",
+        "Advanced Digital Imaging",
+        "Advanced Digital Photography"
+      ]
+    },
+    {
+      "prefix": "CHLD",
+      "name": "CHLD",
+      "course_count": 96,
+      "section_count": 435,
+      "colleges": [
+        "barstow-community-college",
+        "citrus-college",
+        "foothill-college",
+        "mt-san-antonio-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Activities for School-Age Children",
+        "Admin of Child Dev Programs",
+        "ADMINISTRATION & SUPERVISION OF CHILDREN'S PROGRAMS PART I",
+        "ADMINISTRATION & SUPERVISION OF CHILDREN'S PROGRAMS PART II",
+        "Administration I: Programs in Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 57,
+      "section_count": 415,
+      "colleges": [
+        "cabrillo-college",
+        "chaffey-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "college-of-the-desert",
+        "cypress-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "lemoore-college",
+        "madera-community-college",
+        "moorpark-college",
+        "rio-hondo-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "ALC/DRUG COUNSEL",
+        "ALCHOL/DRUG COUNS",
+        "ALCOHOL COUNSEL",
+        "ASSERT TRAINING",
+        "BASIC PHARMACOLOGY"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 73,
+      "section_count": 406,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "citrus-college",
+        "coalinga-college",
+        "coastline-community-college",
+        "college-of-the-siskiyous",
+        "cosumnes-river-college",
+        "cuyamaca-college",
+        "folsom-lake-college",
+        "fullerton-college",
+        "gavilan-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "mission-college",
+        "moorpark-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "African American Humanities",
+        "African American Identities, Cultures, and Issues",
+        "American Humanities",
+        "Arts & Culture of San Diego",
+        "Asian Humanities"
+      ]
+    },
+    {
+      "prefix": "DANCE",
+      "name": "Dance",
+      "course_count": 171,
+      "section_count": 399,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "clovis-community-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "folsom-lake-college",
+        "fresno-city-college",
+        "laney-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "ADV MEX FOLKDANCE",
+        "Baile Folklórico I",
+        "Baile Folklórico II",
+        "Ballet Conditioning: Pre-Pointe and Pointe I",
+        "Ballet Conditioning: Pre-Pointe and Pointe II"
+      ]
+    },
+    {
+      "prefix": "ANTHRO",
+      "name": "ANTHRO",
+      "course_count": 20,
+      "section_count": 388,
+      "colleges": [
+        "chaffey-college",
+        "clovis-community-college",
+        "east-los-angeles-college",
+        "fresno-city-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Anthropology Of Religion, Magic And Witchcraft",
+        "Archaeology: Reconstructing The Human Past",
+        "Fundamentals Of Forensic Anthropology",
+        "Gender, Sex And Culture",
+        "Human Biological Evolution"
+      ]
+    },
+    {
+      "prefix": "ADMJ",
+      "name": "ADMJ",
+      "course_count": 111,
+      "section_count": 379,
+      "colleges": [
+        "american-river-college",
+        "bakersfield-college",
+        "de-anza-college",
+        "folsom-lake-college",
+        "monterey-peninsula-college",
+        "napa-valley-college",
+        "porterville-college",
+        "sacramento-city-college",
+        "sierra-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Admin of Justice Pathways",
+        "Administ of Justice Internship",
+        "Advanced Firearms",
+        "Alcohol, Narcotics and Drug Abuse",
+        "Arrest and Control Techniques P.C. 832"
+      ]
+    },
+    {
+      "prefix": "ENGLISH",
+      "name": "Literature",
+      "course_count": 39,
+      "section_count": 371,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Advanced Technical Writing",
+        "African-American Literature I",
+        "American Literature I",
+        "American Literature II",
+        "British Literature I"
+      ]
+    },
+    {
+      "prefix": "FIRET",
+      "name": "FIRET",
+      "course_count": 21,
+      "section_count": 370,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "ACLS",
+        "ADV FIRFTR CE",
+        "BAS FIRE ACADEMY 1",
+        "BAS FIRE ACADEMY 2",
+        "BASIC LIFE SUPPORT"
+      ]
+    },
+    {
+      "prefix": "CDEV",
+      "name": "CDEV",
+      "course_count": 69,
+      "section_count": 363,
+      "colleges": [
+        "allan-hancock-college",
+        "barstow-community-college",
+        "butte-college",
+        "college-of-the-desert",
+        "compton-college",
+        "contra-costa-college",
+        "cuyamaca-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "grossmont-college",
+        "lemoore-college",
+        "madera-community-college",
+        "napa-valley-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "rio-hondo-college",
+        "santa-ana-college",
+        "solano-community-college",
+        "ventura-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "ADMIN I: PROGRAMS",
+        "ADMIN II: PERSONNL",
+        "Administration I: Programs in",
+        "Administration II: Personnel",
+        "Analyzing and Applying Teacher"
+      ]
+    },
+    {
+      "prefix": "TA",
+      "name": "TA",
+      "course_count": 124,
+      "section_count": 357,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "college-of-the-desert",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "fresno-city-college",
+        "sacramento-city-college",
+        "southwestern-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Acting for Musical Theatre",
+        "Acting for the Camera",
+        "Acting for the Camera I",
+        "ACTING I",
+        "ACTING II"
+      ]
+    },
+    {
+      "prefix": "ARTF",
+      "name": "ARTF",
+      "course_count": 60,
+      "section_count": 342,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "2 Dimensional Art Studio Lab",
+        "African Art",
+        "Art Entrepreneurship",
+        "Art History: Prehist-Gothic",
+        "Art History: Renaiss-Modern"
+      ]
+    },
+    {
+      "prefix": "ES/A",
+      "name": "ES/A",
+      "course_count": 122,
+      "section_count": 340,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adv Weight Trng/Physical Fit",
+        "Advan Gentle/Restore/Yin Yoga",
+        "Advanced Baseball",
+        "Advanced Basketball",
+        "Advanced Cheer Conditioning"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Health",
+      "course_count": 39,
+      "section_count": 340,
+      "colleges": [
+        "allan-hancock-college",
+        "butte-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "de-anza-college",
+        "foothill-college",
+        "fresno-city-college",
+        "lassen-community-college",
+        "madera-community-college",
+        "monterey-peninsula-college",
+        "reedley-college",
+        "shasta-college",
+        "southwestern-college",
+        "victor-valley-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Career Choices in Healthcare",
+        "Community Health Worker I",
+        "Community Health Worker II",
+        "Community Mental Health Prep I",
+        "Community Mentl Health Prep II"
+      ]
+    },
+    {
+      "prefix": "C",
+      "name": "C",
+      "course_count": 41,
+      "section_count": 336,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DATA STRUCTURES & ALGORITHMS IN C++",
+        "ADVANCED DATA STRUCTURES & ALGORITHMS IN JAVA",
+        "ADVANCED DATA STRUCTURES & ALGORITHMS IN PYTHON",
+        "AWS CLOUD PRACTITIONER CERTIFICATION PREPARATION",
+        "COMPUTER ARCHITECTURE & ORGANIZATION"
+      ]
+    },
+    {
+      "prefix": "NURSING",
+      "name": "Nursing",
+      "course_count": 49,
+      "section_count": 328,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college"
+      ],
+      "sample_titles": [
+        "Adult Health Care I",
+        "Adult Health Care II",
+        "Adult Health Care III",
+        "Adult Health Care IV",
+        "Advanced Medical-Surgical Nursing"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 144,
+      "section_count": 327,
+      "colleges": [
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "butte-college",
+        "chaffey-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "gavilan-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "solano-community-college",
+        "southwestern-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced News Media Production",
+        "Advanced Photojournalism",
+        "ADVANCED PHOTOJOURNALISM",
+        "Advanced Reporting and Writing",
+        "Basic Photojournalism"
+      ]
+    },
+    {
+      "prefix": "CINEMA",
+      "name": "CINEMA",
+      "course_count": 44,
+      "section_count": 326,
+      "colleges": [
+        "chaffey-college",
+        "los-angeles-city-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "2 - Digital Video Production Workshop II",
+        "2 - Editing Fundamentals II",
+        "2 - Intermediate Motion Picture Sound And Post Production Sound Design",
+        "2 - Motion Picture Stage Electric and Lighting Techniques",
+        "Advanced Cinematography And Creative Techniques"
+      ]
+    },
+    {
+      "prefix": "CSIS",
+      "name": "CSIS",
+      "course_count": 84,
+      "section_count": 326,
+      "colleges": [
+        "barstow-community-college",
+        "cuyamaca-college",
+        "gavilan-college",
+        "grossmont-college",
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Administering Windows Server Core Infrastructure",
+        "Al Jumpstart",
+        "Al Prompt Design",
+        "Al- Workplace Ethical Issues",
+        "Assembly Lang/Machine Architec"
+      ]
+    },
+    {
+      "prefix": "EMLS",
+      "name": "EMLS",
+      "course_count": 83,
+      "section_count": 320,
+      "colleges": [
+        "bakersfield-college",
+        "fresno-city-college",
+        "porterville-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "ADV ACAD GRMR",
+        "ADV ACAD LIS/SPEAK",
+        "ADV DISCRSE: HUMANITIES",
+        "Advanced Communication Skills",
+        "Advanced Composition"
+      ]
+    },
+    {
+      "prefix": "THEATER",
+      "name": "THEATER",
+      "course_count": 71,
+      "section_count": 316,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "2 - Actors' Workshop-Level II",
+        "2 - Advanced Applied Acting-Level II",
+        "2 - Play Production and Company Performance II",
+        "2 - Rehearsals and Performances II",
+        "3 - Applied Costuming for the Theater III"
+      ]
+    },
+    {
+      "prefix": "CHICANO",
+      "name": "CHICANO",
+      "course_count": 21,
+      "section_count": 307,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Central American Film",
+        "Chicana/o/x Art, Literature, and Film",
+        "Chicanas and Chicanos in Film",
+        "Chicano Literature",
+        "Contemporary Mexican Literature"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "CRIM",
+      "course_count": 28,
+      "section_count": 304,
+      "colleges": [
+        "bakersfield-college",
+        "clovis-community-college",
+        "fresno-city-college",
+        "madera-community-college",
+        "porterville-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "COMMUN RELATIONS",
+        "Community Relations",
+        "CONSTITUT RIGHTS",
+        "Constitutional Criminal Procedure",
+        "Correct Interving & Counseling"
+      ]
+    },
+    {
+      "prefix": "FASH",
+      "name": "Fashion",
+      "course_count": 155,
+      "section_count": 303,
+      "colleges": [
+        "allan-hancock-college",
+        "butte-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CLOTHING CONSTRUCTION",
+        "Advanced Fashion Design",
+        "ADVANCED FASHION DESIGN",
+        "Apparel Analysis",
+        "Apparel Construction I"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 65,
+      "section_count": 303,
+      "colleges": [
+        "foothill-college",
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "ADVANCED ARCHERY",
+        "ADVANCED BADMINTON: SINGLES & DOUBLES",
+        "Advanced Basketball",
+        "ADVANCED HATHA YOGA",
+        "ADVANCED TAI CHI (TAIJI)"
+      ]
+    },
+    {
+      "prefix": "GUID",
+      "name": "GUID",
+      "course_count": 25,
+      "section_count": 299,
+      "colleges": [
+        "chaffey-college",
+        "college-of-the-siskiyous",
+        "gavilan-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "ADVANCED LEARNING SKILLS LAB",
+        "Career Exp & Life Planning",
+        "Career Exploration",
+        "Career Explore/Life Planning",
+        "College Readiness"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "BOT",
+      "course_count": 57,
+      "section_count": 295,
+      "colleges": [
+        "contra-costa-college",
+        "cuyamaca-college",
+        "gavilan-college",
+        "grossmont-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat for Workplace",
+        "Basic Communication Skills for Business",
+        "Basic Comp Skills for Arabic",
+        "Building Keyboarding Skill I",
+        "Building Keyboarding Skill II"
+      ]
+    },
+    {
+      "prefix": "CISC",
+      "name": "CISC",
+      "course_count": 37,
+      "section_count": 295,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "C/C++ Programming",
+        "Computer Familiarization",
+        "Computer Familiarization – MS Office 2019 and Internet Explorer 11",
+        "Computer Org and Assembly Lang",
+        "Data Structures in C++"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "Cosmetology",
+      "course_count": 105,
+      "section_count": 293,
+      "colleges": [
+        "barstow-community-college",
+        "compton-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "golden-west-college",
+        "laney-college",
+        "pasadena-city-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "solano-community-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Prep for State Brd Review",
+        "Adv. Barber Crssover/Test Prep",
+        "Advanced Cosmetology",
+        "Advanced Cosmetology and Introduction to State Board Review",
+        "Advanced Cosmetology Applications"
+      ]
+    },
+    {
+      "prefix": "RE",
+      "name": "Real",
+      "course_count": 98,
+      "section_count": 292,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "chaffey-college",
+        "coastline-community-college",
+        "compton-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "folsom-lake-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "gavilan-college",
+        "grossmont-college",
+        "orange-coast-college",
+        "sacramento-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "solano-community-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adv Real Estate Appraisal",
+        "Adv Real Estate Finance",
+        "Advanced Real Estate Finance",
+        "Appraisal Principles and Proce",
+        "CA Mortgage Loan Broker/Lend"
+      ]
+    },
+    {
+      "prefix": "ADM JUS",
+      "name": "ADM JUS",
+      "course_count": 33,
+      "section_count": 288,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Advanced Forensic Science",
+        "Applications In Crime Analysis",
+        "California Criminal Procedures I",
+        "Community Relations I",
+        "Concepts Of Criminal Law"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 127,
+      "section_count": 287,
+      "colleges": [
+        "barstow-community-college",
+        "de-anza-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "2D Foundations",
+        "3-Dimensional Design",
+        "3D Foundations",
+        "Abstraction",
+        "Acrylic Painting I"
+      ]
+    },
+    {
+      "prefix": "VBUS",
+      "name": "VBUS",
+      "course_count": 59,
+      "section_count": 286,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "3D Animation using Blender",
+        "3D Modeling Using Blender",
+        "Accounting for Non-Accountant",
+        "Accounting Terminology",
+        "Adobe Acrobat"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 68,
+      "section_count": 284,
+      "colleges": [
+        "bakersfield-college",
+        "coastline-community-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "foothill-college",
+        "fullerton-college",
+        "grossmont-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "san-diego-mesa-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CONVERSATION I",
+        "ADVANCED CONVERSATION II",
+        "Advanced Japanese",
+        "ADVANCED JAPANESE READING AND COMPOSITION",
+        "Anime I: Study of Culture"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 80,
+      "section_count": 283,
+      "colleges": [
+        "allan-hancock-college",
+        "butte-college",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "evergreen-valley-college",
+        "foothill-college",
+        "los-medanos-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "palo-verde-college",
+        "san-jose-city-college",
+        "solano-community-college",
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "12-LEAD ECG INTERPRETATION I: INTRODUCTION",
+        "12-LEAD ECG INTERPRETATION II: ACUTE CORONARY SYNDROMES & CONDUCTION ABNORMALITIES",
+        "12-LEAD ECG INTERPRETATION III: ADVANCED TOPICS & CLINICAL APPLICATIONS",
+        "A12ecg",
+        "BLS Field experience"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "ABE",
+      "course_count": 58,
+      "section_count": 275,
+      "colleges": [
+        "college-of-the-desert",
+        "palo-verde-college",
+        "pasadena-city-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Academic Reading & Writing Esl",
+        "Academic Skills",
+        "Adult Basic Education Mathema",
+        "Adult Basic Education Reading",
+        "Adult Basic Education Spellin"
+      ]
+    },
+    {
+      "prefix": "ANTHR",
+      "name": "ANTHR",
+      "course_count": 28,
+      "section_count": 274,
+      "colleges": [
+        "berkeley-city-college",
+        "cabrillo-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "laney-college",
+        "los-medanos-college",
+        "merritt-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "AMERICAN INDIAN HISTORY AND CULTURE",
+        "Anthro of Religion",
+        "Archaeological Field School",
+        "Biological Anthropology",
+        "Biological Anthropology Laboratory"
+      ]
+    },
+    {
+      "prefix": "HCRS",
+      "name": "Medical",
+      "course_count": 39,
+      "section_count": 274,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Assistant Externship",
+        "Advanced Medical Billing",
+        "Advanced Medical Coding",
+        "Advanced Pharmacology",
+        "Basic Cardiac Rhythm Interpretation"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emergency",
+      "course_count": 50,
+      "section_count": 271,
+      "colleges": [
+        "american-river-college",
+        "antelope-valley-community-college-district",
+        "chaffey-college",
+        "college-of-the-desert",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "hartnell-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "merritt-college",
+        "moorpark-college",
+        "oxnard-college",
+        "rio-hondo-college",
+        "santa-ana-college",
+        "southwestern-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support (ACLS) Provider",
+        "Anatomy and Physiology for EMS",
+        "Basic Life Support (BLS) Provider",
+        "Basic Life Support Healthcare Provider CPR",
+        "Cardiorespiratory Emergencies"
+      ]
+    },
+    {
+      "prefix": "NRN",
+      "name": "NRN",
+      "course_count": 42,
+      "section_count": 270,
+      "colleges": [
+        "college-of-the-desert",
+        "hartnell-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "ACUTE CMPLX ALT HLTH",
+        "Care of Clients With Complex",
+        "Care of Clients With Potential",
+        "Care of Diverse Individuals",
+        "CHRON ALTER HEALTH"
+      ]
+    },
+    {
+      "prefix": "COMS",
+      "name": "Communication",
+      "course_count": 39,
+      "section_count": 266,
+      "colleges": [
+        "college-of-the-siskiyous",
+        "compton-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "napa-valley-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Adv. Communication- Healthcare",
+        "Advanced Public Communication",
+        "Argumentation",
+        "Argumentation and Debate",
+        "Assembly Programming Course"
+      ]
+    },
+    {
+      "prefix": "LIBR",
+      "name": "LIBR",
+      "course_count": 33,
+      "section_count": 266,
+      "colleges": [
+        "american-river-college",
+        "bakersfield-college",
+        "cabrillo-college",
+        "compton-college",
+        "cosumnes-river-college",
+        "el-camino-community-college-district",
+        "folsom-lake-college",
+        "foothill-college",
+        "golden-west-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "porterville-college",
+        "sacramento-city-college",
+        "santa-ana-college",
+        "victor-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Academic Writing Styles and AI",
+        "Arrangement and Description",
+        "Artificial Intelligence and Research",
+        "Artificial Intelligence and Research Skills",
+        "Children's Library Services"
+      ]
+    },
+    {
+      "prefix": "COUNS",
+      "name": "COUNS",
+      "course_count": 31,
+      "section_count": 262,
+      "colleges": [
+        "contra-costa-college",
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "los-medanos-college",
+        "san-jose-city-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Career & Life Planning",
+        "Career and Major Exploration",
+        "Career Planning",
+        "Career Planning/Development",
+        "College Success"
+      ]
+    },
+    {
+      "prefix": "ANATOMY",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 261,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Introduction To Human Anatomy"
+      ]
+    },
+    {
+      "prefix": "BUSE",
+      "name": "Business",
+      "course_count": 22,
+      "section_count": 261,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Law & the Legal Envir",
+        "Business Mathematics",
+        "Business Organization & Mgmt",
+        "Customer Service"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "CA",
+      "course_count": 70,
+      "section_count": 256,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "compton-college",
+        "cuyamaca-college",
+        "evergreen-valley-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "orange-coast-college",
+        "san-jose-city-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Administering Windows Server",
+        "Adv Food Prep for Fine Dining",
+        "Adv Work Exp in Culinary Arts",
+        "Advanced Baking & Pastry Arts",
+        "Advanced Baking and Pastry"
+      ]
+    },
+    {
+      "prefix": "CAOT",
+      "name": "CAOT",
+      "course_count": 42,
+      "section_count": 256,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "oxnard-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat For The Office And The Web",
+        "Business Communications",
+        "Business English",
+        "Business Terminology",
+        "Career Skills for the Workplace"
+      ]
+    },
+    {
+      "prefix": "ANAT",
+      "name": "Human",
+      "course_count": 25,
+      "section_count": 255,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "pasadena-city-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Anatomical Preparations",
+        "DISSECTION ANATOMY",
+        "Essentials of Anatomy and Physiology",
+        "Essentls Anatomy/Physiol",
+        "Fundamentals of Anatomy and Physiology"
+      ]
+    },
+    {
+      "prefix": "CDE",
+      "name": "CDE",
+      "course_count": 53,
+      "section_count": 254,
+      "colleges": [
+        "chaffey-college",
+        "college-of-the-desert",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Admin of Child Develop Prgms",
+        "ADULT SUPERVISION",
+        "Adult Supervision in EC",
+        "Advanced Curriculum Theory",
+        "Brain Research and Teaching"
+      ]
+    },
+    {
+      "prefix": "ADJU",
+      "name": "ADJU",
+      "course_count": 56,
+      "section_count": 252,
+      "colleges": [
+        "barstow-community-college",
+        "mt-san-antonio-college",
+        "san-diego-miramar-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "832 PC Laws of Arrest",
+        "Admin Justice Report Writing",
+        "Admin of Justice Work Exper Ed",
+        "Arrest and Control",
+        "Basic Traffic Accident Invest"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 72,
+      "section_count": 251,
+      "colleges": [
+        "bakersfield-college",
+        "butte-college",
+        "clovis-community-college",
+        "college-of-the-siskiyous",
+        "compton-college",
+        "cypress-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "fullerton-college",
+        "madera-community-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "porterville-college",
+        "reedley-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Advanced Programming in C++",
+        "Assem Lan Prgrmg IBM PC",
+        "Assembly Language Programming",
+        "Assembly Language/Machine Arch",
+        "Beauty of Comptr Sci Prncpls"
+      ]
+    },
+    {
+      "prefix": "ACTG",
+      "name": "Accounting",
+      "course_count": 28,
+      "section_count": 250,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ACCOUNTING FOR GOVERNMENT & NOT-FOR-PROFIT",
+        "ACCOUNTING FOR SMALL BUSINESS",
+        "ACCOUNTING INFORMATION SYSTEMS",
+        "ADVANCED ACCOUNTING",
+        "ADVANCED TAX ACCOUNTING I"
+      ]
+    },
+    {
+      "prefix": "PHYSICS",
+      "name": "Physics",
+      "course_count": 21,
+      "section_count": 249,
+      "colleges": [
+        "coalinga-college",
+        "east-los-angeles-college",
+        "lemoore-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Classical Mechanics",
+        "Directed Study - Physics",
+        "Electricity Magnetism and Waves",
+        "General Physics I",
+        "General Physics I With Calculus"
+      ]
+    },
+    {
+      "prefix": "CMST",
+      "name": "Communication",
+      "course_count": 44,
+      "section_count": 248,
+      "colleges": [
+        "butte-college",
+        "coastline-community-college",
+        "golden-west-college",
+        "orange-coast-college",
+        "santa-ana-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Argumentation & Debate",
+        "Argumentation and Debate",
+        "Argumentation and Oral Debate",
+        "Direct Practice Soc Med Strat",
+        "Essentials of Argumentation"
+      ]
+    },
+    {
+      "prefix": "KINE",
+      "name": "KINE",
+      "course_count": 88,
+      "section_count": 247,
+      "colleges": [
+        "college-of-the-desert",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "napa-valley-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "ADAPTED TENNIS",
+        "ADV PSA FIT TRAINING",
+        "Advanced First Aid and Emergency Care",
+        "ADVANCED YOGA",
+        "Archery - Beginning"
+      ]
+    },
+    {
+      "prefix": "COUNSEL",
+      "name": "College",
+      "course_count": 10,
+      "section_count": 245,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Career Planning",
+        "Career Planning And Development",
+        "Career Planning For Students With Disabilities",
+        "College Success Seminar",
+        "College Survival"
+      ]
+    },
+    {
+      "prefix": "STDV",
+      "name": "Planning",
+      "course_count": 5,
+      "section_count": 244,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Career and Life Planning",
+        "Educational Planning",
+        "Lifelong Learning and Career Planning",
+        "Tools for College Success",
+        "University Transfer Preparation"
+      ]
+    },
+    {
+      "prefix": "HSS",
+      "name": "Test",
+      "course_count": 19,
+      "section_count": 243,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "High School Equivalency Test",
+        "HS Equival Test Prep - Math",
+        "HS Equival Test Prep - Math A",
+        "HS Equival Test Prep - Math B",
+        "HS Equival Test Prep - Read"
+      ]
+    },
+    {
+      "prefix": "BA",
+      "name": "BA",
+      "course_count": 80,
+      "section_count": 242,
+      "colleges": [
+        "clovis-community-college",
+        "college-of-the-siskiyous",
+        "fresno-city-college",
+        "madera-community-college",
+        "reedley-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat",
+        "Adobe After Effects",
+        "Adobe Dreamweaver - Web Design",
+        "Adobe Express - Generative AI",
+        "Adobe Firefly - Generative AI"
+      ]
+    },
+    {
+      "prefix": "BIOSC",
+      "name": "BIOSC",
+      "course_count": 43,
+      "section_count": 242,
+      "colleges": [
+        "contra-costa-college",
+        "diablo-valley-college",
+        "los-medanos-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Advanced Histotechniques",
+        "Beginning Histotechniques",
+        "Biology of Health",
+        "Bioscience Practicum Research",
+        "Cell and Molecular Biology"
+      ]
+    },
+    {
+      "prefix": "COMSTD",
+      "name": "Communication",
+      "course_count": 9,
+      "section_count": 242,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Family Communication",
+        "Fund/Interpersonal Commun",
+        "Fund/Small Group Communication",
+        "Fund/Speech Communication",
+        "Gender & Communication"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "FILM",
+      "course_count": 79,
+      "section_count": 242,
+      "colleges": [
+        "allan-hancock-college",
+        "clovis-community-college",
+        "college-of-the-desert",
+        "compton-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "lassen-community-college",
+        "madera-community-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "reedley-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "3D Computer Animation 1",
+        "3D Computer Animation 2",
+        "AMERICAN FILM",
+        "American Independent Cinema",
+        "AUDIO PRODUCTION"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "HOSP",
+      "course_count": 108,
+      "section_count": 242,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "cuesta-college",
+        "diablo-valley-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "rio-hondo-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "ASIAN CUISINE I",
+        "Bakeshop: Basic Baking Techniques",
+        "Bakeshop: Cakes, Tortes and Decorating Techniques",
+        "Bakeshop: French Pastries and Restaurant-Style Desserts",
+        "Bakeshop: Pies and Tarts"
+      ]
+    },
+    {
+      "prefix": "CART",
+      "name": "CART",
+      "course_count": 35,
+      "section_count": 240,
+      "colleges": [
+        "college-of-the-desert",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "ADVANCED COOKING",
+        "BAKING AND PASTRIES I",
+        "BAKING FUNDAMENTALS",
+        "BANQUET AND CATERING",
+        "BREAKFAST BREADS"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "Business",
+      "course_count": 57,
+      "section_count": 239,
+      "colleges": [
+        "foothill-college",
+        "monterey-peninsula-college",
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Accounting",
+        "Breaking the Glass Ceiling: Women in Business Leadership",
+        "BUSINESS & PROFESSIONAL ETHICS",
+        "Business Communication",
+        "Business Ethics"
+      ]
+    },
+    {
+      "prefix": "ACDV",
+      "name": "Success",
+      "course_count": 21,
+      "section_count": 235,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Bridge to BC: First-Year Student Success",
+        "Computer Literacy for Career and College Success",
+        "Math Skills for Academic Success",
+        "Memory Strategies For Academic Success",
+        "Note Taking Strategies for Academic Success"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 121,
+      "section_count": 234,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "cypress-college",
+        "fullerton-college",
+        "moorpark-college",
+        "orange-coast-college",
+        "porterville-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adv Clinical Mammography Lab",
+        "Advanced Clinical Lab CT",
+        "Advanced Imaging Techniques",
+        "Advanced Principles of Exposure",
+        "Advanced Radiographic Procedures"
+      ]
+    },
+    {
+      "prefix": "EMER",
+      "name": "Older",
+      "course_count": 20,
+      "section_count": 231,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Books Come Alive for Older Adults",
+        "Ceramics for Older Adults",
+        "Creative Arts for Older Adults",
+        "Creative Writing for Seniors",
+        "Food Preparation and Good Nutrition for Older Adults"
+      ]
+    },
+    {
+      "prefix": "KINES",
+      "name": "KINES",
+      "course_count": 78,
+      "section_count": 231,
+      "colleges": [
+        "american-river-college",
+        "clovis-community-college",
+        "coalinga-college",
+        "contra-costa-college",
+        "cosumnes-river-college",
+        "diablo-valley-college",
+        "folsom-lake-college",
+        "lemoore-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "reedley-college",
+        "sacramento-city-college",
+        "shasta-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adapt Total Fitness",
+        "Advanced Golf",
+        "Advanced Sports Medicine and Athletic Training",
+        "Analy of Baseball Off",
+        "Anatomy and Physiology for Yoga Teachers"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "COMP",
+      "course_count": 33,
+      "section_count": 226,
+      "colleges": [
+        "bakersfield-college",
+        "contra-costa-college",
+        "cypress-college",
+        "fullerton-college",
+        "lemoore-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Programming With C and C++",
+        "Assembly Language Programming/Computer Organization",
+        "Beginning iOS App Development",
+        "CompTIA A+",
+        "CompTIA Linux+"
+      ]
+    },
+    {
+      "prefix": "ETHNS",
+      "name": "American",
+      "course_count": 6,
+      "section_count": 220,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Independent Studies in Ethnic Studies",
+        "Introduction to African American Studies – Reserved - UMOJA",
+        "Introduction to Asian American Studies",
+        "Introduction to Chicana/o/x Studies",
+        "Introduction to Ethnic Studies – HSI-Early College Program"
+      ]
+    },
+    {
+      "prefix": "FITNS",
+      "name": "FITNS",
+      "course_count": 41,
+      "section_count": 213,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Aerobic Mix",
+        "Aerobics: Cardio-Kickboxing",
+        "Aquatic Fitness I",
+        "Aquatic Fitness III- Deep Water Jogging",
+        "Basic Yoga"
+      ]
+    },
+    {
+      "prefix": "NUTRI",
+      "name": "Nutrition",
+      "course_count": 20,
+      "section_count": 212,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "diablo-valley-college",
+        "folsom-lake-college",
+        "los-medanos-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Clinical Experience in Health Care Facilities",
+        "Cultural Foods of the World",
+        "Field Experience in Nutritional Care Management",
+        "Food and Nutrition: Cross Cultrl Perspec",
+        "Food Theory and Preparation"
+      ]
+    },
+    {
+      "prefix": "MEDS",
+      "name": "Medical",
+      "course_count": 12,
+      "section_count": 211,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary Resuscitation for Healthcare Providers",
+        "Clinical Medical Assistant 1",
+        "Clinical Medical Assistant Externship",
+        "Clinical Medical Assistant Skills Learning Lab",
+        "Clinical Medical Assisting 2"
+      ]
+    },
+    {
+      "prefix": "NCAD",
+      "name": "Older",
+      "course_count": 5,
+      "section_count": 211,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Balance Awareness for Older Adults",
+        "Forum on Local and Global Topics",
+        "Older Adult Art",
+        "Orchestra for Older Adults",
+        "Stay Fit for Older Adults"
+      ]
+    },
+    {
+      "prefix": "COMSC",
+      "name": "COMSC",
+      "course_count": 44,
+      "section_count": 210,
+      "colleges": [
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "los-medanos-college",
+        "san-jose-city-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Programming with C and C++",
+        "Advanced Python Programming",
+        "Assembly Language Programming/Computer Organization",
+        "C++ Programming",
+        "Cloud Machine Learning"
+      ]
+    },
+    {
+      "prefix": "HUMAN",
+      "name": "HUMAN",
+      "course_count": 47,
+      "section_count": 210,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "fresno-city-college",
+        "laney-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "los-medanos-college",
+        "merritt-college",
+        "west-los-angeles-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "African American Humanities",
+        "American Humanities",
+        "Asian-Amer Human",
+        "CLASSIC MYTHS",
+        "Cultural Patterns of Western Civilization"
+      ]
+    },
+    {
+      "prefix": "KINF",
+      "name": "KINF",
+      "course_count": 35,
+      "section_count": 209,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advanced Pickleball",
+        "Advanced Tennis",
+        "Advanced Volleyball",
+        "Advanced Walking for Fitness",
+        "Advanced Weight Training"
+      ]
+    },
+    {
+      "prefix": "HDEV",
+      "name": "HDEV",
+      "course_count": 28,
+      "section_count": 205,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Adlt Supv/Mentor Early Care&amp;Ed",
+        "Admin I: Programs in ECE",
+        "Career and Life Planning",
+        "Career Development Across the Lifespan",
+        "Child Growth and Development"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "LAW",
+      "course_count": 65,
+      "section_count": 205,
+      "colleges": [
+        "coastline-community-college",
+        "compton-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "hartnell-college",
+        "los-angeles-city-college",
+        "los-angeles-mission-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "oxnard-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Bankruptcy Law/Procedures",
+        "Business Law",
+        "Business Law I",
+        "Business Law II",
+        "Civil Litigation 1"
+      ]
+    },
+    {
+      "prefix": "CABT",
+      "name": "CABT",
+      "course_count": 38,
+      "section_count": 203,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Accessible Docs",
+        "Accessible Media",
+        "Adv Documents",
+        "Advanced Spreadsheets",
+        "Ag Computer Applications"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "AH",
+      "course_count": 26,
+      "section_count": 196,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "gavilan-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Ancient Art",
+        "Apprec/Intro Art",
+        "Art India/SE Asia",
+        "Art of the Americas",
+        "China/Korea/Japan"
+      ]
+    },
+    {
+      "prefix": "PHILOS",
+      "name": "Philosophy",
+      "course_count": 22,
+      "section_count": 195,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Asian Philosophy",
+        "Comparative Survey Of World Religions",
+        "Critical Thinking and Composition",
+        "Deductive Logic",
+        "Environmental Ethics"
+      ]
+    },
+    {
+      "prefix": "JOURNAL",
+      "name": "JOURNAL",
+      "course_count": 19,
+      "section_count": 194,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-valley-college"
+      ],
+      "sample_titles": [
+        "1 - Beginning Computerized Composition",
+        "2 - Magazine Production II",
+        "3 - Practical Editing III",
+        "3 - Publication Laboratory III",
+        "3 - Techniques For Staff Editors III"
+      ]
+    },
+    {
+      "prefix": "LL",
+      "name": "Older",
+      "course_count": 5,
+      "section_count": 193,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Creative Arts for Older Adults",
+        "Fitness for Older Adults",
+        "Musical Experience",
+        "Special Interest Discussion Groups",
+        "Writing for Older Adults"
+      ]
+    },
+    {
+      "prefix": "PARA",
+      "name": "PARA",
+      "course_count": 86,
+      "section_count": 191,
+      "colleges": [
+        "bakersfield-college",
+        "cuyamaca-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "grossmont-college",
+        "porterville-college",
+        "san-diego-miramar-college",
+        "santa-ana-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Admin Law & Regulatory Compli.",
+        "Adv. Law Office Proce., Transa",
+        "Adv. Legal Research, Analysis",
+        "Adv. Work Experience - CLIRRC",
+        "Adv. Work Experience - Para"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 110,
+      "section_count": 190,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "cosumnes-river-college",
+        "diablo-valley-college",
+        "foothill-college",
+        "fullerton-college",
+        "monterey-peninsula-college",
+        "orange-coast-college",
+        "santa-rosa-junior-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Adaptive Greenhouse Management",
+        "Adaptive Horticulture - Basic Skills and Practices",
+        "Adaptive Nursery and Landscape Management",
+        "Adaptive Plant Propagation",
+        "Adaptive Vegetable and Orchard Management"
+      ]
+    },
+    {
+      "prefix": "KNACT",
+      "name": "KNACT",
+      "course_count": 65,
+      "section_count": 188,
+      "colleges": [
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Advanced Hatha Yoga",
+        "Advanced Plyometrics and Agility Training for Female Athletes",
+        "Advanced Volleyball",
+        "Advanced Yoga for Health and Fitness",
+        "Beginning Aquatic Fitness"
+      ]
+    },
+    {
+      "prefix": "ARBC",
+      "name": "Arabic",
+      "course_count": 17,
+      "section_count": 187,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Arabic Civilizations",
+        "Arabic for Arabic Speaker I",
+        "Arabic for Arabic Speaker II",
+        "Arabic I",
+        "Arabic II"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 34,
+      "section_count": 187,
+      "colleges": [
+        "hartnell-college",
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Accelerated Pre-Calculus &",
+        "Analytic Geom. & Calc. I",
+        "Analytic Geom. & Calc. II",
+        "Analytic Geom. & Calc. III",
+        "Analytic Geometry and Calculus I"
+      ]
+    },
+    {
+      "prefix": "CISP",
+      "name": "Programming",
+      "course_count": 33,
+      "section_count": 183,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "mt-san-antonio-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advance Programming Python Lab",
+        "Advanced C++ Programming",
+        "Advanced C++ Programming Lab",
+        "Advanced Java Laboratory",
+        "Advanced Java Programming"
+      ]
+    },
+    {
+      "prefix": "SPANISH",
+      "name": "Spanish",
+      "course_count": 15,
+      "section_count": 183,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Advanced Spanish Through Latin American Literature",
+        "Advanced Spanish Through Spanish Literature",
+        "Civilization Of Spain",
+        "Composition And Conversation For Spanish Speakers",
+        "Elementary Spanish I"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "AT",
+      "course_count": 87,
+      "section_count": 182,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "cypress-college",
+        "fresno-city-college",
+        "fullerton-college",
+        "lassen-community-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "=Work Exp in Auto Tech II",
+        "ADVANCED ANESTHESIA EQUIPMENT - THEORY AND LAB",
+        "Advanced Automotive Skill and Speed Development",
+        "Advanced Engine Performance",
+        "ADVANCED PRINCIPLES OF ANESTHESIA TECHNOLOGY"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 38,
+      "section_count": 179,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college",
+        "san-diego-city-college",
+        "santa-rosa-junior-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Agricultural Economics",
+        "Agricultural Enterprise Project",
+        "Agricultural Marketing",
+        "Agricultural Sales",
+        "Agriculture Internship"
+      ]
+    },
+    {
+      "prefix": "ELDN",
+      "name": "ELDN",
+      "course_count": 23,
+      "section_count": 179,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Advanced Grammar",
+        "Advanced Reading",
+        "Advanced Writing",
+        "Beginning Conversation",
+        "ELD Lab"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "IT",
+      "course_count": 56,
+      "section_count": 174,
+      "colleges": [
+        "bakersfield-college",
+        "coastline-community-college",
+        "madera-community-college",
+        "porterville-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat",
+        "AI Intergration: Local &amp; Cloud",
+        "AWS Cloud Architecting",
+        "AWS Cloud Foundations",
+        "Business Information Systems"
+      ]
+    },
+    {
+      "prefix": "ESCI",
+      "name": "ESCI",
+      "course_count": 39,
+      "section_count": 170,
+      "colleges": [
+        "citrus-college",
+        "college-of-the-siskiyous",
+        "de-anza-college",
+        "lemoore-college",
+        "shasta-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Ancient Life",
+        "California Geology",
+        "Earth System Science",
+        "Earthquakes/Volcanoes/Geol Haz",
+        "Energy, Environment, &amp; Climate"
+      ]
+    },
+    {
+      "prefix": "ITIS",
+      "name": "ITIS",
+      "course_count": 38,
+      "section_count": 170,
+      "colleges": [
+        "chaffey-college",
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Applications using Javascript",
+        "AWS Cloud Architecture",
+        "Cisco Internetworking I",
+        "CISSP Cert Exam Prep",
+        "Cloud Essentials"
+      ]
+    },
+    {
+      "prefix": "KINI",
+      "name": "KINI",
+      "course_count": 30,
+      "section_count": 170,
+      "colleges": [
+        "mt-san-antonio-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Pickleball",
+        "Badminton - Advanced",
+        "Badminton - Beginning",
+        "Badminton - Intermediate",
+        "Filipino Martial Arts - Begin"
+      ]
+    },
+    {
+      "prefix": "MUFHL",
+      "name": "Music",
+      "course_count": 21,
+      "section_count": 168,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Basic Musicianship",
+        "Exploring Music",
+        "Introduction to American Popular Music – HSI - Early College Program",
+        "Introduction to Music",
+        "Introduction to Music: Rock and Roll"
+      ]
+    },
+    {
+      "prefix": "KFIT",
+      "name": "KFIT",
+      "course_count": 27,
+      "section_count": 167,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Body Conditioning",
+        "Advanced Hiking",
+        "Advanced Pilates Mat",
+        "Advanced Yoga",
+        "Beginning Body Conditioning"
+      ]
+    },
+    {
+      "prefix": "MATHS",
+      "name": "Support",
+      "course_count": 18,
+      "section_count": 167,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Guided Individualized Support for Mathematics",
+        "Guided Individualized Support for Mathematics and Statistics",
+        "Support Course for Trigonometry for Calculus – MATHS73/MATH373 Linked Section",
+        "Support for Business Mathematics – MATHS45/MATH341 Linked Section",
+        "Support for Calculus for Biology and Medicine I – MATH 355/MATHS 65 COMBO"
+      ]
+    },
+    {
+      "prefix": "EMTC",
+      "name": "Paramedic",
+      "course_count": 21,
+      "section_count": 165,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiovascular Life Support",
+        "Anatomy and Physiology for Emergency Care",
+        "Basic Electrocardiograph Interpretation",
+        "CPR for the Healthcare Provider",
+        "Emergency Medical Responder"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "HUMA",
+      "course_count": 20,
+      "section_count": 165,
+      "colleges": [
+        "barstow-community-college",
+        "compton-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "An Introduction to the Humanities",
+        "Antiquity to Renaissance",
+        "Envi. Justice & the Humanities",
+        "Exploring Human Values/Film",
+        "Human Sexuality"
+      ]
+    },
+    {
+      "prefix": "CHIL",
+      "name": "CHIL",
+      "course_count": 32,
+      "section_count": 164,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Adlt Superv/Mentor Ec",
+        "Admin of Early Childhood Progm",
+        "Child Devel Center Practicum",
+        "Children With Special Needs",
+        "Curriculum: Art"
+      ]
+    },
+    {
+      "prefix": "ESLL",
+      "name": "Listening",
+      "course_count": 16,
+      "section_count": 164,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "foothill-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Academic Communication, Notetaking, and College Success Skills",
+        "Academic Listening, Note-taking, and Discussion",
+        "Academic Listening, Speaking, and Presentation Skills",
+        "ADVANCED COMPOSITION & READING",
+        "ADVANCED GRAMMAR"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Medical",
+      "course_count": 66,
+      "section_count": 163,
+      "colleges": [
+        "allan-hancock-college",
+        "cabrillo-college",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "san-jose-city-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Admin Medical Assisting I",
+        "Administrative MA",
+        "ADMINISTRATIVE MEDICAL OFFICE PROCEDURES I",
+        "ADMINISTRATIVE MEDICAL OFFICE PROCEDURES II",
+        "ADV TRAINING"
+      ]
+    },
+    {
+      "prefix": "NURADN",
+      "name": "Nursing",
+      "course_count": 14,
+      "section_count": 163,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Basic Pharmacology",
+        "Clinical Nursing Skills",
+        "Coop Ed: Nursing A.D.N.",
+        "ECG & Dysrhythmia Interpret",
+        "Family-Child Nursing"
+      ]
+    },
+    {
+      "prefix": "FT",
+      "name": "Fire",
+      "course_count": 56,
+      "section_count": 161,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "cabrillo-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Apparatus and Equipment",
+        "Basic Wildland Fire Academy",
+        "Bldg Constr for Fire Prot",
+        "Build Constr Fire P",
+        "Build Construction/Fire Protec"
+      ]
+    },
+    {
+      "prefix": "CHDEV",
+      "name": "CHDEV",
+      "course_count": 38,
+      "section_count": 160,
+      "colleges": [
+        "berkeley-city-college",
+        "fresno-city-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Adult Supervision and Mentoring in Early Care and Education",
+        "Advanced Practicum-Field Experience",
+        "California Preschool Learning Foundations: English Language Development",
+        "California Preschool Learning Foundations: Literacy",
+        "Child Growth and Development"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 43,
+      "section_count": 160,
+      "colleges": [
+        "bakersfield-college",
+        "berkeley-city-college",
+        "citrus-college",
+        "coastline-community-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "folsom-lake-college",
+        "fullerton-college",
+        "grossmont-college",
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "porterville-college",
+        "sacramento-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "sierra-college",
+        "solano-community-college",
+        "southwestern-college",
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Beg Conversational French",
+        "Conv and Comp in French I",
+        "Conversational French",
+        "Elementary French",
+        "Elementary French - Level I"
+      ]
+    },
+    {
+      "prefix": "TAP",
+      "name": "Production",
+      "course_count": 39,
+      "section_count": 160,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Children's Theatre Rehearsal and Performance I",
+        "Children's Theatre Rehearsal and Performance II",
+        "Children's Theatre Rehearsal and Performance III",
+        "Children's Theatre Rehearsal and Performance IV",
+        "Children's Theatre Technical Production I"
+      ]
+    },
+    {
+      "prefix": "COLL",
+      "name": "Success",
+      "course_count": 6,
+      "section_count": 159,
+      "colleges": [
+        "bakersfield-college",
+        "college-of-the-desert",
+        "pasadena-city-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Becoming a Successful Online Student",
+        "FIRST YEAR SEMINAR",
+        "Foundations for Success in College and Life",
+        "Making Transfer Easy",
+        "Student Success Career Pathway"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 74,
+      "section_count": 159,
+      "colleges": [
+        "chaffey-college",
+        "cuesta-college",
+        "gavilan-college",
+        "lemoore-college",
+        "mt-san-antonio-college",
+        "santa-rosa-junior-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adv Outdoor Cook",
+        "Advanced Pastry Arts",
+        "Advanced Professional Baking",
+        "Art of Pro Cooking",
+        "Artisan Bread"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 37,
+      "section_count": 159,
+      "colleges": [
+        "coalinga-college",
+        "college-of-the-desert",
+        "hartnell-college",
+        "lemoore-college",
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "African American Literature",
+        "American Lit II",
+        "American Literature",
+        "AMERICAN LITERATURE I",
+        "American Literature to 1865"
+      ]
+    },
+    {
+      "prefix": "ESC",
+      "name": "ESC",
+      "course_count": 17,
+      "section_count": 158,
+      "colleges": [
+        "chaffey-college",
+        "clovis-community-college",
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Astronomy Lab",
+        "Computer Skls for Colleg & Car",
+        "Earth Science",
+        "Earth Science Laboratory"
+      ]
+    },
+    {
+      "prefix": "OFFT",
+      "name": "OFFT",
+      "course_count": 29,
+      "section_count": 158,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Basic Image Editing",
+        "Best Practices in Customer Service",
+        "Business Branding",
+        "Business Plan I: Executive Summary",
+        "Business Plan II: The Organizational Plan"
+      ]
+    },
+    {
+      "prefix": "DM",
+      "name": "DM",
+      "course_count": 80,
+      "section_count": 157,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "cabrillo-college",
+        "gavilan-college",
+        "santa-ana-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "3D Animation Fundamentals",
+        "3D Modeling Intermediate",
+        "3D Modeling: The Fundamentals",
+        "Advanced Motion Picture Techni",
+        "Advanced News & Sports Product"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Communication",
+      "course_count": 23,
+      "section_count": 157,
+      "colleges": [
+        "citrus-college",
+        "contra-costa-college",
+        "monterey-peninsula-college",
+        "pasadena-city-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Argumentation & Debate",
+        "Argumentation and Debate",
+        "ARGUMENTATION AND DEBATE",
+        "Argumentation and Discussion",
+        "Critical Thinking and Persuasion (IGETC )"
+      ]
+    },
+    {
+      "prefix": "NCEL",
+      "name": "NCEL",
+      "course_count": 43,
+      "section_count": 154,
+      "colleges": [
+        "foothill-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "ADVANCED GRAMMAR",
+        "Advanced Grammar and Editing",
+        "Advanced Listening and Speaking",
+        "Advanced Reading and Writing",
+        "ADVANCED-BEGINNING ENGLISH AS A SECOND LANGUAGE I"
+      ]
+    },
+    {
+      "prefix": "NF",
+      "name": "Nutrition",
+      "course_count": 22,
+      "section_count": 154,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "chaffey-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Careers in Nutrition",
+        "Cooking for Athletic Performan",
+        "Cooking for Health &amp; Wellness",
+        "Cultural and Ethnic Foods",
+        "Cultural and Ethnic Foods Lab"
+      ]
+    },
+    {
+      "prefix": "CHIC",
+      "name": "CHIC",
+      "course_count": 15,
+      "section_count": 153,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Chicana/o Literature",
+        "Chicana/o Sociology",
+        "Chicano Art",
+        "Chicano Culture",
+        "Chicano Images in Film"
+      ]
+    },
+    {
+      "prefix": "FTEC",
+      "name": "Fire",
+      "course_count": 44,
+      "section_count": 153,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "compton-college",
+        "el-camino-community-college-district",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Agil, Fitn, Heal and Sfty",
+        "Bldg Constrct-Fire Protct",
+        "Building Construction for Fire Protection",
+        "Building Construction for the Fire Service",
+        "Emergency Medical Foundations"
+      ]
+    },
+    {
+      "prefix": "HSCI",
+      "name": "HSCI",
+      "course_count": 25,
+      "section_count": 152,
+      "colleges": [
+        "bakersfield-college",
+        "cuesta-college",
+        "evergreen-valley-college",
+        "porterville-college",
+        "san-jose-city-college",
+        "sierra-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT (AEMT) Didactic",
+        "AEMT - Clinical/Field Exp",
+        "Anatomy/Pathophysio for EMS",
+        "Contemporary Health and Society",
+        "CPR / AED - Basic Life Support for Providers and Professionals"
+      ]
+    },
+    {
+      "prefix": "BI",
+      "name": "BI",
+      "course_count": 30,
+      "section_count": 151,
+      "colleges": [
+        "college-of-the-desert",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "ANAT & PHYS I",
+        "ANAT & PHYS II",
+        "Architectural Drawing I",
+        "Architectural Drawing II",
+        "Architectural Drawing III-BIM"
+      ]
+    },
+    {
+      "prefix": "KIN MAJ",
+      "name": "KIN MAJ",
+      "course_count": 31,
+      "section_count": 150,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Academic Success For Student Athletes",
+        "Advanced Athletic Training",
+        "Care And Prevention Of Athletic Injuries",
+        "Corrective Exercise Strategies for the Movement Professional",
+        "Diversity & Equity in Sport"
+      ]
+    },
+    {
+      "prefix": "D",
+      "name": "Dental",
+      "course_count": 40,
+      "section_count": 148,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DENTAL ASSISTING SKILLS",
+        "ASSESSMENT PROCEDURES IN DENTAL HYGIENE",
+        "CLINICAL DENTAL HYGIENE I",
+        "CLINICAL DENTAL HYGIENE II",
+        "CLINICAL DENTAL HYGIENE IV"
+      ]
+    },
+    {
+      "prefix": "ESLA",
+      "name": "Review",
+      "course_count": 25,
+      "section_count": 148,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Citizenship Preparation, Beginning",
+        "Citizenship Preparation, Intermediate-Advanced",
+        "ESL and American Culture and Customs",
+        "ESL and American Humor and Slang",
+        "ESL for Academic Success: Reading and Writing I"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "Sign",
+      "course_count": 48,
+      "section_count": 148,
+      "colleges": [
+        "de-anza-college",
+        "diablo-valley-college",
+        "golden-west-college",
+        "los-medanos-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "American Sign Language (ASL) I",
+        "American Sign Language (ASL) II",
+        "American Sign Language (ASL) III",
+        "American Sign Language (ASL) IV",
+        "American Sign Language 1"
+      ]
+    },
+    {
+      "prefix": "SPORT",
+      "name": "Conditioning",
+      "course_count": 55,
+      "section_count": 148,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Academic Study Skills for Student Athletes",
+        "Baseball, Intercollegiate-Men",
+        "Basketball, Intercollegiate-Men, Fall",
+        "Basketball, Intercollegiate-Men, Spring",
+        "Basketball, Intercollegiate-Women, Fall"
+      ]
+    },
+    {
+      "prefix": "PH",
+      "name": "Health",
+      "course_count": 36,
+      "section_count": 147,
+      "colleges": [
+        "chaffey-college",
+        "college-of-the-desert",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced First Aid/Emr/Cpr and Basic Life Support",
+        "COLLEGE PHYSICS I",
+        "Comm Health Worker Princ",
+        "Community Health Worker (CHW) Internship Placement and Performance",
+        "Community Health Worker (CHW) Principles and Practices I"
+      ]
+    },
+    {
+      "prefix": "FIPT",
+      "name": "Fire",
+      "course_count": 60,
+      "section_count": 146,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Bldg Construct for Fire Protec",
+        "Chief Fire Officer 3",
+        "Command Operations",
+        "Conf Space Rescue Awareness",
+        "Confined Space Rescue Tech"
+      ]
+    },
+    {
+      "prefix": "LINC",
+      "name": "LINC",
+      "course_count": 31,
+      "section_count": 146,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "3-D DESIGN CONCEPTS",
+        "ARTIFICIAL INTELLIGENCE INTEGRATION IN EDUCATIONAL PRACTICES",
+        "ARTIFICIAL INTELLIGENCE LEADERSHIP & EMERGING EDUCATIONAL TRENDS",
+        "ARTIFICIAL INTELLIGENCE LITERACY & ETHICS IN EDUCATION",
+        "BASIC MAKERSPACE SKILLS I"
+      ]
+    },
+    {
+      "prefix": "POLI",
+      "name": "Political",
+      "course_count": 33,
+      "section_count": 146,
+      "colleges": [
+        "barstow-community-college",
+        "citrus-college",
+        "compton-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "foothill-college",
+        "napa-valley-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "American Political Development",
+        "Civil Rights and Liberties in the United States",
+        "Civil Rights/Liberties-Us",
+        "Comparative Government",
+        "COMPARATIVE GOVERNMENT & POLITICS"
+      ]
+    },
+    {
+      "prefix": "BLAS",
+      "name": "African",
+      "course_count": 15,
+      "section_count": 145,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "African American Art",
+        "African American History I",
+        "African American History II",
+        "African American Literature",
+        "African Art and Culture"
+      ]
+    },
+    {
+      "prefix": "WORK",
+      "name": "Work",
+      "course_count": 14,
+      "section_count": 143,
+      "colleges": [
+        "cabrillo-college",
+        "college-of-the-siskiyous",
+        "monterey-peninsula-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Exploratory Work Experience",
+        "General Work Experience",
+        "Internship and Work Experience",
+        "Introduction to Wastewater Treatment",
+        "Introduction to Water Treatment"
+      ]
+    },
+    {
+      "prefix": "ARC",
+      "name": "ARC",
+      "course_count": 31,
+      "section_count": 142,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-harbor-college",
+        "los-angeles-pierce-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college"
+      ],
+      "sample_titles": [
+        "Architectural Design I",
+        "Architectural Design II",
+        "Architectural Drawing I",
+        "Architectural Drawing II",
+        "Architectural Drawing III"
+      ]
+    },
+    {
+      "prefix": "BADM",
+      "name": "Business",
+      "course_count": 24,
+      "section_count": 141,
+      "colleges": [
+        "barstow-community-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Acct Software Appl Part a",
+        "Acct Software Appl Part B",
+        "Applied Accounting I",
+        "Applied Accounting II",
+        "Business Communications"
+      ]
+    },
+    {
+      "prefix": "MUIVI",
+      "name": "MUIVI",
+      "course_count": 35,
+      "section_count": 140,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Guitar",
+        "Advanced Voice",
+        "Applied Music",
+        "Applied Music II",
+        "Applied Music Practicum"
+      ]
+    },
+    {
+      "prefix": "DNCE",
+      "name": "Dance",
+      "course_count": 81,
+      "section_count": 139,
+      "colleges": [
+        "mt-san-antonio-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Ballet Fundamentals",
+        "Ballet I",
+        "Ballet II",
+        "Ballet III",
+        "Ballet IV"
+      ]
+    },
+    {
+      "prefix": "NS",
+      "name": "Nursing",
+      "course_count": 44,
+      "section_count": 139,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "moorpark-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Adv. Nursing Sci. Clinical Lab",
+        "Advanced Nursing Science",
+        "Basic Cardiac Dysrhyth Interp",
+        "Basic Pathophysiology",
+        "Beginning Nursing Lab I"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "SPED",
+      "course_count": 39,
+      "section_count": 138,
+      "colleges": [
+        "butte-college",
+        "cabrillo-college",
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Adapted Fitness",
+        "Adapted Seated Fitness",
+        "Adapted Strength and Cond",
+        "Adaptive Physical Ed 1",
+        "Adaptive Speech-Lang Skills"
+      ]
+    },
+    {
+      "prefix": "AOJ",
+      "name": "AOJ",
+      "course_count": 33,
+      "section_count": 137,
+      "colleges": [
+        "coalinga-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Adv Fingerprint Identification",
+        "Advanced Forensic Photography",
+        "Comm Police/Patrol Procedure",
+        "Community and Justice System",
+        "Control & Supervision of Inmates"
+      ]
+    },
+    {
+      "prefix": "ENGM",
+      "name": "ENGM",
+      "course_count": 43,
+      "section_count": 137,
+      "colleges": [
+        "hartnell-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Acad Listen/Speak II (NC)",
+        "Acad Listen/Speak III (NC)",
+        "Acad Listening/Speaking I (NC)",
+        "Acad Listening/Speaking III",
+        "Acad Reading/Writing I (NC)"
+      ]
+    },
+    {
+      "prefix": "HCD",
+      "name": "HCD",
+      "course_count": 13,
+      "section_count": 137,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Adaptive Learning Strategies",
+        "Advanced Diagnostic Learning in English",
+        "Building Foundations for Success – HSI-Early College Program",
+        "Career and Workforce Skills",
+        "College Success – African American/Umoja-SBA emphasis"
+      ]
+    },
+    {
+      "prefix": "PLGL",
+      "name": "PLGL",
+      "course_count": 62,
+      "section_count": 137,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "cuesta-college",
+        "mt-san-antonio-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Administrative Law and Procedure",
+        "Advanced Legal Analysis &amp; Writ",
+        "Business Orgs",
+        "Case Management",
+        "CIVIL AND CRIMINAL EVIDENCE"
+      ]
+    },
+    {
+      "prefix": "BUSL",
+      "name": "BUSL",
+      "course_count": 19,
+      "section_count": 136,
+      "colleges": [
+        "chaffey-college",
+        "mt-san-antonio-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Adv Legal Research & Writing",
+        "Advanced Business Law",
+        "American Law and Democracy",
+        "Business Law",
+        "Business Law I"
+      ]
+    },
+    {
+      "prefix": "DA",
+      "name": "DA",
+      "course_count": 73,
+      "section_count": 136,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "cypress-college",
+        "fresno-city-college",
+        "orange-coast-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "reedley-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Ballet",
+        "ADVANCED CHAIRSIDE TECHNIQUES",
+        "Advanced Jazz Dance",
+        "Advanced Modern Dance",
+        "Advanced Tap Dance"
+      ]
+    },
+    {
+      "prefix": "KNES",
+      "name": "KNES",
+      "course_count": 40,
+      "section_count": 136,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Active Isolated Stretching",
+        "Advanced Badminton",
+        "Advanced Swimming",
+        "Aerobic Power Walking",
+        "Aerobic Swimming"
+      ]
+    },
+    {
+      "prefix": "ARTD",
+      "name": "ARTD",
+      "course_count": 40,
+      "section_count": 135,
+      "colleges": [
+        "monterey-peninsula-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "3D Arts &amp; Technology I",
+        "3D Arts &amp; Technology II",
+        "3D Arts &amp; Technology III",
+        "Beginning Painting I",
+        "Beginning Painting II"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Chinese",
+      "course_count": 38,
+      "section_count": 135,
+      "colleges": [
+        "chaffey-college",
+        "citrus-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "cypress-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "fresno-city-college",
+        "fullerton-college",
+        "laney-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "rio-hondo-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CANTONESE READING & WRITING: LITERATURE",
+        "ADVANCED CHINESE READING AND COMPOSITION",
+        "Beginning Spoken Chinese",
+        "CHINESE CALLIGRAPHY",
+        "CHINESE CINEMA"
+      ]
+    },
+    {
+      "prefix": "BUAD",
+      "name": "Business",
+      "course_count": 24,
+      "section_count": 134,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Business and Society",
+        "Business Communications",
+        "Business English",
+        "Business Law I",
+        "Business Mathematics"
+      ]
+    },
+    {
+      "prefix": "CT",
+      "name": "CT",
+      "course_count": 42,
+      "section_count": 132,
+      "colleges": [
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Bldg Codes and Zoning",
+        "Blueprint Read:Arch/Construct",
+        "Build Const: Materials/Methods",
+        "Careers in Cons/Man",
+        "Commercial Refrigeration"
+      ]
+    },
+    {
+      "prefix": "HEAL",
+      "name": "HEAL",
+      "course_count": 14,
+      "section_count": 132,
+      "colleges": [
+        "allan-hancock-college",
+        "barstow-community-college",
+        "citrus-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Balance and Mobility",
+        "Emergency Medical Response",
+        "Emergency Medical Services Career Preparation",
+        "Emergency Medical Technician - Basic",
+        "Health and Lifestyle"
+      ]
+    },
+    {
+      "prefix": "PERG",
+      "name": "College",
+      "course_count": 5,
+      "section_count": 132,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Career-Life Planning",
+        "College Success",
+        "Introduction to College",
+        "Life Skills & Personal Adjust",
+        "Stress Management & Well-Being"
+      ]
+    },
+    {
+      "prefix": "KINT",
+      "name": "KINT",
+      "course_count": 50,
+      "section_count": 131,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "pasadena-city-college",
+        "santa-rosa-junior-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Active Lifestyles: Personal Wellness and Nutrition",
+        "Advanced Basketball",
+        "Advanced Indoor Soccer",
+        "Advanced Volleyball",
+        "ANATOMICAL PRINCIPLES OF KINESIOLOGY AND FITNESS"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Medical",
+      "course_count": 39,
+      "section_count": 131,
+      "colleges": [
+        "cosumnes-river-college",
+        "cypress-college",
+        "fullerton-college",
+        "monterey-peninsula-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Admin Med Asst II",
+        "Administrative Medical Assisti",
+        "Administrative Medical Assisting",
+        "Allied Health Human Behavior",
+        "Allied Health Medical Ethics"
+      ]
+    },
+    {
+      "prefix": "ASTRO",
+      "name": "Astronomy",
+      "course_count": 20,
+      "section_count": 130,
+      "colleges": [
+        "cabrillo-college",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "los-medanos-college",
+        "madera-community-college",
+        "reedley-college",
+        "san-jose-city-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Astronomy Lab",
+        "Astronomy Laboratory",
+        "Directed Studies in Astronomy",
+        "Elementary Astronomy",
+        "Field Astro Calif Mountains"
+      ]
+    },
+    {
+      "prefix": "HLED",
+      "name": "Health",
+      "course_count": 7,
+      "section_count": 130,
+      "colleges": [
+        "bakersfield-college",
+        "golden-west-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Drugs, Health &amp; Society",
+        "Health Education",
+        "Healthy Aging for Life Learn",
+        "Nutrition and Health",
+        "Personal and Social Determinants of Health"
+      ]
+    },
+    {
+      "prefix": "ADJUS",
+      "name": "ADJUS",
+      "course_count": 44,
+      "section_count": 129,
+      "colleges": [
+        "contra-costa-college",
+        "diablo-valley-college",
+        "los-medanos-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Advanced Crime Scene Forensics",
+        "Basic Law Enforcement Academy",
+        "Community & the Justice System",
+        "Community and the Justice System",
+        "COMMUNITY RELATIONS"
+      ]
+    },
+    {
+      "prefix": "ACCS",
+      "name": "Skills",
+      "course_count": 29,
+      "section_count": 128,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Academic Success Strategies",
+        "Acquired Brain Injury",
+        "Basic Math Skills",
+        "Basic Reading &amp; Writing Skills",
+        "Comm Intervention"
+      ]
+    },
+    {
+      "prefix": "ALH",
+      "name": "ALH",
+      "course_count": 41,
+      "section_count": 128,
+      "colleges": [
+        "butte-college",
+        "cabrillo-college",
+        "el-camino-community-college-district",
+        "orange-coast-college",
+        "shasta-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Applied Pharmacology",
+        "Asepsis &amp; Surgical Procedures",
+        "Basic Sciences for Surg Tech",
+        "Certified Surg Tech Exam Prep",
+        "Clin Medical Assisting I Lab"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 58,
+      "section_count": 128,
+      "colleges": [
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "mission-college",
+        "rio-hondo-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "A+ & SECURITY PRIN",
+        "AI ESSENTIALS",
+        "AWS 1 Cloud Practitioner- Foundational",
+        "AWS 2 Solutions Architect- Associate",
+        "BEG C++ PROG"
+      ]
+    },
+    {
+      "prefix": "HSSOC",
+      "name": "History",
+      "course_count": 11,
+      "section_count": 127,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Ethnic Studies",
+        "Government 1",
+        "Introduction to Economics",
+        "Psychology",
+        "U.S. History 1"
+      ]
+    },
+    {
+      "prefix": "AHSD",
+      "name": "AHSD",
+      "course_count": 42,
+      "section_count": 126,
+      "colleges": [
+        "el-camino-community-college-district",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ALGEBRA IA",
+        "ALGEBRA IB",
+        "ART HISTORY",
+        "CONTEMPORARY AMERICAN SOCIAL ISSUES",
+        "ENVIRONMENTAL SCIENCE &ndash; ECOLOGY"
+      ]
+    },
+    {
+      "prefix": "CETH",
+      "name": "Ethnic",
+      "course_count": 4,
+      "section_count": 126,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Ethnic Studies, Cultural Pluralism, and American Law and Justice",
+        "Introduction to Ethnic Studies",
+        "Masculinities in U.S. Culture and Society",
+        "Women of Color in the USA"
+      ]
+    },
+    {
+      "prefix": "DRAMA",
+      "name": "DRAMA",
+      "course_count": 48,
+      "section_count": 126,
+      "colleges": [
+        "contra-costa-college",
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Advanced Principles of Acting",
+        "Advanced Styles in Scene Study: From Shakespeare to Shaw",
+        "Auditioning and Preparation for the Camera",
+        "Auditioning and Preparation for the Camera II",
+        "Auditioning Techniques"
+      ]
+    },
+    {
+      "prefix": "CHST",
+      "name": "CHST",
+      "course_count": 31,
+      "section_count": 125,
+      "colleges": [
+        "oxnard-college",
+        "rio-hondo-college",
+        "santa-ana-college",
+        "ventura-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Adult Supervision in Early Childhood Programs",
+        "Chicana Contemporary Issues",
+        "Chicana Latina Feminism",
+        "Chicana/o Cultural Identity",
+        "Chicano and Latino Std Issues"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 70,
+      "section_count": 123,
+      "colleges": [
+        "chaffey-college",
+        "college-of-alameda",
+        "cosumnes-river-college",
+        "gavilan-college",
+        "orange-coast-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "ADVANCED POWERPLANTS I",
+        "ADVANCED POWERPLANTS II",
+        "Aero Lab Projects",
+        "AIRFRAME A",
+        "Airframe Asmbly/Rig/ECS FAA"
+      ]
+    },
+    {
+      "prefix": "MICRO",
+      "name": "Microbiology",
+      "course_count": 2,
+      "section_count": 123,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "General Microbiology",
+        "Introductory Microbiology"
+      ]
+    },
+    {
+      "prefix": "CISA",
+      "name": "Microsoft",
+      "course_count": 14,
+      "section_count": 122,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Beginning Word Processing – Microsoft Word 2021",
+        "Database Management using Microsoft Access",
+        "Intermediate Database Management – Microsoft Access 2024",
+        "Intermediate Database Management using Access",
+        "Intermediate Electronic Spreadsheets – Microsoft Excel 2019"
+      ]
+    },
+    {
+      "prefix": "MUSP",
+      "name": "MUSP",
+      "course_count": 84,
+      "section_count": 122,
+      "colleges": [
+        "citrus-college",
+        "pasadena-city-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Applied Music (Individual Instruction): Brass",
+        "Applied Music (Individual Instruction): Guitar",
+        "Applied Music (Individual Instruction): Percussion",
+        "Applied Music (Individual Instruction): Piano",
+        "Applied Music (Individual Instruction): Strings"
+      ]
+    },
+    {
+      "prefix": "ATH",
+      "name": "ATH",
+      "course_count": 52,
+      "section_count": 121,
+      "colleges": [
+        "allan-hancock-college",
+        "cabrillo-college",
+        "evergreen-valley-college",
+        "gavilan-college",
+        "palo-verde-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "AGILITY/STRENGTH DEVELOPMENT",
+        "Athl. Conditioning",
+        "BASEBALL",
+        "Baseball Skills Dev",
+        "BASKETBALL"
+      ]
+    },
+    {
+      "prefix": "ELET",
+      "name": "ELET",
+      "course_count": 13,
+      "section_count": 121,
+      "colleges": [
+        "bakersfield-college",
+        "fullerton-college",
+        "lemoore-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Programmable Logic Controllers",
+        "Basic Electronics (DC)",
+        "Computer Integrated Manufacturing",
+        "Electric Motors and Controls",
+        "Electrical Trades Mathematics I"
+      ]
+    },
+    {
+      "prefix": "SOCO",
+      "name": "Sociology",
+      "course_count": 10,
+      "section_count": 121,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Adv Principles of Sociology",
+        "Contemporary Social Problems",
+        "Globalization & Social Change",
+        "Health and Society",
+        "Intro to Race and Ethnicity"
+      ]
+    },
+    {
+      "prefix": "HSENG",
+      "name": "English",
+      "course_count": 19,
+      "section_count": 120,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Bldg Vocabulary 2",
+        "Building Vocabulary 1",
+        "Building Vocabulary 3",
+        "College Preparatory Compositio",
+        "Composition 1"
+      ]
+    },
+    {
+      "prefix": "MTEC",
+      "name": "MTEC",
+      "course_count": 19,
+      "section_count": 120,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED SOUND DESIGN FOR GAMES",
+        "HISTORY OF MUSIC TECHNOLOGY",
+        "INTRODUCTION TO GAME AUDIO",
+        "INTRODUCTION TO MUSIC TECHNOLOGY",
+        "MIXING & MASTERING I"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 39,
+      "section_count": 119,
+      "colleges": [
+        "pasadena-city-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat and PDF",
+        "Advertising Principles",
+        "BASIC BOOKKEEPING",
+        "BASIC BUSINESS ENGLISH AND COMMUNICATIONS",
+        "BASIC BUSINESS MATH"
+      ]
+    },
+    {
+      "prefix": "ITAL",
+      "name": "Italian",
+      "course_count": 43,
+      "section_count": 119,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "el-camino-community-college-district",
+        "los-medanos-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college",
+        "sierra-college",
+        "southwestern-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Begin Conversational Italian",
+        "Beginning Italian",
+        "Continuing Elementary Italian",
+        "Continuing Intermediat Italian",
+        "Elementary Italian"
+      ]
+    },
+    {
+      "prefix": "ENGWR",
+      "name": "Writing",
+      "course_count": 10,
+      "section_count": 118,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Accelerated College Writing – Reserved Re-emerging Scholars",
+        "Advanced Writing Across the Curriculum (WAC)",
+        "Basic Writing Skill Development",
+        "College Composition and Literature",
+        "Critical Thinking and Writing through Literature"
+      ]
+    },
+    {
+      "prefix": "PBHS",
+      "name": "Health",
+      "course_count": 8,
+      "section_count": 118,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Drugs, Health, and Society",
+        "Health Education Promotion and Strategies",
+        "Health, Social Justice and Equity",
+        "Introduction to Public Health",
+        "Introduction to Public Health Informatics and Technology"
+      ]
+    },
+    {
+      "prefix": "ASAM",
+      "name": "Asian",
+      "course_count": 10,
+      "section_count": 117,
+      "colleges": [
+        "de-anza-college",
+        "golden-west-college"
+      ],
+      "sample_titles": [
+        "Asian American Experiences Past to Present",
+        "Asian American Women",
+        "Asian Americans and American Ideals, Institutions and Politics",
+        "Asian Americans and Asia",
+        "Asian Americans and Racism"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "DH",
+      "course_count": 95,
+      "section_count": 117,
+      "colleges": [
+        "cabrillo-college",
+        "cypress-college",
+        "fresno-city-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "santa-rosa-junior-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Advanced Periodontics",
+        "ADVANCED PERIODONTICS",
+        "ADVANCED TECHNIQUES IN CLINICAL DENTAL HYGIENE",
+        "CAPSTONE 2",
+        "CAREERS/LEADRSHP/RESEARCH"
+      ]
+    },
+    {
+      "prefix": "OCEA",
+      "name": "Oceanography",
+      "course_count": 9,
+      "section_count": 117,
+      "colleges": [
+        "barstow-community-college",
+        "cuyamaca-college",
+        "el-camino-community-college-district",
+        "grossmont-college",
+        "mt-san-antonio-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college",
+        "victor-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Intro to Oceanography - Honors",
+        "Intro to Oceanography Lab",
+        "Introduction to Oceanography",
+        "Introduction to the Marine Environment",
+        "Naturl Hist Greater SD Region"
+      ]
+    },
+    {
+      "prefix": "SWHS",
+      "name": "Work",
+      "course_count": 41,
+      "section_count": 117,
+      "colleges": [
+        "bakersfield-college",
+        "butte-college",
+        "chaffey-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "golden-west-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "santa-rosa-junior-college",
+        "southwestern-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Addiction Studies Practicum",
+        "Advanced Practices in Human Services",
+        "Advanced Techniques for Working with Groups",
+        "Basic Individual Intervention",
+        "Case Management"
+      ]
+    },
+    {
+      "prefix": "AAD",
+      "name": "AAD",
+      "course_count": 28,
+      "section_count": 116,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Adv Projects Photoshop",
+        "Bus Practices Creative Pro",
+        "Digital Animation",
+        "Digital Art Studio: Cncpt/Prac",
+        "Digital Illustration"
+      ]
+    },
+    {
+      "prefix": "AGNR",
+      "name": "AGNR",
+      "course_count": 37,
+      "section_count": 116,
+      "colleges": [
+        "shasta-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Agriculture Economics",
+        "Animal Health & Sanitation",
+        "Basic Logging Equipment Ops",
+        "Beginning Forestry",
+        "Computers in Ag and Nat Res"
+      ]
+    },
+    {
+      "prefix": "NURVN",
+      "name": "Nursing",
+      "course_count": 20,
+      "section_count": 116,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Advanced Med-Surg Nursing",
+        "Advanced Med-Surg Nursing Lab",
+        "Advanced Skills/Simulation Lab",
+        "Begin Skills & Simulation Lab",
+        "Beginning Med/Surg Lab"
+      ]
+    },
+    {
+      "prefix": "PHYC",
+      "name": "Physics",
+      "course_count": 6,
+      "section_count": 116,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Electricity, Magnetism & Heat",
+        "Fundamentals of Physics",
+        "Introductory Physics",
+        "Light, Optics & Modern Physics",
+        "Mechanics and Waves"
+      ]
+    },
+    {
+      "prefix": "ESLG",
+      "name": "Grammar",
+      "course_count": 8,
+      "section_count": 114,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced ESL Grammar",
+        "Advanced-Low Grammar",
+        "Basic English Grammar",
+        "Elements of English Sentences",
+        "Grammar for Intermediate ESL Writers"
+      ]
+    },
+    {
+      "prefix": "MCOM",
+      "name": "MCOM",
+      "course_count": 25,
+      "section_count": 114,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Advanced Screen Writing",
+        "Audio Multi-Track Production 1",
+        "Audio Multi-Track Production 2",
+        "Audio Multi-Track Production 3",
+        "Digital Program Production"
+      ]
+    },
+    {
+      "prefix": "RSPT",
+      "name": "Respiratory",
+      "course_count": 42,
+      "section_count": 114,
+      "colleges": [
+        "bakersfield-college",
+        "foothill-college",
+        "porterville-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "ADULT MECHANICAL VENTILATION",
+        "Advanced Cardiovascular Life Support - In Hospital Support",
+        "ADVANCED PULMONARY DIAGNOSTICS",
+        "ADVANCED RESPIRATORY THERAPY PHARMACOLOGY",
+        "APPLIED SCIENCE FOR RESPIRATORY THERAPY"
+      ]
+    },
+    {
+      "prefix": "ADS",
+      "name": "ADS",
+      "course_count": 66,
+      "section_count": 113,
+      "colleges": [
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "madera-community-college",
+        "napa-valley-college",
+        "oxnard-college",
+        "palo-verde-college",
+        "san-jose-city-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Addiction Prevention",
+        "Addiction Stud Intern Seminar",
+        "ADS Ethics and Confidentiality",
+        "ADS Field Exp. I",
+        "ADS Field Exp. II"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "AG",
+      "course_count": 58,
+      "section_count": 112,
+      "colleges": [
+        "allan-hancock-college",
+        "clovis-community-college",
+        "fresno-city-college",
+        "lemoore-college",
+        "reedley-college",
+        "shasta-college",
+        "ventura-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Small Animal Nursing",
+        "Ag & Nat. Res. Leadership III",
+        "Ag & Nat. Res. Leadership IV",
+        "Ag and Nat. Res. Leadership I",
+        "Ag and Nat. Res. Leadership II"
+      ]
+    },
+    {
+      "prefix": "SPFT",
+      "name": "Training",
+      "course_count": 20,
+      "section_count": 112,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "AEROBIC CIRCUITS",
+        "Bootcamp",
+        "Core and Restore I - Fundamentals",
+        "Core and Restore II - Beginning",
+        "CROSS FITNESS I - FUNDAMENTALS"
+      ]
+    },
+    {
+      "prefix": "CFE",
+      "name": "CFE",
+      "course_count": 16,
+      "section_count": 110,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Child Development Practicum-Emergent Leadership",
+        "Child Development Practicum-Observation and Assessment",
+        "Creative Experiences for Children",
+        "Curriculum Strategies for School Age Programs",
+        "Diversity in Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "ESTU",
+      "name": "Chicano",
+      "course_count": 8,
+      "section_count": 110,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Chicano Culture",
+        "Honors Introduction to Ethnic Studies",
+        "Introduction to African American Studies",
+        "Introduction to Ethnic Studies",
+        "The Chicano in Contemporary United States Society"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 46,
+      "section_count": 110,
+      "colleges": [
+        "american-river-college",
+        "barstow-community-college",
+        "coastline-community-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "gavilan-college",
+        "golden-west-college",
+        "orange-coast-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "santa-ana-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Applied Management",
+        "Business Communications",
+        "Business Writing",
+        "Elements of Management",
+        "Foodservice Management"
+      ]
+    },
+    {
+      "prefix": "ANIM",
+      "name": "ANIM",
+      "course_count": 41,
+      "section_count": 109,
+      "colleges": [
+        "mt-san-antonio-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "3DS Char Anim & Adv Key Tech",
+        "3DS Max Adv Effects & Comp",
+        "3DS Max Adv Model and Mtrls",
+        "3DS Max Fundamentals",
+        "Adv Matrials & Rndring in Maya"
+      ]
+    },
+    {
+      "prefix": "BUSA",
+      "name": "Accounting",
+      "course_count": 19,
+      "section_count": 109,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Accounting Ethics &amp; Leadership",
+        "Accounting Fundamentals for Bookkeepers",
+        "Accounting Principles for Bookkeepers",
+        "Bookkeeping - Accounting",
+        "Business Mathematics"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 40,
+      "section_count": 109,
+      "colleges": [
+        "chaffey-college",
+        "college-of-the-desert",
+        "sacramento-city-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Acute Care",
+        "Advanced Procedures Lab",
+        "Advanced Procedures Theory",
+        "Advanced Procedures-Advanced Modalities and Treatment Procedures",
+        "Beginning Procedures - Physical Therapy Modalities and Procedures"
+      ]
+    },
+    {
+      "prefix": "ADN",
+      "name": "Nursing",
+      "course_count": 34,
+      "section_count": 108,
+      "colleges": [
+        "rio-hondo-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "ADN Practicum",
+        "ADN Work Experience I",
+        "ADN Work Experience II",
+        "ADN Work Experience III",
+        "Adult Nursing"
+      ]
+    },
+    {
+      "prefix": "DMA",
+      "name": "DMA",
+      "course_count": 40,
+      "section_count": 108,
+      "colleges": [
+        "bakersfield-college",
+        "evergreen-valley-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "san-jose-city-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "2D ANIMATION",
+        "3D ANIMATION &amp; SIMULATIONS",
+        "3D Animation and Modeling",
+        "3D MODELING &amp; SCULPTING",
+        "Accessibility and UX Design"
+      ]
+    },
+    {
+      "prefix": "ICA",
+      "name": "ICA",
+      "course_count": 43,
+      "section_count": 108,
+      "colleges": [
+        "moorpark-college",
+        "oxnard-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Cond for Cross Country",
+        "Cond for Men&#39;s Baseball",
+        "Cond for Men&#39;s Basketball",
+        "Cond for Men&#39;s Soccer",
+        "Cond for Women&#39;s Basketball"
+      ]
+    },
+    {
+      "prefix": "FTVE",
+      "name": "FTVE",
+      "course_count": 53,
+      "section_count": 107,
+      "colleges": [
+        "cuesta-college",
+        "diablo-valley-college",
+        "gavilan-college",
+        "oxnard-college",
+        "rio-hondo-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced TV Studio Production",
+        "American Cinema 1900-1950",
+        "American Cinema 1950 to the Present",
+        "American Cinema/American Culture",
+        "American Ethnic Cultures in Film"
+      ]
+    },
+    {
+      "prefix": "NCAL",
+      "name": "Older",
+      "course_count": 22,
+      "section_count": 107,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ACTING I FOR OLDER ADULTS",
+        "ACTING III FOR OLDER ADULTS",
+        "ADVANCED CERAMICS FOR OLDER ADULTS",
+        "AUDITIONING FOR THEATRE FOR OLDER ADULTS",
+        "BEGINNING CERAMICS HANDBUILDING FOR OLDER ADULTS"
+      ]
+    },
+    {
+      "prefix": "AFRAM",
+      "name": "African",
+      "course_count": 31,
+      "section_count": 106,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "contra-costa-college",
+        "fresno-city-college",
+        "laney-college",
+        "merritt-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "AFRAM MUSIC",
+        "AFRAM WOMEN",
+        "AFRICAN AMERICAN CULTURE: BLACK MUSIC, ART, AND LITERATURE",
+        "African American Experience Through Films",
+        "African American History: Africa to 1865"
+      ]
+    },
+    {
+      "prefix": "DRAM",
+      "name": "DRAM",
+      "course_count": 50,
+      "section_count": 106,
+      "colleges": [
+        "butte-college",
+        "san-diego-city-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Advanced Stagecraft",
+        "Beginning Acting",
+        "Beginning Costuming"
+      ]
+    },
+    {
+      "prefix": "FN",
+      "name": "Nutrition",
+      "course_count": 25,
+      "section_count": 106,
+      "colleges": [
+        "butte-college",
+        "clovis-community-college",
+        "coastline-community-college",
+        "fresno-city-college",
+        "madera-community-college",
+        "orange-coast-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "Applied Nutrition",
+        "Careers-Dietetics/FDSCI",
+        "CHILD NUTRITION",
+        "Dietary Mang Work Exp Ed 3",
+        "Food and Culture"
+      ]
+    },
+    {
+      "prefix": "HOC",
+      "name": "HOC",
+      "course_count": 30,
+      "section_count": 106,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Adv. Medical/Surgical Theory",
+        "Advanced Clinical Practicum",
+        "Advanced Project-Based Medical Surgical Reasoning",
+        "Advanced Skills/Simulation Lab",
+        "Beg. Clinical Practicum"
+      ]
+    },
+    {
+      "prefix": "KINX",
+      "name": "KINX",
+      "course_count": 36,
+      "section_count": 106,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Baseball - Men",
+        "Basketball - Men",
+        "Basketball - Women",
+        "Beach Volleyball - Women",
+        "Cardio Lab Supervision"
+      ]
+    },
+    {
+      "prefix": "JAPAN",
+      "name": "Japanese",
+      "course_count": 24,
+      "section_count": 105,
+      "colleges": [
+        "cabrillo-college",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "east-los-angeles-college",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "laney-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-pierce-college",
+        "sacramento-city-college",
+        "san-jose-city-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Conversational Japanese",
+        "Elementary Japanese",
+        "ELEMENTARY JAPANESE",
+        "Elementary Japanese 1",
+        "Elementary Japanese Conversation"
+      ]
+    },
+    {
+      "prefix": "V",
+      "name": "Veterinary",
+      "course_count": 31,
+      "section_count": 105,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED SMALL ANIMAL NURSING",
+        "ANIMAL CARE SKILLS I",
+        "CAREER EXPLORATION FOR VETERINARY NURSES",
+        "CLINICAL INTERNSHIP I",
+        "CLINICAL INTERNSHIP II"
+      ]
+    },
+    {
+      "prefix": "AVIM",
+      "name": "AVIM",
+      "course_count": 37,
+      "section_count": 104,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Aircraft Cabin Atmosphere Cntl",
+        "Aircraft Hydraulic Systems",
+        "Aircraft Landing Gear Systems",
+        "Aircraft Propeller Systems",
+        "Aircraft Weld / Sht Mtl Struc"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 18,
+      "section_count": 104,
+      "colleges": [
+        "hartnell-college",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Chemistry",
+        "General Chemistry",
+        "General Chemistry I",
+        "General Chemistry I - Honors",
+        "General Chemistry II"
+      ]
+    },
+    {
+      "prefix": "DEAF",
+      "name": "American",
+      "course_count": 15,
+      "section_count": 104,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I – HSI-Early College Program",
+        "American Sign Language II – HSI-Early College Program",
+        "American Sign Language III",
+        "American Sign Language IV",
+        "American Sign Language Literature"
+      ]
+    },
+    {
+      "prefix": "ELL",
+      "name": "ELL",
+      "course_count": 45,
+      "section_count": 104,
+      "colleges": [
+        "coastline-community-college",
+        "golden-west-college",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Adv Academic Reading &amp;Writing",
+        "Adv Listen &amp; Speak Trans Acad",
+        "Adv Read &amp; Write Tran Acad",
+        "Advanced Grammar Review 1",
+        "Advanced Pronunciation"
+      ]
+    },
+    {
+      "prefix": "AFRO AM",
+      "name": "African",
+      "course_count": 6,
+      "section_count": 103,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "African-American Literature I",
+        "Black Americans And The Political System",
+        "Introduction to African American Studies",
+        "The African American Experience in the U.S. after Reconstruction",
+        "The African American Experience in the U.S. before Reconstruction"
+      ]
+    },
+    {
+      "prefix": "MACH",
+      "name": "MACH",
+      "course_count": 59,
+      "section_count": 103,
+      "colleges": [
+        "fullerton-college",
+        "laney-college",
+        "napa-valley-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Adv Multi Axis Programming",
+        "Advanced CNC Machining (formerly MACH 088 F)",
+        "Advanced CNC Programming Using Mastercam (formerly MACH 052 F)",
+        "Advanced CNC Swiss Style Lathe Set-Up and Operation",
+        "Advanced Machine Tools (formerly MACH 093 F)"
+      ]
+    },
+    {
+      "prefix": "THA",
+      "name": "THA",
+      "course_count": 71,
+      "section_count": 103,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "moorpark-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Acting for Film &amp; Television I",
+        "Acting for Film and TV I",
+        "Acting for Film and TV II",
+        "Acting I",
+        "Acting II"
+      ]
+    },
+    {
+      "prefix": "ENGLT",
+      "name": "Literature",
+      "course_count": 35,
+      "section_count": 102,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "African American Literature",
+        "African-American Literature (1730-1930)",
+        "African-American Literature (1930-Present)",
+        "American Literature I",
+        "American Literature II"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Science",
+      "course_count": 21,
+      "section_count": 100,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "barstow-community-college",
+        "golden-west-college",
+        "lassen-community-college",
+        "moorpark-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "solano-community-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Atmospheric Science Laboratory",
+        "Concepts in Physical Science",
+        "Earth &amp; the Universe",
+        "Eastern Sierra NV-Adv Studies"
+      ]
+    },
+    {
+      "prefix": "KINACT",
+      "name": "KINACT",
+      "course_count": 17,
+      "section_count": 99,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Advanced Body Conditioning",
+        "Advanced Tennis",
+        "Advanced Volleyball",
+        "Basketball",
+        "Beginning Body Conditioning"
+      ]
+    },
+    {
+      "prefix": "CISN",
+      "name": "CISN",
+      "course_count": 33,
+      "section_count": 98,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "mt-san-antonio-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Network Systems Administration",
+        "Cisco CCNA Netwrking &amp; Routing",
+        "Cisco CCNA Ntwrk &amp; Routing Lab",
+        "CISCO Networking Academy (CCNA)tm: Enterprise Networking, Security, and Automation – Cisco Networking Academy",
+        "CISCO Networking Academy (CCNA)tm: Introduction to Networks"
+      ]
+    },
+    {
+      "prefix": "ENGTC",
+      "name": "ENGTC",
+      "course_count": 16,
+      "section_count": 98,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Applications for Industrial Robotics",
+        "CNC Programming and Machining",
+        "Computer Aided Design and Drafting - AutoCAD",
+        "Computer Aided Drafting Design, Advanced Concepts - AutoCAD",
+        "Framework for Applied Robotics"
+      ]
+    },
+    {
+      "prefix": "ID",
+      "name": "ID",
+      "course_count": 51,
+      "section_count": 98,
+      "colleges": [
+        "chaffey-college",
+        "mt-san-antonio-college",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Appl Color/Dsgn Theory",
+        "BIM for Interior Design NC",
+        "Building Info Modeling for ID",
+        "Building Systems for ID",
+        "Business Practices for ID"
+      ]
+    },
+    {
+      "prefix": "NCE",
+      "name": "NCE",
+      "course_count": 30,
+      "section_count": 98,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Advanced Grammar and Editing",
+        "Advanced Listening and Speaking",
+        "Advanced Reading and Writing",
+        "Beginning ESL College Skills",
+        "Beginning ESL I"
+      ]
+    },
+    {
+      "prefix": "COU",
+      "name": "COU",
+      "course_count": 15,
+      "section_count": 97,
+      "colleges": [
+        "hartnell-college",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Career and Personality Assessments",
+        "Career Interest & Ability Asse",
+        "Careers and Life Styles",
+        "Careers Search Tools",
+        "Ensuring Transfer Success"
+      ]
+    },
+    {
+      "prefix": "CULIN",
+      "name": "CULIN",
+      "course_count": 42,
+      "section_count": 97,
+      "colleges": [
+        "contra-costa-college",
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Advanced Classical and Modern Food Preparation",
+        "American Food and Culture",
+        "Artisan Breads",
+        "Baking Fundamentals",
+        "Becoming ServSafe Certified"
+      ]
+    },
+    {
+      "prefix": "HSE",
+      "name": "Hisetged",
+      "course_count": 9,
+      "section_count": 97,
+      "colleges": [
+        "hartnell-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Hiset/Ged Level 1",
+        "HISET/GED Level 1 in Spanish",
+        "HISET/GED Level 2 in Spanish",
+        "Hiset/Ged Level 3",
+        "HISET/GED Level 3 in Spanish"
+      ]
+    },
+    {
+      "prefix": "BUSM",
+      "name": "Business",
+      "course_count": 12,
+      "section_count": 96,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Business Organization &amp; Manage",
+        "Human Relations in Business",
+        "Human Resource Management",
+        "Prin of Cont Qual Improvement",
+        "Principle of Export and Import"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "EET",
+      "course_count": 24,
+      "section_count": 96,
+      "colleges": [
+        "cuesta-college",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Alternating Current Circuits",
+        "Circuit Diagnosis and Analysis: Troubleshooting",
+        "Comm and Indust Wiring Sys",
+        "Comp Instr and Control",
+        "Digital Circuits and Devices"
+      ]
+    },
+    {
+      "prefix": "LANHT",
+      "name": "Landscape",
+      "course_count": 47,
+      "section_count": 96,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Advanced Landscape Design",
+        "ALPINES LAB",
+        "Applied Aerial Tree Work",
+        "Applied Structural Pruning",
+        "ARBORICULTURE (EVENING)"
+      ]
+    },
+    {
+      "prefix": "MICR",
+      "name": "Microbiology",
+      "course_count": 12,
+      "section_count": 96,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "mt-san-antonio-college",
+        "oxnard-college",
+        "pasadena-city-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Directed Studies: Microbiology",
+        "Fundamentals of Microbiology",
+        "General Microbiology",
+        "Introduction to Immunology",
+        "Microbiology"
+      ]
+    },
+    {
+      "prefix": "PD",
+      "name": "PD",
+      "course_count": 17,
+      "section_count": 96,
+      "colleges": [
+        "allan-hancock-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adapted Computer Instruction",
+        "Adult Learning Assessment",
+        "Career Plan: Career Mjr Selec",
+        "Career Plan: Job Search Skills",
+        "Career Planning"
+      ]
+    },
+    {
+      "prefix": "REAL ES",
+      "name": "Real",
+      "course_count": 12,
+      "section_count": 96,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Common-Interest Developments",
+        "Escrow Principles",
+        "Legal Aspects Of Real Estate I",
+        "Legal Aspects Of Real Estate II",
+        "Property Management"
+      ]
+    },
+    {
+      "prefix": "VMED",
+      "name": "VMED",
+      "course_count": 23,
+      "section_count": 96,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Acute Care Theory Nurse Assist",
+        "Behavior Tech Cert Training",
+        "Body Systems for Medical Asstn",
+        "Busines Proc for Med Assistant",
+        "Caregiver Training"
+      ]
+    },
+    {
+      "prefix": "SOCIO",
+      "name": "SOCIO",
+      "course_count": 18,
+      "section_count": 95,
+      "colleges": [
+        "contra-costa-college",
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking About Social and Cultural Issues",
+        "Families, Relationships, and Commitment",
+        "Gender, Culture, and Society",
+        "Introduction to Marriage and Family",
+        "Introduction to Race and Ethnicity"
+      ]
+    },
+    {
+      "prefix": "CRPS",
+      "name": "CRPS",
+      "course_count": 8,
+      "section_count": 94,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Forage Crops",
+        "Integrated Pest Management",
+        "Introduction to Viticulture",
+        "Plant Pest Identification and Control",
+        "Plant Science"
+      ]
+    },
+    {
+      "prefix": "GNBUS",
+      "name": "GNBUS",
+      "course_count": 25,
+      "section_count": 94,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Beg. Keyboarding",
+        "Bus Comp Apps",
+        "Business Ethics",
+        "Business Info Work",
+        "Business Law"
+      ]
+    },
+    {
+      "prefix": "WEE",
+      "name": "Work",
+      "course_count": 8,
+      "section_count": 94,
+      "colleges": [
+        "allan-hancock-college",
+        "college-of-the-siskiyous",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Beginning Work Experience Education",
+        "Coop. Work Exp: General",
+        "Intermediate Work Experience Education",
+        "Internship Work Experience Education",
+        "Pre-Internship Preparation"
+      ]
+    },
+    {
+      "prefix": "AHIS",
+      "name": "History",
+      "course_count": 21,
+      "section_count": 93,
+      "colleges": [
+        "el-camino-community-college-district",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Art Hist Mex/Central/S America",
+        "Art History Prehistoric-Gothic",
+        "Art History Renaissance-Modern",
+        "Art/Visual Cultr: Glbl Perspec",
+        "Culture and Art of Pompeii"
+      ]
+    },
+    {
+      "prefix": "NCOM",
+      "name": "Academic",
+      "course_count": 2,
+      "section_count": 92,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Academic Enrichment",
+        "Journalism and Mass Communications Skills Development"
+      ]
+    },
+    {
+      "prefix": "NCOA",
+      "name": "Older",
+      "course_count": 5,
+      "section_count": 91,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Chorus Singing for Older Adults",
+        "Dance Grooves for Older Adults",
+        "Painting for Older Adults",
+        "Principles of Mind and Body Health for Older Adults II: Strength and Balance",
+        "Principles of Mind and Body Health for Older Adults: Flexibility and Balance"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 55,
+      "section_count": 91,
+      "colleges": [
+        "clovis-community-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "sacramento-city-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Adv Prsnl & Prof Resp",
+        "Assistive Technology for OTAs",
+        "Clin Reasn and Elect Doc in Ot",
+        "Clinical Practicum IV",
+        "Clinical Practicum V"
+      ]
+    },
+    {
+      "prefix": "PFIT",
+      "name": "PFIT",
+      "course_count": 33,
+      "section_count": 91,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Advanced Weight Training",
+        "Aerobic Conditioning",
+        "Beginning Weight Training",
+        "Circuit Training",
+        "Core Fitness Training"
+      ]
+    },
+    {
+      "prefix": "ATCBE",
+      "name": "ATCBE",
+      "course_count": 57,
+      "section_count": 89,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "A/C System tests",
+        "Batteries",
+        "Battery Drain",
+        "Brake Fluids",
+        "Caliper Assembly"
+      ]
+    },
+    {
+      "prefix": "ECOL",
+      "name": "ECOL",
+      "course_count": 11,
+      "section_count": 89,
+      "colleges": [
+        "coastline-community-college",
+        "cuesta-college",
+        "gavilan-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adapted Exercise",
+        "Art: Drawing",
+        "Art: Painting",
+        "Art: Watercolor",
+        "Composing Your Life Story"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "Hazmat",
+      "course_count": 20,
+      "section_count": 89,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Company Officer 2B: Gen Admin",
+        "Company Officer 2C: Fire Insp",
+        "Company Officer 2E: Wildland",
+        "Fire Control 5A",
+        "Haz Mat Tech Spec Refresh II"
+      ]
+    },
+    {
+      "prefix": "KIND",
+      "name": "Dance",
+      "course_count": 36,
+      "section_count": 89,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Ballet Fundamentals Ic",
+        "Basic Modern Dance I",
+        "Basic Modern Dance II",
+        "Basic Yogalates",
+        "Beg Modern Dance I"
+      ]
+    },
+    {
+      "prefix": "BUSTEC",
+      "name": "BUSTEC",
+      "course_count": 34,
+      "section_count": 88,
+      "colleges": [
+        "american-river-college",
+        "chaffey-college",
+        "cosumnes-river-college",
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Administrative Bookkeeping",
+        "Advanced Business Applications",
+        "Beginning Computer Keyboarding",
+        "Business Procedures for Professional Success",
+        "Comp Keybrd: Speed & Accuracy"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 25,
+      "section_count": 88,
+      "colleges": [
+        "allan-hancock-college",
+        "cosumnes-river-college",
+        "fresno-city-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Advanced ICD Coding",
+        "Basic ICD-CM Coding",
+        "Basic Medical Terminology",
+        "Basic Pharmacology",
+        "Comp Info for Health Info Tech"
+      ]
+    },
+    {
+      "prefix": "MUSE",
+      "name": "MUSE",
+      "course_count": 31,
+      "section_count": 88,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Beginning Guitar I",
+        "Beginning Guitar II",
+        "Elementary Piano I",
+        "Elementary Piano II",
+        "Harmony I"
+      ]
+    },
+    {
+      "prefix": "CISS",
+      "name": "Security",
+      "course_count": 22,
+      "section_count": 87,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "mt-san-antonio-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Cisco Networking Academy(R): CyberOps Associate – Cisco Networking Academy",
+        "Cisco Networking Academy(R): Network Security – Cisco Networking Academy",
+        "CNASM Service Learning",
+        "Computer Forensics and Investigation",
+        "Cyber Cloud Sec Firewalls Lab"
+      ]
+    },
+    {
+      "prefix": "MM/AN",
+      "name": "Animation",
+      "course_count": 27,
+      "section_count": 87,
+      "colleges": [
+        "berkeley-city-college"
+      ],
+      "sample_titles": [
+        "2D Digital Animation",
+        "3D Character Animation",
+        "3D Layout and Lighting",
+        "3D Rigging",
+        "Animation and Game Studio Practice"
+      ]
+    },
+    {
+      "prefix": "BUMA",
+      "name": "BUMA",
+      "course_count": 14,
+      "section_count": 86,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "BUS CALC",
+        "BUS COMMUNICATIONS",
+        "BUS MGMT WORK EXPER",
+        "BUSINESS LAW I",
+        "BUSINESS STATISTICS"
+      ]
+    },
+    {
+      "prefix": "MUP",
+      "name": "Ensemble",
+      "course_count": 25,
+      "section_count": 86,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Chamber Jazz Ensemble",
+        "Advanced College Choir",
+        "Advanced Concert Band",
+        "Advanced Concert Choir",
+        "Advanced Jazz Band"
+      ]
+    },
+    {
+      "prefix": "NESL",
+      "name": "NESL",
+      "course_count": 25,
+      "section_count": 86,
+      "colleges": [
+        "el-camino-community-college-district",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Advanced Listen/Spkng/Pronun",
+        "Advanced Reading",
+        "Advanced Writing & Grammar",
+        "Citizenship Preparation",
+        "Elementary Writing & Grammar"
+      ]
+    },
+    {
+      "prefix": "PEAT",
+      "name": "Offseason",
+      "course_count": 22,
+      "section_count": 86,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Intercollegiate Basketball",
+        "Intercollegiate Cross Country",
+        "Intercollegiate Football",
+        "Intercollegiate Soccer",
+        "Intercollegiate Volleyball"
+      ]
+    },
+    {
+      "prefix": "STU",
+      "name": "STU",
+      "course_count": 6,
+      "section_count": 86,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Career and Job Search Prep",
+        "College Success",
+        "Employment Skills",
+        "Gen Tutor Lab/Supvsd Tutoring",
+        "Get Connected: Orien - College"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "ACR",
+      "course_count": 41,
+      "section_count": 85,
+      "colleges": [
+        "college-of-the-desert",
+        "compton-college",
+        "cypress-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Auto Detailing",
+        "Air Cond Fundamentals",
+        "AIR COND/REF/ELEC I",
+        "AIR COND/REF/ELEC II",
+        "Air Conditioning Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CDFS",
+      "name": "CDFS",
+      "course_count": 36,
+      "section_count": 85,
+      "colleges": [
+        "cuesta-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Admin I Prog ECE",
+        "Admin II Pers Lead in ECE",
+        "Adult Supervision: The Mentor Teacher",
+        "Adult Supervision/Mentoring",
+        "Art and Scientific Inquiry for ECE"
+      ]
+    },
+    {
+      "prefix": "IATH",
+      "name": "Intercollegiate",
+      "course_count": 23,
+      "section_count": 84,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Defensive Football Lab",
+        "Intercoll Phys Fitness-Wm Golf",
+        "Intercollegiate Baseball",
+        "Intercollegiate Football",
+        "Intercollegiate Men&#39;s Basketball - Fall"
+      ]
+    },
+    {
+      "prefix": "LETP",
+      "name": "LETP",
+      "course_count": 18,
+      "section_count": 84,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Arrest and Control/Driving (PSP)",
+        "Community Service Officer",
+        "Defensive Tactics Instructor",
+        "Dispatch Field Training Program",
+        "Field Training Program"
+      ]
+    },
+    {
+      "prefix": "NCCC",
+      "name": "NCCC",
+      "course_count": 27,
+      "section_count": 84,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "120-140 WPM Speed Goal",
+        "120-140 WPM: Multi-Voice Focus",
+        "160 WPM Speed Goal",
+        "160 WPM: Multi-Voice Focus",
+        "180 WPM Speed Goal"
+      ]
+    },
+    {
+      "prefix": "PDEV",
+      "name": "PDEV",
+      "course_count": 10,
+      "section_count": 84,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Assertiveness Training",
+        "Career Exploration Internship",
+        "Career Exploration-Self Assess",
+        "Career Planning",
+        "College and Life Success"
+      ]
+    },
+    {
+      "prefix": "WEXP",
+      "name": "Work",
+      "course_count": 5,
+      "section_count": 84,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "cuesta-college",
+        "folsom-lake-college",
+        "pasadena-city-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Work Experience",
+        "Work Experience - General",
+        "Work Experience in (Subject)",
+        "WORK EXPERIENCE/INTERNSHIP"
+      ]
+    },
+    {
+      "prefix": "DDP",
+      "name": "DDP",
+      "course_count": 27,
+      "section_count": 83,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "3D ANIMATION",
+        "ACCESSIBILITY COMPLIANCE",
+        "ASSISTIVE TECH",
+        "CHARACTER ANIMATION",
+        "CONTENT FOR ACCESSIBILITY"
+      ]
+    },
+    {
+      "prefix": "HUSV",
+      "name": "HUSV",
+      "course_count": 37,
+      "section_count": 83,
+      "colleges": [
+        "allan-hancock-college",
+        "berkeley-city-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Addiction Studies Prac Seminar",
+        "Addiction Studies Practicum",
+        "Addiction Treatment &amp; Recovery",
+        "Adulthood and Aging",
+        "Alcohol, Other Drugs, and Addi"
+      ]
+    },
+    {
+      "prefix": "LING",
+      "name": "Language",
+      "course_count": 21,
+      "section_count": 83,
+      "colleges": [
+        "bakersfield-college",
+        "clovis-community-college",
+        "cypress-college",
+        "de-anza-college",
+        "fresno-city-college",
+        "lemoore-college",
+        "madera-community-college",
+        "monterey-peninsula-college",
+        "mt-san-antonio-college",
+        "pasadena-city-college",
+        "porterville-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "Foundations of Language",
+        "HISTORY OF THE ENGLISH LANGUAGE",
+        "INDEPENDENT STUDY",
+        "INTRO TO LANGUAGE",
+        "Intro to World Languages"
+      ]
+    },
+    {
+      "prefix": "MUSA",
+      "name": "MUSA",
+      "course_count": 42,
+      "section_count": 83,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Acoustics for Audio Production",
+        "Advanced Applied Music - Master Class (formerly titled Advanced Applied Music - Individualized Priv",
+        "Advanced Percussion I",
+        "Advanced Percussion II",
+        "Advanced Voice-English and American Art Song"
+      ]
+    },
+    {
+      "prefix": "DANCEST",
+      "name": "Dance",
+      "course_count": 21,
+      "section_count": 82,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Ballet II",
+        "Ballet III",
+        "Choreography I",
+        "Choreography II"
+      ]
+    },
+    {
+      "prefix": "MAKR",
+      "name": "MAKR",
+      "course_count": 30,
+      "section_count": 82,
+      "colleges": [
+        "college-of-alameda",
+        "college-of-the-desert",
+        "folsom-lake-college",
+        "moorpark-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "3D Printer - Design and Testing",
+        "3D Printer - Introduction and Safety",
+        "3D Printer - Production",
+        "BASIC MAKERSPACE SKILLS 2",
+        "BASIC MAKERSPACE SKILLS I"
+      ]
+    },
+    {
+      "prefix": "BUSC",
+      "name": "Computer",
+      "course_count": 13,
+      "section_count": 81,
+      "colleges": [
+        "monterey-peninsula-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Applied Business Statistics",
+        "Computer Applications - Microsoft Office Excel",
+        "Computer Applications - Microsoft Office PowerPoint",
+        "Computer Applications - Microsoft Office Word",
+        "Keyboarding"
+      ]
+    },
+    {
+      "prefix": "CH",
+      "name": "Chemistry",
+      "course_count": 8,
+      "section_count": 81,
+      "colleges": [
+        "college-of-the-desert",
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "BIO-ORGANIC CHEMISTRY",
+        "FUNDAMENTALS OF CHEMISTRY",
+        "GEN CHEMISTRY II",
+        "GENERAL CHEMISTRY I",
+        "INTRO GENERAL CHEM"
+      ]
+    },
+    {
+      "prefix": "RADTEC",
+      "name": "Radiographic",
+      "course_count": 24,
+      "section_count": 81,
+      "colleges": [
+        "chaffey-college",
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Anat and Rad Pos III",
+        "Anat/Radiographic Positioning",
+        "Anatomy/Radiograph Position II",
+        "Fluoro and Clin App",
+        "Introduction to Radiologic Technology"
+      ]
+    },
+    {
+      "prefix": "ARTDM",
+      "name": "Digital",
+      "course_count": 26,
+      "section_count": 80,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "3D Modeling and Animation I",
+        "3D Modeling and Animation II",
+        "Design Portfolio and Career Preparation",
+        "Digital Animation",
+        "Digital Illustration"
+      ]
+    },
+    {
+      "prefix": "HE",
+      "name": "Health",
+      "course_count": 11,
+      "section_count": 80,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "coalinga-college",
+        "gavilan-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Ethnic Health Issues",
+        "First Aid and Emergency Care",
+        "Health Education",
+        "HEALTH EDUCATION",
+        "HUMAN SEXUALITY"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 36,
+      "section_count": 80,
+      "colleges": [
+        "bakersfield-college",
+        "butte-college",
+        "coalinga-college",
+        "fresno-city-college",
+        "gavilan-college",
+        "orange-coast-college",
+        "porterville-college",
+        "sacramento-city-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Air Cond &amp; Refrig Controls",
+        "Air Cond/Refrigeratn Princpl",
+        "Air Conditioning Service",
+        "BASIC ELECTRICAL",
+        "Basic Electrical for HVAC-R"
+      ]
+    },
+    {
+      "prefix": "CHD",
+      "name": "Child Development",
+      "course_count": 34,
+      "section_count": 79,
+      "colleges": [
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Admin II:Personnel/Leadership",
+        "Adult Supervision & Mentoring",
+        "Adult Supervision in Early Childhood Programs",
+        "Art and Creative Development of Young Children",
+        "Child Abuse"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 30,
+      "section_count": 79,
+      "colleges": [
+        "butte-college",
+        "citrus-college",
+        "evergreen-valley-college",
+        "gavilan-college",
+        "orange-coast-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "ADVANCED COSMETOLOGY",
+        "Advanced Hairstyling and Hair Extension Techniques",
+        "BEGINNING COSMO",
+        "Business and Licensing Preparation for Cosmetologists",
+        "Cosmetology Advanced 1"
+      ]
+    },
+    {
+      "prefix": "CPE",
+      "name": "CPE",
+      "course_count": 10,
+      "section_count": 79,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Academics for Disabled",
+        "Applied Arts-Disabled",
+        "Communication Skills-Disabled",
+        "Community Integration-Disabled",
+        "Culinary Arts for Disabled"
+      ]
+    },
+    {
+      "prefix": "ENGIN",
+      "name": "Engineering",
+      "course_count": 38,
+      "section_count": 79,
+      "colleges": [
+        "chaffey-college",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "laney-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis",
+        "Computer Programming for Engineers Using MATLAB",
+        "COMPUTER PROGRAMMING FOR ENGINEERS USING MATLAB",
+        "Energy, Society, and the Environment",
+        "Engineer Appls of Digital Comp"
+      ]
+    },
+    {
+      "prefix": "FCS",
+      "name": "Life",
+      "course_count": 9,
+      "section_count": 79,
+      "colleges": [
+        "allan-hancock-college",
+        "cosumnes-river-college",
+        "evergreen-valley-college",
+        "mt-san-antonio-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Child Development",
+        "Consumer and Family Finance",
+        "Human Development: A Life Span",
+        "Life Management",
+        "Life Management and Adulting"
+      ]
+    },
+    {
+      "prefix": "FTMA",
+      "name": "FTMA",
+      "course_count": 38,
+      "section_count": 79,
+      "colleges": [
+        "moorpark-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Beginning Audio Production",
+        "Beginning Motion Picture Prod",
+        "Beginning Radio and Podcasting",
+        "Beginning Single Camera Prod",
+        "Cinema As Expression Comm"
+      ]
+    },
+    {
+      "prefix": "HEIT",
+      "name": "HEIT",
+      "course_count": 26,
+      "section_count": 79,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Basic Pharmacology",
+        "Computerized Health Information Systems",
+        "CPT Coding",
+        "Current Procedural Terminology (CPT) Coding",
+        "Directed Clinical Practice"
+      ]
+    },
+    {
+      "prefix": "KINTM",
+      "name": "Team",
+      "course_count": 40,
+      "section_count": 79,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Baseball Team Class, Men",
+        "Basketball Team Activity, Men",
+        "Basketball Team Activty, Women",
+        "Basketbl Team Activity, Women",
+        "Football Team Activity"
+      ]
+    },
+    {
+      "prefix": "KNICA",
+      "name": "Intercollegiate",
+      "course_count": 37,
+      "section_count": 79,
+      "colleges": [
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Advanced Baseball Skills for Athletes",
+        "Advanced Basketball Skills for Athletes",
+        "Advanced Soccer Skills for Athletes",
+        "Advanced Softball Skills for Athletes",
+        "Advanced Volleyball Skills for Athletes"
+      ]
+    },
+    {
+      "prefix": "TVR",
+      "name": "Production",
+      "course_count": 30,
+      "section_count": 79,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DIGITAL VIDEO EFFECTS EDITING",
+        "ADVANCED RADIO PRODUCTION",
+        "BEGINNING AUDIO PRODUCTION",
+        "BEGINNING DIGITAL VIDEO EDITING",
+        "BEGINNING RADIO PRODUCTION"
+      ]
+    },
+    {
+      "prefix": "APE",
+      "name": "Adapted",
+      "course_count": 25,
+      "section_count": 78,
+      "colleges": [
+        "evergreen-valley-college",
+        "gavilan-college",
+        "san-jose-city-college",
+        "santa-rosa-junior-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "ADAPT CARDIO TRNG",
+        "Adapted Body Conditioning",
+        "Adapted Functional Movement",
+        "ADAPTED PE",
+        "ADAPTED PHYSICAL EDUCATION"
+      ]
+    },
+    {
+      "prefix": "FIRS",
+      "name": "Fire",
+      "course_count": 30,
+      "section_count": 78,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Advncd Incident Comm Sys I-400",
+        "Auto Extrication",
+        "Bldg Construction-Fire Protect",
+        "Chief Fire Officer 3A: HR Mgt",
+        "Chief Fire Officer 3B: Bgt/Fis"
+      ]
+    },
+    {
+      "prefix": "ITRN",
+      "name": "ITRN",
+      "course_count": 5,
+      "section_count": 78,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "INTERNSHIP"
+      ]
+    },
+    {
+      "prefix": "LRNRE",
+      "name": "LRNRE",
+      "course_count": 26,
+      "section_count": 78,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Basic English for Life and Career Success",
+        "Basic Math for Life and Career Success",
+        "Career Awareness, Disability",
+        "Career Awareness, Disability and Success",
+        "COMMUNICATION STRATEGIES"
+      ]
+    },
+    {
+      "prefix": "TAFILM",
+      "name": "Film",
+      "course_count": 13,
+      "section_count": 78,
+      "colleges": [
+        "american-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Cinema Genres – Horror/Suspense Films",
+        "Diversity in American Film",
+        "Film Editing",
+        "Film Making"
+      ]
+    },
+    {
+      "prefix": "VOCE",
+      "name": "VOCE",
+      "course_count": 31,
+      "section_count": 78,
+      "colleges": [
+        "allan-hancock-college",
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Beginning Floral Design",
+        "Beginning Keyboard &amp; Mouse",
+        "CA Conservation Awareness",
+        "Computer Skills Lab",
+        "Computers and You: Level 2"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 22,
+      "section_count": 77,
+      "colleges": [
+        "hartnell-college",
+        "mission-college",
+        "palo-verde-college",
+        "rio-hondo-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "College Physics II",
+        "Engineering Physics-Atomic",
+        "Engineering Physics-Electricity and Magnetism",
+        "Engineering Physics-Light and Heat"
+      ]
+    },
+    {
+      "prefix": "AFAB",
+      "name": "Aircraft",
+      "course_count": 7,
+      "section_count": 76,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Aircraft Sheetmetal &amp; Composite Structure",
+        "Advanced Composite Fabrication, Assembly, and Repair",
+        "Aerospace Workplace Issues and Ethics",
+        "Aircraft Production Systems",
+        "Aircraft Structures"
+      ]
+    },
+    {
+      "prefix": "AP",
+      "name": "Photography",
+      "course_count": 37,
+      "section_count": 76,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Advanced Portfolio",
+        "Alt Photo Processes I",
+        "Alt Photo Processes II",
+        "Basic Product Photography",
+        "Black and White Photography I"
+      ]
+    },
+    {
+      "prefix": "BSOT",
+      "name": "BSOT",
+      "course_count": 23,
+      "section_count": 76,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Bsot Work Experience Ed.",
+        "Communication & Team Building",
+        "Computer Basics",
+        "Computerized 10-KEY",
+        "Cust Srvc & Attitude in Wrkplc"
+      ]
+    },
+    {
+      "prefix": "PHILO",
+      "name": "Philosophy",
+      "course_count": 20,
+      "section_count": 76,
+      "colleges": [
+        "cabrillo-college",
+        "contra-costa-college",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Comparative Religion",
+        "Critical Thinking, Logic, and Composition",
+        "Ethics",
+        "History of Western Philosophy: Descartes to Present",
+        "History of Western Philosophy: Pre-Socratic to Medieval Period"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "ANSC",
+      "course_count": 29,
+      "section_count": 75,
+      "colleges": [
+        "bakersfield-college",
+        "cosumnes-river-college",
+        "moorpark-college",
+        "porterville-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Animal Behavior",
+        "Animal Behavior Lab",
+        "Animal Diseases",
+        "Animal Diversity",
+        "Applied Animal Nutrition"
+      ]
+    },
+    {
+      "prefix": "ATC",
+      "name": "ATC",
+      "course_count": 47,
+      "section_count": 75,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Aerodynamics",
+        "Air Navigation",
+        "Aircraft and Engines",
+        "Airline Operations",
+        "Aviation and Travel Internship"
+      ]
+    },
+    {
+      "prefix": "BIT",
+      "name": "Business",
+      "course_count": 27,
+      "section_count": 75,
+      "colleges": [
+        "college-of-the-desert",
+        "cosumnes-river-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ADMINISTRATIVE BUSINESS PROCEDURES",
+        "Building Inspection Principles for Disabled Access",
+        "BUSINESS DOCUMENT PROCESSING",
+        "BUSINESS RECORDS SKILLS",
+        "BUSINESS SOFTWARE - CUSTOMER RELATIONSHIP MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "ETEC",
+      "course_count": 45,
+      "section_count": 75,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "los-medanos-college",
+        "rio-hondo-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Aerospace Engineering",
+        "Aerospace Engineering I",
+        "Aerospace Engineering II",
+        "Alternating Current Circuits",
+        "Analytical Instrumentation"
+      ]
+    },
+    {
+      "prefix": "HD",
+      "name": "College",
+      "course_count": 7,
+      "section_count": 75,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Career and Life Planning",
+        "Career Exploration and Development",
+        "College and Life Management",
+        "College Success and Transfer Exploration",
+        "College Success for Student Athletes"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 19,
+      "section_count": 75,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "cypress-college",
+        "folsom-lake-college",
+        "fullerton-college",
+        "sacramento-city-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Content Considerations for Digital Marketing",
+        "Digital Marketing (formerly New Media)",
+        "Independent Studies in Marketing",
+        "Internet Marketing"
+      ]
+    },
+    {
+      "prefix": "RCP",
+      "name": "Care",
+      "course_count": 49,
+      "section_count": 75,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Adv Diag in Respiratory Care",
+        "Adv Neonatal & Pediatric RC",
+        "Advance Mechanical Ventilation",
+        "Advanced Cardiopulmonary Dise",
+        "Advanced Cardiopulmonary Respiratory Care"
+      ]
+    },
+    {
+      "prefix": "RN",
+      "name": "RN",
+      "course_count": 22,
+      "section_count": 75,
+      "colleges": [
+        "fresno-city-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "ADLT CMMN HLTH PROB",
+        "ADLT CMMN HLTH SKL",
+        "ADLT CMPLX HLTH",
+        "ADV NRSG PHARM APPS",
+        "BEHAVR EMTNL DSRDRS"
+      ]
+    },
+    {
+      "prefix": "CWS",
+      "name": "Water",
+      "course_count": 26,
+      "section_count": 74,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Adv Wastewtr Treatm Plant Ops",
+        "Adv Water Treatment Plnt Oper",
+        "Adv Wtr Distribution Systems",
+        "Advan Electric & Instr Process",
+        "Advanced Water Treatment I"
+      ]
+    },
+    {
+      "prefix": "RLST",
+      "name": "RLST",
+      "course_count": 25,
+      "section_count": 74,
+      "colleges": [
+        "american-river-college",
+        "orange-coast-college",
+        "victor-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Intro New Testament/Early Chri",
+        "Intro to Crit Thinking",
+        "Intro to Religious Studies",
+        "Introduction Religious Studies",
+        "Introduction to Atheism"
+      ]
+    },
+    {
+      "prefix": "ADAPT",
+      "name": "Adapted",
+      "course_count": 14,
+      "section_count": 73,
+      "colleges": [
+        "american-river-college",
+        "cabrillo-college",
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Adapted Aerobic Activity",
+        "Adapted Aquatics",
+        "Adapted Lifetime Sports",
+        "Adapted Personal Safety",
+        "Adapted Physical Education"
+      ]
+    },
+    {
+      "prefix": "DFST",
+      "name": "American",
+      "course_count": 18,
+      "section_count": 73,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language II Skill Building Lab",
+        "American Sign Language III",
+        "American Sign Language III/IV Skill Building Lab"
+      ]
+    },
+    {
+      "prefix": "R",
+      "name": "Technology",
+      "course_count": 26,
+      "section_count": 73,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CLINICAL EXPERIENCE: COMPUTED TOMOGRAPHY",
+        "ADVANCED CLINICAL EXPERIENCE: MAMMOGRAPHY",
+        "ADVANCED MODALITIES IN IMAGING",
+        "ADVANCED RADIOGRAPHIC PRINCIPLES",
+        "APPLIED RADIOGRAPHIC TECHNOLOGY I"
+      ]
+    },
+    {
+      "prefix": "BIP",
+      "name": "BIP",
+      "course_count": 25,
+      "section_count": 72,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat",
+        "Basic Principles of Coding for the Medical Office",
+        "Beginning Medical Insurance",
+        "Business Info. Professional",
+        "Business Information Professional"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "Eldt",
+      "course_count": 10,
+      "section_count": 72,
+      "colleges": [
+        "ventura-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Cm Dl Orientation",
+        "Comrcial Drivr Train Prmt Prep",
+        "Comrcial Drivr Train Rang Oper",
+        "Comrcial Drivr Train Rd Skil",
+        "Haz Mat Endt Eldt Part a"
+      ]
+    },
+    {
+      "prefix": "ENGRD",
+      "name": "Reading",
+      "course_count": 4,
+      "section_count": 72,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Critical Reading as Critical Thinking",
+        "Reading Across the Disciplines for Content Courses",
+        "Reading Across the Disciplines for Content Courses II",
+        "Reading Across the Disciplines: Speed Reading"
+      ]
+    },
+    {
+      "prefix": "ET",
+      "name": "ET",
+      "course_count": 35,
+      "section_count": 72,
+      "colleges": [
+        "allan-hancock-college",
+        "american-river-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "rio-hondo-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Biomedical Equipment Technology",
+        "Computer Aided Drafting and Design",
+        "Digital Tools in Architecture",
+        "Electronic Communication Regulations",
+        "Electronics Projects Laboratory I"
+      ]
+    },
+    {
+      "prefix": "ETNC",
+      "name": "ETNC",
+      "course_count": 12,
+      "section_count": 72,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "African Americans in U.S. History 1865 to Present",
+        "African Americans in U.S. History to 1877",
+        "African-American Arts and Music",
+        "American Government and African American Politics",
+        "Asian Americans and Pacific Islanders in American Society"
+      ]
+    },
+    {
+      "prefix": "EWRT",
+      "name": "Literary",
+      "course_count": 8,
+      "section_count": 72,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Editorial Leadership Literary Magazine, Student Edition",
+        "Introduction to Creative Writing",
+        "Literary Magazine I, Student Edition",
+        "Literary Magazine II, Student Edition",
+        "Literature and Composition"
+      ]
+    },
+    {
+      "prefix": "JOURN",
+      "name": "Media",
+      "course_count": 30,
+      "section_count": 72,
+      "colleges": [
+        "cabrillo-college",
+        "clovis-community-college",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "laney-college",
+        "los-medanos-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "ADV MEDIA WRITING",
+        "BEG MEDIA WRITING",
+        "Data Journalism",
+        "EDITORIAL LEADRSHP",
+        "Independent Study in Journalism"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 16,
+      "section_count": 72,
+      "colleges": [
+        "hartnell-college",
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Basic Conversational Spanish and Culture",
+        "Elem Span for Chicano Students",
+        "Elem Span for Span Speakers",
+        "Elem Span for Spanish Speakers",
+        "Elementary Spanish"
+      ]
+    },
+    {
+      "prefix": "THRT",
+      "name": "THRT",
+      "course_count": 19,
+      "section_count": 72,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ACTING I",
+        "ADVANCED ACTING",
+        "ADVANCED TECHNICAL THEATER",
+        "COSTUME CRAFTS",
+        "FUNDAMENTALS OF STAGE LIGHTING"
+      ]
+    },
+    {
+      "prefix": "ES/T",
+      "name": "Cond",
+      "course_count": 50,
+      "section_count": 71,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adv Prevent/Care Athl Injury",
+        "Compassion Training",
+        "Fitness Specialist Internship",
+        "Intro to Applied Kinesiology",
+        "Intro to Exercise Physiology"
+      ]
+    },
+    {
+      "prefix": "FPT",
+      "name": "Fire",
+      "course_count": 19,
+      "section_count": 71,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Building Construction for Fire Protection",
+        "Emergency Medical Technician Clinical Experience",
+        "Emergency Medical Technician Laboratory",
+        "Emergency Medical Technician Theory",
+        "Emergency Medical Technician-I Refresher Course"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "IS",
+      "course_count": 29,
+      "section_count": 71,
+      "colleges": [
+        "clovis-community-college",
+        "madera-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "ADV WEB DEVELOP",
+        "BEGINN JAVA",
+        "CAREERS IN COMPUTING",
+        "Computer Concepts",
+        "COMPUTER CONCEPTS"
+      ]
+    },
+    {
+      "prefix": "JRNL",
+      "name": "JRNL",
+      "course_count": 8,
+      "section_count": 71,
+      "colleges": [
+        "bakersfield-college",
+        "foothill-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Beginning Reporting",
+        "INTERMEDIATE REPORTING/NEWSWRITING",
+        "INTRODUCTION TO REPORTING & NEWSWRITING",
+        "Media and Society",
+        "Multimedia Reporting"
+      ]
+    },
+    {
+      "prefix": "KINLEC",
+      "name": "KINLEC",
+      "course_count": 7,
+      "section_count": 71,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Biomechanics",
+        "Diet and Fitness",
+        "First Aid",
+        "Intro to Athletic Training",
+        "Intro to Kinesiology"
+      ]
+    },
+    {
+      "prefix": "CACM",
+      "name": "CACM",
+      "course_count": 23,
+      "section_count": 70,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking",
+        "Advanced Pastry",
+        "Baking and Pastry",
+        "Contemporary Service",
+        "Cooking Techniques"
+      ]
+    },
+    {
+      "prefix": "CONS",
+      "name": "CONS",
+      "course_count": 24,
+      "section_count": 70,
+      "colleges": [
+        "fresno-city-college",
+        "santa-rosa-junior-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Applied Equip Operation Pract",
+        "BASIC RES CONSTR",
+        "Career Plng/Hvy Equip Ops",
+        "Comm Driver Lrnr's Permit Prep",
+        "CONS SAFETY"
+      ]
+    },
+    {
+      "prefix": "CVTE",
+      "name": "CVTE",
+      "course_count": 28,
+      "section_count": 70,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Cardiovascular Pharmacology",
+        "Cardiovascular Physiology I",
+        "Cardiovascular Physiology II",
+        "Cardiovascular Tech Skills Lab",
+        "Clinical Practicum I"
+      ]
+    },
+    {
+      "prefix": "EMC",
+      "name": "EMC",
+      "course_count": 24,
+      "section_count": 70,
+      "colleges": [
+        "santa-rosa-junior-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "12-Lead ECG Interpretation",
+        "Advanced Cardiac Life Support",
+        "Basic Arrhythmia Recognition Course",
+        "Basic Life Support",
+        "BLS Provider"
+      ]
+    },
+    {
+      "prefix": "FS",
+      "name": "Fire",
+      "course_count": 35,
+      "section_count": 70,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "1st Aid/Cpr Pub Emp",
+        "Basic Firefighter (basic 32)",
+        "Bldg Construction Fire Protect",
+        "Bldgconstr for Fire Protection",
+        "Cal Fire Module 1C Wildland Ff"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "RESP",
+      "course_count": 31,
+      "section_count": 70,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Pulmonary Diagnos & Proced",
+        "Assessment in Respiratory Care",
+        "Cardio Pathology/Pathophysiol",
+        "Cardiopul Physiology/Disease",
+        "Cardiopulmonary Pharmacology"
+      ]
+    },
+    {
+      "prefix": "CAHM",
+      "name": "CAHM",
+      "course_count": 35,
+      "section_count": 69,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Adv Baking and Pastry",
+        "Adv Culinary Arts",
+        "Art of Create Wedding Cake",
+        "Basic Baking & Past",
+        "Basic Wine Grape Viticulture"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "Ideas",
+      "course_count": 16,
+      "section_count": 69,
+      "colleges": [
+        "foothill-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "A World of Ideas: From the Ancient World to the Modern Age",
+        "CULTURES, CIVILIZATIONS & IDEAS: OF EMPIRES & CONFLICT",
+        "CULTURES, CIVILIZATIONS & IDEAS: THE ANCIENT WORLD",
+        "CULTURES, CIVILIZATIONS & IDEAS: THE MODERN WORLD",
+        "ETHICS IN ARTIFICIAL INTELLIGENCE"
+      ]
+    },
+    {
+      "prefix": "KATH",
+      "name": "Intercollegiate",
+      "course_count": 20,
+      "section_count": 69,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "INTERCOLLEGIATE SPORTS &ndash; BADMINTON",
+        "INTERCOLLEGIATE SPORTS &ndash; BASEBALL",
+        "INTERCOLLEGIATE SPORTS &ndash; BASKETBALL",
+        "INTERCOLLEGIATE SPORTS &ndash; CROSS COUNTRY",
+        "INTERCOLLEGIATE SPORTS &ndash; FOOTBALL"
+      ]
+    },
+    {
+      "prefix": "GDS",
+      "name": "GDS",
+      "course_count": 38,
+      "section_count": 68,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "3D Animation and Modeling",
+        "Artificial Intelligence and Creativity",
+        "Design Agency and Branding",
+        "Digital Drawing",
+        "Digital Illustration with Adobe Illustrator"
+      ]
+    },
+    {
+      "prefix": "HEOC",
+      "name": "HEOC",
+      "course_count": 10,
+      "section_count": 68,
+      "colleges": [
+        "napa-valley-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Applied Pharmacology",
+        "Basic Anatomy & Physiology",
+        "Health Occupations Work Exper",
+        "Intravenous Therapy",
+        "Intro to Careers in Healthcare"
+      ]
+    },
+    {
+      "prefix": "OH",
+      "name": "OH",
+      "course_count": 23,
+      "section_count": 68,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Annuals and Perennials",
+        "Arboriculture",
+        "Cooperative Work Experience",
+        "Floral Design I",
+        "Floral Design II"
+      ]
+    },
+    {
+      "prefix": "REAL",
+      "name": "Real",
+      "course_count": 25,
+      "section_count": 68,
+      "colleges": [
+        "citrus-college",
+        "monterey-peninsula-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "15-Hour National Uniform Standards of Professional Appraisal Practice (USPAP)",
+        "Advanced Real Estate Finance and Investments",
+        "Appraisal I: Principles and Procedures",
+        "Appraisal II: Residential Real Estate Appraisal",
+        "Escrow I"
+      ]
+    },
+    {
+      "prefix": "ECS",
+      "name": "ECS",
+      "course_count": 26,
+      "section_count": 67,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Admin I: Programs in ECE",
+        "Admin II Pers Leader in ECE",
+        "Art for Young Child",
+        "Child Growth and Development",
+        "Child Health, Safety &amp; Nutrition"
+      ]
+    },
+    {
+      "prefix": "ESLLAB",
+      "name": "Center",
+      "course_count": 11,
+      "section_count": 67,
+      "colleges": [
+        "american-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "ESL Center: Advanced Skills in ESL",
+        "ESL Center: Advanced-Low Skills in ESL",
+        "ESL Center: Advanced-Low Support in ESL",
+        "ESL Center: Intermediate-High Skills in ESL",
+        "ESL Center: Intermediate-High Support in ESL"
+      ]
+    },
+    {
+      "prefix": "RT",
+      "name": "RT",
+      "course_count": 34,
+      "section_count": 67,
+      "colleges": [
+        "allan-hancock-college",
+        "butte-college",
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Adv Diag Imag/Resrc",
+        "Adv Diag Imaging",
+        "Adv Pat Care: Veni",
+        "Adv Pos Lab/Clin IV",
+        "Adv Pos Lab/Clinc V"
+      ]
+    },
+    {
+      "prefix": "BT",
+      "name": "BT",
+      "course_count": 31,
+      "section_count": 66,
+      "colleges": [
+        "fresno-city-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED ACCTG",
+        "BEGINNING EXCEL",
+        "BUSINESS ENGLISH",
+        "CMPTR APPLCTN II",
+        "CMPTR DOC PROC I"
+      ]
+    },
+    {
+      "prefix": "CHLX",
+      "name": "Chicanx",
+      "course_count": 2,
+      "section_count": 66,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Chicano/a, Latino/a Literature",
+        "Introduction to Chicanx and Latinx Studies"
+      ]
+    },
+    {
+      "prefix": "CTZN",
+      "name": "Citizenship",
+      "course_count": 1,
+      "section_count": 66,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Citizenship"
+      ]
+    },
+    {
+      "prefix": "ENSL",
+      "name": "ENSL",
+      "course_count": 30,
+      "section_count": 66,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Beginning English: Speaking and Listening",
+        "Beginning English: Writing, Reading, and Vocabulary",
+        "English Skills for Success I",
+        "English Skills for Success II",
+        "High-Beginning Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "ENV SCI",
+      "name": "Environmental",
+      "course_count": 5,
+      "section_count": 66,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Environmental Science Laboratory",
+        "Geography Of California",
+        "Global Climate Change",
+        "Introduction to Environmental Science",
+        "The Human Environment: Biological Processes"
+      ]
+    },
+    {
+      "prefix": "LIB",
+      "name": "LIB",
+      "course_count": 26,
+      "section_count": 66,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "grossmont-college",
+        "hartnell-college",
+        "pasadena-city-college",
+        "san-jose-city-college",
+        "southwestern-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "ARCHIVES &amp; DIGITAL COLLECTIONS INTERNSHIP",
+        "COLLEGE RESEARCH SKILLS",
+        "Electronic Research/Internet",
+        "Honors Introduction to Research",
+        "Inf Comp in the Sci & App Tech"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "MFGT",
+      "course_count": 28,
+      "section_count": 66,
+      "colleges": [
+        "bakersfield-college",
+        "evergreen-valley-college",
+        "hartnell-college",
+        "madera-community-college",
+        "porterville-college",
+        "reedley-college",
+        "san-jose-city-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Advanced Agricultural Process",
+        "ADVANCED WELDING",
+        "Agricultural and Industrial",
+        "Applied Agricultural Mechatron",
+        "BLUEPRINT READING"
+      ]
+    },
+    {
+      "prefix": "PHT",
+      "name": "Pharmacy",
+      "course_count": 27,
+      "section_count": 66,
+      "colleges": [
+        "foothill-college",
+        "santa-rosa-junior-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Ambulatory Pharmacy Practice",
+        "AMBULATORY PHARMACY PRACTICE",
+        "ASEPTIC TECHNIQUE & IV PREPARATION",
+        "Career Success",
+        "Critical Thinking and Management Skills for the Pharm Tech"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 36,
+      "section_count": 65,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "mt-san-antonio-college",
+        "orange-coast-college",
+        "rio-hondo-college",
+        "santa-rosa-junior-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Electronics",
+        "Advanced Motor Control-PLC",
+        "Alternating Current Theory",
+        "Automatn 1- Industrial Control",
+        "Commercial &amp; Industrial Wiring &amp; Cabling"
+      ]
+    },
+    {
+      "prefix": "FRENCH",
+      "name": "French",
+      "course_count": 14,
+      "section_count": 65,
+      "colleges": [
+        "clovis-community-college",
+        "east-los-angeles-college",
+        "fresno-city-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "Advanced French Conversation I",
+        "Advanced French I",
+        "Beginning French",
+        "Conversational French",
+        "Elementary French I"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 25,
+      "section_count": 65,
+      "colleges": [
+        "hartnell-college",
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "African American History",
+        "Amer Hist II",
+        "California Hist",
+        "Current Events",
+        "History of California"
+      ]
+    },
+    {
+      "prefix": "HSSCI",
+      "name": "Science",
+      "course_count": 10,
+      "section_count": 65,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Basic Science 1",
+        "Biology 1A",
+        "Chemistry 1B",
+        "Earth Science 1",
+        "Health Science"
+      ]
+    },
+    {
+      "prefix": "MNLO",
+      "name": "Forklift",
+      "course_count": 3,
+      "section_count": 65,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Forklift Lab IV, V",
+        "Forklift Operator",
+        "Forklift Operator Lab/Electric"
+      ]
+    },
+    {
+      "prefix": "POL SCI",
+      "name": "Politics",
+      "course_count": 10,
+      "section_count": 65,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Environmental Politics",
+        "Introduction to Comparative Politics",
+        "Introduction To Globalization",
+        "Introduction to International Relations",
+        "Introduction To Research In Political Science"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 16,
+      "section_count": 65,
+      "colleges": [
+        "allan-hancock-college",
+        "cypress-college",
+        "evergreen-valley-college",
+        "fullerton-college",
+        "mt-san-antonio-college",
+        "oxnard-college",
+        "rio-hondo-college",
+        "san-jose-city-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Academic Literacy and Critical Thinking",
+        "Academic Reading",
+        "Analysis and Critical Reading",
+        "College Literacy Skills",
+        "College Reading Skills"
+      ]
+    },
+    {
+      "prefix": "BET",
+      "name": "BET",
+      "course_count": 18,
+      "section_count": 64,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Beg Keyboarding/Typing",
+        "Business English",
+        "Career App for Word Processing",
+        "Communications for Business",
+        "Desktop Pub: Ms Publisher"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "CARP",
+      "course_count": 18,
+      "section_count": 64,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Bathrooms: Design/Build",
+        "Beginning Carpentry",
+        "Digital Fabrication I",
+        "Digital Fabrication II",
+        "Finish Carpentry"
+      ]
+    },
+    {
+      "prefix": "NSG",
+      "name": "Nursing",
+      "course_count": 48,
+      "section_count": 64,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Assoc Degree Nursing Capstone",
+        "AT Adv Med/Surg Nursing II",
+        "AT Adv Med/Surg Nursing III",
+        "AT Assoc Degree Nsg Capstone",
+        "AT Clinical III"
+      ]
+    },
+    {
+      "prefix": "POSC",
+      "name": "POSC",
+      "course_count": 23,
+      "section_count": 64,
+      "colleges": [
+        "cuyamaca-college",
+        "cypress-college",
+        "fullerton-college",
+        "grossmont-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "American Foreign Policy",
+        "Basic Law Enforcement Academy",
+        "California Government and Politics",
+        "Comparative Govt and Politics",
+        "Comparative Politics"
+      ]
+    },
+    {
+      "prefix": "ARTGD",
+      "name": "Design",
+      "course_count": 7,
+      "section_count": 63,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "History of Graphic Design",
+        "Identity System Design",
+        "Intro to Graphic Design",
+        "Introduction to Digital Media",
+        "Motion Graphic Animation"
+      ]
+    },
+    {
+      "prefix": "ASCI",
+      "name": "ASCI",
+      "course_count": 24,
+      "section_count": 63,
+      "colleges": [
+        "lemoore-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Animal Breeding",
+        "Animal Disease Control Lab",
+        "Animal Handling and Restraint",
+        "Animal Nutrition",
+        "Animal Nutrition Laboratory"
+      ]
+    },
+    {
+      "prefix": "CSKL",
+      "name": "Academic",
+      "course_count": 7,
+      "section_count": 63,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Academic Skills &amp; GED Prep - Lang Arts/Soc Studies I",
+        "Basic Academic Skills &amp; GED Prep - Lang Arts/Soc Studies II",
+        "Basic Academic Skills &amp; GED Prep - Math/Science 1",
+        "Basic Academic Skills &amp; GED Prep - Math/Science 2",
+        "Basic Academic Skills and GED Preparation III"
+      ]
+    },
+    {
+      "prefix": "FASHN",
+      "name": "Fashion",
+      "course_count": 31,
+      "section_count": 63,
+      "colleges": [
+        "american-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Pattern Making and Design",
+        "Apparel Construction I",
+        "Apparel Construction II",
+        "Apparel Construction, Quilting and Fabric Manipulation",
+        "Apparel Entrepreneur"
+      ]
+    },
+    {
+      "prefix": "NUTF",
+      "name": "Nutrition",
+      "course_count": 10,
+      "section_count": 63,
+      "colleges": [
+        "monterey-peninsula-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Food Prep-Nutr &amp; Life Fitness",
+        "Food Science",
+        "Food Science and Safety Laboratory",
+        "Introduction to Careers in Nutrition, Dietetics, and Food",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "PEAC",
+      "name": "PEAC",
+      "course_count": 34,
+      "section_count": 63,
+      "colleges": [
+        "hartnell-college",
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baseball",
+        "Advanced Volleyball",
+        "Basketball",
+        "Beginning Futsal",
+        "Beginning Swimming"
+      ]
+    },
+    {
+      "prefix": "RNRS",
+      "name": "Health",
+      "course_count": 11,
+      "section_count": 63,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Foundational Concepts of Nursing",
+        "Health Care Participant",
+        "Maternal and Newborn Health",
+        "Medical-Surgical Nursing IV",
+        "Mental Health Concepts"
+      ]
+    },
+    {
+      "prefix": "VNRS",
+      "name": "Nursing",
+      "course_count": 28,
+      "section_count": 63,
+      "colleges": [
+        "bakersfield-college",
+        "citrus-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Adult Growth and Development for the Vocational Nurse",
+        "Advanced Medical Surgical Nursing",
+        "Advanced Medical Surgical Nursing Lab",
+        "Advanced Pharmacology",
+        "Body Structure and Function for the Vocational Nurse II"
+      ]
+    },
+    {
+      "prefix": "WKPR",
+      "name": "WKPR",
+      "course_count": 24,
+      "section_count": 63,
+      "colleges": [
+        "allan-hancock-college",
+        "santa-ana-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Applying Math Skills on Job",
+        "Applying Rdg Skills on the Job",
+        "Applying Wrtg Skills on Job",
+        "Beginning Computers",
+        "Choos the Right Employmnt Path"
+      ]
+    },
+    {
+      "prefix": "ADED",
+      "name": "ADED",
+      "course_count": 27,
+      "section_count": 62,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Computer Operations 1",
+        "Basic Computer Operations 2",
+        "Basic Computer Operations 3",
+        "Carpentry I",
+        "Carpentry II"
+      ]
+    },
+    {
+      "prefix": "ADVM",
+      "name": "ADVM",
+      "course_count": 30,
+      "section_count": 62,
+      "colleges": [
+        "sierra-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Programming",
+        "Advanced Mill 4th and 5th Axis",
+        "CAD for Manufacturing",
+        "CAD for Mechanical Design I",
+        "CAD for Mechanical Design II"
+      ]
+    },
+    {
+      "prefix": "ES/I",
+      "name": "Intercollegiate",
+      "course_count": 22,
+      "section_count": 62,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Intercoll Cross Country I",
+        "Intercoll Cross Country II",
+        "Intercoll Cross Country-NP",
+        "Intercollegiate Basketball I",
+        "Intercollegiate Basketball III"
+      ]
+    },
+    {
+      "prefix": "HTEC",
+      "name": "HTEC",
+      "course_count": 39,
+      "section_count": 62,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Administration of Medications",
+        "Advanced Medical Coding II",
+        "Advanced Medical Terminology I",
+        "Advanced Skill Building in Clinical Laboratory Procedures II",
+        "Basic Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "NR",
+      "name": "NR",
+      "course_count": 21,
+      "section_count": 62,
+      "colleges": [
+        "butte-college",
+        "college-of-the-desert",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Surgical Nursing",
+        "BACKYARD BIRDS",
+        "CONSV NATRL RES LAB",
+        "CONSV NATRL RESRS",
+        "Fundamentals of Professional Nursing"
+      ]
+    },
+    {
+      "prefix": "BASK",
+      "name": "BASK",
+      "course_count": 10,
+      "section_count": 61,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Basic Math",
+        "Basic Reading and Writing",
+        "GED Computer/Calculator Skills",
+        "GED Lab",
+        "Geometry H.S. Eq Exam Prep"
+      ]
+    },
+    {
+      "prefix": "E/ET",
+      "name": "E/ET",
+      "course_count": 11,
+      "section_count": 61,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "BASIC ELECTRICITY",
+        "CAL-OSHA 30-Hour Construction Industry Training for Electrical & Electronics Technology",
+        "COMMERCIAL ELECTRICAL WIRING",
+        "LIGHTING EFFICIENCY TECHNOLOGY",
+        "Motors and Drives"
+      ]
+    },
+    {
+      "prefix": "MUSM",
+      "name": "Music",
+      "course_count": 25,
+      "section_count": 61,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Music Business",
+        "Advanced Studio Sessions",
+        "Audio and Music Production I",
+        "Audio and Music Production II",
+        "Audio for Video Post Production"
+      ]
+    },
+    {
+      "prefix": "THAR",
+      "name": "THAR",
+      "course_count": 32,
+      "section_count": 61,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Costume Technology 2",
+        "Independent Study in Theatre Arts",
+        "Introduction to Acting",
+        "Introduction to Costume Technology",
+        "Introduction to Scenic Design"
+      ]
+    },
+    {
+      "prefix": "AGBS",
+      "name": "AGBS",
+      "course_count": 10,
+      "section_count": 60,
+      "colleges": [
+        "bakersfield-college",
+        "madera-community-college",
+        "porterville-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "AG ACCOUNTING",
+        "AG ECONOMICS",
+        "Agricultural Computer Applications",
+        "Agricultural Economics",
+        "Agriculture Sales and Communication"
+      ]
+    },
+    {
+      "prefix": "KINC",
+      "name": "Varsity",
+      "course_count": 39,
+      "section_count": 60,
+      "colleges": [
+        "citrus-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Judo",
+        "Beginning Boxing",
+        "Beginning Judo",
+        "Intermediate Boxing",
+        "Intermediate Judo"
+      ]
+    },
+    {
+      "prefix": "PSTC",
+      "name": "PSTC",
+      "course_count": 26,
+      "section_count": 60,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Academy Instructor Certification Course",
+        "Arrest and Control Instructor",
+        "Arrest and Control Instructor Update",
+        "Basic Law Enforcement Academy- Module II",
+        "Basic Law Enforcement Academy- Module III"
+      ]
+    },
+    {
+      "prefix": "RELG",
+      "name": "Religions",
+      "course_count": 11,
+      "section_count": 60,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Asian Religions",
+        "ASIAN RELIGIONS",
+        "Intro to the Study of Religion",
+        "Introduction to Christianity",
+        "Relg, Govt, Poltics in America"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 30,
+      "section_count": 60,
+      "colleges": [
+        "butte-college",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Beg Welding",
+        "Fabrication Practicums",
+        "Heavy Plate Welding",
+        "Integrated Welding Aps",
+        "Intermediate Welding"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 10,
+      "section_count": 59,
+      "colleges": [
+        "hartnell-college",
+        "mission-college",
+        "moorpark-college",
+        "palo-verde-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "An Intro to Astronomy",
+        "Astronomy",
+        "Astronomy Laboratory",
+        "Astronomy With Lab",
+        "Elementary Astronomy"
+      ]
+    },
+    {
+      "prefix": "CULN",
+      "name": "Culinary",
+      "course_count": 21,
+      "section_count": 59,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Baking Fundamentals I",
+        "Baking Production and Operations I",
+        "Business Practices for Culn",
+        "Culinary Fundamentals I",
+        "Culinary Principles I"
+      ]
+    },
+    {
+      "prefix": "ICS",
+      "name": "ICS",
+      "course_count": 12,
+      "section_count": 59,
+      "colleges": [
+        "coastline-community-college",
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Community Based Learning in Intercultural Studies - Interpersonal",
+        "Community Based Learning in Intercultural Studies - Systems",
+        "Concepts of Programming Langs",
+        "Data Science &amp; Mach. Learning",
+        "Foundations of Data Sci and AI"
+      ]
+    },
+    {
+      "prefix": "OLDR",
+      "name": "OLDR",
+      "course_count": 22,
+      "section_count": 59,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Advanced Watercolor",
+        "Art/Journaling",
+        "Barbershop Harmony Chorus",
+        "Botanical Illustration",
+        "Ceramics 1"
+      ]
+    },
+    {
+      "prefix": "PEIA",
+      "name": "Intercollegiate",
+      "course_count": 15,
+      "section_count": 59,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Intercollegiate Baseball",
+        "Intercollegiate Basketball, M",
+        "Intercollegiate Basketball, W",
+        "Intercollegiate Conditioning",
+        "Intercollegiate Cross Country"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 27,
+      "section_count": 58,
+      "colleges": [
+        "citrus-college",
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Dental Specialties",
+        "Basic Chairside Assisting",
+        "CA Dental Law & Ethics",
+        "Chairside Assisting",
+        "Dental Anatomy and Vital Signs"
+      ]
+    },
+    {
+      "prefix": "FPTC",
+      "name": "FPTC",
+      "course_count": 30,
+      "section_count": 58,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Basic Air Operations",
+        "Building Construction for Fire Prevention",
+        "COMPANY OFFICER 2B-ADMIN",
+        "Company Officer 2C - Fire Inspections and Investigations",
+        "Company Officer 2D - All-Risk Command Operations"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 24,
+      "section_count": 58,
+      "colleges": [
+        "american-river-college",
+        "butte-college",
+        "cuyamaca-college",
+        "cypress-college",
+        "de-anza-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "grossmont-college",
+        "moorpark-college",
+        "mt-san-antonio-college",
+        "san-diego-mesa-college",
+        "santa-rosa-junior-college",
+        "shasta-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Beginning German",
+        "Conversational German I",
+        "Conversational German II",
+        "Elementary German (Third Quarter)",
+        "Elementary German I"
+      ]
+    },
+    {
+      "prefix": "ALDH",
+      "name": "ALDH",
+      "course_count": 11,
+      "section_count": 57,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Athletic Training I",
+        "Athletic Training II",
+        "Basic Arrhythmia",
+        "Home Health Aide",
+        "Med Aspects Drugs & Alcohol"
+      ]
+    },
+    {
+      "prefix": "CADD",
+      "name": "Design",
+      "course_count": 21,
+      "section_count": 57,
+      "colleges": [
+        "cuyamaca-college",
+        "el-camino-community-college-district",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "grossmont-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Adv 3D Design w/ SolidWorks",
+        "Advanced 3D Design with CATIA",
+        "Advanced Solidworks",
+        "Advanced Technical Graphics",
+        "Architectural CADD & Design"
+      ]
+    },
+    {
+      "prefix": "CINE",
+      "name": "Film",
+      "course_count": 13,
+      "section_count": 57,
+      "colleges": [
+        "pasadena-city-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CINEMATOGRAPHY",
+        "ADVANCED FILMMAKING",
+        "BEGINNING ELECTRONIC FILMMAKING",
+        "CINEMA PRODUCTION PORTFOLIO",
+        "CONTEMPORARY FILM HISTORY"
+      ]
+    },
+    {
+      "prefix": "COMPSCI",
+      "name": "Prog",
+      "course_count": 9,
+      "section_count": 57,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Big Data Analytics",
+        "Computer Architecture & Org",
+        "Discrete Structures",
+        "Introduction to Data Science",
+        "Prog Concept/Meth I (Python)"
+      ]
+    },
+    {
+      "prefix": "DSPS",
+      "name": "DSPS",
+      "course_count": 29,
+      "section_count": 57,
+      "colleges": [
+        "butte-college",
+        "college-of-the-desert",
+        "evergreen-valley-college",
+        "pasadena-city-college",
+        "san-diego-city-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Accessible Computer Lab",
+        "Adaptive Computer Lab",
+        "Adaptive Tech and MS Office",
+        "ADVOCACY AND WORKPLACE RIGHTS",
+        "ALT LEARNNG STRATGS"
+      ]
+    },
+    {
+      "prefix": "R-TV",
+      "name": "R-TV",
+      "course_count": 28,
+      "section_count": 57,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advanced Video Engineering",
+        "Advanced Video Production",
+        "American Film History",
+        "Audio Media Programming",
+        "Begin Commercial Voice-Over"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "AERO",
+      "course_count": 20,
+      "section_count": 56,
+      "colleges": [
+        "mt-san-antonio-college",
+        "solano-community-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Air Transportation",
+        "Aircraft and Engines",
+        "Aircraft Dispatcher Operations",
+        "Aviation Maintenance Technician - General Aircraft Subjects",
+        "Aviation Maintenance Technician - Powerplant - Reciprocating Engines"
+      ]
+    },
+    {
+      "prefix": "AGEH",
+      "name": "AGEH",
+      "course_count": 20,
+      "section_count": 56,
+      "colleges": [
+        "college-of-the-desert",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "AGEH/TURFGRASS WK EX",
+        "ARBORICULTURE",
+        "Environmental Horticulture",
+        "GOLF COURSE MGMT",
+        "HORTICULTURE"
+      ]
+    },
+    {
+      "prefix": "ASHS",
+      "name": "ASHS",
+      "course_count": 14,
+      "section_count": 56,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Counseling Skills, Laws/Ethics",
+        "Families and Addiction",
+        "Family/Relationships",
+        "Fieldwork: Addiction",
+        "Fieldwork: Social Work"
+      ]
+    },
+    {
+      "prefix": "AUTOTEC",
+      "name": "Auto",
+      "course_count": 13,
+      "section_count": 56,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Advanced Auto Electrical Sys",
+        "Auto Electricity/Electronics",
+        "Basic Auto AC Systems",
+        "Brakes",
+        "Consumer Automotive"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "CNST",
+      "course_count": 37,
+      "section_count": 56,
+      "colleges": [
+        "bakersfield-college",
+        "butte-college",
+        "orange-coast-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Blueprnt Readng &amp; Draft",
+        "Building Construction 1",
+        "Building Construction 2",
+        "Building Construction I",
+        "Building Construction II"
+      ]
+    },
+    {
+      "prefix": "CSS",
+      "name": "CSS",
+      "course_count": 16,
+      "section_count": 56,
+      "colleges": [
+        "cuesta-college",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "College Learning Strategies",
+        "College Success",
+        "Comp Archit & Assem Lang Prog",
+        "Data Structures and Algorithms",
+        "Discrete Structures"
+      ]
+    },
+    {
+      "prefix": "DART",
+      "name": "Digital",
+      "course_count": 39,
+      "section_count": 56,
+      "colleges": [
+        "cypress-college",
+        "el-camino-community-college-district",
+        "fullerton-college",
+        "golden-west-college",
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "2D Character Animation",
+        "2D Computer Animation",
+        "3D Character Animation & Riggi",
+        "3D Computer Animation",
+        "3D Game Art and Interaction"
+      ]
+    },
+    {
+      "prefix": "DIES",
+      "name": "DIES",
+      "course_count": 30,
+      "section_count": 56,
+      "colleges": [
+        "san-diego-miramar-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Adv Diesel Fuel Injection Syst",
+        "Adv Electrncs & Emissions Mgmt",
+        "Air Brake Systems",
+        "Alternative-Fueled Engine IV",
+        "Applied Failure Analysis"
+      ]
+    },
+    {
+      "prefix": "DMT",
+      "name": "DMT",
+      "course_count": 38,
+      "section_count": 56,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "3D Printing for AM Support Technicians and Operators",
+        "Applied GD&T (ASME Y14.5m); Coordinate Measuring Machines (CMM)",
+        "CAD Technology Laboratory Creo Parametric (Advanced)",
+        "CAD Technology Laboratory Creo Parametric (Beginning)",
+        "CAD Technology Laboratory Creo Parametric (Intermediate)"
+      ]
+    },
+    {
+      "prefix": "ERSC",
+      "name": "Science",
+      "course_count": 5,
+      "section_count": 56,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Earth, Science, Laboratory",
+        "Environmental Science",
+        "Introduction to Earth Science"
+      ]
+    },
+    {
+      "prefix": "GD",
+      "name": "GD",
+      "course_count": 19,
+      "section_count": 56,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Adobe Photoshop Digital Imag",
+        "Business Skills for Creatives",
+        "Design Techniques with Illustrator",
+        "Digital Illustration",
+        "Digital Photography I"
+      ]
+    },
+    {
+      "prefix": "N",
+      "name": "N",
+      "course_count": 15,
+      "section_count": 56,
+      "colleges": [
+        "cabrillo-college",
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "Nrs Fundmntls I",
+        "Nrs Fundmntls II",
+        "Nrs Fundmntls III",
+        "Nursing Fundamentals IV",
+        "Pharmacology A"
+      ]
+    },
+    {
+      "prefix": "PEIN",
+      "name": "Intercollegiate",
+      "course_count": 19,
+      "section_count": 56,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Intercoll Beach Volleyball",
+        "Intercolleg Volleyball",
+        "Intercollegiate Baseball",
+        "Intercollegiate Bball",
+        "Intercollegiate Cross Country"
+      ]
+    },
+    {
+      "prefix": "SLPA",
+      "name": "SLPA",
+      "course_count": 30,
+      "section_count": 56,
+      "colleges": [
+        "american-river-college",
+        "madera-community-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Admin Procedures",
+        "ADULT DISORDERS: REMEDIATION",
+        "ANALYSIS/OBSERVATN",
+        "Articulation and Phonology for the SLPA",
+        "ASSESS/REMEDIATION"
+      ]
+    },
+    {
+      "prefix": "WRKX",
+      "name": "Work",
+      "course_count": 3,
+      "section_count": 56,
+      "colleges": [
+        "diablo-valley-college",
+        "los-medanos-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Work Experience",
+        "Work Experience Education",
+        "Work Experience Internship"
+      ]
+    },
+    {
+      "prefix": "AGPS",
+      "name": "AGPS",
+      "course_count": 22,
+      "section_count": 55,
+      "colleges": [
+        "college-of-the-desert",
+        "cuesta-college",
+        "pasadena-city-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "ENTOMOLOGY AND INTEGRATED PEST MANAGEMENT",
+        "ENVIRONMENTAL HORTICULTURE",
+        "Intro to Sustainable Ag",
+        "Introduction to Plant Science",
+        "Introduction to Soil Science"
+      ]
+    },
+    {
+      "prefix": "CDES",
+      "name": "Early",
+      "course_count": 19,
+      "section_count": 55,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Anti-Bias Perspective and Diversity Seminar",
+        "Art Education in Early Childhood (formerly CDES 123AF)",
+        "Child Development",
+        "Child Development Independent Study",
+        "Child Development Independent Study Advanced"
+      ]
+    },
+    {
+      "prefix": "CTRP",
+      "name": "CTRP",
+      "course_count": 43,
+      "section_count": 55,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Advanced CAT Systems",
+        "Advanced Vocabulary Development",
+        "Beginning Machine Shorthand Theory",
+        "Computer Aided Transcription - Eclipse",
+        "Court and Deposition Procedures"
+      ]
+    },
+    {
+      "prefix": "DENTAL",
+      "name": "Dental",
+      "course_count": 21,
+      "section_count": 55,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Adv Clinical Procedures Lab",
+        "Advanced Clinical Procedures",
+        "Basic Dental Sciences",
+        "Clinical Experience I",
+        "Clinical Experience II"
+      ]
+    },
+    {
+      "prefix": "FTV",
+      "name": "FTV",
+      "course_count": 19,
+      "section_count": 55,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Screenwriting",
+        "African-American Cinema",
+        "Beginning Audio Production",
+        "Beginning Motion Picture Production",
+        "Directing the Actor for the Camera"
+      ]
+    },
+    {
+      "prefix": "INTD",
+      "name": "Design",
+      "course_count": 29,
+      "section_count": 55,
+      "colleges": [
+        "allan-hancock-college",
+        "diablo-valley-college",
+        "santa-rosa-junior-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Aided Design",
+        "Advanced Graphic Techniques",
+        "Applying Algebra Skills in Advanced Science and Engineering",
+        "Bridge to College Success",
+        "Color Theory and Application"
+      ]
+    },
+    {
+      "prefix": "MARKET",
+      "name": "Marketing",
+      "course_count": 7,
+      "section_count": 55,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education - Marketing",
+        "Fundamentals Of Advertising",
+        "Introduction To Social Media Marketing",
+        "Principles Of Marketing",
+        "Principles Of Selling"
+      ]
+    },
+    {
+      "prefix": "MUSX",
+      "name": "Music",
+      "course_count": 19,
+      "section_count": 55,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Ableton Live",
+        "Advanced Digital Audio Techniques",
+        "Advanced Electronic Music",
+        "Advanced Music Production and Multi-Track Recording",
+        "Advanced Pro Tools"
+      ]
+    },
+    {
+      "prefix": "RTVF",
+      "name": "RTVF",
+      "course_count": 28,
+      "section_count": 55,
+      "colleges": [
+        "butte-college",
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Audio Editing for Film and Video Post Production",
+        "Audio Production",
+        "Beginning Audio Production",
+        "Beginning Radio and Podcasting"
+      ]
+    },
+    {
+      "prefix": "AIRC",
+      "name": "AIRC",
+      "course_count": 22,
+      "section_count": 54,
+      "colleges": [
+        "evergreen-valley-college",
+        "mt-san-antonio-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Air Cond Codes and Standards",
+        "Air Conditioning Principles",
+        "Air Properties and Measurement",
+        "Bldg Automation Network &amp; Prog",
+        "Building Automation Fundament"
+      ]
+    },
+    {
+      "prefix": "AVIA",
+      "name": "AVIA",
+      "course_count": 22,
+      "section_count": 54,
+      "colleges": [
+        "san-diego-miramar-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Instrument Flight Lab",
+        "Aviation - Pilot Ground School",
+        "Aviation Weather",
+        "Aviation/Airport Management",
+        "Basic Instrument Flight Lab"
+      ]
+    },
+    {
+      "prefix": "DSGN",
+      "name": "DSGN",
+      "course_count": 16,
+      "section_count": 54,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Branding and Packaging",
+        "Design Studio I",
+        "Digital Media I",
+        "Digital Media II",
+        "Graphic Design History"
+      ]
+    },
+    {
+      "prefix": "GUIDE",
+      "name": "Success",
+      "course_count": 5,
+      "section_count": 54,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Blueprint for Success",
+        "Career and Life Planning",
+        "College and Life Success",
+        "Cross-Cultural Identity",
+        "Learning and Development"
+      ]
+    },
+    {
+      "prefix": "HEED",
+      "name": "Health",
+      "course_count": 7,
+      "section_count": 54,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support for the Healthcare Provider",
+        "Environmental Health Science",
+        "Health Science",
+        "Healthy Eating, Stress Management, and Weight Control",
+        "Heartsaver First Aid, Adult and Pediatric CPR and AED"
+      ]
+    },
+    {
+      "prefix": "TMACT",
+      "name": "TMACT",
+      "course_count": 17,
+      "section_count": 54,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Basketball",
+        "Basketball II",
+        "Basketball III",
+        "Basketball IV",
+        "Futsal I"
+      ]
+    },
+    {
+      "prefix": "W",
+      "name": "Welding",
+      "course_count": 10,
+      "section_count": 54,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Adv Arc Weld",
+        "Adv MIG Weld",
+        "Adv TIG Weld",
+        "Advanced Welding",
+        "Arc Welding"
+      ]
+    },
+    {
+      "prefix": "ATEC",
+      "name": "ATEC",
+      "course_count": 36,
+      "section_count": 53,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Engine Performance",
+        "Alternative Fuel Vehicle Technologies",
+        "Auto Electrical Diagnosis",
+        "Auto Electrical Systems",
+        "Automatic Transmissions"
+      ]
+    },
+    {
+      "prefix": "DNTL",
+      "name": "DNTL",
+      "course_count": 24,
+      "section_count": 53,
+      "colleges": [
+        "monterey-peninsula-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Topics",
+        "Chairside Assisting I",
+        "Chairside Assisting II",
+        "Clinical II Seminar",
+        "Clinical Practice II"
+      ]
+    },
+    {
+      "prefix": "FIRETEC",
+      "name": "FIRETEC",
+      "course_count": 15,
+      "section_count": 53,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Building Construction",
+        "Emergency Services",
+        "Fire Apparatus and Equipment",
+        "Fire Behavior and Combustion",
+        "Fire Prevention"
+      ]
+    },
+    {
+      "prefix": "GERO",
+      "name": "Gerontology",
+      "course_count": 7,
+      "section_count": 53,
+      "colleges": [
+        "chaffey-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Aging and Older Adulthood",
+        "Aging and the Life Course",
+        "APPLIED HEALTH CARE MANAGEMENT IN GERONTOLOGY",
+        "DIRECTED STUDIES IN GERONTOLOGY",
+        "Dying and Death"
+      ]
+    },
+    {
+      "prefix": "HRC",
+      "name": "HRC",
+      "course_count": 17,
+      "section_count": 53,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "American Regional Cuisine",
+        "Baking Fundamentals I",
+        "Baking Fundamentals II",
+        "Cost Control in Hospitality",
+        "Culinary Fundamentals I"
+      ]
+    },
+    {
+      "prefix": "HSMTH",
+      "name": "Math",
+      "course_count": 11,
+      "section_count": 53,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Algebra 1A",
+        "Algebra 1B",
+        "Basic Consumer Math 1A",
+        "Integrated Math 2B",
+        "Integrated Math 3B"
+      ]
+    },
+    {
+      "prefix": "SOIL",
+      "name": "Soil",
+      "course_count": 1,
+      "section_count": 53,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "32571 SOIL B1 - Introduction to Soil Science Kern Community College"
+      ]
+    },
+    {
+      "prefix": "AMSL",
+      "name": "AMSL",
+      "course_count": 15,
+      "section_count": 51,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "American Sign Language Lev III",
+        "American Sign Language Lev IV",
+        "American Sign Language Level I",
+        "Asl Fingerspelled Signs",
+        "ASL II"
+      ]
+    },
+    {
+      "prefix": "CLS",
+      "name": "CLS",
+      "course_count": 14,
+      "section_count": 51,
+      "colleges": [
+        "fresno-city-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "ADV FOLK DANCE",
+        "ANCIENT MEXICO",
+        "BEG INT MEX FOLKDNC",
+        "BEG MEX FOLKDANCE",
+        "CHICANO ART"
+      ]
+    },
+    {
+      "prefix": "CRTV",
+      "name": "CRTV",
+      "course_count": 18,
+      "section_count": 51,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Advanced Sports Broadcasting",
+        "American Cinema to the 1960s",
+        "Audio Production Techniques",
+        "Contemporary American Cinema (formerly Contemporary Cinema)",
+        "Digital Production and Non-Linear Editing for Video and Film"
+      ]
+    },
+    {
+      "prefix": "MCAG",
+      "name": "MCAG",
+      "course_count": 11,
+      "section_count": 51,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Engine Repair",
+        "Agriculture Irrigation Technology",
+        "Agriculture Safety",
+        "Farm Power Operation",
+        "Heavy Equipment Systems"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 24,
+      "section_count": 51,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "bakersfield-college",
+        "clovis-community-college",
+        "fresno-city-college",
+        "gavilan-college",
+        "golden-west-college",
+        "madera-community-college",
+        "orange-coast-college",
+        "reedley-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "ADV & PROMO",
+        "Consumer Behavior",
+        "Digital Marketing",
+        "Digital Marketing - e-Commerce",
+        "DIGITAL MKTG"
+      ]
+    },
+    {
+      "prefix": "MMART",
+      "name": "MMART",
+      "course_count": 14,
+      "section_count": 51,
+      "colleges": [
+        "berkeley-city-college"
+      ],
+      "sample_titles": [
+        "Data Design for Digital Media",
+        "Data Design for Digital Media Lab",
+        "Design Thinking",
+        "From Movies to Multimedia",
+        "Intermediate Motion Graphics"
+      ]
+    },
+    {
+      "prefix": "PHTA",
+      "name": "PHTA",
+      "course_count": 17,
+      "section_count": 51,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Acute Care/Inpatient Interventions for the PTA",
+        "Administration/Laws/Regulations for the PTA",
+        "Cardiopulmonary Rehab for the PTA",
+        "Clinical Education I for the PTA",
+        "Clinical Education II for the PTA"
+      ]
+    },
+    {
+      "prefix": "PHTO",
+      "name": "Photography",
+      "course_count": 18,
+      "section_count": 51,
+      "colleges": [
+        "allan-hancock-college",
+        "citrus-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Advanced Imaging Techniques",
+        "Advanced Photography",
+        "Beginning Photography",
+        "Business Practices for the Photographer",
+        "Digital Photography"
+      ]
+    },
+    {
+      "prefix": "AHOM",
+      "name": "AHOM",
+      "course_count": 7,
+      "section_count": 50,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Clothing Construction",
+        "Begining Clothing Construction",
+        "Fundamentals of Sewing",
+        "Intermediate Cloth Construct",
+        "Machine Quilting"
+      ]
+    },
+    {
+      "prefix": "ALTW",
+      "name": "Skills",
+      "course_count": 10,
+      "section_count": 50,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ACADEMIC SKILLS (DROP-IN)",
+        "DISABILITY & THE LAW",
+        "HEALTHY RELATIONSHIPS",
+        "INTERMEDIATE CURRENT EVENTS FOR STUDENTS WITH LEARNING DIFFERENCES",
+        "JOB SEARCH SKILLS"
+      ]
+    },
+    {
+      "prefix": "CEM",
+      "name": "CEM",
+      "course_count": 29,
+      "section_count": 50,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "2013 California Energy Code",
+        "Basic Constr Lab",
+        "Basic Construction",
+        "Basic Finish Carpentry",
+        "Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "COOP ED",
+      "name": "Work",
+      "course_count": 5,
+      "section_count": 50,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-trade-technical-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Work Experience - General I"
+      ]
+    },
+    {
+      "prefix": "EMGM",
+      "name": "EMGM",
+      "course_count": 5,
+      "section_count": 50,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Airway/Defibrillation Training",
+        "Basic Life Support CPR and AED",
+        "Emergency Medical Technician",
+        "EMT Refresher",
+        "Indiv Instr in Emerg Med"
+      ]
+    },
+    {
+      "prefix": "ETHNST",
+      "name": "ETHNST",
+      "course_count": 7,
+      "section_count": 50,
+      "colleges": [
+        "clovis-community-college",
+        "fresno-city-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "A Hist of the Mex Am People",
+        "AMERICAN MINORITY GROUPS",
+        "INT ETHNIC STUDIES",
+        "Intro to African-Am Studies",
+        "Intro to Asian-Am Stud"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "Chicana",
+      "course_count": 5,
+      "section_count": 50,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Chicana and Chicano Heritage",
+        "Crit Issue Chicana/Latina Stu",
+        "Intro Chicana & Chicano Study",
+        "Mexican-American History I",
+        "Mexican-American History II"
+      ]
+    },
+    {
+      "prefix": "MM/DI",
+      "name": "Digital",
+      "course_count": 20,
+      "section_count": 50,
+      "colleges": [
+        "berkeley-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Illustration",
+        "Analysis of Contemporary Photographers",
+        "Design Studio Practice",
+        "Digital Printing",
+        "DIGITAL PRINTING FOR PHOTOGRAPHERS"
+      ]
+    },
+    {
+      "prefix": "ORNH",
+      "name": "ORNH",
+      "course_count": 16,
+      "section_count": 50,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Beginning Floral Design",
+        "Edible Garden Installation and Care",
+        "Edible Landscapes",
+        "Fundamentals of Nursery Management and Plant Production",
+        "Introduction to Edible Gardening"
+      ]
+    },
+    {
+      "prefix": "REGN",
+      "name": "Health",
+      "course_count": 10,
+      "section_count": 50,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Health & Illness IV",
+        "Health and Illness I",
+        "Health and Illness II",
+        "Health and Illness III",
+        "Maternal-Child/Pediatric Nrsng"
+      ]
+    },
+    {
+      "prefix": "SCSCI",
+      "name": "Statistics",
+      "course_count": 2,
+      "section_count": 50,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Human Sexuality",
+        "Statistics for Social Science"
+      ]
+    },
+    {
+      "prefix": "THART",
+      "name": "THART",
+      "course_count": 14,
+      "section_count": 50,
+      "colleges": [
+        "laney-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "ACTING I",
+        "ACTING II",
+        "College Theatre",
+        "INDEPENDENT STUDY IN THEATRE ARTS",
+        "Intro to Acting I"
+      ]
+    },
+    {
+      "prefix": "VETT",
+      "name": "VETT",
+      "course_count": 24,
+      "section_count": 50,
+      "colleges": [
+        "santa-rosa-junior-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Clinical Lab Tech",
+        "Emergency/Critical Care",
+        "Intro to Vet Tech",
+        "Introduction to Veterinary Careers",
+        "Lab Animal Med"
+      ]
+    },
+    {
+      "prefix": "AHLTH",
+      "name": "AHLTH",
+      "course_count": 6,
+      "section_count": 49,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "AUTISM TECH TRNG",
+        "HEALTH CAREERS",
+        "HEALTHCARE ETHIC CON",
+        "HLTH & SOC JUSTICE",
+        "PHARMACOLOGY"
+      ]
+    },
+    {
+      "prefix": "ALCB",
+      "name": "ALCB",
+      "course_count": 9,
+      "section_count": 49,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ANALYSIS OF CURRENT EVENTS",
+        "AROUND THE WORLD IN TRAVEL STUDY",
+        "ART APPRECIATION",
+        "CRAFTS",
+        "DRAWING & PAINTING"
+      ]
+    },
+    {
+      "prefix": "FJMP",
+      "name": "FJMP",
+      "course_count": 18,
+      "section_count": 49,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Art Direction",
+        "Audio Storytelling",
+        "Fiction Film Prod Workshop",
+        "Fiction Film Production",
+        "Intro to Audio Production"
+      ]
+    },
+    {
+      "prefix": "HM",
+      "name": "HM",
+      "course_count": 15,
+      "section_count": 49,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Advertising and Sales in Food Service",
+        "Beverage Operation",
+        "Breads and Yeast Doughs",
+        "Calculations in Foodservice Occupations",
+        "Catering"
+      ]
+    },
+    {
+      "prefix": "REC",
+      "name": "REC",
+      "course_count": 22,
+      "section_count": 49,
+      "colleges": [
+        "allan-hancock-college",
+        "antelope-valley-community-college-district",
+        "citrus-college",
+        "cuesta-college",
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Acoustics for Engineers",
+        "Critical Listening Skills for Engineers",
+        "Digital Audio Technology I",
+        "Digital Audio Technology II",
+        "Foundations of Recreation and Leisure Services"
+      ]
+    },
+    {
+      "prefix": "SJS",
+      "name": "SJS",
+      "course_count": 16,
+      "section_count": 49,
+      "colleges": [
+        "american-river-college",
+        "college-of-the-desert",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "gavilan-college",
+        "hartnell-college",
+        "los-medanos-college",
+        "mission-college",
+        "moorpark-college",
+        "oxnard-college",
+        "sacramento-city-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Intro to LGBTQ Studies",
+        "Intro to Social Just Studies",
+        "Intro to Social Justice",
+        "Intro to Women's Studies",
+        "Intro to Women&#39;s Studies"
+      ]
+    },
+    {
+      "prefix": "THEATRE",
+      "name": "THEATRE",
+      "course_count": 12,
+      "section_count": 49,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Introduction to Design",
+        "Introduction to Theatre",
+        "Musical Theatre Performance",
+        "Practicum - Rehearsal/Perform"
+      ]
+    },
+    {
+      "prefix": "ACCTGFS",
+      "name": "Finance",
+      "course_count": 4,
+      "section_count": 48,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Fin Acctg for Non-Acctg Major",
+        "Finance and Investing",
+        "Personal Finance",
+        "US/CA Income Tax Preparation"
+      ]
+    },
+    {
+      "prefix": "BAD",
+      "name": "Business",
+      "course_count": 10,
+      "section_count": 48,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "American Business in Its Global Context",
+        "Artificial Intelligence in Business",
+        "Enrolled Agent - Business Taxation",
+        "Federal Income Tax Law",
+        "Financial Accounting"
+      ]
+    },
+    {
+      "prefix": "BUSMGT",
+      "name": "Management",
+      "course_count": 14,
+      "section_count": 48,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Human Resource Mgmt",
+        "Intro to Facilities Mgmt",
+        "Intro to Human Relations",
+        "Intro to Logistics Management",
+        "Intro to Management"
+      ]
+    },
+    {
+      "prefix": "CONST",
+      "name": "CONST",
+      "course_count": 27,
+      "section_count": 48,
+      "colleges": [
+        "cosumnes-river-college",
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Applied Construction Pre-Apprenticeship Skills",
+        "Building Code Interpretation: Non-Structural",
+        "Construction Details and Specifications",
+        "Construction Job Site Training",
+        "Construction Management"
+      ]
+    },
+    {
+      "prefix": "FAID",
+      "name": "Emergency",
+      "course_count": 7,
+      "section_count": 48,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Certif CPR for Prof Rescuer",
+        "Emerg Medical Technician",
+        "Emergency Med Responder (EMR)",
+        "Emergency Medical Technician",
+        "First Aid, Cardiopulmonary Resuscitation (CPR) and Basic Emergency Care"
+      ]
+    },
+    {
+      "prefix": "HSERV",
+      "name": "HSERV",
+      "course_count": 13,
+      "section_count": 48,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Alc/Drugs and Society",
+        "AOD Physiol/Pharmac",
+        "AOD Practicum I",
+        "Aod Practicum II",
+        "AOD Treatmnt/Recov"
+      ]
+    },
+    {
+      "prefix": "HUMI",
+      "name": "HUMI",
+      "course_count": 11,
+      "section_count": 48,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Arts, Ideas and Values",
+        "But is it Art? Questions and Criticism",
+        "Creative Minds",
+        "Creative Minds - HONORS",
+        "Discussion on the Arts"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "MECH",
+      "course_count": 10,
+      "section_count": 48,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Comp for Robotics/Automation",
+        "Fabrication Techniques",
+        "Fundamentals of Electronics",
+        "Fundamentals of Mechatronics",
+        "Independent Study"
+      ]
+    },
+    {
+      "prefix": "NBE",
+      "name": "NBE",
+      "course_count": 14,
+      "section_count": 48,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Basic Principles of Quilting",
+        "BLS-CPR",
+        "Child Abuse and Neglect",
+        "Child Growth and Development",
+        "Citizen Immigrt"
+      ]
+    },
+    {
+      "prefix": "ADJ",
+      "name": "Administration of Justice",
+      "course_count": 22,
+      "section_count": 47,
+      "colleges": [
+        "college-of-the-siskiyous",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Basic Police Academy - Module I",
+        "Civil Litigation",
+        "Comm Rel and the Justice Syste",
+        "Concepts of Criminal Law",
+        "Criminal Court Process"
+      ]
+    },
+    {
+      "prefix": "AGOR",
+      "name": "AGOR",
+      "course_count": 22,
+      "section_count": 47,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Cannabis Cultivation",
+        "Cannabis Plant and Industry",
+        "Construction Fundamentals",
+        "Horticultural Science",
+        "Integrated Pest Management"
+      ]
+    },
+    {
+      "prefix": "DS",
+      "name": "DS",
+      "course_count": 13,
+      "section_count": 47,
+      "colleges": [
+        "fresno-city-college",
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "Ad Aqua For Phys",
+        "Adaptive Fitness",
+        "Adaptive Weight Training",
+        "BUSINESS STATS",
+        "Community Awareness 1"
+      ]
+    },
+    {
+      "prefix": "ESS",
+      "name": "ESS",
+      "course_count": 8,
+      "section_count": 47,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "California Water",
+        "Energy, Environment, &amp; Climate",
+        "Environmental Regulations",
+        "Field Methods in Ecology",
+        "Internship in ESS"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "MTT",
+      "course_count": 25,
+      "section_count": 47,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "3D Numrcl Cntrl Graphc Prgrmng",
+        "Advanced Manufacturing Processes",
+        "Analog Circuits and Semiconductor Devices",
+        "Cmptr Num Contrl Progrmng",
+        "Computer Numerical Control Programming"
+      ]
+    },
+    {
+      "prefix": "NVN",
+      "name": "NVN",
+      "course_count": 16,
+      "section_count": 47,
+      "colleges": [
+        "college-of-the-desert",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Basic Pharmacology A",
+        "Basic Pharmacology B",
+        "Basic Pharmacology C",
+        "Foundations for Success",
+        "Growth & Devel Across Lifespan"
+      ]
+    },
+    {
+      "prefix": "OCEAN",
+      "name": "Oceanography",
+      "course_count": 8,
+      "section_count": 47,
+      "colleges": [
+        "cabrillo-college",
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Descriptive Oceanography",
+        "Field Studies in Oceanography",
+        "Fundamentals of Oceanography",
+        "Fundamentals of Oceanography with Laboratory",
+        "Intro Oceanography"
+      ]
+    },
+    {
+      "prefix": "BUAC",
+      "name": "BUAC",
+      "course_count": 9,
+      "section_count": 46,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ACCOUNTING WORK EXP",
+        "ACCTG W/QUICKBOOKS",
+        "BOOKKEEPING",
+        "EXCEL FOR ACCOUNTING",
+        "FINANCIAL ACCTG"
+      ]
+    },
+    {
+      "prefix": "CBIS",
+      "name": "CBIS",
+      "course_count": 17,
+      "section_count": 46,
+      "colleges": [
+        "allan-hancock-college",
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Computer Concepts",
+        "Computer Concepts &amp; Apps",
+        "Computer Fundamentals 1",
+        "Database Design and Management-Microsoft Access",
+        "Info Security Planning for Bus"
+      ]
+    },
+    {
+      "prefix": "FOR",
+      "name": "FOR",
+      "course_count": 39,
+      "section_count": 46,
+      "colleges": [
+        "citrus-college",
+        "lassen-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "ADV ANIMAL PACKING",
+        "ADV FIELD STDY I",
+        "ANIMAL PACKING",
+        "ANML PKG FLD STUDY",
+        "BACKPACKING"
+      ]
+    },
+    {
+      "prefix": "IET",
+      "name": "IET",
+      "course_count": 12,
+      "section_count": 46,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Electrical Blueprints",
+        "Electrical Motors/Controls I",
+        "Electrical Motors/Controls II",
+        "Fund of Ctrl Sys Technology",
+        "Industrial Basic Controls"
+      ]
+    },
+    {
+      "prefix": "INWT",
+      "name": "INWT",
+      "course_count": 10,
+      "section_count": 46,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Cloud Architecture (Cloud+)",
+        "Computing Fundamentals (A+)",
+        "Ethical Hacking & PenTesting",
+        "Intro. to Information Security",
+        "Linux Administration (Linux+)"
+      ]
+    },
+    {
+      "prefix": "NBIZ",
+      "name": "NBIZ",
+      "course_count": 12,
+      "section_count": 46,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "California Property Taxation and Assessment",
+        "Introduction to Computers",
+        "Keyboarding and Word Processing",
+        "Microsoft Access Essentials",
+        "Microsoft Excel Essentials"
+      ]
+    },
+    {
+      "prefix": "PAR",
+      "name": "Parenting",
+      "course_count": 11,
+      "section_count": 46,
+      "colleges": [
+        "butte-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Family Dynamics",
+        "PARENTING FOR COGNITIVE AND LANGUAGE DEVELOPMENT (0-5 YEARS OLD)",
+        "PARENTING FOR HEALTH AND PHYSICAL DEVELOPMENT (0-5 YEARS OLD)",
+        "PARENTING FOR SOCIAL AND EMOTIONAL DEVELOPMENT (0-5 YEARS OLD)",
+        "PARENTING YOUR 0 TO 8-MONTH-OLD"
+      ]
+    },
+    {
+      "prefix": "WATR",
+      "name": "Water",
+      "course_count": 32,
+      "section_count": 46,
+      "colleges": [
+        "citrus-college",
+        "cuesta-college",
+        "santa-ana-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Distribution Exm Prep",
+        "Advanced Treatment Exam Prepar",
+        "Advanced Water Distribution",
+        "Advanced Water Treatment",
+        "Advanced Water Treatment Oper"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 19,
+      "section_count": 45,
+      "colleges": [
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Accounting for Governmental & Nonprofit Entities",
+        "Basic Acctg",
+        "Business Financial Planning Using Excel",
+        "Cloud Computing and Analytics in Accounting",
+        "Cost Accounting"
+      ]
+    },
+    {
+      "prefix": "AD",
+      "name": "AD",
+      "course_count": 16,
+      "section_count": 45,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "AD Work Experience Seminar",
+        "Addiction Law and Ethics",
+        "Case Management &amp; Documentatio",
+        "Co-Occurring Disorders",
+        "Effects of Alcohol and Drugs"
+      ]
+    },
+    {
+      "prefix": "ARCE",
+      "name": "Ceramic",
+      "course_count": 20,
+      "section_count": 45,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Alternative Throwing Techniques",
+        "Ceramic Handbuilding I",
+        "Ceramic Handbuilding II",
+        "Ceramic Handbuilding III",
+        "Ceramic Handbuilding IV"
+      ]
+    },
+    {
+      "prefix": "FTC",
+      "name": "Fire",
+      "course_count": 8,
+      "section_count": 45,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Bldg Construction for Fire",
+        "Fire Behavior and Combustion",
+        "Fire Prevention",
+        "Fire Protection Organization",
+        "Fire Protection Systems"
+      ]
+    },
+    {
+      "prefix": "IDES",
+      "name": "Interior",
+      "course_count": 28,
+      "section_count": 45,
+      "colleges": [
+        "american-river-college",
+        "cypress-college",
+        "fullerton-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "3D Rendering Basics",
+        "Advanced 3D Modeling and Rendering",
+        "Applied Color and Design Theory",
+        "Beginning Interior Design Studio",
+        "Building Codes, Construction Basics and Systems"
+      ]
+    },
+    {
+      "prefix": "LA",
+      "name": "LA",
+      "course_count": 21,
+      "section_count": 45,
+      "colleges": [
+        "american-river-college",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Legal Writing",
+        "Civil Procedures and Litigation",
+        "Contract Law",
+        "Corporations Law",
+        "Criminal Law"
+      ]
+    },
+    {
+      "prefix": "MULT",
+      "name": "MULT",
+      "course_count": 19,
+      "section_count": 45,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "3D Character Design & Developm",
+        "3D Modeling",
+        "3D Studio Pre-Production",
+        "3D Texturing and Lighting",
+        "Advanced Unity"
+      ]
+    },
+    {
+      "prefix": "PSCI",
+      "name": "PSCI",
+      "course_count": 24,
+      "section_count": 45,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "coastline-community-college",
+        "compton-college",
+        "cuesta-college",
+        "el-camino-community-college-district",
+        "gavilan-college",
+        "golden-west-college",
+        "orange-coast-college",
+        "victor-valley-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "American Gov: Politics of Race",
+        "Comparative Politics",
+        "Earth Science",
+        "Energy &amp; Matter",
+        "Energy, Electricity &amp; Environ."
+      ]
+    },
+    {
+      "prefix": "ARTNM",
+      "name": "ARTNM",
+      "course_count": 27,
+      "section_count": 44,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "3D Animation – Autodesk Maya 2026",
+        "3D Modeling and Texturing II - Character – Zbrush/Autodesk Maya/Adobe Sub. 3D Pa",
+        "3D Modeling and Texturing III - Environment – Maya/Adobe Sub.3D/Photoshop/Zbrush",
+        "3D Rigging and Rig Building – Autodesk Maya 2026",
+        "Beginning Digital Art – Adobe Creative Suite"
+      ]
+    },
+    {
+      "prefix": "CALS",
+      "name": "CALS",
+      "course_count": 12,
+      "section_count": 44,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Basic Computer Skills",
+        "Career Planning & Development",
+        "Foundations for College",
+        "Modes Exp: Conflict Mngmnt/Res",
+        "Modes Exp: Intro Rec/Expr Lang"
+      ]
+    },
+    {
+      "prefix": "INDA",
+      "name": "INDA",
+      "course_count": 15,
+      "section_count": 44,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Applied Methods of Motion and Process Control",
+        "Corrosion",
+        "Economic Decision Making",
+        "Industrial Automation Networks",
+        "Industrial Automation Systems - Robotics"
+      ]
+    },
+    {
+      "prefix": "VIET",
+      "name": "Vietnamese",
+      "course_count": 19,
+      "section_count": 44,
+      "colleges": [
+        "coastline-community-college",
+        "college-of-alameda",
+        "cosumnes-river-college",
+        "de-anza-college",
+        "evergreen-valley-college",
+        "golden-west-college",
+        "orange-coast-college",
+        "san-diego-mesa-college",
+        "san-jose-city-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Convrstnl Viet/Culture",
+        "Elementary Vietnamese",
+        "Elementary Vietnamese (Second Quarter)",
+        "Elementary Vietnamese (Third Quarter)",
+        "Elementary Vietnamese 1"
+      ]
+    },
+    {
+      "prefix": "CMPR",
+      "name": "CMPR",
+      "course_count": 30,
+      "section_count": 43,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "A+ Essentials Hardware",
+        "A+ Essentials Software",
+        "CompTIA Network+ Guide to",
+        "CompTIA Security+ Guide to Ne",
+        "Computer Architecture & Organ"
+      ]
+    },
+    {
+      "prefix": "DMCP",
+      "name": "DMCP",
+      "course_count": 6,
+      "section_count": 43,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Career Satisfaction",
+        "Foundations of Teams",
+        "Intro to Self-Management",
+        "Prep for Employment",
+        "Professional Career Search"
+      ]
+    },
+    {
+      "prefix": "FDR",
+      "name": "FDR",
+      "course_count": 23,
+      "section_count": 43,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking and Pastry",
+        "Basic Food Preparation",
+        "Beginning Bread Making",
+        "Cost Control for Foodservice Organizations",
+        "Food Service Facilities Planning"
+      ]
+    },
+    {
+      "prefix": "FFT",
+      "name": "FFT",
+      "course_count": 9,
+      "section_count": 43,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Firefighter Training",
+        "Advanced Incident Command Systems",
+        "Firefighter Training",
+        "Human Factors in The Wildland Fire Service",
+        "Introduction to National Incident Management System (NIMS)"
+      ]
+    },
+    {
+      "prefix": "INDR",
+      "name": "Drafting",
+      "course_count": 9,
+      "section_count": 43,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer-Aided Drafting and Design",
+        "Civil Drafting and Geographic Information Systems",
+        "Electrical Design",
+        "Independent Topics in Industrial Drawing",
+        "Intermediate Computer-Aided Drafting and Design"
+      ]
+    },
+    {
+      "prefix": "LNSK",
+      "name": "Strategies",
+      "course_count": 16,
+      "section_count": 43,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Assistive Technology Applications",
+        "Beginning Assistive Technology Projects",
+        "Beginning Math Strategies Lab",
+        "Beginning Reading Strategies Lab",
+        "Beginning Writing Strategies Lab"
+      ]
+    },
+    {
+      "prefix": "NRAD",
+      "name": "NRAD",
+      "course_count": 25,
+      "section_count": 43,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Beg Student Intern",
+        "Bridge Pathway to RN Readines",
+        "Decision Mk Data I",
+        "Decision Mk Data II",
+        "Intermed Student Intern"
+      ]
+    },
+    {
+      "prefix": "PACT",
+      "name": "PACT",
+      "course_count": 13,
+      "section_count": 43,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Archery I",
+        "Badminton I",
+        "Badminton II",
+        "Boxing",
+        "Independent Studies in Personal Activity"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 31,
+      "section_count": 43,
+      "colleges": [
+        "fresno-city-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "ADV CLINICAL RAD",
+        "ADV POSITNG CRAN",
+        "BAS POSITION LAB",
+        "CLINIC ORIENT LAB",
+        "Clinical Experience 1A"
+      ]
+    },
+    {
+      "prefix": "BUSAC",
+      "name": "Accounting",
+      "course_count": 13,
+      "section_count": 42,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Applied Accounting",
+        "Auditing",
+        "Computer Income Tax Return Preparation- Individuals",
+        "Cost Accounting",
+        "Federal Income Taxes-Individuals"
+      ]
+    },
+    {
+      "prefix": "CG",
+      "name": "Success",
+      "course_count": 6,
+      "section_count": 42,
+      "colleges": [
+        "cabrillo-college",
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "College Success Skill Workshop",
+        "First Year Experience",
+        "Major/Career Exploration",
+        "Plan for Success",
+        "Study Strategies Lab"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 18,
+      "section_count": 42,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Adult Supervision &amp; Mentoring in Childhood Care &amp; Education",
+        "Care and Education for Infants and Toddlers",
+        "Child Growth and Development",
+        "Child Health and Safety",
+        "Child, Family, and Community"
+      ]
+    },
+    {
+      "prefix": "EMED",
+      "name": "Emergency",
+      "course_count": 11,
+      "section_count": 42,
+      "colleges": [
+        "contra-costa-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support (CPR for Healthcare Providers)",
+        "EMERGENCY MEDICAL RESPONDER",
+        "Emergency Medical Technician",
+        "EMERGENCY MEDICAL TECHNOLOGY AMBULANCE RIDE-ALONGS",
+        "EMERGENCY MEDICAL TECHNOLOGY LECTURE AND LABORATORY"
+      ]
+    },
+    {
+      "prefix": "HLTN",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 42,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "BASIC LIFE SUPPORT (BLS) PROVIDER",
+        "INTRODUCTION TO MEDICAL TERMINOLOGY",
+        "MEDICAL FRONT OFFICE CLERK PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "RMGT",
+      "name": "RMGT",
+      "course_count": 16,
+      "section_count": 42,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Culinary/Lead",
+        "Bakery/Pastry Training",
+        "Controlling Food Service Costs",
+        "Culinary I",
+        "Culinary II"
+      ]
+    },
+    {
+      "prefix": "RUSS",
+      "name": "Russian",
+      "course_count": 14,
+      "section_count": 42,
+      "colleges": [
+        "american-river-college",
+        "de-anza-college",
+        "diablo-valley-college",
+        "pasadena-city-college",
+        "sacramento-city-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Elementary Russian",
+        "ELEMENTARY RUSSIAN - LEVEL 1",
+        "ELEMENTARY RUSSIAN - LEVEL 2",
+        "Elementary Russian (Second Quarter)",
+        "Elementary Russian (Third Quarter)"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Social",
+      "course_count": 15,
+      "section_count": 42,
+      "colleges": [
+        "bakersfield-college",
+        "cypress-college",
+        "de-anza-college",
+        "foothill-college",
+        "fullerton-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Community Based Learning in Social Sciences - Historical",
+        "Community Based Learning in Social Sciences - Philosophical",
+        "Community Based Learning in Social Sciences - Sociological",
+        "INDEPENDENT STUDY IN SOCIAL SCIENCE",
+        "INTRODUCTION TO COMMUNITY/CIVIC ENGAGEMENT"
+      ]
+    },
+    {
+      "prefix": "THEAT",
+      "name": "THEAT",
+      "course_count": 11,
+      "section_count": 42,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Beginning Acting",
+        "Chicanx/Latinx Theatre",
+        "Costume Design",
+        "Intermediate Acting",
+        "Introduction to Film"
+      ]
+    },
+    {
+      "prefix": "VTAH",
+      "name": "Veterinary",
+      "course_count": 20,
+      "section_count": 42,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Advanced Animal Care And Mgt",
+        "Advanced Surgical Nursing",
+        "Animal Care and Management",
+        "Animal Surgery and Anesthesia",
+        "Clin Path Lab"
+      ]
+    },
+    {
+      "prefix": "BIOT",
+      "name": "Biotechnology",
+      "course_count": 34,
+      "section_count": 41,
+      "colleges": [
+        "american-river-college",
+        "citrus-college",
+        "moorpark-college",
+        "rio-hondo-college",
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Adv Tpcs in QA and Reg Affairs",
+        "Advanced Topics in Quality Assurance and Regulatory Affairs",
+        "Biomanufacturing Process Sciences and Engineering Principles",
+        "Biomfg Process Sciences",
+        "Biotechnology and Human Health"
+      ]
+    },
+    {
+      "prefix": "CISB",
+      "name": "CISB",
+      "course_count": 10,
+      "section_count": 41,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Computer Information Systems",
+        "Generative AI, Language Models",
+        "Machine &amp; Deep Learning in Bus",
+        "Macintosh Applications",
+        "Microcomputer Application"
+      ]
+    },
+    {
+      "prefix": "DESGN",
+      "name": "Design",
+      "course_count": 19,
+      "section_count": 41,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Architectural Modeling and Design",
+        "Architecture and Construction",
+        "Commercial Engineering Design and Drafting",
+        "Commercial MEP Design",
+        "Engineering Modeling and Design"
+      ]
+    },
+    {
+      "prefix": "EARTH",
+      "name": "Earth",
+      "course_count": 3,
+      "section_count": 41,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "Earth Science Laboratory",
+        "Earth Science Lecture And Laboratory"
+      ]
+    },
+    {
+      "prefix": "ENVS",
+      "name": "Environmental Science",
+      "course_count": 12,
+      "section_count": 41,
+      "colleges": [
+        "coastline-community-college",
+        "college-of-the-siskiyous",
+        "cuesta-college",
+        "cypress-college",
+        "fullerton-college",
+        "gavilan-college",
+        "napa-valley-college",
+        "pasadena-city-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "CHEMISTRY AND THE ENVIRONMENT",
+        "Environmental Biology",
+        "Environmental Biology Lab",
+        "Environmental Science",
+        "HUMAN IMPACT ON THE ENVIRONMENT"
+      ]
+    },
+    {
+      "prefix": "ETHST",
+      "name": "Race",
+      "course_count": 6,
+      "section_count": 41,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Community Building and Transformation in Urban America",
+        "Economics and Social Change: Racial Conflict and Class in America",
+        "Introduction to Ethnic Studies",
+        "Introduction to Race, Class and Schools",
+        "Introduction to Race, Gender and Health"
+      ]
+    },
+    {
+      "prefix": "FRNC",
+      "name": "French",
+      "course_count": 16,
+      "section_count": 41,
+      "colleges": [
+        "pasadena-city-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced French Oral and Written Composition",
+        "Basic French Conversation and Culture",
+        "Beginning French",
+        "ELEMENTARY FRENCH - LEVEL 1",
+        "ELEMENTARY FRENCH - LEVEL 2"
+      ]
+    },
+    {
+      "prefix": "GRART",
+      "name": "Graphic",
+      "course_count": 13,
+      "section_count": 41,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator Basics",
+        "Adobe Photoshop Basics",
+        "Advanced Photoshop",
+        "Applied Graphic Design 1",
+        "Applied Graphic Design 2"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "HLSC",
+      "course_count": 6,
+      "section_count": 41,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "EKG TECHNICIAN",
+        "HUMAN DISEASE",
+        "INTRODUCTION TO HEALTH SCIENCES",
+        "MEDICAL TERMINOLOGY",
+        "PHARMACOLOGY FOR HEALTH PROFESSIONS"
+      ]
+    },
+    {
+      "prefix": "INTE",
+      "name": "INTE",
+      "course_count": 16,
+      "section_count": 41,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "AutoCAD for Interiors",
+        "Elements of Interior Design",
+        "Environmental Lighting Design",
+        "Hist Furniture and Interiors",
+        "Int. Blding System/Codes"
+      ]
+    },
+    {
+      "prefix": "OT",
+      "name": "OT",
+      "course_count": 23,
+      "section_count": 41,
+      "colleges": [
+        "clovis-community-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "BEGIN KEYBOARDING",
+        "COMPUTER BASICS",
+        "Diag/Treat-Orthop Disorders I",
+        "Diag/Treat-Orthop Disorders II",
+        "FILING PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "TAC",
+      "name": "TAC",
+      "course_count": 24,
+      "section_count": 41,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Acting I - Acting for Everyone",
+        "Acting II",
+        "Beg TV Studio Production",
+        "Beginning Audio Product"
+      ]
+    },
+    {
+      "prefix": "ARCHI",
+      "name": "ARCHI",
+      "course_count": 19,
+      "section_count": 40,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Architectural Design I",
+        "Architectural Design II",
+        "Architectural Design III",
+        "Architectural Graphics I",
+        "Architectural Graphics II"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 28,
+      "section_count": 40,
+      "colleges": [
+        "butte-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Auto Elec Sys",
+        "Auto Elect Systems Lab",
+        "Auto Electrical Systems Lec",
+        "Auto Engines Lecture",
+        "Auto Heating & AC Lab"
+      ]
+    },
+    {
+      "prefix": "BIS",
+      "name": "BIS",
+      "course_count": 12,
+      "section_count": 40,
+      "colleges": [
+        "evergreen-valley-college",
+        "oxnard-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Business Document Production",
+        "Computerized Medical Billing",
+        "Electronic Health Records",
+        "Global Communication",
+        "Hum Relations in Workplace"
+      ]
+    },
+    {
+      "prefix": "DENTL",
+      "name": "Dental",
+      "course_count": 25,
+      "section_count": 40,
+      "colleges": [
+        "college-of-alameda",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Chairside",
+        "ADVANCED CHAIRSIDE PROCEDURES",
+        "Anatomy, Physiology, Medical Emergies, And Pharmacology",
+        "BIODENTAL SCIENCES",
+        "CHAIRSIDE PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "ELCT",
+      "name": "Electrical",
+      "course_count": 28,
+      "section_count": 40,
+      "colleges": [
+        "barstow-community-college",
+        "san-diego-city-college",
+        "santa-ana-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "A+ Opr Sys Tech",
+        "Ac Circuit Theory and Analysis",
+        "Accessing the Wan",
+        "Basic Maint of Pcs",
+        "Dc Circuit Theory/Analy"
+      ]
+    },
+    {
+      "prefix": "FASHD",
+      "name": "Fashion",
+      "course_count": 11,
+      "section_count": 40,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Adv Clothing Construct",
+        "Apparel Production",
+        "Begin. Clothing Construction",
+        "Beginning Patternmaking",
+        "CAD for Fashion"
+      ]
+    },
+    {
+      "prefix": "HSART",
+      "name": "HSART",
+      "course_count": 6,
+      "section_count": 40,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Drawing and Painting 2",
+        "Literature Brought to Life",
+        "Music Theory 1",
+        "Short Stories",
+        "The Film As Art"
+      ]
+    },
+    {
+      "prefix": "LS",
+      "name": "LS",
+      "course_count": 22,
+      "section_count": 40,
+      "colleges": [
+        "cabrillo-college",
+        "evergreen-valley-college",
+        "moorpark-college",
+        "oxnard-college",
+        "san-jose-city-college",
+        "southwestern-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Basic Math Skills I",
+        "Basic Math Skills II",
+        "Basic Reading Skills I",
+        "Basic Reading Skills II",
+        "Basic Writing Skills"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "Health",
+      "course_count": 15,
+      "section_count": 40,
+      "colleges": [
+        "cuesta-college",
+        "cypress-college",
+        "fullerton-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Civic Engagement in Public Health (formerly KIN 289 C)",
+        "Contemporary Personal Health (formerly KIN 284 C)",
+        "Health Disparities",
+        "Honors Introduction to Public Health (formerly KIN 280HC)",
+        "Interpersonal Neurobiology and the Mind-Body Connection"
+      ]
+    },
+    {
+      "prefix": "RC",
+      "name": "Care",
+      "course_count": 28,
+      "section_count": 40,
+      "colleges": [
+        "american-river-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Adv Clnic App/Interp Bld Gases",
+        "Adv Resp Thrpy Asmtic Patient",
+        "Adv Spclty Vent/Oxgn Dlvry Dev",
+        "Adv Specialty Resp Gases",
+        "Advanced Emergency Management"
+      ]
+    },
+    {
+      "prefix": "GLST",
+      "name": "Global",
+      "course_count": 11,
+      "section_count": 39,
+      "colleges": [
+        "american-river-college",
+        "cuesta-college",
+        "foothill-college",
+        "monterey-peninsula-college",
+        "orange-coast-college",
+        "sacramento-city-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Global Issues",
+        "GLOBAL ISSUES",
+        "Global Problems/Issues",
+        "Intro to Global Studies",
+        "Introduction to Global Studies"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "PSC",
+      "course_count": 14,
+      "section_count": 39,
+      "colleges": [
+        "butte-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Concepts in Physical Science",
+        "Earth Science With Lab",
+        "Fundamentals of Sci. Computing",
+        "Fundamentals-Aerospace Science",
+        "Fundamentals-Electric Circuits"
+      ]
+    },
+    {
+      "prefix": "ABT",
+      "name": "ABT",
+      "course_count": 21,
+      "section_count": 38,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Ag Bus Dev for New Organic",
+        "Ag Whole Farm Planning",
+        "Agribusiness Economics",
+        "Agric Computer Applications",
+        "Agric Laws & Regulations"
+      ]
+    },
+    {
+      "prefix": "ANCT",
+      "name": "Animal",
+      "course_count": 27,
+      "section_count": 38,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Anatomy &amp; Physiology Mammals",
+        "Animal Behavior",
+        "Animal Behavior Lab",
+        "Animal Care &amp; Handling I",
+        "Animal Care &amp; Handling Lab I"
+      ]
+    },
+    {
+      "prefix": "APT",
+      "name": "APT",
+      "course_count": 24,
+      "section_count": 38,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Adv Commercl Pilot Flight Lab",
+        "Adv Flght Instructor Flght Lab",
+        "Adv Instrmnt Pilot Flight Lab",
+        "Advanced Aircraft &amp; Engines",
+        "Aerodynamics"
+      ]
+    },
+    {
+      "prefix": "BRE",
+      "name": "Real",
+      "course_count": 9,
+      "section_count": 38,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Intro to Real Estate Careers",
+        "Legal Aspects R.E. I",
+        "Real Estate Appraisal",
+        "Real Estate Economics",
+        "Real Estate Finance"
+      ]
+    },
+    {
+      "prefix": "CNET",
+      "name": "CNET",
+      "course_count": 27,
+      "section_count": 38,
+      "colleges": [
+        "allan-hancock-college",
+        "cuesta-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "A+ Certification Preparation",
+        "Cloud Comp for Tech",
+        "Computer Networks",
+        "Computer Tech Fundamentals",
+        "Cyber Security Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CNSTR",
+      "name": "CNSTR",
+      "course_count": 12,
+      "section_count": 38,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "BIM",
+        "Blueprint Reading",
+        "Building Codes",
+        "Energy Efficiency Construction",
+        "Estimating"
+      ]
+    },
+    {
+      "prefix": "ECHD",
+      "name": "ECHD",
+      "course_count": 21,
+      "section_count": 38,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Administration and Management of Early Childhood Programs (DS6)",
+        "Adult Supervision in Early Childhood Classrooms",
+        "Care and Education for Infants and Toddlers",
+        "Child Growth and Development (DS1)",
+        "Creative Activities (DS3)"
+      ]
+    },
+    {
+      "prefix": "ENGCW",
+      "name": "Writing",
+      "course_count": 8,
+      "section_count": 38,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "College Literary Magazine",
+        "Comedy Writing Workshop",
+        "Creative Non-Fiction Writing Workshop – HSI - Early College Program",
+        "Creative Writing",
+        "Feature Film Screenwriting Workshop I"
+      ]
+    },
+    {
+      "prefix": "EST",
+      "name": "EST",
+      "course_count": 21,
+      "section_count": 38,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "A+PC MAINTENANCE",
+        "AC FUNDAMENTALS",
+        "BLDG MGMT SYS",
+        "COMMRCL/INDUST NETWRKG",
+        "DC FUND OF ELTRN"
+      ]
+    },
+    {
+      "prefix": "KINPE",
+      "name": "KINPE",
+      "course_count": 14,
+      "section_count": 38,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Archery",
+        "Basketball",
+        "Beginning Hiking",
+        "Beginning Weight Training",
+        "Body Sculpting"
+      ]
+    },
+    {
+      "prefix": "MENT",
+      "name": "Tech",
+      "course_count": 12,
+      "section_count": 38,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Adv Med-Surg Nsg Psy Tech Clin",
+        "Interviewing &amp; Counseling",
+        "Intro Psyc Technology Clinical",
+        "Intro to Psychiatric Technolog",
+        "Med Surg &amp; Pharm for Psyc Tech"
+      ]
+    },
+    {
+      "prefix": "MRSC",
+      "name": "MRSC",
+      "course_count": 24,
+      "section_count": 38,
+      "colleges": [
+        "coastline-community-college",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Aquarium and Aquaculture Exp",
+        "Aquarium Life Support Op&amp;Maint",
+        "Aquarium Science Management 1",
+        "Aquarium Science Management 2",
+        "Aquarium Science Management 3"
+      ]
+    },
+    {
+      "prefix": "SE",
+      "name": "Involved",
+      "course_count": 2,
+      "section_count": 38,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Independent Living/Work Skills for Persons with Disabilities",
+        "Involved Elder"
+      ]
+    },
+    {
+      "prefix": "AGHE",
+      "name": "AGHE",
+      "course_count": 16,
+      "section_count": 37,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Anat/Phys of Domestic Animals",
+        "Animal Surgical Nursing",
+        "Applied Animal Health Procedur",
+        "Clinical Pathology",
+        "Clinical Pathology B"
+      ]
+    },
+    {
+      "prefix": "AMTP",
+      "name": "Aircraft",
+      "course_count": 34,
+      "section_count": 37,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Aircraft Communication and Navigation Applications",
+        "Aircraft Communication and Navigation Fundamentals",
+        "Aircraft Inspection Applications",
+        "Aircraft Inspection Fundamentals",
+        "Aircraft Propellers and Propeller Systems Applications"
+      ]
+    },
+    {
+      "prefix": "ATECH",
+      "name": "ATECH",
+      "course_count": 13,
+      "section_count": 37,
+      "colleges": [
+        "college-of-alameda"
+      ],
+      "sample_titles": [
+        "ADV. ENGINE PERFORMANCE (CLEAN AIR COURSE PHASE I)",
+        "ADVANCED AUTOMOTIVE CHASSIS",
+        "Advanced Automotive Electronics",
+        "ADVANCED AUTOMOTIVE TRANSAXLES AND TRANSMISSIONS",
+        "ADVANCED ENGINE REPAIR"
+      ]
+    },
+    {
+      "prefix": "DRAFT",
+      "name": "Design",
+      "course_count": 13,
+      "section_count": 37,
+      "colleges": [
+        "chaffey-college",
+        "fresno-city-college",
+        "los-angeles-mission-college",
+        "los-angeles-trade-technical-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Adv CAD Modeling and Apls",
+        "Advanced Mechanical Design",
+        "Architectural Design I",
+        "Architectural Design II",
+        "Blueprint Reading I"
+      ]
+    },
+    {
+      "prefix": "ECT",
+      "name": "ECT",
+      "course_count": 17,
+      "section_count": 37,
+      "colleges": [
+        "laney-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advanced Direct Digital Controls",
+        "Advanced Refrigeration & Troubleshooting",
+        "Blueprint Reading and Interpretation for ECT",
+        "CADD &amp; Digital Design Media I",
+        "Commercial HVAC Systems and Troubleshooting"
+      ]
+    },
+    {
+      "prefix": "ESLW",
+      "name": "ESLW",
+      "course_count": 13,
+      "section_count": 37,
+      "colleges": [
+        "american-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Composition",
+        "Advanced Grammar and Editing",
+        "Advanced Listening and Speaking",
+        "Advanced Reading and Writing",
+        "High Beginning Listening and Speaking"
+      ]
+    },
+    {
+      "prefix": "HSER",
+      "name": "HSER",
+      "course_count": 12,
+      "section_count": 37,
+      "colleges": [
+        "american-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Alcoholism: Intervention, Treatment and Recovery",
+        "Ethical Issues and Client's Rights",
+        "Independent Studies in Human Services",
+        "Introduction to Chemical Dependency",
+        "Introduction to Human Services"
+      ]
+    },
+    {
+      "prefix": "JRNAL",
+      "name": "News",
+      "course_count": 13,
+      "section_count": 37,
+      "colleges": [
+        "contra-costa-college",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Independent Study",
+        "Introduction to Newswriting and Reporting",
+        "Mass Media of Communication",
+        "News Production Fundamentals",
+        "News Production Laboratory I"
+      ]
+    },
+    {
+      "prefix": "MEDT",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 37,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "MNFG",
+      "name": "MNFG",
+      "course_count": 22,
+      "section_count": 37,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Adv Conv Lathe Concepts/Operat",
+        "Adv Conv Mill Concepts/Operati",
+        "Advanced CNC Lathe Programmin",
+        "Basic Conv Mach Concepts/Oper",
+        "Basic ESPRIT EDGE"
+      ]
+    },
+    {
+      "prefix": "NURSE",
+      "name": "Nursing",
+      "course_count": 17,
+      "section_count": 37,
+      "colleges": [
+        "american-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Focused Learning in the First Year of the ARC Nursing Program",
+        "Focused Learning in the Second Year of the ARC Nursing Program",
+        "Fundamentals of Health and Nursing Care",
+        "Home Health Aide",
+        "LVN-RN (Associate Degree Nursing) Transition"
+      ]
+    },
+    {
+      "prefix": "AFAM",
+      "name": "African",
+      "course_count": 2,
+      "section_count": 36,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "An Introduction to African American Studies",
+        "Introduction to Black Feminism"
+      ]
+    },
+    {
+      "prefix": "ARHI",
+      "name": "ARHI",
+      "course_count": 8,
+      "section_count": 36,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "Hist of Latinx and Chicanx Art",
+        "History of Asian Art",
+        "History of Photography",
+        "History of Women in Art"
+      ]
+    },
+    {
+      "prefix": "CBTE",
+      "name": "Microsoft",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Basic Computer Keyboarding",
+        "Beginning Microsoft Access",
+        "Beginning Microsoft Excel",
+        "Beginning Microsoft PowerPoint",
+        "Beginning Microsoft Word"
+      ]
+    },
+    {
+      "prefix": "CDF",
+      "name": "CDF",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Admin I Programs in ECE",
+        "Admin II Personnel/Leadership",
+        "Child Growth/Development",
+        "Child/Family/Community",
+        "Children With Special Needs"
+      ]
+    },
+    {
+      "prefix": "CIST",
+      "name": "CIST",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Python",
+        "Computer Organization and Assembly Programming",
+        "Computer Programming I (C++ Programming)",
+        "Computer Programming I (Java)",
+        "Data Structures using Advanced C++"
+      ]
+    },
+    {
+      "prefix": "HUSEV",
+      "name": "HUSEV",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Addictive Behavior",
+        "Chem Dep Counseling",
+        "Chem Dep Sem/Intern",
+        "Diverse Communities",
+        "Family & Addiction"
+      ]
+    },
+    {
+      "prefix": "JLE",
+      "name": "JLE",
+      "course_count": 13,
+      "section_count": 36,
+      "colleges": [
+        "gavilan-college"
+      ],
+      "sample_titles": [
+        "BAS ACAD LEV III",
+        "BASIC ACADEMY REQUAL",
+        "BASIC POLICE ACAD",
+        "CIT ACADEMY",
+        "DEFENSIVE TACTICS INSTRUCTOR"
+      ]
+    },
+    {
+      "prefix": "LCAS",
+      "name": "Chicanx",
+      "course_count": 1,
+      "section_count": 36,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Intro to Chicanx Studies"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 25,
+      "section_count": 36,
+      "colleges": [
+        "mt-san-antonio-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "African American Literature",
+        "American Literature through 1865",
+        "American Literature through 1865 Honors",
+        "Approaches to Literature",
+        "Bible As Lit: New Testamet"
+      ]
+    },
+    {
+      "prefix": "MAD",
+      "name": "Formerly",
+      "course_count": 29,
+      "section_count": 36,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "3D Storyboarding and Layout",
+        "Advanced 3D (formerly Advanced Animation-Mac)",
+        "Beginning 3D",
+        "Beginning Single Camera Production",
+        "Cinematography"
+      ]
+    },
+    {
+      "prefix": "REST",
+      "name": "Real",
+      "course_count": 16,
+      "section_count": 36,
+      "colleges": [
+        "de-anza-college",
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Legal Aspects of Real Estate",
+        "Principles of Real Estate",
+        "Property Management",
+        "Real Estate Economics",
+        "Real Estate Finance"
+      ]
+    },
+    {
+      "prefix": "RTEC",
+      "name": "RTEC",
+      "course_count": 18,
+      "section_count": 36,
+      "colleges": [
+        "bakersfield-college",
+        "el-camino-community-college-district",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Adv Imaging/Special Procd",
+        "Biologic/Organic Laboratory Analysis",
+        "Clinical Experience 1",
+        "Clinical Experience 2",
+        "Clinical Experience 4"
+      ]
+    },
+    {
+      "prefix": "ASTRON",
+      "name": "ASTRON",
+      "course_count": 3,
+      "section_count": 35,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Life in the Universe",
+        "Planets & Solar System w/Lab",
+        "Stars and Galaxies"
+      ]
+    },
+    {
+      "prefix": "DDSN",
+      "name": "Design",
+      "course_count": 18,
+      "section_count": 35,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Design Studio I",
+        "Design Studio II",
+        "Design Studio III",
+        "Digital Illustration for Graphic Design I",
+        "Digital Illustration for Graphic Design II"
+      ]
+    },
+    {
+      "prefix": "GID",
+      "name": "Design",
+      "course_count": 11,
+      "section_count": 35,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED T-SHIRT DESIGN & GARMENT PRINTING",
+        "BEGINNING T-SHIRT DESIGN & GARMENT PRINTING",
+        "DESIGN THINKING",
+        "FUNDAMENTALS OF 3-D ANIMATION",
+        "GRAPHIC DESIGN DRAWING"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "PS",
+      "course_count": 14,
+      "section_count": 35,
+      "colleges": [
+        "cabrillo-college",
+        "chaffey-college",
+        "college-of-the-desert",
+        "folsom-lake-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Amer Poli Thought",
+        "California Politics & Culture",
+        "COMPARATIVE GOVERNMT",
+        "Comparative Politics",
+        "International Relations"
+      ]
+    },
+    {
+      "prefix": "BCA",
+      "name": "Comp",
+      "course_count": 8,
+      "section_count": 34,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Bus Comp Apps",
+        "Comp Calc",
+        "Comp Operationg Sys",
+        "Comp. Keyboarding",
+        "Intro to Comp Key"
+      ]
+    },
+    {
+      "prefix": "CISW",
+      "name": "CISW",
+      "course_count": 19,
+      "section_count": 34,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "mt-san-antonio-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Web Publishing",
+        "Cascading Style Sheets",
+        "Client-side Web Scripting",
+        "Database-Driven Web Applications",
+        "Designing Accessible Websites"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 12,
+      "section_count": 34,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Basic Food Production",
+        "Beginning Beermaking",
+        "Beverage Management",
+        "Culinary Arts Work Exper Educ",
+        "Food and Beverage Cost Control"
+      ]
+    },
+    {
+      "prefix": "DENA",
+      "name": "Dental",
+      "course_count": 19,
+      "section_count": 34,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Basic Dental Assisting",
+        "Basic Dental Assisting Lab",
+        "Basic Dental Science",
+        "Clinical Bus Mgmt Lab",
+        "Clinical Business Management"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 18,
+      "section_count": 34,
+      "colleges": [
+        "cypress-college",
+        "foothill-college",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Abdomen Sonography",
+        "Abdominal Sonography",
+        "Adv Vascular Ultrasound",
+        "Carotid and Arterial Sonography",
+        "Clinical Experience 2"
+      ]
+    },
+    {
+      "prefix": "DRA",
+      "name": "DRA",
+      "course_count": 20,
+      "section_count": 34,
+      "colleges": [
+        "college-of-the-desert",
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Acting 1",
+        "Acting II-Acting for Camera",
+        "AUTOCAD",
+        "Entertainment Lighting",
+        "INTRO SKETCHUP/REVIT"
+      ]
+    },
+    {
+      "prefix": "F/TV",
+      "name": "F/TV",
+      "course_count": 27,
+      "section_count": 34,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "American Cultures in Film",
+        "Animated Film Post-Production Workshop",
+        "Animated Film Pre-Production Workshop",
+        "Animated Film Production Workshop",
+        "Audio Post-Production"
+      ]
+    },
+    {
+      "prefix": "FAC",
+      "name": "Fire",
+      "course_count": 16,
+      "section_count": 34,
+      "colleges": [
+        "rio-hondo-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Advanced Fire Course",
+        "Advanced Fire Physical Abil Tr",
+        "Basic Fire Academy- Fire Fight",
+        "Beginning Fire Physical Abi Tr",
+        "Biddle Physical Ability Test"
+      ]
+    },
+    {
+      "prefix": "GENSCI",
+      "name": "Science",
+      "course_count": 2,
+      "section_count": 34,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Science Skills and Strategies I",
+        "Science Skills and Strategies II"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 12,
+      "section_count": 34,
+      "colleges": [
+        "butte-college",
+        "citrus-college",
+        "college-of-the-desert",
+        "gavilan-college",
+        "mission-college",
+        "sierra-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese I",
+        "Beginning Japanese II",
+        "ELEMENTARY JAPANESE",
+        "Elementary Japanese - Level I",
+        "Elementary Japanese - Level II"
+      ]
+    },
+    {
+      "prefix": "SOCIL",
+      "name": "SOCIL",
+      "course_count": 5,
+      "section_count": 34,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Intro to Sociology",
+        "Soc of Family",
+        "Soc of Gender",
+        "Soc of Race & Ethn",
+        "Social Problems"
+      ]
+    },
+    {
+      "prefix": "WEL",
+      "name": "Welding",
+      "course_count": 22,
+      "section_count": 34,
+      "colleges": [
+        "palo-verde-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Adv Gas Metal Arc Welding",
+        "Adv Gas Tungsten Arc Welding",
+        "Adv Oxyacetylene Gas Welding",
+        "Advanced Welding Applications",
+        "ARC and MIG Welding I"
+      ]
+    },
+    {
+      "prefix": "BUSR",
+      "name": "Real",
+      "course_count": 10,
+      "section_count": 33,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Appraisal: Principles &amp; Proced",
+        "Escrow Procedures I",
+        "Landlord-Tenant Law",
+        "Legal Aspects of Real Estate",
+        "Mortgage Loan Brokering &amp; Lend"
+      ]
+    },
+    {
+      "prefix": "CARER",
+      "name": "Career",
+      "course_count": 6,
+      "section_count": 33,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Career and Life Planning",
+        "Career and Life Planning - Noncredit",
+        "Career and Major Exploration",
+        "Career Assessment",
+        "College and Career Readiness II"
+      ]
+    },
+    {
+      "prefix": "CYBR",
+      "name": "CYBR",
+      "course_count": 19,
+      "section_count": 33,
+      "colleges": [
+        "coastline-community-college",
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Application Security",
+        "CISSP",
+        "Cloud Security",
+        "Cyber Hygiene",
+        "Cybercrime and CSIRT"
+      ]
+    },
+    {
+      "prefix": "EDAC",
+      "name": "EDAC",
+      "course_count": 5,
+      "section_count": 33,
+      "colleges": [
+        "de-anza-college",
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "Civic Responsibility",
+        "INTRODUCTION TO COLLEGE & ACCOMMODATIONS",
+        "Professional Conduct",
+        "Vocational Interests and Aptitudes",
+        "Workforce Skills"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 13,
+      "section_count": 33,
+      "colleges": [
+        "cypress-college",
+        "hartnell-college",
+        "moorpark-college",
+        "oxnard-college",
+        "santa-rosa-junior-college",
+        "sierra-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Developing Literacy",
+        "Elementary School Teaching",
+        "Intro Elem Classr w/ Field Exp",
+        "Intro to Ed in a Changing Worl",
+        "Intro to Education"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "ENTR",
+      "course_count": 10,
+      "section_count": 33,
+      "colleges": [
+        "allan-hancock-college",
+        "barstow-community-college",
+        "cypress-college",
+        "fullerton-college",
+        "santa-ana-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurial Mindset",
+        "Entrepreneurship Basic: Design Thinking and Supply Chain",
+        "Entrepreneurship, Introduction",
+        "Entrepreurship & Innovation",
+        "Intro to Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "HUSR",
+      "name": "HUSR",
+      "course_count": 22,
+      "section_count": 33,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Advanced Fieldwork",
+        "Chemical Dependency: Intervention, Treatment, and Recovery",
+        "Counseling the Family of the Addicted Person",
+        "Crisis Intervention and Referral",
+        "Cross-Cultural Criminology"
+      ]
+    },
+    {
+      "prefix": "LIBT",
+      "name": "Library",
+      "course_count": 24,
+      "section_count": 33,
+      "colleges": [
+        "cuesta-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Adolescent Lit",
+        "Advanced Online Searching",
+        "Ethics in the Info Age",
+        "Info Tech Internship",
+        "Internet Research Skills"
+      ]
+    },
+    {
+      "prefix": "MM/VI",
+      "name": "MM/VI",
+      "course_count": 11,
+      "section_count": 33,
+      "colleges": [
+        "berkeley-city-college"
+      ],
+      "sample_titles": [
+        "Documentary Production and Editing",
+        "Editing I: Introduction to Video Editing",
+        "Editing I: Introduction to Video Editing Lab",
+        "Intermediate Narrative Scriptwriting",
+        "Introduction to Narrative Scriptwriting"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 22,
+      "section_count": 33,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical-Surgical Nurs",
+        "Clinical Practice for Nur 251",
+        "Clinical Practice for Nur 255",
+        "Clinical Practice for Nur 258",
+        "Clinical Practice for Nur 260"
+      ]
+    },
+    {
+      "prefix": "RNB",
+      "name": "Clinical",
+      "course_count": 15,
+      "section_count": 33,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Judgement/Simulation",
+        "Advanced Clinical Practicum",
+        "Advanced Medical Surgical Nursing",
+        "Clinical Preceptorship",
+        "Community Mental Health Nursing"
+      ]
+    },
+    {
+      "prefix": "ARTHS",
+      "name": "History",
+      "course_count": 8,
+      "section_count": 32,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "Contemporary Art History",
+        "Critical Thinking in Visual Studies",
+        "History of Asian Art",
+        "History of Baroque to 20th Century Art"
+      ]
+    },
+    {
+      "prefix": "BCIS",
+      "name": "BCIS",
+      "course_count": 13,
+      "section_count": 32,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Adobe Acrobat Professional",
+        "Advanced Keyboarding",
+        "Basics of Computers",
+        "Beg Legal Office Procedures",
+        "Beginning Keyboarding"
+      ]
+    },
+    {
+      "prefix": "EHSM",
+      "name": "EHSM",
+      "course_count": 9,
+      "section_count": 32,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Air Quality Management",
+        "Construction Safety Standards",
+        "Cooperative Work Experience",
+        "Environmental & OSH Mgmt",
+        "Hazardous Materials Mgmt Apps"
+      ]
+    },
+    {
+      "prefix": "ENGE",
+      "name": "Engineering",
+      "course_count": 8,
+      "section_count": 32,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Comp. Methods in Enge",
+        "Computer-Aided Design",
+        "Digital Systems",
+        "Dynamics",
+        "Electric Circuits"
+      ]
+    },
+    {
+      "prefix": "GRC",
+      "name": "GRC",
+      "course_count": 30,
+      "section_count": 32,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "ADOBE AFTER EFFCTS",
+        "ADOBE ILLUSTRATOR",
+        "ADOBE INDESIGN",
+        "ADOBE PROF CERT",
+        "APP GRAPH-ADOBE TOOLS"
+      ]
+    },
+    {
+      "prefix": "HSRDG",
+      "name": "Reading",
+      "course_count": 4,
+      "section_count": 32,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Bldg Reading Sklls 2",
+        "Building Reading Sklls 1",
+        "Reading Improvement",
+        "Reading Proficiency Dev"
+      ]
+    },
+    {
+      "prefix": "INFS",
+      "name": "INFS",
+      "course_count": 12,
+      "section_count": 32,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Data Communications/Networking",
+        "Information &amp; Communication Technology Essentials",
+        "Internet Protocols and Principles",
+        "Internet Research",
+        "Introduction to Database Management Systems"
+      ]
+    },
+    {
+      "prefix": "LR",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 32,
+      "colleges": [
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Information Skills for College and Beyond"
+      ]
+    },
+    {
+      "prefix": "MEDI",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 32,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "MET",
+      "course_count": 12,
+      "section_count": 32,
+      "colleges": [
+        "de-anza-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Basic Mechanical Systems",
+        "Cal/OSHA 10 General Safety",
+        "Climate Change Laboratory",
+        "Drawing Mechanical Systems",
+        "Fundamentals of Instruments and Electricity"
+      ]
+    },
+    {
+      "prefix": "PUBH",
+      "name": "Health",
+      "course_count": 14,
+      "section_count": 32,
+      "colleges": [
+        "mt-san-antonio-college",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker III",
+        "Drugs, Health, and Society",
+        "History of Western Medicine",
+        "Intro to Public Health Honors",
+        "Introduction to Epidemiology"
+      ]
+    },
+    {
+      "prefix": "VSO",
+      "name": "VSO",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "BASEBALL",
+        "BASKETBALL",
+        "BEACH VOLLEYBALL",
+        "FOOTBALL",
+        "GOLF"
+      ]
+    },
+    {
+      "prefix": "WDTEC",
+      "name": "Industry",
+      "course_count": 7,
+      "section_count": 32,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD/CAM Techniques in the Cabinet-Making Industry",
+        "CAD/CAM Techniques in the Cabinet-Making Industry",
+        "CAL-OSHA 30-Hour General Industry Training",
+        "Furniture Cabinet Layout I",
+        "Furniture Cabinet Layout II"
+      ]
+    },
+    {
+      "prefix": "AI",
+      "name": "AI",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "chaffey-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "laney-college"
+      ],
+      "sample_titles": [
+        "AI: Prompt Eng & Systems",
+        "Applied Generative Artificial Intelligence I",
+        "Computer Vision I",
+        "Deep Learning (DL) I",
+        "Deep Learning (DL) II"
+      ]
+    },
+    {
+      "prefix": "ARTC",
+      "name": "Design",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Contemporary Illustration",
+        "Corporate ID and Branding",
+        "Creative Design &amp; Compositing",
+        "Dynamic Sketching",
+        "Fundamentals of Graphic Design"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "coalinga-college",
+        "hartnell-college",
+        "lemoore-college",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Argumentation and Debate",
+        "Argumentation, Advocacy, and Debate",
+        "Argumentation, Advocacy, and Debate - Honors",
+        "Improving Communication in Interpersonal Relationships",
+        "Improving Communication in Interpersonal Relationships - Honors"
+      ]
+    },
+    {
+      "prefix": "DENHY",
+      "name": "Dental",
+      "course_count": 27,
+      "section_count": 31,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Clinical Dental Hygiene IV",
+        "Community Oral Health"
+      ]
+    },
+    {
+      "prefix": "DN-T",
+      "name": "Pilates",
+      "course_count": 8,
+      "section_count": 31,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Dance Audition Techniques",
+        "History and Appreciation Dance",
+        "Introduction to Dance",
+        "Pilates Teaching-Mat &amp; Reform",
+        "Teach Pilates Aux Equipment"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "Teaching",
+      "course_count": 8,
+      "section_count": 31,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "chaffey-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "lassen-community-college",
+        "rio-hondo-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Elementary Teaching Fieldwork",
+        "Intro Elem Classroom Teaching",
+        "Introduction to Education",
+        "Introduction to Special Education",
+        "Introduction to Teaching"
+      ]
+    },
+    {
+      "prefix": "FDM",
+      "name": "FDM",
+      "course_count": 20,
+      "section_count": 31,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "3D Design",
+        "3D Design- Intermediate",
+        "Apparel Line Production",
+        "Beginning Sewing",
+        "Computer Fashion Laboratory"
+      ]
+    },
+    {
+      "prefix": "INDIS",
+      "name": "Life",
+      "course_count": 5,
+      "section_count": 31,
+      "colleges": [
+        "american-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Freshman Seminar – Health and Health Professions",
+        "Italian Life and Culture in Study Abroad",
+        "Study Skills for Science Disciplines",
+        "Study Skills for Science Disciplines II",
+        "United Kingdom Life and Culture in Study Abroad"
+      ]
+    },
+    {
+      "prefix": "PTEC",
+      "name": "Process",
+      "course_count": 26,
+      "section_count": 31,
+      "colleges": [
+        "bakersfield-college",
+        "coastline-community-college",
+        "cypress-college",
+        "fullerton-college",
+        "los-medanos-college",
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Fundamental Physics Principles for Industrial Technology",
+        "Human Relations for Healthcare Workers",
+        "Industrial Chemistry for Advanced Manufacturing",
+        "Industrial Safety, Health, and Environment",
+        "Industrial Technology Career Preparation"
+      ]
+    },
+    {
+      "prefix": "AB",
+      "name": "AB",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "allan-hancock-college",
+        "butte-college",
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Graphics",
+        "Agricultural Accounting",
+        "Agricultural Economics",
+        "Auto Body Metal",
+        "Auto Body Repair"
+      ]
+    },
+    {
+      "prefix": "ADAM",
+      "name": "Apparel",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "college-of-alameda"
+      ],
+      "sample_titles": [
+        "Advance Design and Line Development I",
+        "Advanced Design and Line Development II",
+        "Apparel Construction I",
+        "Apparel Construction II",
+        "Apparel Design and Sketching I"
+      ]
+    },
+    {
+      "prefix": "CISD",
+      "name": "Data",
+      "course_count": 16,
+      "section_count": 30,
+      "colleges": [
+        "folsom-lake-college",
+        "mt-san-antonio-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Big Data Integration &amp; Process",
+        "Big Data Modeling &amp; Analysis",
+        "Data Analysis",
+        "Data Analytics with Tableau",
+        "Data Modeling and Machine Learning"
+      ]
+    },
+    {
+      "prefix": "EMMS",
+      "name": "Emergency",
+      "course_count": 9,
+      "section_count": 30,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician 1: Basic Training",
+        "Emergency Medical Technician 1: Basic Training Application",
+        "EMT-1: Recertification",
+        "First Aid, CPR and AED",
+        "Paramedic - Clinical"
+      ]
+    },
+    {
+      "prefix": "FMS",
+      "name": "Film",
+      "course_count": 7,
+      "section_count": 30,
+      "colleges": [
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Film Genre",
+        "Film History I (1895-1949)",
+        "Film History II (1950-present)",
+        "Honors Seminar: Introduction to Critical Theory",
+        "Independent Studies in Film and Media Studies"
+      ]
+    },
+    {
+      "prefix": "HTCH",
+      "name": "Medical",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Terminology",
+        "Basic Medical Accounting and Record Keeping",
+        "Basic Medical Terminology",
+        "Communication for Health Care Personnel",
+        "ECG and Orthopedic Technology"
+      ]
+    },
+    {
+      "prefix": "IMMT",
+      "name": "IMMT",
+      "course_count": 21,
+      "section_count": 30,
+      "colleges": [
+        "barstow-community-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Basic Layout",
+        "Cal/OSHA 10 General Safety",
+        "Construction Drawings",
+        "Craft-Related Quantitative Skills",
+        "Distillation Towers and Vessels"
+      ]
+    },
+    {
+      "prefix": "LAC",
+      "name": "Level",
+      "course_count": 7,
+      "section_count": 30,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "AI Essentials",
+        "LEARNING ASSISTANCE",
+        "Level 1 Tutor Certification",
+        "Level 2 Tutor Certification",
+        "Level 3 Tutor Certification"
+      ]
+    },
+    {
+      "prefix": "NAJ",
+      "name": "Enforcement",
+      "course_count": 1,
+      "section_count": 30,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Law Enforcement"
+      ]
+    },
+    {
+      "prefix": "OLAD",
+      "name": "Older",
+      "course_count": 6,
+      "section_count": 30,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "COMMUNITY ORCHESTRA FOR OLDER ADULTS",
+        "HISTORY OF EUROPEAN ART FOR OLDER ADULTS",
+        "LIFE REVIEW",
+        "MUSIC APPRECIATION FOR OLDER ADULTS",
+        "SEWING TECHNIQUES FOR OLDER ADULTS"
+      ]
+    },
+    {
+      "prefix": "PHO",
+      "name": "Photography",
+      "course_count": 8,
+      "section_count": 30,
+      "colleges": [
+        "butte-college",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Adv Photography Lab",
+        "Beg Black & White Photography",
+        "Beginning Digital Photography",
+        "Commercial/Studio Photography",
+        "Interm Black/White Darkroom"
+      ]
+    },
+    {
+      "prefix": "PYSO",
+      "name": "Physiology",
+      "course_count": 2,
+      "section_count": 30,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "BASIC PHYSIOLOGY AND ANATOMY",
+        "HUMAN PHYSIOLOGY"
+      ]
+    },
+    {
+      "prefix": "STEM",
+      "name": "Stem",
+      "course_count": 5,
+      "section_count": 30,
+      "colleges": [
+        "allan-hancock-college",
+        "bakersfield-college",
+        "citrus-college",
+        "porterville-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education in STEM",
+        "How to be a Successful STEM Student",
+        "STEM Success Strategies",
+        "Step Up to Science Technology Engineering and Mathematics (STEM)"
+      ]
+    },
+    {
+      "prefix": "WT",
+      "name": "WT",
+      "course_count": 18,
+      "section_count": 30,
+      "colleges": [
+        "coalinga-college",
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Smaw",
+        "Advanced SMAW",
+        "Beginning SMAW",
+        "Blueprint and Symbol Reading",
+        "Gas Metal Arc Welding"
+      ]
+    },
+    {
+      "prefix": "AHS",
+      "name": "Health",
+      "course_count": 6,
+      "section_count": 29,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "CARDIOLOGY FOR ALLIED HEALTH",
+        "COMMUNITY HEALTH PROMOTION",
+        "HEALTH CAREERS EXPLORATION",
+        "INTERPROFESSIONAL COMPETENCIES FOR COLLABORATIVE PRACTICE",
+        "INTRODUCTION TO ALLIED HEALTH PROGRAMS"
+      ]
+    },
+    {
+      "prefix": "BUSO",
+      "name": "Business",
+      "course_count": 3,
+      "section_count": 29,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business English",
+        "Oral Comm for Business"
+      ]
+    },
+    {
+      "prefix": "CSFT",
+      "name": "CSFT",
+      "course_count": 11,
+      "section_count": 29,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Beginning Bachata Latin Dance",
+        "Beginning Tai Chi",
+        "Beginning Tai Chi Fan",
+        "Full-Body Barre Workout",
+        "Latin Salsa Dancing"
+      ]
+    },
+    {
+      "prefix": "DRAF",
+      "name": "DRAF",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "citrus-college",
+        "cypress-college",
+        "fullerton-college",
+        "golden-west-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD for Industry",
+        "Advanced Computer Aided Design (CAD and Design Tools)",
+        "Advanced Digital Design Tools",
+        "Advanced Digital Design Tools Part I",
+        "AutoCAD for Industry"
+      ]
+    },
+    {
+      "prefix": "ENVT",
+      "name": "Water",
+      "course_count": 19,
+      "section_count": 29,
+      "colleges": [
+        "allan-hancock-college",
+        "folsom-lake-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "HAZWOPER - Refresher 8hr",
+        "Introduction Environmental Health &amp; Occupational Safety",
+        "Introduction to Water, Wastewater and Recycled Water Management",
+        "Math for Water and Wastewater Operators",
+        "Science for Water and Wastewater Operators"
+      ]
+    },
+    {
+      "prefix": "LARAZ",
+      "name": "LARAZ",
+      "course_count": 8,
+      "section_count": 29,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Building Pre-Collegiate Skills-Level II",
+        "Chicana/o-Latina/o Theatre",
+        "Contemporary Chicano/Latino Literature",
+        "History of Latinos in the United States (1846 - Present)",
+        "Introduction to Analysis of American Political Institutions"
+      ]
+    },
+    {
+      "prefix": "LIB SCI",
+      "name": "Methods",
+      "course_count": 4,
+      "section_count": 29,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "College Research Skills",
+        "Digital Assets: Tools and Methods",
+        "Internet Research Methods",
+        "Media and Information Literacy: Research Strategies and Beyond"
+      ]
+    },
+    {
+      "prefix": "LIR",
+      "name": "Methods",
+      "course_count": 2,
+      "section_count": 29,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Introduction to Information Literacy",
+        "Research Methods Online World"
+      ]
+    },
+    {
+      "prefix": "NCBS",
+      "name": "Support",
+      "course_count": 9,
+      "section_count": 29,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "BRIDGE TO COLLEGE LEVEL MATHEMATICS I",
+        "FOUNDATIONS OF COMPUTER PROGRAMMING",
+        "JUST-IN-TIME SUPPORT FOR MATH 1A",
+        "JUST-IN-TIME SUPPORT FOR MATH 1A - MPS",
+        "JUST-IN-TIME SUPPORT FOR MATH 1B"
+      ]
+    },
+    {
+      "prefix": "PAL",
+      "name": "Paralegals",
+      "course_count": 14,
+      "section_count": 29,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Bankruptcy Law",
+        "Beg. Legal Research Paralegals",
+        "Beginning Legal Writing",
+        "Ca Employment and Labor Law",
+        "Conflict Resolution & Negotiat"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 19,
+      "section_count": 29,
+      "colleges": [
+        "clovis-community-college",
+        "madera-community-college",
+        "reedley-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Civil Procedure: Pleadings",
+        "COMMUNITY BEER MAKING",
+        "COMMUNITY WINE TASTING",
+        "FERMENTATION SCI",
+        "INTG PEST MGMT"
+      ]
+    },
+    {
+      "prefix": "SURV",
+      "name": "Surveying",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "mt-san-antonio-college",
+        "reedley-college",
+        "santa-ana-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Plane Surveying",
+        "Advanced Problems in Surv I",
+        "Advanced Surveying",
+        "Boundary Control & Legal Princ",
+        "CAD for Surveyors &amp; Civil Engr"
+      ]
+    },
+    {
+      "prefix": "ACE",
+      "name": "ACE",
+      "course_count": 10,
+      "section_count": 28,
+      "colleges": [
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "ADAS",
+        "Advanced Comfort Systems",
+        "Auto Electrical Systems I",
+        "Auto Heating and AC Systems",
+        "Automotive Engine Management"
+      ]
+    },
+    {
+      "prefix": "ADST",
+      "name": "Addiction",
+      "course_count": 11,
+      "section_count": 28,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Addiction Counseling Studies Field Experience Seminar",
+        "Addiction Prevention, Intervention, Treatment, and Recovery",
+        "Addiction Studies Field Experience",
+        "Case Management in Addiction Counseling",
+        "Co-occurring Disorders"
+      ]
+    },
+    {
+      "prefix": "AMLA",
+      "name": "Amla",
+      "course_count": 11,
+      "section_count": 28,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "American Culture for ELLs",
+        "American English Pronunciation",
+        "AMLA Advanced Grammar",
+        "AmLa Advanced Reading",
+        "AMLA Conversational English"
+      ]
+    },
+    {
+      "prefix": "APRN",
+      "name": "APRN",
+      "course_count": 13,
+      "section_count": 28,
+      "colleges": [
+        "allan-hancock-college",
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Automotive Electrical Systems",
+        "Automotive Fuel Injection",
+        "Automotive Mechanisms",
+        "Electricity",
+        "Gaseous Fuels"
+      ]
+    },
+    {
+      "prefix": "AVA",
+      "name": "AVA",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Airframe 1",
+        "Airframe 2",
+        "Airframe 3",
+        "General Aviation 2",
+        "General Aviation I"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 23,
+      "section_count": 28,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Clinic Seminar",
+        "Clinic Seminar II",
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III"
+      ]
+    },
+    {
+      "prefix": "DMAD",
+      "name": "DMAD",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "2D Animation",
+        "3D Computer Graphics Animation",
+        "Designing for Screens",
+        "Digital Portfolio Development",
+        "Graphic Design"
+      ]
+    },
+    {
+      "prefix": "DT",
+      "name": "Design",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "coalinga-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "3-DIMENSIONAL BUILDING DESIGN &amp; REPRESENTATION",
+        "ADVANCED SYSTEMS DESIGN AND FABRICATION",
+        "BUILDING DESIGN &amp; CONSTRUCTION TECHNICAL GRAPHICS",
+        "BUILDING INFORMATION MODELING DESIGN (BIM DESIGN)",
+        "Commercial Driver Testing"
+      ]
+    },
+    {
+      "prefix": "ELIT",
+      "name": "ELIT",
+      "course_count": 7,
+      "section_count": 28,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Asian Pacific American Literature",
+        "Introduction to Fiction",
+        "Introduction to Poetry",
+        "Introduction to Shakespeare",
+        "Major American Writers (The Modern Age, 1914-the Present)"
+      ]
+    },
+    {
+      "prefix": "FDAT",
+      "name": "FDAT",
+      "course_count": 16,
+      "section_count": 28,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Construction",
+        "Couture Embellishment",
+        "Design 1",
+        "Design 2",
+        "Digital Patternmaking and 3D Modeling"
+      ]
+    },
+    {
+      "prefix": "LE",
+      "name": "LE",
+      "course_count": 16,
+      "section_count": 28,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Basic Law Enforcement Academy",
+        "Complaint Dispatcher",
+        "Core Custody Academy",
+        "Field Training Officer",
+        "Field Training Officer Update"
+      ]
+    },
+    {
+      "prefix": "OCEANO",
+      "name": "Oceanography",
+      "course_count": 3,
+      "section_count": 28,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-harbor-college",
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-valley-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Introduction To Oceanography",
+        "Lectures In Marine Biology",
+        "Physical Oceanography Laboratory"
+      ]
+    },
+    {
+      "prefix": "PARN",
+      "name": "Ages",
+      "course_count": 12,
+      "section_count": 28,
+      "colleges": [
+        "allan-hancock-college",
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Connected Parenting",
+        "Developmental Movement for Ages 1 - 2 years.",
+        "Developmental Movement for Ages 3 - 5 years.",
+        "Joyful Parenting: Art, Music, and Movement for Ages 1.5 - 2.5 years.",
+        "Joyful Parenting: Art, Music, and Movement for Ages 2.5 - 5 years."
+      ]
+    },
+    {
+      "prefix": "PHTC",
+      "name": "Photography",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Advanced Black and White Photography",
+        "Advanced Digital Photography",
+        "Beginning Black and White Photography",
+        "Beginning Color Photography",
+        "Beginning Digital Photography"
+      ]
+    },
+    {
+      "prefix": "PHYR",
+      "name": "PHYR",
+      "course_count": 19,
+      "section_count": 28,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Acute Care Techniques",
+        "Acute Care Techniques Lab",
+        "Directed Clinical Practice I",
+        "Directed Clinical Practice II",
+        "Directed Clinical Practice III"
+      ]
+    },
+    {
+      "prefix": "STUDEV",
+      "name": "Success",
+      "course_count": 4,
+      "section_count": 28,
+      "colleges": [
+        "coalinga-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Career Planning",
+        "College Success",
+        "Ensuring Transfer Success"
+      ]
+    },
+    {
+      "prefix": "AC/R",
+      "name": "AC/R",
+      "course_count": 11,
+      "section_count": 27,
+      "colleges": [
+        "cypress-college"
+      ],
+      "sample_titles": [
+        "Air Flow Design &amp; Psychrometrics",
+        "Blueprints and Dimension Analysis (formerly AC/R 037 C)",
+        "Commercial Refrigeration",
+        "Control Logic Programming",
+        "Electricity for Air Conditioning and Refrigeration II"
+      ]
+    },
+    {
+      "prefix": "ACRP",
+      "name": "Automotive",
+      "course_count": 23,
+      "section_count": 27,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Auto Accident Reconstruction",
+        "Auto Coll Repair Non-Majors",
+        "Automotive Collision Analysis",
+        "Basic Automotive Painting - Refinishing",
+        "Beg Auto Collision Repair I"
+      ]
+    },
+    {
+      "prefix": "BUSS",
+      "name": "Marketing",
+      "course_count": 7,
+      "section_count": 27,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advertising and Promotion",
+        "Principles of Marketing",
+        "Professional Selling",
+        "Retail Mgmt &amp; Merchandising",
+        "Social Media Marketing"
+      ]
+    },
+    {
+      "prefix": "CCNC",
+      "name": "Microsoft",
+      "course_count": 9,
+      "section_count": 27,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Computer and You: Level 2",
+        "Computer Skills Lab",
+        "Computers and You: Level 1",
+        "Intro to Microsoft Excel",
+        "Intro to Microsoft PowerPoint"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "CNT",
+      "course_count": 21,
+      "section_count": 27,
+      "colleges": [
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Computer Network Fundamentals",
+        "Digital Forensics Fundamentals",
+        "Exploring Cyber Defense",
+        "Exploring Cyber Safety",
+        "IBM SkillsBuild Micro-Credential: Cybersecurity I - Noncredit"
+      ]
+    },
+    {
+      "prefix": "FRCC",
+      "name": "Forestry",
+      "course_count": 5,
+      "section_count": 27,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Applied Mapping and Surveying in Forestry",
+        "Fire Ecology and Management",
+        "Forestry, Climate, and Conservation Work Experience",
+        "Forestry, Land Management, and Conservation I",
+        "Forestry, Land Management, and Conservation II"
+      ]
+    },
+    {
+      "prefix": "HIMS",
+      "name": "HIMS",
+      "course_count": 16,
+      "section_count": 27,
+      "colleges": [
+        "san-diego-mesa-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Adv Directed Clinical Practice",
+        "Applied Research Project",
+        "Electronic Health Records",
+        "Ethics in Healthcare Admin",
+        "Financial Management"
+      ]
+    },
+    {
+      "prefix": "HSOTH",
+      "name": "Spanish",
+      "course_count": 8,
+      "section_count": 27,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Spanish 1",
+        "Spanish 1A",
+        "Spanish 2",
+        "Spanish 2B",
+        "Spanish 3"
+      ]
+    },
+    {
+      "prefix": "LRN",
+      "name": "Algebra",
+      "course_count": 4,
+      "section_count": 27,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "College Algebra Prep",
+        "Composition 2",
+        "Introductory Algebra",
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "MEDIC",
+      "name": "Medical",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Assisting",
+        "Anatomy and Physiology for Medical Assisting",
+        "Clinical Practicum Experience",
+        "Clinical Skills I",
+        "Clinical Skills II"
+      ]
+    },
+    {
+      "prefix": "MEDOP",
+      "name": "MEDOP",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Admin Med Assist Proced",
+        "Clinical Procedures",
+        "Electronic Health Records",
+        "Health Care Essentials",
+        "Human Structures and Functions"
+      ]
+    },
+    {
+      "prefix": "PEA",
+      "name": "Adapted",
+      "course_count": 10,
+      "section_count": 27,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Adapted Aerobic Swimming",
+        "Adapted Aquatic Exercise",
+        "Adapted Cardiovascular Training",
+        "Adapted Strength Development",
+        "Adapted Total Fitness"
+      ]
+    },
+    {
+      "prefix": "PHTG",
+      "name": "Photography",
+      "course_count": 19,
+      "section_count": 27,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Advanced Photography",
+        "Basic Photography",
+        "Commercial Lighting I",
+        "Commercial Lighting II",
+        "Experimental Photography"
+      ]
+    },
+    {
+      "prefix": "RADSC",
+      "name": "RADSC",
+      "course_count": 21,
+      "section_count": 27,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "ADVANCED IMAGING PROCEDURES",
+        "Clinical Experience I",
+        "CLINICAL EXPERIENCE II",
+        "CLINICAL EXPERIENCE III",
+        "CLINICAL EXPERIENCE IV"
+      ]
+    },
+    {
+      "prefix": "RDG",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 27,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "College Read & Critical Think"
+      ]
+    },
+    {
+      "prefix": "WELDING",
+      "name": "Welding",
+      "course_count": 8,
+      "section_count": 27,
+      "colleges": [
+        "los-angeles-pierce-college"
+      ],
+      "sample_titles": [
+        "Advanced Semi-Automatic Welding",
+        "Advanced Shielded Metal Arc Welding",
+        "Gas Tungsten Arc Welding I",
+        "Gas Tungsten Arc Welding II",
+        "Oxy-Acetylene Welding I"
+      ]
+    },
+    {
+      "prefix": "ACAD",
+      "name": "Post",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Officer Training I",
+        "Advanced Officer Training III",
+        "Advanced Officer Training IV",
+        "Kern County Sheriff&#39;s Office D",
+        "POST P.C. 832 Arrest"
+      ]
+    },
+    {
+      "prefix": "AODS",
+      "name": "AODS",
+      "course_count": 10,
+      "section_count": 26,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "AODS Internship",
+        "AODS Internship Seminar",
+        "AODS Law and Ethics",
+        "Case Management",
+        "Chem Depend Family Counsel Tec"
+      ]
+    },
+    {
+      "prefix": "CGRA",
+      "name": "Digital",
+      "course_count": 11,
+      "section_count": 26,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Video Production",
+        "Animation 1",
+        "Beginning Audio Production",
+        "Digital Graphic Design",
+        "Digital Portfolio"
+      ]
+    },
+    {
+      "prefix": "FIRTC",
+      "name": "FIRTC",
+      "course_count": 10,
+      "section_count": 26,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Basic Wildland FF",
+        "Build Construct",
+        "Driver Operator 1A",
+        "Driver Operator 1B",
+        "Ethical Leadership"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "Hospitality",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Event Planning and Catering",
+        "Financial Accounting",
+        "Food Safety &amp; Sanitation",
+        "Hospitality Cost Control",
+        "Hospitality Law"
+      ]
+    },
+    {
+      "prefix": "KUMY",
+      "name": "Kumeyaay",
+      "course_count": 10,
+      "section_count": 26,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Ethnobotany",
+        "Ethnobotany/Ethnoecology Lab",
+        "Ethnoecology",
+        "Kumey Hist I: Precontact-1845",
+        "Kumeyaay Arts and Culture I"
+      ]
+    },
+    {
+      "prefix": "MARK",
+      "name": "MARK",
+      "course_count": 4,
+      "section_count": 26,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Advertising Principles",
+        "Principles of Marketing",
+        "Principles of Retailing",
+        "Professional Selling"
+      ]
+    },
+    {
+      "prefix": "MEDAS",
+      "name": "Medical",
+      "course_count": 7,
+      "section_count": 26,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Assisting I",
+        "Administrative Medical Assisting II",
+        "Clinical Medical Assisting I",
+        "Clinical Medical Assisting II",
+        "Clinical Medical Assisting III"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Chemphys",
+      "course_count": 2,
+      "section_count": 26,
+      "colleges": [
+        "clovis-community-college",
+        "cuyamaca-college",
+        "grossmont-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "INT CHEM/PHYS SCI",
+        "Intro to Scientific Thought"
+      ]
+    },
+    {
+      "prefix": "WEX",
+      "name": "Cooperative",
+      "course_count": 1,
+      "section_count": 26,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "General Cooperative Work Exp"
+      ]
+    },
+    {
+      "prefix": "AGB",
+      "name": "Agriculture",
+      "course_count": 12,
+      "section_count": 25,
+      "colleges": [
+        "cosumnes-river-college",
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Agri Sales and Comm",
+        "Agriculture Accounting",
+        "Agriculture Computer Applications",
+        "Agriculture Economics",
+        "Agriculture Sales and Communication"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Anthropology",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "hartnell-college",
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Aztecs, Maya",
+        "Biological Anthropology",
+        "Biological Anthropology Laboratory",
+        "Cultural Anthropology",
+        "Intro to Biological Anthro"
+      ]
+    },
+    {
+      "prefix": "ARTB",
+      "name": "Visual",
+      "course_count": 6,
+      "section_count": 25,
+      "colleges": [
+        "monterey-peninsula-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Basic Studio Arts",
+        "Color Fundamentals",
+        "Intro Visual Art &amp; Art History",
+        "Survey of the Arts",
+        "Visual Fundamentals: Three-Dimensional Design"
+      ]
+    },
+    {
+      "prefix": "CM",
+      "name": "Construction",
+      "course_count": 18,
+      "section_count": 25,
+      "colleges": [
+        "citrus-college",
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "CONSTRCT LAW SURVEY",
+        "CONSTRUCT MGMT WK EXP",
+        "CONSTRUCT PLANNING",
+        "Construction Contract Documents, Codes and Specifications",
+        "Construction Equipment and Methods"
+      ]
+    },
+    {
+      "prefix": "CNG",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 25,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Education and Career Asmnt"
+      ]
+    },
+    {
+      "prefix": "ELAC",
+      "name": "ELAC",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Academic List and Speak I",
+        "Academic List and Speak II",
+        "Engl Lang Gram - Low Int/Int",
+        "English Pronunciation",
+        "Grammar - High Interm/Adv"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "ENGT",
+      "course_count": 19,
+      "section_count": 25,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "moorpark-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Advanced Visualization, Sketching, and Rendering",
+        "AutoCAD for Basic CADD Applications",
+        "Basic Electronics",
+        "Capstone Project in Elect ENGT",
+        "Capstone Project in Mecha ENGT"
+      ]
+    },
+    {
+      "prefix": "FR",
+      "name": "French",
+      "course_count": 7,
+      "section_count": 25,
+      "colleges": [
+        "cabrillo-college",
+        "chaffey-college",
+        "college-of-the-desert",
+        "cuesta-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "ELEM FRENCH I",
+        "Elementary French I",
+        "Elementary French II",
+        "French I",
+        "French II"
+      ]
+    },
+    {
+      "prefix": "FSE",
+      "name": "Funeral",
+      "course_count": 13,
+      "section_count": 25,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Embalming I",
+        "Embalming II",
+        "Funeral Directing I",
+        "Funeral Directing II",
+        "Funeral Service Counseling"
+      ]
+    },
+    {
+      "prefix": "HLTED",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 25,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "EXPLORING HEALTH ISSUES",
+        "FIRST AID AND SAFETY",
+        "HEALTH AND WELLNESS: PERSONAL CHANGE",
+        "Stress and Healthy Adaptation"
+      ]
+    },
+    {
+      "prefix": "INTRP",
+      "name": "Interpreting",
+      "course_count": 24,
+      "section_count": 25,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "ASL-English Interpreting Support Lab",
+        "Consecutive Interpreting from ASL",
+        "Consecutive Interpreting from English",
+        "Discourse Analysis and Translation",
+        "Ethics and Professional Standards of Interpreting"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "Legal",
+      "course_count": 18,
+      "section_count": 25,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Business Organizations",
+        "Civil Litigation I",
+        "Civil Litigation Procedures",
+        "Computer Assist Legal Research",
+        "Computer Skills for Legal Prof"
+      ]
+    },
+    {
+      "prefix": "NAIS",
+      "name": "Native",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "de-anza-college",
+        "mt-san-antonio-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Ethnic Studies and the Historical Experiences of Native Americans",
+        "Intro to Native Amer Studies",
+        "Native American History II"
+      ]
+    },
+    {
+      "prefix": "PEIC",
+      "name": "Intercollegiate",
+      "course_count": 8,
+      "section_count": 25,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Intercollegiate Baseball",
+        "Intercollegiate Football",
+        "Intercollegiate Men's Basketball",
+        "Intercollegiate Men's Soccer",
+        "Intercollegiate Women's Basketball"
+      ]
+    },
+    {
+      "prefix": "PMGT",
+      "name": "PMGT",
+      "course_count": 18,
+      "section_count": 25,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Backcountry Technical Rescue",
+        "Basic Horticulture for Parks",
+        "Basic Outdoor Skills",
+        "Conservation of Our Natural Resources",
+        "Duties of the Park Professional"
+      ]
+    },
+    {
+      "prefix": "POSCI",
+      "name": "POSCI",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college"
+      ],
+      "sample_titles": [
+        "COMPARATIVE GOVERNMENT",
+        "Global Issues",
+        "INTERNATIONAL RELATIONS",
+        "Introduction to Global Studies",
+        "Law and Democracy"
+      ]
+    },
+    {
+      "prefix": "RDTC",
+      "name": "RDTC",
+      "course_count": 21,
+      "section_count": 25,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "CLINICAL PRACTICUM, 1",
+        "CLINICAL PRACTICUM, 2",
+        "CLINICAL PRACTICUM, 4",
+        "CLINICAL PRACTICUM, 5",
+        "CLINICAL PRACTICUM, 6"
+      ]
+    },
+    {
+      "prefix": "SOCSC",
+      "name": "SOCSC",
+      "course_count": 10,
+      "section_count": 25,
+      "colleges": [
+        "college-of-alameda",
+        "contra-costa-college",
+        "diablo-valley-college",
+        "laney-college"
+      ],
+      "sample_titles": [
+        "American Popular Culture",
+        "Contemporary Women",
+        "Global Issues",
+        "Introduction to Global Studies",
+        "Introduction to LGBTQ Studies"
+      ]
+    },
+    {
+      "prefix": "SUST",
+      "name": "SUST",
+      "course_count": 13,
+      "section_count": 25,
+      "colleges": [
+        "el-camino-community-college-district",
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "California Planning Practices",
+        "Energy & Carbon Reduc in Bldgs",
+        "Environment, Health & Equity",
+        "Global Sustainability & Integr",
+        "Introduction to Sustainability"
+      ]
+    },
+    {
+      "prefix": "VN",
+      "name": "Nursing",
+      "course_count": 15,
+      "section_count": 25,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "lassen-community-college",
+        "rio-hondo-college",
+        "sacramento-city-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adult Nursing Theory",
+        "Basic Pharmacology",
+        "Clinical Lab 1",
+        "Clinical Lab II",
+        "Fundamentals of Patient Care for Vocational Nurses"
+      ]
+    },
+    {
+      "prefix": "WLDT",
+      "name": "Welding",
+      "course_count": 11,
+      "section_count": 25,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Adv Weldng Certification Lab",
+        "Advanced Welding",
+        "Beginning Welding",
+        "Blacksmithing Projects",
+        "G.M.A.W. Welding"
+      ]
+    },
+    {
+      "prefix": "A",
+      "name": "Descrip",
+      "course_count": 3,
+      "section_count": 24,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "DESCRIP ASTRONOMY",
+        "PLANET ASTRO"
+      ]
+    },
+    {
+      "prefix": "AUSER",
+      "name": "Automotive",
+      "course_count": 17,
+      "section_count": 24,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Collision Repair",
+        "Advanced Automotive Painting and Refinishing",
+        "Automotive Brakes",
+        "Automotive Drivetrains",
+        "Automotive Electrical/Electronic Systems"
+      ]
+    },
+    {
+      "prefix": "BLDG",
+      "name": "Construction",
+      "course_count": 10,
+      "section_count": 24,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "BUILDING CONSTRUCTION CODES AND STANDARDS",
+        "ESTIMATING FOR BUILDING CONSTRUCTION",
+        "GREEN BUILDING AND ENERGY EFFICIENCIES",
+        "INSPECTION OF ARCHITECTURAL DETAILS",
+        "LEGAL FACTORS OF CONSTRUCTION"
+      ]
+    },
+    {
+      "prefix": "CAM",
+      "name": "CAM",
+      "course_count": 12,
+      "section_count": 24,
+      "colleges": [
+        "cosumnes-river-college",
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "CNC MILL PRG/OP1",
+        "CNC MILL PRG/OP2",
+        "CNC OPER & MAINT",
+        "CNC PROG 4 MACHNST",
+        "Culinary Computations"
+      ]
+    },
+    {
+      "prefix": "CITZ",
+      "name": "Citizenship",
+      "course_count": 3,
+      "section_count": 24,
+      "colleges": [
+        "allan-hancock-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Citizenship",
+        "Preparation for Citizenship",
+        "U. S. Citizenship Interview Pr"
+      ]
+    },
+    {
+      "prefix": "CLP",
+      "name": "Overview",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Overview of College, Majors, and Career Options",
+        "Self-Assessment"
+      ]
+    },
+    {
+      "prefix": "DAST",
+      "name": "Dental",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Patient Assessment and Dental Imaging",
+        "Biodental Science",
+        "Board Preparation",
+        "Chairside Assisting",
+        "Clinical Experience I"
+      ]
+    },
+    {
+      "prefix": "DEVSER",
+      "name": "DEVSER",
+      "course_count": 17,
+      "section_count": 24,
+      "colleges": [
+        "fresno-city-college",
+        "madera-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "ADAPTED FITNESS",
+        "ADPT COMPUTER LIT",
+        "CAREER AWARENESS",
+        "COLLEGE TRANSITN",
+        "COMM SKLS/STRAT 2"
+      ]
+    },
+    {
+      "prefix": "FSN",
+      "name": "Nutrition",
+      "course_count": 6,
+      "section_count": 24,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Basic Nutrition for Health",
+        "Behavioral Nutrition",
+        "Culinology &amp; Nutrition Pros",
+        "Food/Nutrition/Customs/Culture",
+        "Introduction to Food Science"
+      ]
+    },
+    {
+      "prefix": "GISG",
+      "name": "GISG",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Advanced Geog Info Sys App",
+        "GIS and Cartography",
+        "GIS Work Experience",
+        "Intro to Digital Image Process",
+        "Intro to Mapping/Geog Info Sys"
+      ]
+    },
+    {
+      "prefix": "L",
+      "name": "Tutor",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "TUTOR TRAINING I",
+        "TUTOR TRAINING II"
+      ]
+    },
+    {
+      "prefix": "MUST",
+      "name": "Electronic",
+      "course_count": 21,
+      "section_count": 24,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Crossroads Electronic Digital Instrument Pop Collective",
+        "Electronic Digital Instrument (EDI) Controllers I",
+        "Electronic Digital Instrument (EDI) Controllers II",
+        "Electronic Digital Instrument Experimental Orchestra",
+        "Electronic Digital Instrument Practices I"
+      ]
+    },
+    {
+      "prefix": "PHLE",
+      "name": "PHLE",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Laboratory Procedures",
+        "Intro to Phleb.: Clinical Lab",
+        "Phlebotomy Laboratory Exp.",
+        "Venipuncture Laboratory"
+      ]
+    },
+    {
+      "prefix": "PSE",
+      "name": "Tutor",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "TUTOR TRAINING I",
+        "TUTOR TRAINING II"
+      ]
+    },
+    {
+      "prefix": "PSYCT",
+      "name": "PSYCT",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology",
+        "Crisis Management",
+        "Group Process",
+        "Human Development",
+        "Nursing Science A"
+      ]
+    },
+    {
+      "prefix": "RLEST",
+      "name": "Real",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "BRE Salesperson/Broker Exam Preparation",
+        "Legal Aspects of Real Estate",
+        "PRINCIPLES OF REAL ESTATE",
+        "Property Management",
+        "REAL ESTATE APPRAISAL"
+      ]
+    },
+    {
+      "prefix": "SEWN",
+      "name": "Sewing",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Machine Embroidery 1",
+        "Sewing Fundamentals 1",
+        "Sewing Fundamentals 2",
+        "Sewing Open Lab"
+      ]
+    },
+    {
+      "prefix": "SKDV",
+      "name": "SKDV",
+      "course_count": 3,
+      "section_count": 24,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Be a Successful Online Student",
+        "Info Literacy &amp; Research Skill",
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "SPECH",
+      "name": "Comm",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Argumentation",
+        "Intercultural Comm",
+        "Interpersonal Comm",
+        "Small Group Comm"
+      ]
+    },
+    {
+      "prefix": "AE",
+      "name": "Train",
+      "course_count": 5,
+      "section_count": 23,
+      "colleges": [
+        "gavilan-college"
+      ],
+      "sample_titles": [
+        "ADAPTED PHYSICAL ED",
+        "INDEP TRAIN IV",
+        "VOC TRAIN I",
+        "VOC TRAIN III",
+        "VOC TRAIN VI"
+      ]
+    },
+    {
+      "prefix": "APPR",
+      "name": "Sheet",
+      "course_count": 23,
+      "section_count": 23,
+      "colleges": [
+        "bakersfield-college",
+        "college-of-alameda"
+      ],
+      "sample_titles": [
+        "Apprentice Inside Wireman 1",
+        "Apprentice Inside Wireman 10",
+        "Apprentice Inside Wireman 2",
+        "Apprentice Inside Wireman 3",
+        "Apprentice Inside Wireman 4"
+      ]
+    },
+    {
+      "prefix": "AS",
+      "name": "AS",
+      "course_count": 13,
+      "section_count": 23,
+      "colleges": [
+        "madera-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "BEEF PRODUCTION",
+        "EQUINE HANDLING",
+        "EQUINE SCIENCE",
+        "EQUITATION",
+        "INTRO ANIMAL SCI"
+      ]
+    },
+    {
+      "prefix": "AUTOT",
+      "name": "AUTOT",
+      "course_count": 13,
+      "section_count": 23,
+      "colleges": [
+        "fresno-city-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "AUTO BRAKING SYS",
+        "AUTO ELEC SYSTMS",
+        "AUTO ESSENTIALS",
+        "AUTO TECH",
+        "BAR DIAGNOSIS/REPAIR"
+      ]
+    },
+    {
+      "prefix": "CBOT",
+      "name": "CBOT",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Admin Office Procedures",
+        "Advanced Word Processing",
+        "Business Desktop Publishing",
+        "Intro to Word Processing",
+        "Keyboarding"
+      ]
+    },
+    {
+      "prefix": "CTMF",
+      "name": "Woodworking",
+      "course_count": 7,
+      "section_count": 23,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Woodturning",
+        "Advanced Woodworking I",
+        "Advanced Woodworking II",
+        "Basic Woodworking",
+        "Intermediate Woodworking"
+      ]
+    },
+    {
+      "prefix": "CYDA",
+      "name": "CYDA",
+      "course_count": 15,
+      "section_count": 23,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "ADV Security IMP and MGMT",
+        "Advanced Cyber Defense ARCH",
+        "APPL Intrusion DETN and ANLYS",
+        "APPL NET Security Monitoring",
+        "CRIT INFRA and SC Protection"
+      ]
+    },
+    {
+      "prefix": "DRD",
+      "name": "Strategies",
+      "course_count": 13,
+      "section_count": 23,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Assistive Technology Training Center Lab",
+        "Career Development and Work Experience 1",
+        "College Resources and Strategies",
+        "College Success 1: Notetaking and Time Management",
+        "College Success 2: Comprehension and Test Taking Strategies"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "DRFT",
+      "course_count": 18,
+      "section_count": 23,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college",
+        "solano-community-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "3D Modeling with Fusion 360",
+        "Architectural Drafting I",
+        "AutoCAD Basics",
+        "Blueprint Reading",
+        "Blueprint Reading: Manufactrng"
+      ]
+    },
+    {
+      "prefix": "EGSS",
+      "name": "Ethnic",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Introduction to Ethnic Studies",
+        "Introduction to LGBTQ+ Studies"
+      ]
+    },
+    {
+      "prefix": "FBM",
+      "name": "FBM",
+      "course_count": 15,
+      "section_count": 23,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Bar Management &amp; Profit",
+        "Buffet and Catering Service",
+        "Dining Room Service",
+        "Directed Practice for FBM 1",
+        "Distilled Spirits &amp; Mixology"
+      ]
+    },
+    {
+      "prefix": "MUSIC-CM",
+      "name": "Music",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Advanced MIDI and Electronic Music",
+        "Beginning MIDI and Electronic Music",
+        "Intermediate MIDI and Electronic Music",
+        "Intermediate Music Business",
+        "Intermediate Songwriting"
+      ]
+    },
+    {
+      "prefix": "NCEN",
+      "name": "Bridge",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "BRIDGE TO TRANSFER ENGLISH",
+        "ENGLISH BRIDGE"
+      ]
+    },
+    {
+      "prefix": "NRM",
+      "name": "Natural",
+      "course_count": 10,
+      "section_count": 23,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Chainsaw Safe Operation and Care",
+        "Current Topics in Natural Resources",
+        "Geographic Info. Systems Applications in Natural Resources",
+        "Independent Study in Natural Resource Management",
+        "Introduction to Environmental Conservation"
+      ]
+    },
+    {
+      "prefix": "PAC",
+      "name": "PAC",
+      "course_count": 10,
+      "section_count": 23,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Advanced Officers Course",
+        "Basic Academy Intensive Modular I",
+        "Field Training Officer Course",
+        "Firearms",
+        "First Aid/CPR"
+      ]
+    },
+    {
+      "prefix": "PLUMB",
+      "name": "PLUMB",
+      "course_count": 17,
+      "section_count": 23,
+      "colleges": [
+        "american-river-college",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Drawing in the Piping Trades",
+        "Beginning Drawing & Plan Reading for the Piping Trades",
+        "Certification Preparation",
+        "Construction Management in Plumbing",
+        "Medical Gas and Vacuum Systems"
+      ]
+    },
+    {
+      "prefix": "RISE",
+      "name": "First",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "First Year Seminar"
+      ]
+    },
+    {
+      "prefix": "RNURS",
+      "name": "Nursing",
+      "course_count": 14,
+      "section_count": 23,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Nursing Practice",
+        "Leadership/Management and Professionalism in Nursing",
+        "Nursing Career Seminar",
+        "Nursing in Health and Illness I",
+        "Nursing in Health and Illness II"
+      ]
+    },
+    {
+      "prefix": "WMST",
+      "name": "WMST",
+      "course_count": 10,
+      "section_count": 23,
+      "colleges": [
+        "de-anza-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Feminism and Social Action",
+        "Intro to Women, Gender &amp; Relig",
+        "Intro to Women&#39;s Studies",
+        "Introduction to LGBT Studies",
+        "Introduction to Women's Studies"
+      ]
+    },
+    {
+      "prefix": "AIS",
+      "name": "AIS",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ACCESSIBILITY",
+        "MEDICAL BILLING",
+        "MICROSOFT OFFICE",
+        "OFFICE SUPPORT SKILLS",
+        "OFFICE TECHNOLOGIES"
+      ]
+    },
+    {
+      "prefix": "BUHM",
+      "name": "Mgmt",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "CUSTOMER SERVICE MGMT",
+        "HOSP. LAW",
+        "HOSP. SALES AND MARKETING",
+        "HOTL/REST MGMT WK EX",
+        "INTRO TO FOOD & BEV MGMT"
+      ]
+    },
+    {
+      "prefix": "EDIT",
+      "name": "EDIT",
+      "course_count": 9,
+      "section_count": 22,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Accessible Course Content",
+        "Ad. Ed. Portfolio",
+        "Computers & Digital Media",
+        "Copyright and Creativity",
+        "Curriculum and Instruction"
+      ]
+    },
+    {
+      "prefix": "EL2",
+      "name": "Writing",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Beg Listening and Speaking",
+        "Beginning Grammar and Writing",
+        "High Beginning Grammar and Writing",
+        "High Beginning Listening and Speaking",
+        "High Intermediate Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "ELD",
+      "name": "ELD",
+      "course_count": 12,
+      "section_count": 22,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Advanced Grammar",
+        "Advanced Reading",
+        "Advanced Writing",
+        "High Intermediate Conversation",
+        "High Intermediate Reading"
+      ]
+    },
+    {
+      "prefix": "ENVIR",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 22,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Environmental Science"
+      ]
+    },
+    {
+      "prefix": "FORE",
+      "name": "FORE",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Ecology",
+        "Forestry Skills",
+        "Geographic Information Systems in Natural Resources",
+        "Introduction to Forestry",
+        "Wildland Fire Ecology"
+      ]
+    },
+    {
+      "prefix": "FTNC",
+      "name": "Firefighter",
+      "course_count": 2,
+      "section_count": 22,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Fall Firefighter In-Service Tr",
+        "Spring Firefighter In-Service Training"
+      ]
+    },
+    {
+      "prefix": "GDES",
+      "name": "Design",
+      "course_count": 15,
+      "section_count": 22,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Adobe Creative Apps for Graphic Design",
+        "Blogs and Site Development: WordPress",
+        "Design Thinking",
+        "Digital Illustration: Illustrator",
+        "History of Media and Communication"
+      ]
+    },
+    {
+      "prefix": "JAPA",
+      "name": "Japanese",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Bgn Converstnl Japanese",
+        "Cultrl Aspects Japan Lang",
+        "Elementary Japanese I",
+        "Elementary Japanese II",
+        "Inter Convrstnl Japanese"
+      ]
+    },
+    {
+      "prefix": "PARLG",
+      "name": "PARLG",
+      "course_count": 10,
+      "section_count": 22,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Advanced Legal Research and Writing",
+        "Criminal Law",
+        "Estate Planning and Probate Procedure",
+        "FAMILY LAW",
+        "INTRO TO CIVIL PROCEDURE AND LITIGATION PRACTICE"
+      ]
+    },
+    {
+      "prefix": "PHSO",
+      "name": "Human",
+      "course_count": 5,
+      "section_count": 22,
+      "colleges": [
+        "monterey-peninsula-college",
+        "moorpark-college",
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Human Physiology",
+        "Human Physiology Lab",
+        "Independent Study"
+      ]
+    },
+    {
+      "prefix": "READING",
+      "name": "Reading",
+      "course_count": 3,
+      "section_count": 22,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-southwest-college"
+      ],
+      "sample_titles": [
+        "College Reading and Critical Thinking",
+        "Critical Reading and Analysis",
+        "Reading For College Success"
+      ]
+    },
+    {
+      "prefix": "RESD",
+      "name": "Resp",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Adult Resp Intensive Care",
+        "Cardiopulmonar Pathophysiology",
+        "Comprehensive Pulmonary Assess",
+        "Current Issues in Resp Care",
+        "Neonatal Intensive Care"
+      ]
+    },
+    {
+      "prefix": "STDY",
+      "name": "Academic",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "mt-san-antonio-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Academic Success",
+        "Academic Success Basics",
+        "College Learning Skills",
+        "College Study Skills",
+        "Online Learning Skills"
+      ]
+    },
+    {
+      "prefix": "SUPV",
+      "name": "Communications",
+      "course_count": 5,
+      "section_count": 22,
+      "colleges": [
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "los-angeles-pierce-college",
+        "los-angeles-southwest-college",
+        "los-angeles-trade-technical-college"
+      ],
+      "sample_titles": [
+        "Elements Of Supervision",
+        "Human Relations (Developing Supervisory Leadership)",
+        "Oral Business Communications",
+        "Oral Communications",
+        "Written Communications For Supervisors"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Social",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Intro to Case Management",
+        "Introduction to Social Work",
+        "Social Work Fields of Service"
+      ]
+    },
+    {
+      "prefix": "TI",
+      "name": "TI",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Consecutive Interpreting I",
+        "Consecutive Interpreting II",
+        "Fundamentals of Spanish T & I",
+        "Sight Translation",
+        "Simultaneous Interpreting I"
+      ]
+    },
+    {
+      "prefix": "WELL",
+      "name": "WELL",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "cuesta-college",
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Adult Fitness",
+        "Movement Anatomy (formerly titled Kinesiology)",
+        "Stress Management and Relaxation Training",
+        "The Body-Mind Connection"
+      ]
+    },
+    {
+      "prefix": "EDT",
+      "name": "Design",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "mt-san-antonio-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Architectural/Structural Drafting",
+        "Beginning 3D Modeling-CREO",
+        "Beginning 3D Modeling-SolidWorks",
+        "Building Electrical Design Documents",
+        "Building Electrical Systems Design"
+      ]
+    },
+    {
+      "prefix": "EGN",
+      "name": "EGN",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis",
+        "Engineering Graphics & Design",
+        "Intro to Engineering",
+        "Intro to Engineering Lab",
+        "Materials Science & Engineerin"
+      ]
+    },
+    {
+      "prefix": "ELTY",
+      "name": "Electrical",
+      "course_count": 6,
+      "section_count": 21,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ALTERNATING CURRENT CIRCUITS &ndash; PRINCIPLES AND APPLICATIONS",
+        "BASIC ELECTRICITY - ELECTRONICS",
+        "ELECTRICAL INSPECTION AND CODES",
+        "ELECTRICAL POWER DISTRIBUTION SYSTEMS AND MACHINERY",
+        "INTRODUCTION TO ELECTRICAL TECHNOLOGY"
+      ]
+    },
+    {
+      "prefix": "FDSV",
+      "name": "Food",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advancd Food Service Practicum",
+        "Advanced Baking",
+        "Food and Nutrition Orientation",
+        "Food Service Production Laboratory I",
+        "Food Service Production Laboratory II"
+      ]
+    },
+    {
+      "prefix": "FMA",
+      "name": "FMA",
+      "course_count": 10,
+      "section_count": 21,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Audio for Film Production",
+        "Communication through Game Design",
+        "Early Film History",
+        "Film Appreciation",
+        "Intermediate Screenwriting"
+      ]
+    },
+    {
+      "prefix": "GEND",
+      "name": "Gender",
+      "course_count": 5,
+      "section_count": 21,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college",
+        "san-diego-city-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Intro Women's Studies",
+        "Introduction to Gender Studies",
+        "Introduction to LGBTQ Studies",
+        "Modern Hist Women World/Civil",
+        "Psychology of Gender"
+      ]
+    },
+    {
+      "prefix": "GERON",
+      "name": "Aging",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "american-river-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Aging Policy and Practice",
+        "Independent Studies in Gerontology",
+        "Introduction to Geropsychology and the Aging Brain",
+        "Introduction to Social Gerontology: Aging in Contemporary Society",
+        "Psychology of Aging: Adult Development and Aging"
+      ]
+    },
+    {
+      "prefix": "JAMS",
+      "name": "JAMS",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Advanced Intermediate Multimed",
+        "Advanced Multimedia News Produ",
+        "Intermediate Multimedia News P",
+        "Introduction to Photojournalis",
+        "Introduction to Visual Communi"
+      ]
+    },
+    {
+      "prefix": "LVN",
+      "name": "LVN",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "cuesta-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "Clinical I: Medication Admin",
+        "Clinical II: Adult Acute, Moth",
+        "Clinical III: Ment Hlth, Tm Ld",
+        "IV THERAPY/BLOOD WDRAWAL",
+        "IV, Blood, and Phlebotomy Lab"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "MT",
+      "course_count": 14,
+      "section_count": 21,
+      "colleges": [
+        "allan-hancock-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Applied Machining I (NC)",
+        "CNC CAD/CAM",
+        "CNC G Code",
+        "CNC Machine Tool Programming",
+        "CNC Machining I"
+      ]
+    },
+    {
+      "prefix": "NATR",
+      "name": "NATR",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Energy and Sustainability",
+        "Environmental Restoration",
+        "Field Studies: Birds and Plants of the High Sierra",
+        "Fisheries Ecology and Management",
+        "Independent Studies in Natural Resources"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Philosophy",
+      "course_count": 4,
+      "section_count": 21,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Africana Philosophy",
+        "Critical Thinking and Logic",
+        "Ethics",
+        "Intro to Philosophy"
+      ]
+    },
+    {
+      "prefix": "PHMT",
+      "name": "Pharmacy",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Pharmacology &amp; Medication Mgmt",
+        "Pharmacy Calculations",
+        "Pharmacy Law and Ethics",
+        "Pharmacy Ops &amp; Distribution",
+        "Pharmacy Tech Cert Exam Prep"
+      ]
+    },
+    {
+      "prefix": "PSYT",
+      "name": "Nursing",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "bakersfield-college",
+        "cuesta-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Concepts of Nursing Care of the Client with Developmental Disabilities",
+        "Develop. Disabled",
+        "Intro To Psy Tech",
+        "Nursing Science",
+        "Nursing Science Concepts"
+      ]
+    },
+    {
+      "prefix": "VFOOD",
+      "name": "VFOOD",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Baking & Pastry Basics",
+        "Food Service Manager Test Prep",
+        "Introduction to Baking & Pastr",
+        "Introduction to Bread Making",
+        "Introduction to Cakes and Deco"
+      ]
+    },
+    {
+      "prefix": "VONUR",
+      "name": "VONUR",
+      "course_count": 14,
+      "section_count": 21,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Drug Dosage Calculations for Health Occupations",
+        "IV Therapy/Blood Withdrawal",
+        "Leadership & Ethics",
+        "Maternity Clinical Skills Lab",
+        "Maternity Nursing Care Management & Interventions"
+      ]
+    },
+    {
+      "prefix": "WEBD",
+      "name": "WEBD",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Advanced JavaScript",
+        "Creating User-Centered Content",
+        "E-Commerce Website Creation",
+        "Full Stack JavaScript",
+        "HTML and CSS - Beginning"
+      ]
+    },
+    {
+      "prefix": "WFT",
+      "name": "Wildland",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "allan-hancock-college",
+        "pasadena-city-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "WILDLAND FIRE ACADEMY",
+        "Wildland Fire Behavior",
+        "Wildland Fire Investigation, Prevention, and Public Information",
+        "Wildland Fire Logistics, Finance, and Planning",
+        "WILDLAND FIRE OPERATIONS (GROUND, AIR)"
+      ]
+    },
+    {
+      "prefix": "AAPI",
+      "name": "Aapi",
+      "course_count": 2,
+      "section_count": 20,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "AAPI Identities and Cultures",
+        "Intro AAPI Studies"
+      ]
+    },
+    {
+      "prefix": "ABDY",
+      "name": "Automotive",
+      "course_count": 12,
+      "section_count": 20,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Collision Repair",
+        "Advanced Automotive Collision Repair I",
+        "Advanced Automotive Collision Repair II",
+        "Advanced Automotive Refinishing",
+        "Advanced Automotive Refinishing I"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "ACT",
+      "course_count": 15,
+      "section_count": 20,
+      "colleges": [
+        "american-river-college",
+        "college-of-the-desert",
+        "oxnard-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "ACT Access to Computers",
+        "ACT Internet Skills",
+        "ACT Writing Skills",
+        "ACT Writing Skills (NC)",
+        "Automotive Collision Basics"
+      ]
+    },
+    {
+      "prefix": "AOD",
+      "name": "AOD",
+      "course_count": 9,
+      "section_count": 20,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Chem Dep Practicum Seminar",
+        "Co-Occurring Disorders",
+        "Counseling Diverse Populations",
+        "Fund of Chemical Dependency",
+        "Individual, Group and Family"
+      ]
+    },
+    {
+      "prefix": "ASIAN",
+      "name": "Asian",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college",
+        "los-angeles-harbor-college",
+        "west-los-angeles-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Asian American Film and Media",
+        "Asian American History",
+        "Asian-Amer Human",
+        "Contemporary Asian American Issues",
+        "The Peoples And Cultures Of Asia"
+      ]
+    },
+    {
+      "prefix": "ATL",
+      "name": "Systems",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Automotive Braking Systems",
+        "Automotive Manual Transmissions and Drive Train Systems",
+        "Diesel Fuel Systems",
+        "Electric and Hybrid Vehicle Powertrain Systems",
+        "Independent Study in Advanced Transportation"
+      ]
+    },
+    {
+      "prefix": "CARPT",
+      "name": "Wall",
+      "course_count": 2,
+      "section_count": 20,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Wall and Ceiling Fabric Installation",
+        "Work Experience in Carpenters Apprenticeship"
+      ]
+    },
+    {
+      "prefix": "CTEC",
+      "name": "CTEC",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Additions and Remodeling",
+        "Base Residential Cabinets",
+        "Building Fundamentals",
+        "Building Without Plans",
+        "Bus/Legal Aspct Contrctng"
+      ]
+    },
+    {
+      "prefix": "CWE",
+      "name": "Exper",
+      "course_count": 3,
+      "section_count": 20,
+      "colleges": [
+        "gavilan-college",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Gen Coop Wk Exper Ed",
+        "GENERAL WORK EXPER",
+        "OCCUPAT WORK EXPER"
+      ]
+    },
+    {
+      "prefix": "DRON",
+      "name": "Drone",
+      "course_count": 16,
+      "section_count": 20,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Advanced Drone Piloting Skills",
+        "Advanced FPV Piloting and Racing",
+        "Aerial Mapping and Photogrammetry",
+        "Applied Drone Piloting",
+        "Basic Drone Maintenance and Repair"
+      ]
+    },
+    {
+      "prefix": "ELTE",
+      "name": "ELTE",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Acceptability of Electronic Assemblies",
+        "Analog Circuit Analysis",
+        "Digital Circuit Analysis",
+        "Direct Current and Alternating Current Principles",
+        "Electronic Communications I"
+      ]
+    },
+    {
+      "prefix": "ERTH",
+      "name": "ERTH",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "CA State Parks Field Studies",
+        "Earth Science for Educators",
+        "Earth Sciences",
+        "Introduction to Climate Scien.",
+        "Oceanography"
+      ]
+    },
+    {
+      "prefix": "HES",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Drugs, Health, and Society",
+        "Health and Social Justice",
+        "Intro to Public Health",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "HOTFS",
+      "name": "Hospitality",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Food and Beverage Management",
+        "Hospitality Human Resources",
+        "Hospitality Internship",
+        "Hospitality Law",
+        "Hospitality Marketing Mgmt"
+      ]
+    },
+    {
+      "prefix": "HSAD",
+      "name": "Suprvsd",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ALCOHOL/DRUG WK EXP",
+        "COUNS DIVERSE POPULATNS",
+        "HUMAN SERVICES COUNS",
+        "INTRO ALCOHOL/DRUGS",
+        "LAW/ETHICS COMM RES"
+      ]
+    },
+    {
+      "prefix": "HSN",
+      "name": "Part",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "INTEGRATED MATH I PART A",
+        "INTEGRATED MATH I PART B",
+        "INTEGRATED MATH II PART A",
+        "INTEGRATED MATH II PART B",
+        "INTEGRATED MATH III PART A"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "Social",
+      "course_count": 9,
+      "section_count": 20,
+      "colleges": [
+        "monterey-peninsula-college",
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Family Strengthening Models",
+        "Human Services and Social Work Field Practicum",
+        "Human Services and Social Work Seminar",
+        "Intro to Human Aging",
+        "Intro to Social Work"
+      ]
+    },
+    {
+      "prefix": "II",
+      "name": "Tutor",
+      "course_count": 2,
+      "section_count": 20,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Supervised Tutoring",
+        "Tutor Training"
+      ]
+    },
+    {
+      "prefix": "LIS",
+      "name": "Skills",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "berkeley-city-college",
+        "butte-college",
+        "college-of-alameda",
+        "laney-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Information Seeking Behavior",
+        "INTRODUCTION TO INFORMATION RESOURCES",
+        "Research Skills I",
+        "Research Skills II",
+        "Research Skills III"
+      ]
+    },
+    {
+      "prefix": "MEDIA",
+      "name": "MEDIA",
+      "course_count": 15,
+      "section_count": 20,
+      "colleges": [
+        "contra-costa-college",
+        "laney-college"
+      ],
+      "sample_titles": [
+        "DaVinci Resolve: Advanced Video",
+        "DaVinci Resolve: Advanced Video Editing",
+        "DaVinci Resolve: Video Editing",
+        "Digital Film Editing",
+        "Digital Film Editing II"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Human Behavior in Organizations",
+        "Human Resources Management",
+        "Management Principles",
+        "Small Business Management",
+        "Supervisory Management"
+      ]
+    },
+    {
+      "prefix": "MLTT",
+      "name": "Practicum",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Blood Bank and Immunology",
+        "Clinical Chem Lab Operations",
+        "Clinical Microbiology",
+        "Directed Practicum Chemistry",
+        "Directed Practicum Hematology"
+      ]
+    },
+    {
+      "prefix": "MORT",
+      "name": "Funeral",
+      "course_count": 14,
+      "section_count": 20,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Cemetery and Crematory Operations",
+        "Embalming",
+        "Funeral Directing",
+        "Funeral Service Administration I",
+        "Funeral Service Administration II"
+      ]
+    },
+    {
+      "prefix": "PLEG",
+      "name": "PLEG",
+      "course_count": 11,
+      "section_count": 20,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Advanced Legal Research and Writing",
+        "Civil Litigation I",
+        "Civil Litigation II",
+        "Constitutional Law",
+        "Criminal Law and Procedure"
+      ]
+    },
+    {
+      "prefix": "RECR",
+      "name": "Recreation",
+      "course_count": 11,
+      "section_count": 20,
+      "colleges": [
+        "american-river-college",
+        "east-los-angeles-college",
+        "el-camino-community-college-district",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Camp Counsling: Ldrshp/Prgrmng",
+        "Inclusive Leisure",
+        "Introduction to Recreation",
+        "Introduction to Recreation and Leisure",
+        "Introduction to Recreation and Leisure Services"
+      ]
+    },
+    {
+      "prefix": "SDEV",
+      "name": "Test",
+      "course_count": 2,
+      "section_count": 20,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "GED Test Preparation",
+        "Pre-GED Test Preparation"
+      ]
+    },
+    {
+      "prefix": "TART",
+      "name": "Theatre",
+      "course_count": 15,
+      "section_count": 20,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Contemporary Theatre Production I",
+        "Advanced Contemporary Theatre Production II",
+        "Advanced Musical Theatre Production I",
+        "Advanced Musical Theatre Production II",
+        "Beginning Acting"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "TECH",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "mt-san-antonio-college",
+        "napa-valley-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity and Basic Electronics",
+        "Basics of Electric Motor Controls",
+        "Customer Relations -Technician",
+        "Industrial Safety",
+        "Internship in Technology I"
+      ]
+    },
+    {
+      "prefix": "TECM",
+      "name": "Contemporary",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Contemporary Mathematics for Careers"
+      ]
+    },
+    {
+      "prefix": "ACTC",
+      "name": "Canvas",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Applying Canvas Design Tools",
+        "Introduction to Artificial Intelligence",
+        "Introduction to Canvas",
+        "Navigating the Future of AI in the Classroom",
+        "Teaching in an Artificial Intelligence Era"
+      ]
+    },
+    {
+      "prefix": "ADT",
+      "name": "ADT",
+      "course_count": 14,
+      "section_count": 19,
+      "colleges": [
+        "cosumnes-river-college",
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Architectural 3D Modeling",
+        "Architectural Computer-Aided Drawing I",
+        "Architectural Design Technology - Building Information Modeling (BIM) I",
+        "Architectural Design Technology - Building Information Modeling (BIM) II",
+        "Automatic Transmission"
+      ]
+    },
+    {
+      "prefix": "ARTP",
+      "name": "Photography",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Advanced Photogaphy",
+        "Beginning Photography : Black and White",
+        "Digital Photography I",
+        "Digital Photography II",
+        "History of Photography"
+      ]
+    },
+    {
+      "prefix": "ARTPH",
+      "name": "Photography",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Basic Film and Darkroom Photography",
+        "Color Photography",
+        "Digital Photography",
+        "Documentary Photography",
+        "Fashion, Wedding, and Portrait Photography"
+      ]
+    },
+    {
+      "prefix": "ASAME",
+      "name": "Asian",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Asian American Communities",
+        "ASIAN AMERICAN HISTORY FROM 1945 TO THE PRESENT",
+        "Asian and Asian American Popular Culture",
+        "Asians and Asian Americans Through Films",
+        "Introduction to Asian American and Pacific Islander Studies"
+      ]
+    },
+    {
+      "prefix": "ATCH",
+      "name": "ATCH",
+      "course_count": 16,
+      "section_count": 19,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Auto Elec Accessor",
+        "Auto Electricity",
+        "Auto Maintenance",
+        "Auto Repair Business",
+        "Auto Transmissions"
+      ]
+    },
+    {
+      "prefix": "BSRT",
+      "name": "BSRT",
+      "course_count": 15,
+      "section_count": 19,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Cardiopulm Diagnos",
+        "Adv Cardiopulmo Pathophys",
+        "Adv Pharm",
+        "Basic Research Meth and Stats",
+        "Capstone I"
+      ]
+    },
+    {
+      "prefix": "BUSMKT",
+      "name": "Marketing",
+      "course_count": 7,
+      "section_count": 19,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Customer Service",
+        "International Marketing",
+        "Intro to Import/Export",
+        "Marketing Principles"
+      ]
+    },
+    {
+      "prefix": "CNIT",
+      "name": "CNIT",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Admin MS Windows Desktop OS",
+        "Certification Preparation",
+        "Cisco CCNA Networking I",
+        "Cisco CCNA Networking II",
+        "Cloud Computing&amp;Virtualization"
+      ]
+    },
+    {
+      "prefix": "ETECH",
+      "name": "ETECH",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "3D Animation",
+        "Advanced AutoCAD",
+        "Architecture/Green Design-A",
+        "Architecture/Green Design-B",
+        "Architecture/Green Design-C"
+      ]
+    },
+    {
+      "prefix": "FDNT",
+      "name": "Nutrition",
+      "course_count": 3,
+      "section_count": 19,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Elementary Nutrition",
+        "Introduction to Nutrition, Dietetics and Food Service",
+        "Nutrition and Physical Fitness"
+      ]
+    },
+    {
+      "prefix": "FRCH",
+      "name": "French",
+      "course_count": 7,
+      "section_count": 19,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Cont Int Conversational French",
+        "Continuing Elementary French",
+        "Continuing Intermediate French",
+        "Elementary French",
+        "French Culture Through Cinema"
+      ]
+    },
+    {
+      "prefix": "GED",
+      "name": "Prep",
+      "course_count": 8,
+      "section_count": 19,
+      "colleges": [
+        "golden-west-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "GED Lang Arts Prep",
+        "GED Math Prep",
+        "GED Prep: Mathematical Reason",
+        "GED Prep: Reasoning Language",
+        "GED Prep: Science"
+      ]
+    },
+    {
+      "prefix": "GIST",
+      "name": "GIST",
+      "course_count": 8,
+      "section_count": 19,
+      "colleges": [
+        "foothill-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "ADVANCED GEOSPATIAL TECHNOLOGY & SPATIAL ANALYSIS",
+        "Cartographic Design for GIS",
+        "Introduction to Geospatial Technology",
+        "INTRODUCTION TO GEOSPATIAL TECHNOLOGY",
+        "INTRODUCTION TO MAPPING & SPATIAL REASONING"
+      ]
+    },
+    {
+      "prefix": "HLTOC",
+      "name": "Medical",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "college-of-alameda",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Communication Skills for the Health Care Professional",
+        "CPR and First Aid for Allied Health Programs",
+        "Medical Terminology",
+        "Medical Terminology I",
+        "Medical Terminology II"
+      ]
+    },
+    {
+      "prefix": "INDE",
+      "name": "INDE",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "bakersfield-college",
+        "santa-rosa-junior-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Career Plan/Industrial Tech",
+        "Drafting and Drawing for Interiors",
+        "Industrial Trade Basics",
+        "Interior Environment and Space Planning",
+        "Intro to Manual Machining"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD",
+        "CAD for Manufacturing",
+        "CAM II",
+        "CNC Operation",
+        "Intro to CNC Programming"
+      ]
+    },
+    {
+      "prefix": "MTRK",
+      "name": "Truck",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education",
+        "Diesel Engine Management Systems",
+        "Introduction to Medium and Heavy Truck Maintenance and Inspection",
+        "Medium and Heavy Truck Chassis Service, Diagnosis and Repair",
+        "Medium and Heavy Truck Drivetrain Service, Diagnosis, and Repair"
+      ]
+    },
+    {
+      "prefix": "PEFI",
+      "name": "Lifelong",
+      "course_count": 2,
+      "section_count": 19,
+      "colleges": [
+        "college-of-the-siskiyous"
+      ],
+      "sample_titles": [
+        "Lifelong Fitness (STC - Women&#39;s Basketball)",
+        "Mat Pilates"
+      ]
+    },
+    {
+      "prefix": "PHYO",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 19,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Human Physiology"
+      ]
+    },
+    {
+      "prefix": "RDT",
+      "name": "RDT",
+      "course_count": 18,
+      "section_count": 19,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DIGITAL DENTISTRY CAD CAM III",
+        "ADVANCED FIXED PROSTHODONTICS",
+        "ADVANCED FUNCTIONAL OCCLUSION AND BIOMECHANICS OF THE MASTICATORY SYSTEM",
+        "ADVANCED REMOVABLE PARTIAL DENTURES (RPDs)",
+        "BEGINNING COMPLETE DENTURES"
+      ]
+    },
+    {
+      "prefix": "SORL",
+      "name": "Recreation",
+      "course_count": 3,
+      "section_count": 19,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Access Provision in Outdoor Recreation",
+        "Demographics and Behaviors in Outdoor Recreation",
+        "Introduction to Recreation and Leisure"
+      ]
+    },
+    {
+      "prefix": "VHLTH",
+      "name": "VHLTH",
+      "course_count": 6,
+      "section_count": 19,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to Biotechnology",
+        "Introductory Biotech Lab",
+        "Overview Acute Care Nursing",
+        "Overview of the Nursing Assist",
+        "Pers Caregvr/Care Aide-Skills"
+      ]
+    },
+    {
+      "prefix": "VWT",
+      "name": "VWT",
+      "course_count": 16,
+      "section_count": 19,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Cultural Appreciation of Wine",
+        "Fall Vineyard Operations",
+        "Fall Winery Operations",
+        "Fundamentals of Enology",
+        "General Viticulture"
+      ]
+    },
+    {
+      "prefix": "WS",
+      "name": "Water",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "berkeley-city-college",
+        "cabrillo-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Basic Water &amp; Wastewater",
+        "FEMINIST PHILOSOPHY",
+        "Gender and Science",
+        "Global Women Gender",
+        "INTRODUCTION TO WOMEN'S STUDIES"
+      ]
+    },
+    {
+      "prefix": "BUSMK",
+      "name": "Marketing",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Advertising and Gender",
+        "Content Marketing",
+        "Digital Marketing Analytics",
+        "Digital Marketing Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CMA",
+      "name": "CMA",
+      "course_count": 16,
+      "section_count": 18,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Arch Design & Visual Commun I",
+        "Compr Aided Drafting & Design",
+        "Concrete & Masonry Technology",
+        "Constr Mgt and Scheduling",
+        "Construction Graphics"
+      ]
+    },
+    {
+      "prefix": "CMGT",
+      "name": "Construction",
+      "course_count": 15,
+      "section_count": 18,
+      "colleges": [
+        "gavilan-college",
+        "mt-san-antonio-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "ANALYSIS CON DRAW",
+        "Bldg Contractor's License Law",
+        "Building Codes and Zoning",
+        "Building Information Modeling",
+        "CON MATERIAL/SYSTEM"
+      ]
+    },
+    {
+      "prefix": "CMT",
+      "name": "Construction",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Computer Estimating for Construction",
+        "Construction Estimating",
+        "Construction Safety",
+        "Construction Scheduling and Critical Path Method",
+        "Introduction to Construction Plans and Specifications"
+      ]
+    },
+    {
+      "prefix": "DSSS",
+      "name": "DSSS",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Developing Skills for College Success",
+        "Educational Support and Employment Preparation",
+        "Have Internet; Will Travel",
+        "Improving Skills: Self-Determination Skills",
+        "Money Skills"
+      ]
+    },
+    {
+      "prefix": "EGTECH",
+      "name": "Engineering",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "CIM-CNC",
+        "Intro to Additive Mfg",
+        "Intro to Engineering Design",
+        "Principles of Engineering"
+      ]
+    },
+    {
+      "prefix": "ELTRN",
+      "name": "Electrician",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Electrical Workers State Certification Preparation",
+        "Electrician Trainee I",
+        "Electrician Trainee II",
+        "Electrician Trainee III",
+        "Electrician Trainee IV"
+      ]
+    },
+    {
+      "prefix": "EVCT",
+      "name": "Vehicle",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Battery Technologies I",
+        "Braking Systems I",
+        "Electric Vehicle Fundamental Skills",
+        "Electronics I",
+        "Introduction to Electric Vehicle Technology and Safety"
+      ]
+    },
+    {
+      "prefix": "G",
+      "name": "Geology",
+      "course_count": 3,
+      "section_count": 18,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ENVIRONMNTAL GEOLOGY",
+        "PHYSICAL GEOLOGY",
+        "THE EARTH SCIENCES"
+      ]
+    },
+    {
+      "prefix": "GS",
+      "name": "Guidance",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "coalinga-college",
+        "college-of-the-desert",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Consumer Skills",
+        "GLOBAL STUDIES",
+        "Guidance Studies Content Area Support",
+        "Guidance Studies Math",
+        "Guidance Studies Math for Academic Readiness"
+      ]
+    },
+    {
+      "prefix": "MEDTEC",
+      "name": "MEDTEC",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Advanced Phlebotomy Venipuncture Skills",
+        "Chemistry and Urinalysis Practicum",
+        "Clinical Chemistry",
+        "Clinical Microbiology",
+        "Hematology"
+      ]
+    },
+    {
+      "prefix": "MM/MW",
+      "name": "MM/MW",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "berkeley-city-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Graphic Visualization",
+        "Fundamentals of Graphic Visualization Lab",
+        "Introduction to Web Design",
+        "Introduction to Web Design Lab",
+        "Social Media Marketing and Data Analytics"
+      ]
+    },
+    {
+      "prefix": "NCGO",
+      "name": "Google",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Google Cybersecurity",
+        "Google Data Analytics",
+        "Google Digital Marketing and E-commerce",
+        "Google IT Automation with Python",
+        "Google IT Support"
+      ]
+    },
+    {
+      "prefix": "NCPE",
+      "name": "Adapted",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Adapted Aerobic Exercise",
+        "Adapted Aquatics",
+        "Adapted Core Stretching",
+        "Adapted Fitness",
+        "Adapted Functional Fitness"
+      ]
+    },
+    {
+      "prefix": "NCRL",
+      "name": "Real",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Legal Aspects of Real Estate I",
+        "Principles of Real Estate",
+        "Property Management",
+        "Real Estate Appraisal Principles and Procedures",
+        "Real Estate Economics"
+      ]
+    },
+    {
+      "prefix": "NRSE",
+      "name": "Nursing",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Foundations of Nursing",
+        "Leadership in Nursing",
+        "LVN to RN Transition",
+        "Maternal-Health Child Nursing",
+        "Medical Surgical Nursing I"
+      ]
+    },
+    {
+      "prefix": "PASS",
+      "name": "PASS",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Financial Literacy Basics",
+        "Fundamental Computer Skills",
+        "Language Arts",
+        "Math",
+        "MS Office: Basic Word & Excel"
+      ]
+    },
+    {
+      "prefix": "PDSS",
+      "name": "PDSS",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Adapted Computer Basics",
+        "Basic Writ Stu/W Disabilities",
+        "Cognitive Communication Skills",
+        "Self-Advocacy",
+        "Study Strat Stu/W Disabilities"
+      ]
+    },
+    {
+      "prefix": "TTHA",
+      "name": "Theatre",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Lighting Design I",
+        "Lighting Design II",
+        "Production Makeup",
+        "Stagecrafts",
+        "Tech Theatre Practicum III"
+      ]
+    },
+    {
+      "prefix": "VEN",
+      "name": "Operations",
+      "course_count": 17,
+      "section_count": 18,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Grapevine Physiology",
+        "Introduction to Soil Science",
+        "Introduction to Viticulture",
+        "Introduction to Winemaking/Enology",
+        "Sensory Evaluation of Wine"
+      ]
+    },
+    {
+      "prefix": "VT",
+      "name": "Veterinary",
+      "course_count": 17,
+      "section_count": 18,
+      "colleges": [
+        "allan-hancock-college",
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Anatomy-Physiology of Animals",
+        "Animal Disease: Pathology",
+        "Clin. Pathology &amp; Microbiology",
+        "Clinical Laboratory Techniques for Veterinary Technicians",
+        "Dentistry for the Veterinary Technician"
+      ]
+    },
+    {
+      "prefix": "AET",
+      "name": "AET",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "butte-college",
+        "coalinga-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Ag-Irrigation Management",
+        "Basic Surveying",
+        "Diesel Engines & Machine Sys",
+        "Introduction to Alternative Energy Technology (Same as ET 120)",
+        "Photovoltaic Systems Design and Installation (Same as ET 121)"
+      ]
+    },
+    {
+      "prefix": "ARTG",
+      "name": "Art",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "monterey-peninsula-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Art&amp;Culture-GalleryMuseumCommu",
+        "Graphic Arts Portfolio",
+        "Graphic Design: Images and Type",
+        "Introduction to Computers for Graphic Arts",
+        "Introduction to Photoshop"
+      ]
+    },
+    {
+      "prefix": "BSNC",
+      "name": "Prep",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "GED Prep - Lang Arts/Soc Stud",
+        "GED Prep - Math/Science"
+      ]
+    },
+    {
+      "prefix": "CHT",
+      "name": "Basics",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "AI for Professionals",
+        "Artificial Intelligence Basics",
+        "Comp Basics - Nav the Internet",
+        "Comp Use in Technology",
+        "Computer Basics - Introduction"
+      ]
+    },
+    {
+      "prefix": "ECHT",
+      "name": "ECHT",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Basic Electronic Fabrication",
+        "CompTIA Netwk+ Cert Prep",
+        "Comptia Security+ Comp Hdwr",
+        "Digital Systms/Comptr Logic I",
+        "Intro Direct/Altrntng Circuits"
+      ]
+    },
+    {
+      "prefix": "FRNCH",
+      "name": "French",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "diablo-valley-college",
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Elementary French II",
+        "Fifth Term French",
+        "First Term French",
+        "Fourth Term French"
+      ]
+    },
+    {
+      "prefix": "GAME",
+      "name": "Game",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "citrus-college",
+        "moorpark-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "3D for Game Design",
+        "Advanced Environment and Vehicle Modeling",
+        "Game Design Technologies I",
+        "Game Design Technologies II",
+        "Game Level Design"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "de-anza-college",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Introduction to Physical Geography",
+        "Physical Geography",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "antelope-valley-community-college-district",
+        "citrus-college",
+        "cuesta-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Elementary German - Level I",
+        "Elementary German - Level II",
+        "Elementary German 1",
+        "Elementary German 2",
+        "German I"
+      ]
+    },
+    {
+      "prefix": "NTR",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Human Nutrition",
+        "Introduction to Public Health",
+        "Nutrition and Disease",
+        "Personal Health and Wellness"
+      ]
+    },
+    {
+      "prefix": "TUTR",
+      "name": "Supervised",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "orange-coast-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "General Studies",
+        "Supervised Tutoring Noncredit"
+      ]
+    },
+    {
+      "prefix": "BBK",
+      "name": "Quickbooks",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Bookkeeper Internship",
+        "Computerized Bookkeeping and Accounting 1",
+        "Payroll Record Keeping and Reporting",
+        "QuickBooks Level 1",
+        "QuickBooks Level 2"
+      ]
+    },
+    {
+      "prefix": "BGN",
+      "name": "Business",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Administrative Assistant Internship",
+        "Basic Keyboarding",
+        "Business English Grammar",
+        "Introduction to Banking",
+        "Introduction to the Administrative Professional"
+      ]
+    },
+    {
+      "prefix": "BRDCAST",
+      "name": "Production",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Beginning Audio Production",
+        "Beginning Radio Production",
+        "Broadcast and Electronic Media",
+        "High Def Cinematography",
+        "Postproduction"
+      ]
+    },
+    {
+      "prefix": "CFK",
+      "name": "CFK",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "A Taste of Spanish",
+        "Air Dry Clay Sculptures",
+        "Arabic for Kids",
+        "Arts &amp; Crafts Workshop",
+        "Chemistry in the Kitchen"
+      ]
+    },
+    {
+      "prefix": "CGID",
+      "name": "CGID",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Design Thinking",
+        "Digital Video Production",
+        "Intro to Digital Media Arts",
+        "Introduction to Graphic Design",
+        "Motion Graphics I"
+      ]
+    },
+    {
+      "prefix": "CNSE",
+      "name": "CNSE",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Azure Cloud Fundamentals",
+        "CompTIA Advanced Security Prac",
+        "Fundamentals of IT Essentials",
+        "Fundamentals: Computer Network",
+        "Internetworking &amp; TCP/IP"
+      ]
+    },
+    {
+      "prefix": "CONMT",
+      "name": "Construction",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "BLUEPRINT READING AND INTERPRETATION",
+        "California Title 24 Part 6 Nonresidential Energy Standards",
+        "California Title 24 Part 6 Residential Energy Standards",
+        "Computer Applications in Construction Procedures in Scheduling",
+        "Computer Applications in Contracting-Business Management"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Alcohol Narcotics & Drug Abuse",
+        "Community Relations",
+        "Crime Scene Inv",
+        "Criminal Investigation",
+        "Criminal Law"
+      ]
+    },
+    {
+      "prefix": "DES",
+      "name": "Design",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Design and Society",
+        "Design I",
+        "Design II",
+        "Digital Illustration I",
+        "Digital Illustration II"
+      ]
+    },
+    {
+      "prefix": "DLIT",
+      "name": "DLIT",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "AI Basics",
+        "Basic Computers and Devices",
+        "Digital Literacy",
+        "Intro. to Online Learning",
+        "MS Office 365 Basic"
+      ]
+    },
+    {
+      "prefix": "EDEV",
+      "name": "EDEV",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Academic Reading Foundations",
+        "Adaptive Computer Technology A",
+        "Assisted Cmptr Literacy",
+        "Assistive Computer Technology",
+        "Career Preparation"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Engineering Graphics and Design",
+        "Engineering Materials",
+        "Introduction to Circuit Analysis",
+        "Introduction to Circuit Analysis Laboratory",
+        "Introduction to Computing for Engineers"
+      ]
+    },
+    {
+      "prefix": "FASN",
+      "name": "Construction",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Clothing Construction 1",
+        "Clothing Construction 2",
+        "Clothing Construction 3",
+        "Corset Construction",
+        "Fitting and Pattern Alteration"
+      ]
+    },
+    {
+      "prefix": "KNPR",
+      "name": "Sport",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to Kinesiology",
+        "Kinesiology-Related Occupation",
+        "Sport and Society",
+        "Sport Ethics",
+        "Sport Psychology"
+      ]
+    },
+    {
+      "prefix": "OCEN",
+      "name": "Oceanography",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "cuesta-college",
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Introductory Oceanography",
+        "Introductory Oceanography Lab",
+        "Oceanography",
+        "Oceanography Lab"
+      ]
+    },
+    {
+      "prefix": "PLSCI",
+      "name": "Plant",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Ca Water",
+        "Intro to Soils",
+        "Plant Science",
+        "Plant Science Lab",
+        "Sustain. Food Sys."
+      ]
+    },
+    {
+      "prefix": "SWCD",
+      "name": "SWCD",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Alcoholism: Intervention, Treatment and Recovery",
+        "Ethical Issues and Client's Rights",
+        "Independent Studies in Social Work and Chemical Dependency",
+        "Introduction to Chemical Dependency",
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "WMN",
+      "name": "Womens",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "INDEPENDENT STUDY IN WOMEN'S STUDIES",
+        "INTRODUCTION TO WOMEN'S STUDIES",
+        "PSYCHOLOGY OF WOMEN: SEX & GENDER DIFFERENCES",
+        "WOMEN IN GLOBAL PERSPECTIVE"
+      ]
+    },
+    {
+      "prefix": "WOOD",
+      "name": "Woodworking",
+      "course_count": 3,
+      "section_count": 16,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Woodworking",
+        "Intermediate Cabinetmaking",
+        "Introduction to Woodworking"
+      ]
+    },
+    {
+      "prefix": "WTT",
+      "name": "Treatment",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Intro to Wastewater Treatment",
+        "Intro to Wtr Trtmnt/Small Wtr",
+        "Water Distribution Systems",
+        "Water Treatment Tech Work Exp"
+      ]
+    },
+    {
+      "prefix": "AIRE",
+      "name": "AIRE",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Refrig. & AC Lab",
+        "Advanced Refrig. & AC Theory",
+        "Basic Refrig. & AC Theory",
+        "Basic Refrigeration & AC Lab",
+        "Construction Drawings"
+      ]
+    },
+    {
+      "prefix": "AIRM",
+      "name": "Aircraft",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Air Comm, Nav &amp; Autopilot",
+        "Aircraft Airframe Structures",
+        "Aircraft Powerplant Systems",
+        "Aircraft Powerplant Theory",
+        "Aircraft Propellers"
+      ]
+    },
+    {
+      "prefix": "CADM",
+      "name": "Core",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Basic Baton Course",
+        "Corrections Officer Core Course",
+        "Supervisor Core Course",
+        "Weaponless Defense and Control Tactics"
+      ]
+    },
+    {
+      "prefix": "CSTR",
+      "name": "CSTR",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "California Accessibility and Energy Codes",
+        "Concrete and Masonry",
+        "Construction Management",
+        "Construction Materials, Specifications and Purchasing",
+        "Construction Plans Reading (formerly Construction Blueprint Reading)"
+      ]
+    },
+    {
+      "prefix": "CTCH",
+      "name": "CTCH",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Bldg Code I",
+        "Blueprint Reading",
+        "Construction Management",
+        "Finish Carpentry",
+        "Floor Framing"
+      ]
+    },
+    {
+      "prefix": "ENGED",
+      "name": "English",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "american-river-college",
+        "cosumnes-river-college",
+        "folsom-lake-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Independent Studies in English - Education",
+        "Introduction to Elementary Teaching with Field Experience",
+        "Service Learning: Tutoring Elementary Students in Reading",
+        "Structure of English"
+      ]
+    },
+    {
+      "prefix": "ENGLB",
+      "name": "Center",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "cosumnes-river-college",
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Reading and Writing Across the Curriculum",
+        "Reading Center I",
+        "Reading Center II",
+        "Writing Center I",
+        "Writing Center II"
+      ]
+    },
+    {
+      "prefix": "GRMN",
+      "name": "German",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "cabrillo-college",
+        "orange-coast-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Elem German I",
+        "ELEMENTARY GERMAN - LEVEL 1",
+        "ELEMENTARY GERMAN - LEVEL 2",
+        "Elementary German 1",
+        "Elementary German II"
+      ]
+    },
+    {
+      "prefix": "GWOS",
+      "name": "GWOS",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Gender and Violence",
+        "Gender, Sexuality, and Popular Culture",
+        "Introduction to Feminist Theory",
+        "Introduction to Gender and Women&rsquo;s Studies",
+        "Introduction to LGBTQ+ Studies"
+      ]
+    },
+    {
+      "prefix": "HMSV",
+      "name": "Human",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college",
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Human Services Level 1",
+        "Human Services Level 2",
+        "Intro to Social Work & Hmn Svc",
+        "Introduction to Human Services",
+        "Social Work & HMSV Fieldwork"
+      ]
+    },
+    {
+      "prefix": "HO",
+      "name": "HO",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary Res",
+        "Health Occupations Work Exp",
+        "Medical Assist Administrative",
+        "Medical Assisting: Core",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "HVACR",
+      "name": "Hvac",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "chaffey-college",
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Heat Pumps & Troubleshooting",
+        "HVAC Electrical Systems",
+        "HVAC Flues and Ducts",
+        "HVAC Refrigerants Handling",
+        "HVACR Piping Practices"
+      ]
+    },
+    {
+      "prefix": "KORE",
+      "name": "Korean",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "de-anza-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Continuing Intermediate Korean",
+        "Elementary Korean (First Quarter)",
+        "Elementary Korean (Second Quarter)",
+        "Elementary Korean (Third Quarter)",
+        "Korean Culture Through Cinema"
+      ]
+    },
+    {
+      "prefix": "MACT",
+      "name": "Cadcam",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD/CAM",
+        "Application/Adv CAD/CAM I",
+        "Application/Adv CAD/CAM II",
+        "Application/CNC Controlled I",
+        "Application/CNC Controlled II"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Clinical",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Clincal Chemistry Practicum",
+        "Clincial Chemistry I Lab",
+        "Clinical Chemistry I",
+        "Clinical Hematology",
+        "Clinical Hematology Lab"
+      ]
+    },
+    {
+      "prefix": "MMAC",
+      "name": "MMAC",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "3D Character Creation",
+        "3D Computer Animation 1",
+        "3D Computer Animation 2",
+        "Computer Video Editing",
+        "Digital Tools for Visual Media"
+      ]
+    },
+    {
+      "prefix": "MOA",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Medical Office Assisting",
+        "Advanced Medical Terminology",
+        "Beginning Medical Office Assisting",
+        "Beginning Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "Marketing",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "pasadena-city-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Consumer Behavior",
+        "Principles of Marketing",
+        "PRINCIPLES OF MARKETING",
+        "Principles of Selling",
+        "PROMOTIONS AND MARKETING COMMUNICATIONS"
+      ]
+    },
+    {
+      "prefix": "NART",
+      "name": "Expressions",
+      "course_count": 2,
+      "section_count": 15,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Art Expressions I: Creative Process and Art",
+        "Art Expressions II: Art History and Contemporary Imagination"
+      ]
+    },
+    {
+      "prefix": "NHSN",
+      "name": "Medical",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "American Heart Association CPR BLS",
+        "Health Care Industry Employment Readiness",
+        "Healthcare Careers Exploration",
+        "Medical Insurance Claims",
+        "Medical Office Administration"
+      ]
+    },
+    {
+      "prefix": "PETH",
+      "name": "PETH",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Care & Prev of Athlet Injuries",
+        "Introduction to Kinesiology",
+        "Mentals Skills for Sports Perf",
+        "Sport in Society",
+        "Theory and Analys Football II"
+      ]
+    },
+    {
+      "prefix": "POLSC",
+      "name": "POLSC",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "contra-costa-college",
+        "evergreen-valley-college",
+        "los-medanos-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Comparative Politics",
+        "Dynamics of African American Politics in America",
+        "International Relations",
+        "Introduction to Constitutional Law: Your Liberties and Rights",
+        "Introduction to International Relations"
+      ]
+    },
+    {
+      "prefix": "PT",
+      "name": "Disabilities",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "coalinga-college",
+        "cypress-college"
+      ],
+      "sample_titles": [
+        "Developmental Disabilities",
+        "Developmental Disabilities Cinical",
+        "Developmental Disabilities I",
+        "Developmental Disabilities II",
+        "Introduction to Developmental Disabilities"
+      ]
+    },
+    {
+      "prefix": "RA&T",
+      "name": "RA&T",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Audio Recording Technology I",
+        "Electroacoustic Composition",
+        "Intro Comp Prog-Audio Focus",
+        "Live Sound",
+        "Music Business/Career Overview"
+      ]
+    },
+    {
+      "prefix": "WE",
+      "name": "Work",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "evergreen-valley-college",
+        "lassen-community-college",
+        "lemoore-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Career Pathway Work Experience",
+        "General Work Experience",
+        "Occup. Work Exper.",
+        "Work Experience",
+        "Work Experience Education"
+      ]
+    },
+    {
+      "prefix": "WRK",
+      "name": "Work",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "General Work Experience",
+        "Occupational Work Experience",
+        "Occupational Work Experience for Fire Prevention Internship (2.0 - 3.0 Units)",
+        "Occupational Work Experience for Mechatronic Technology (1.0 - 4.0 Units)"
+      ]
+    },
+    {
+      "prefix": "ASAMER",
+      "name": "ASAMER",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "ASAMER SOC'L ISS",
+        "HMONG CULTURE",
+        "INT ASIAN-AMRCNS",
+        "INTRO ASIAN ART"
+      ]
+    },
+    {
+      "prefix": "ASIA",
+      "name": "History",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "santa-ana-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Asian-American History I",
+        "Asian-American History II",
+        "Filipino-American History",
+        "Introduction to Asian American"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "Microsoft",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Collaborate and Integrate with SharePoint and MS Office 365",
+        "Intermediate Microsoft Excel",
+        "Introduction to Microsoft Excel",
+        "Introduction to Microsoft Powerpoint",
+        "Microsoft Word – Course 1"
+      ]
+    },
+    {
+      "prefix": "CFS",
+      "name": "CFS",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Care/Educ for Infants/Toddlers",
+        "Child Development",
+        "Children with Special Needs",
+        "Curriculum/Environment in ECh",
+        "Infant/Toddler Development"
+      ]
+    },
+    {
+      "prefix": "CMUN",
+      "name": "CMUN",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "gavilan-college"
+      ],
+      "sample_titles": [
+        "BUSINESS COMMUNICATION",
+        "FUND CMUN STUDIES",
+        "INTERCULTURAL COMM",
+        "INTERPERSONAL COMM",
+        "INTRO CONFLICT RES"
+      ]
+    },
+    {
+      "prefix": "CNA",
+      "name": "Nursing",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Acute Care Nuring Assist Lab",
+        "Acute Care Nursing Assistant",
+        "Certified Nursing Asst (CNA)",
+        "Certified Nursing Asst Lab"
+      ]
+    },
+    {
+      "prefix": "CRLP",
+      "name": "Selfassessment",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "EXPLORING CAREER FIELDS",
+        "SELF-ASSESSMENT"
+      ]
+    },
+    {
+      "prefix": "CRM",
+      "name": "Food",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Bar and Beverage Management",
+        "Culinary Foundations",
+        "Food and Beverage Management",
+        "Institutional Food Prod. Mgmt",
+        "Institutional Food Production"
+      ]
+    },
+    {
+      "prefix": "ELDT",
+      "name": "ELDT",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "AC Circuit Analysis",
+        "Basic DC Electronics",
+        "Basic DC Laboratory",
+        "DC/AC Circ Analys Lab W/Pspice",
+        "Digital Circuits Laboratory"
+      ]
+    },
+    {
+      "prefix": "ESLV",
+      "name": "Vesl",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "VESL CHILD CARE PROVIDER, MODULE A",
+        "VESL CHILD CARE PROVIDER, MODULE B",
+        "VESL HEALTH CARE, MODULE A",
+        "VESL HEALTH CARE, MODULE B",
+        "VESL WORK READINESS AND COMMUNICATION SKILLS, MODULE A"
+      ]
+    },
+    {
+      "prefix": "FASHM",
+      "name": "Fashion",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Fashion Promotion",
+        "Fashion Retail Merch & Mgmt",
+        "Intro to the Fashion Industry",
+        "Retail Buying",
+        "Textiles"
+      ]
+    },
+    {
+      "prefix": "FTWO",
+      "name": "Boss",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Engine Boss S-231",
+        "Int Wldlnd Fire Behavior S-290",
+        "Intro/Wldlnd Fr Be Calcs S-390",
+        "S-230 Crew Boss (Single Rsrc)",
+        "Strike Team/TFor Ldr - AH-330"
+      ]
+    },
+    {
+      "prefix": "GRPH",
+      "name": "Design",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "3D Modeling for Production",
+        "Advanced Design for Publishing",
+        "Design 1 on the Computer",
+        "Digital Design and Publishing",
+        "Digital Imagery"
+      ]
+    },
+    {
+      "prefix": "HHS",
+      "name": "HHS",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Counseling Diverse Populations",
+        "Development and Progression of Addictive Patterns of Behavior",
+        "Dual Diagnosis Clinical Experience",
+        "Group Process and Leadership",
+        "Introduction to Case Management"
+      ]
+    },
+    {
+      "prefix": "HTT",
+      "name": "HTT",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Airline Internship",
+        "Careers Hospitality/Tourism NC",
+        "Certified Travel Associate",
+        "Computer Reserv-SABRE",
+        "Cultural Tourism"
+      ]
+    },
+    {
+      "prefix": "IDSGN",
+      "name": "Product",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Assembly and Fabrication Workshop",
+        "Color Visualization for Product Design",
+        "Industrial and Product Design Foundations",
+        "Introduction to Industrial and Product Design",
+        "Soft Good Product Design Studio"
+      ]
+    },
+    {
+      "prefix": "KNAC",
+      "name": "Beginning",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Advanced Badminton",
+        "Advanced Soccer",
+        "Beginning Badminton",
+        "Beginning Hatha Yoga",
+        "Beginning Self-Defense"
+      ]
+    },
+    {
+      "prefix": "KNHE",
+      "name": "Health",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmo Resus. FirstAid",
+        "Health and Social Justice",
+        "Healthful Living",
+        "Introduction to Public Health",
+        "Men's Health Issues"
+      ]
+    },
+    {
+      "prefix": "KNIA",
+      "name": "KNIA",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Baseball",
+        "Basketball- Men",
+        "Basketball-Women",
+        "Conditioning for Athletes",
+        "Cross Country-Women"
+      ]
+    },
+    {
+      "prefix": "LEARN",
+      "name": "LEARN",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Academic Assistance",
+        "HS Equiv Test Prep",
+        "Sup Tutor in Writing",
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "LGBT",
+      "name": "Lgbt",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "allan-hancock-college",
+        "el-camino-community-college-district",
+        "napa-valley-college",
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "AIDS in the LGBT Community",
+        "Indep Study in LGBT Education",
+        "Introduction to LGBT Studies",
+        "Introduction to LGBTQ+ Studie",
+        "Queer (LGBTIQ) Film History"
+      ]
+    },
+    {
+      "prefix": "NAWD",
+      "name": "Skill",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Employability Skills",
+        "Skill Bldng Work/Community"
+      ]
+    },
+    {
+      "prefix": "PEAD",
+      "name": "Adaptive",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Adapted Swimming",
+        "Adaptive Circuit Endurance",
+        "Adaptive Core Strengthening"
+      ]
+    },
+    {
+      "prefix": "PHYSC",
+      "name": "Science",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "berkeley-city-college",
+        "diablo-valley-college",
+        "evergreen-valley-college",
+        "fresno-city-college",
+        "los-medanos-college",
+        "san-jose-city-college",
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "General Physical Science",
+        "Independent Study",
+        "INTRO PHYSC",
+        "INTRODUCTION TO THE MARINE ENVIRONMENT"
+      ]
+    },
+    {
+      "prefix": "RAILR",
+      "name": "Railroad",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Railroad Field Operations",
+        "Railroad General Code of Operating Rules",
+        "Railroad Operations",
+        "Railroad Safety, Quality, and Environment",
+        "Railroad Technical Careers"
+      ]
+    },
+    {
+      "prefix": "SL",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "American Sign Language(ASL)1",
+        "Intro to American Sign Lang"
+      ]
+    },
+    {
+      "prefix": "VITI",
+      "name": "Viticulture",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Fruit to Wine - Enology",
+        "Viticulture and Enology",
+        "Viticulture Practices from Bud Break to Harvest",
+        "Viticulture Practices from Harvest through Dormancy",
+        "Wine Component Tasting, Hospitality and Service, and Food Pairing"
+      ]
+    },
+    {
+      "prefix": "VRE",
+      "name": "Real",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Escrow",
+        "Legal Aspects of Real Estate",
+        "Real Estate Career Exploration",
+        "Real Estate Economics",
+        "Real Estate Employability Skil"
+      ]
+    },
+    {
+      "prefix": "ADPE",
+      "name": "Adapted",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Adapted Aerobics",
+        "Adapted Flexibility and Movement Techniques",
+        "Adapted Functional Training",
+        "Adapted Personal Fitness",
+        "Adapted Weight Training"
+      ]
+    },
+    {
+      "prefix": "AHLT",
+      "name": "Emergency",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Basic CPR",
+        "Emergency Medical Technician - Basic",
+        "Emergency Medical Technician Basic Refresher - EMSA Certificaion",
+        "First Aid and Personal Safety"
+      ]
+    },
+    {
+      "prefix": "AMUS",
+      "name": "Community",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Community Band",
+        "Community Chorus",
+        "Community Jazz Band",
+        "Community Orchestra",
+        "Community Small Ensembles"
+      ]
+    },
+    {
+      "prefix": "ARAB",
+      "name": "Arabic",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "coastline-community-college",
+        "mt-san-antonio-college",
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Elementary Arabic",
+        "Elementary Arabic 1",
+        "Elementary Arabic 2",
+        "First Course in Arabic",
+        "Second Course in Arabic"
+      ]
+    },
+    {
+      "prefix": "ARABIC",
+      "name": "Arabic",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "chaffey-college",
+        "los-angeles-city-college",
+        "sacramento-city-college",
+        "west-los-angeles-college"
+      ],
+      "sample_titles": [
+        "Elementary Arabic",
+        "Elementary Arabic I",
+        "Elementary Standard Arabic I",
+        "Elementary Standard Arabic II"
+      ]
+    },
+    {
+      "prefix": "AUTOB",
+      "name": "AUTOB",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "college-of-alameda"
+      ],
+      "sample_titles": [
+        "ADVANCED STUDY IN REFINISHING",
+        "BASIC METHODS OF PAINT PREPARATION AND EQUIPMENT",
+        "Independent Study in Auto Body",
+        "Introduction to Automotive Plastic Parts Repair",
+        "SERVICE WELDING FOR TRANSPORTATION TECHNOLOGY"
+      ]
+    },
+    {
+      "prefix": "CISG",
+      "name": "Games",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Electronic Sports (eSports) I Beginning",
+        "Electronic Sports (eSports) II Intermediate",
+        "History of Video Games",
+        "Introduction to Computer Game Design",
+        "Introduction to Game Narrative and Game Design"
+      ]
+    },
+    {
+      "prefix": "CSP",
+      "name": "Social",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Introduction to Casework in Social Services",
+        "Introduction to Community Building and Change Making",
+        "Introduction to Social Work and Human Services",
+        "Practicum in Sociology, Community Studies, and Community Health Work"
+      ]
+    },
+    {
+      "prefix": "DCDT",
+      "name": "Diesel",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Basic Hydraulic Principles of Diesel Technology",
+        "Clean Diesel Software Support",
+        "Diesel Brake Systems",
+        "Diesel Electrical Systems",
+        "Diesel Engine Repair"
+      ]
+    },
+    {
+      "prefix": "EMTP",
+      "name": "Paramedics",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adv Life Sprt Para Lab I",
+        "Adv Life Sup Para Theory I",
+        "EMS Community Experience I",
+        "Field Trng for Paramedics I",
+        "Field Trng for Paramedics II"
+      ]
+    },
+    {
+      "prefix": "ENSC",
+      "name": "Environmental",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Energy Resource/Conserv",
+        "Environ-Human Interactn",
+        "Environmental Science",
+        "Environmental Science Lab"
+      ]
+    },
+    {
+      "prefix": "FTW",
+      "name": "Wildland",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "NWCG Wildland Firefighter Academy",
+        "Wildfire Chain Saws",
+        "Wildland Engine Firefighter",
+        "Wildland Fire Behavior",
+        "Wildland Fire Control"
+      ]
+    },
+    {
+      "prefix": "GRMAN",
+      "name": "Term",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Fifth Term German",
+        "First Term German",
+        "Fourth Term German",
+        "Second Term German",
+        "Sixth Term German"
+      ]
+    },
+    {
+      "prefix": "HCI",
+      "name": "Healthcare",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "american-river-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "Healthcare Interpreting Fieldwork",
+        "Healthcare Interpreting I",
+        "Healthcare Interpreting II",
+        "Healthcare Interpreting III",
+        "Healthcare Interpreting IV"
+      ]
+    },
+    {
+      "prefix": "IDS",
+      "name": "IDS",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "foothill-college",
+        "hartnell-college",
+        "santa-ana-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Boronda Study-Life & Culture",
+        "Human Sexuality",
+        "Humanities Through the Arts",
+        "RESEARCH METHODOLOGY FOR HEALTH PROFESSIONALS",
+        "Tutorial Proced &amp; Methods (NC)"
+      ]
+    },
+    {
+      "prefix": "LFGD",
+      "name": "Operations",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "All-Terrain Vehicle Operations",
+        "Emerg Med Care Sick/Injured",
+        "Intro/Open Water Lifeguarding",
+        "Rescue Watercraft Operations"
+      ]
+    },
+    {
+      "prefix": "LIBSKL",
+      "name": "LIBSKL",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "clovis-community-college",
+        "fresno-city-college",
+        "madera-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "AI IN EDUC AND EMPLOYMENT",
+        "INF/CMPTR LITRCY",
+        "Info Comp/Research Skls",
+        "INTRO TO AI LIT",
+        "INTRO TO AI LITERACY"
+      ]
+    },
+    {
+      "prefix": "LT",
+      "name": "LT",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Access and Technical Services in Libraries",
+        "Digital Assets: Tools and Methodologies",
+        "Foundations of Library and Information Services",
+        "Information Literacy and Research Skills",
+        "Introduction to Information Organization And Management"
+      ]
+    },
+    {
+      "prefix": "M/LAT",
+      "name": "M/LAT",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "berkeley-city-college",
+        "college-of-alameda",
+        "laney-college",
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "History of Latinos in the United States: 1800 to Present",
+        "Introduction to Chicana/o and Latina/o Studies",
+        "Introduction to Curanderismo: Sacred Healing Traditions andPractices of Mexico and the Southwest US",
+        "LATIN-AMERICAN FOLKLORE",
+        "Latinx Culture: Music, Art, and Theater"
+      ]
+    },
+    {
+      "prefix": "NVOC",
+      "name": "Welding",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "ACEDD-GIS Skills Development",
+        "Advanced Architecture Using Revit and 3D Software",
+        "AutoCAD for Basic CADD Applications",
+        "Basic Electric Arc Welding",
+        "Introduction to Welding Processes"
+      ]
+    },
+    {
+      "prefix": "PHLB",
+      "name": "Phlebotomy",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "cuesta-college",
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy",
+        "Phlebotomy DCP",
+        "Phlebotomy Extern"
+      ]
+    },
+    {
+      "prefix": "PUB",
+      "name": "Public Administration",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Asphalt and Portland Cement Concrete",
+        "California Occupational Safety and Health",
+        "Environmental Management",
+        "Introduction to Public Works",
+        "Municipal and Urban Tree Care"
+      ]
+    },
+    {
+      "prefix": "RCARE",
+      "name": "RCARE",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "CLINCL APP I",
+        "CLINCL APP III",
+        "INTRO RCARE PROF",
+        "MECHNICL VENTILTR",
+        "NEONATAL DISEASES"
+      ]
+    },
+    {
+      "prefix": "SLAN",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "compton-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II"
+      ]
+    },
+    {
+      "prefix": "WARE",
+      "name": "WARE",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Forklift Operations",
+        "Introduction to Operations and Supply Chain Management",
+        "Introduction to Purchasing",
+        "Introduction to Warehousing and Distribution",
+        "Material Handling"
+      ]
+    },
+    {
+      "prefix": "WSTS",
+      "name": "WSTS",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "AFRAM WOMEN",
+        "ASSERT TRAINING",
+        "DOMEST VIOLENCE",
+        "LA CHICANA&LATINA",
+        "ROLES OF WOMEN"
+      ]
+    },
+    {
+      "prefix": "AABS",
+      "name": "Black",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Introduction to Black Studies"
+      ]
+    },
+    {
+      "prefix": "ACS",
+      "name": "Becoming",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Becoming a College Scholar-A First-Year Seminar"
+      ]
+    },
+    {
+      "prefix": "AFRO",
+      "name": "Afroamerican",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Afro-American History I",
+        "Afro-American History II",
+        "Intro to African Am Culture"
+      ]
+    },
+    {
+      "prefix": "ATMN",
+      "name": "ATMN",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Basic Programmable Logic Controllers",
+        "DC and AC Fundamentals",
+        "Introduction to Automation Applications",
+        "Introduction to Robotics and Programming",
+        "Print Reading with Geometric Dimensioning and Tolerancing"
+      ]
+    },
+    {
+      "prefix": "BCT",
+      "name": "BCT",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Adv Framing Techniques",
+        "Basic Elctricty",
+        "Basic Plumbing",
+        "Blueprint Rdg",
+        "Cabinetry I"
+      ]
+    },
+    {
+      "prefix": "BMGR",
+      "name": "Business",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Effective Business Presentations",
+        "Introduction to Employment Law",
+        "Management Skills I",
+        "Marketing Principles",
+        "Understanding Business Contracts"
+      ]
+    },
+    {
+      "prefix": "CELA",
+      "name": "CELA",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "ACCESSIBLE CONTENT",
+        "AI into Teaching",
+        "COMPETENCY BASED EDUCATION",
+        "Designing Short-Term Courses",
+        "DUAL ENROLL/EDUC"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "ECN",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics",
+        "The Global Economy"
+      ]
+    },
+    {
+      "prefix": "EMR",
+      "name": "EMR",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "AMB OPS",
+        "EMR"
+      ]
+    },
+    {
+      "prefix": "ENGD",
+      "name": "Autocad",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced 2-D Autocad",
+        "Blueprint Readng for Construct",
+        "Intro to 2-D Autocad",
+        "Introduction to Drafting",
+        "Introduction to Solidworks"
+      ]
+    },
+    {
+      "prefix": "ENVHR",
+      "name": "Floral",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Art of Floral",
+        "Fund Env Hort",
+        "Intro Env Sci"
+      ]
+    },
+    {
+      "prefix": "ENVMT",
+      "name": "ENVMT",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Geographical Information Systems Applications",
+        "Introduction to Creek and Watershed Restoration: General Aspects",
+        "Introduction to Sustainable Environmental Systems",
+        "Introduction to Urban Agroecology",
+        "Natural History of the Bay Area: Biogeography"
+      ]
+    },
+    {
+      "prefix": "FDST",
+      "name": "Food",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Food Customs and Culture",
+        "Food Processing Technology",
+        "Food Safety",
+        "Food Systems Management",
+        "Introduction to Food Science and Technology"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "cabrillo-college",
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Intro to Investments",
+        "Introduction to Financial Planning",
+        "Money Management"
+      ]
+    },
+    {
+      "prefix": "FISCI",
+      "name": "Fire",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "Building Construction for the Fire Service",
+        "Fire Behavior and Combustion",
+        "Fire Prevention",
+        "Fire Protection Systems",
+        "Firefighter Academy"
+      ]
+    },
+    {
+      "prefix": "FLGHT",
+      "name": "Grsch",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "COMM PILOT1 FLGHT LAB",
+        "FLGHT INSTR FLGHT LAB",
+        "FLGHT INSTR GR/SCH",
+        "INSTR RATE SIMLAB",
+        "INSTR RATING GR/SCH"
+      ]
+    },
+    {
+      "prefix": "FSM",
+      "name": "FSM",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "fresno-city-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "ELEM FS COMP 1",
+        "ELEM FS COMP 2",
+        "EXPERIENTAL FOOD PREP",
+        "FD SERV SUPERVSN",
+        "FOOD PRODUCTION MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "HAL",
+      "name": "Fitness",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Fun Fitness for Healthy Aging",
+        "Music Exercises for Fitness",
+        "Technology Basics for Seniors",
+        "Telling Your Story"
+      ]
+    },
+    {
+      "prefix": "HCTM",
+      "name": "HCTM",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Culinary Internship 1",
+        "Culinary Internship 2",
+        "Cultures and Cuisines",
+        "Intermediate Cul/Garde Manger",
+        "Intro Culinary & Kitchen Ops"
+      ]
+    },
+    {
+      "prefix": "HOEC",
+      "name": "HOEC",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Chocolate Desserts",
+        "Clothing Construction 2",
+        "Clothing Construction 3",
+        "Embroidery Machine Basics",
+        "Serger Sewing"
+      ]
+    },
+    {
+      "prefix": "HT",
+      "name": "HT",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Beginning Histotechniques",
+        "Cellular and Molecular Biology",
+        "Histochem &amp; Immunohistochem",
+        "Intro to Histotechnology",
+        "Sci Basics for Histotechnician"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Industrial Technology Careers"
+      ]
+    },
+    {
+      "prefix": "INST",
+      "name": "Leadership",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Advanced Applied Leadership",
+        "Beginning Applied Leadership",
+        "Intermediate Applied Leadership"
+      ]
+    },
+    {
+      "prefix": "J",
+      "name": "News",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ADVAN NEWS MEDIA PROD",
+        "INTERM NEWS MEDIA PROD",
+        "JOURNALISM WK EXPER",
+        "MULTIMEDIA STORYLELLING",
+        "NEWS MEDIA PROD"
+      ]
+    },
+    {
+      "prefix": "LART",
+      "name": "Academic",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Academic Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "MAND",
+      "name": "Mandarin",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "de-anza-college",
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Chinese Characters",
+        "Elementary Mandarin",
+        "Elementary Mandarin (First Quarter)",
+        "Elementary Mandarin (Second Quarter)",
+        "Elementary Mandarin (Third Quarter)"
+      ]
+    },
+    {
+      "prefix": "MC",
+      "name": "Mass",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "INTRO TO MASS MEDIA"
+      ]
+    },
+    {
+      "prefix": "MM",
+      "name": "MM",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "fresno-city-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "DRIVE FUNDAMENTALS",
+        "Electrical for the Industrial Mechanic",
+        "ELECTRICAL FUND",
+        "Introduction to Industrial Mechanics",
+        "MACH SHOP/REPAIR"
+      ]
+    },
+    {
+      "prefix": "PHAR",
+      "name": "Pharmacy",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Body Systems II",
+        "Inpatient Pharmacy Services",
+        "Introduction to Pharmacy Techn",
+        "Pharmacy Calculations",
+        "Pharmacy Operations"
+      ]
+    },
+    {
+      "prefix": "PHARM",
+      "name": "PHARM",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "coalinga-college",
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Acute Care Practicum",
+        "Introduction to Pharmacology",
+        "Introduction to Pharmacy Practice",
+        "Pharmaceutical Calculations I",
+        "Pharmaceutical Calculations II"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "mission-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Intro Philosophy",
+        "Introduction to Ethics",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "PLEGAL",
+      "name": "PLEGAL",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "DEBT COLECT&JDGMT",
+        "EVIDENCE",
+        "LAW OFC ADM/ETHICS",
+        "LAW OFF COMPUTING",
+        "LEG RES & WRITNG I"
+      ]
+    },
+    {
+      "prefix": "RECM",
+      "name": "RECM",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Exploration of Recreation",
+        "Hospitality Cost Control",
+        "Hotel and Lodging Operations",
+        "Introduction to Hospitality",
+        "Leadership Rec/Parks/Tourism"
+      ]
+    },
+    {
+      "prefix": "WKEXP",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "clovis-community-college"
+      ],
+      "sample_titles": [
+        "Work Exper Ed, General"
+      ]
+    },
+    {
+      "prefix": "WLF",
+      "name": "WLF",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "INTEGR FUELS MGMT",
+        "INTRO TO WLF CAREET PATHWAYS",
+        "INTRO WLF FLD STUDIES",
+        "RT-130 SAFETY TRNG",
+        "WILDLAND FIRE-BASICS"
+      ]
+    },
+    {
+      "prefix": "AGS",
+      "name": "Science",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "General Soils",
+        "Introduction to Animal Science",
+        "Plant Science",
+        "Work Experience-AGS",
+        "World Food & Hunger Issues"
+      ]
+    },
+    {
+      "prefix": "AMIND",
+      "name": "Amer",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "fresno-city-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "AMER INDIAN ART",
+        "AMER INDIAN CULTR",
+        "AMER INDIAN HIST"
+      ]
+    },
+    {
+      "prefix": "BMG",
+      "name": "BMG",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Introduction to Management and Supervision",
+        "Introduction to Personal Finance",
+        "Oral Communication in Organizations",
+        "Project Management"
+      ]
+    },
+    {
+      "prefix": "CRWR",
+      "name": "Writing",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "ADVANCED SHORT FICTION WRITING",
+        "INTRODUCTION TO CREATIVE WRITING",
+        "INTRODUCTION TO SHORT FICTION WRITING",
+        "POETRY IN COMMUNITY"
+      ]
+    },
+    {
+      "prefix": "CSCT",
+      "name": "Certification",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Become a CA Notary Public",
+        "CPR Certification in Mixtec",
+        "CPR Certification in Spanish",
+        "ESL for Interior Design for Ad",
+        "Loan Signing Specialist"
+      ]
+    },
+    {
+      "prefix": "FLTEC",
+      "name": "FLTEC",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Air Navigation, Airspace, and Communication",
+        "Airplane Aerodynamics",
+        "Aviation Weather",
+        "Commercial Pilot Ground School",
+        "Federal Aviation Regulations"
+      ]
+    },
+    {
+      "prefix": "FSC",
+      "name": "Fire",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Basic Wildlnd Firefight",
+        "Bldg Const-Fire Protect",
+        "Fire Academy Physical Training",
+        "Fire Behav-Combustion",
+        "Fire Organization-Mgmt"
+      ]
+    },
+    {
+      "prefix": "GDSN",
+      "name": "Design",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Imaging Design",
+        "Branding and Identity Design",
+        "Digital Illustration Design",
+        "Digital Imaging Design",
+        "History of Graphic Design"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "rio-hondo-college",
+        "santa-rosa-junior-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Cartography Design and Geographic Information Systems",
+        "Field Data Applications for GIS",
+        "Fundamentals of Mapping &amp; GIS",
+        "Geographic Information Systems (GIS) in Environmental Technology",
+        "Geospatial Programming and Web Services"
+      ]
+    },
+    {
+      "prefix": "IDE",
+      "name": "IDE",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD",
+        "Advanced Media",
+        "Design Foundation",
+        "Design Foundation II",
+        "Intermediate CAD"
+      ]
+    },
+    {
+      "prefix": "KINL",
+      "name": "Limited",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "barstow-community-college",
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "First Aid and Safety",
+        "Foundations of Sport Psychology",
+        "Introduction to Kinesiology",
+        "Phys Fitness/Phys Limited",
+        "Weight Train-Phys Limited"
+      ]
+    },
+    {
+      "prefix": "LDR",
+      "name": "LDR",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Bus Innovation and Creativity",
+        "Business Presentation Skills",
+        "Human Resources/Labor Relation",
+        "Intro Comm Econ Urbn Plan Dev",
+        "Leadership and Supervision"
+      ]
+    },
+    {
+      "prefix": "MAG",
+      "name": "MAG",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "madera-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "AGR WELD FABR",
+        "DIESEL ENGINES",
+        "ELEC/HYDR SYS/WELD",
+        "GAS/DIESEL ENGINE",
+        "HVY DUTY BRAKE SYS"
+      ]
+    },
+    {
+      "prefix": "MARA",
+      "name": "MARA",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Coastal Navigation",
+        "Intmd Sail - Intro Keel Boats",
+        "Introduction to Sailing",
+        "Maritime Environment",
+        "Maritime Industry"
+      ]
+    },
+    {
+      "prefix": "MIND",
+      "name": "Mindfulness",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Mindfulness in Everyday Life",
+        "The Practice of Mindfulness and Self-Compassion"
+      ]
+    },
+    {
+      "prefix": "MSP",
+      "name": "MSP",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Interactive WEB Design",
+        "Intro to Drone Mngmt & Ops",
+        "Intro to Virtual Reality",
+        "Intro-Computer Graphics",
+        "Introduction to Digital Art"
+      ]
+    },
+    {
+      "prefix": "NCBU",
+      "name": "Business",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Excel for Accounting and Bookkeeping",
+        "Fundamentals of Business Entities Taxation",
+        "Fundamentals of Individual Taxation - Federal and State",
+        "How to Market your Small Business",
+        "How to Start a Small Business"
+      ]
+    },
+    {
+      "prefix": "OSRM",
+      "name": "Health",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Environmental Health and Hazardous Materials",
+        "Environmental, Health, and Safety Law and Administration",
+        "Forklift Training",
+        "Managing Employee Safety and Health",
+        "Occupational Health"
+      ]
+    },
+    {
+      "prefix": "PMED",
+      "name": "PMED",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Clinical Behavior, Patient Assessment, and Airway Management",
+        "Independent Studies in Paramedic",
+        "Prehospital Medicine and Clinical Internship",
+        "Preparatory",
+        "Trauma, Shock, EMS Operations, and Field Internship"
+      ]
+    },
+    {
+      "prefix": "RA",
+      "name": "Recording",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Basic Tracking Sessions",
+        "Introduction to Recording Arts",
+        "Music Fundamentals for Audio Professionals",
+        "ProTools Production and Editing",
+        "Recording Arts II"
+      ]
+    },
+    {
+      "prefix": "RSPC",
+      "name": "Resp",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Basic Resp C Equipment",
+        "Clinical Lab 2",
+        "Clinical Lab 3",
+        "Intro Mechanical Ventilation",
+        "Physician Series 1"
+      ]
+    },
+    {
+      "prefix": "SDGE",
+      "name": "Electric",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Electric Lineman IA",
+        "Electric Lineman IB",
+        "Electric Lineman IIA",
+        "Electric Lineman IIB",
+        "Electric Lineman IIIA"
+      ]
+    },
+    {
+      "prefix": "ST",
+      "name": "ST",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "madera-community-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Central Service Technology",
+        "Central Service Technology Lab",
+        "Intro to Surgical Tech",
+        "Subspecialties",
+        "SUPERVISED TUTOR"
+      ]
+    },
+    {
+      "prefix": "STSS",
+      "name": "College",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "bakersfield-college"
+      ],
+      "sample_titles": [
+        "College and Career Readiness",
+        "College Planning and Success Strategies",
+        "Personal and Career Exploration",
+        "Strategies for Personal and Academic Success"
+      ]
+    },
+    {
+      "prefix": "WSTU",
+      "name": "Womens",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "compton-college",
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro to Women's Studies",
+        "Introduction to Women&#39;s Studies"
+      ]
+    },
+    {
+      "prefix": "ABOD",
+      "name": "Auto",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Adv Automotive Painting",
+        "Advanced Auto Body",
+        "Advanced Automotive Painting",
+        "Auto Body Repair I",
+        "Automotive Painting"
+      ]
+    },
+    {
+      "prefix": "AFMT",
+      "name": "Manufacturing",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Airframe Composite Manufacturing I",
+        "Airframe Composite Manufacturing II",
+        "Airframe Manufacturing Capstone I",
+        "Airframe Manufacturing Capstone II",
+        "Airframe Manufacturing Producibility"
+      ]
+    },
+    {
+      "prefix": "AGAS",
+      "name": "Science",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "cuesta-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Equine Science",
+        "Intro to Animal Science",
+        "Principles of Animal Science"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural Accounting",
+        "Agriculture Work Exp",
+        "Basic Agricultural Mechanics",
+        "Beginning Horseshoeing",
+        "Food Animal Selection"
+      ]
+    },
+    {
+      "prefix": "AIRT",
+      "name": "Traffic",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Air Traffic Control Laboratory",
+        "Air Traffic Control Team Skill",
+        "Aircraft Recogn &amp; Performance",
+        "Enroute Air Traffic Control",
+        "Enroute Radar Laboratory"
+      ]
+    },
+    {
+      "prefix": "BLDC",
+      "name": "Construction",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Bldg Contractor's License Law",
+        "Building Inspection",
+        "Construction Management I",
+        "Construction Plan Reading",
+        "Construction Practices I"
+      ]
+    },
+    {
+      "prefix": "CHEMT",
+      "name": "Chemical",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Careers in Chemical Technology",
+        "Instrumentation",
+        "Internship in Stockroom",
+        "Post Practicum Seminar in Chemical Technology",
+        "Research in Chemistry"
+      ]
+    },
+    {
+      "prefix": "CHINESE",
+      "name": "Chinese",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "east-los-angeles-college",
+        "los-angeles-city-college"
+      ],
+      "sample_titles": [
+        "Conversational Chinese",
+        "Elementary Chinese I",
+        "Elementary Chinese II",
+        "Intermediate Chinese I"
+      ]
+    },
+    {
+      "prefix": "COSER",
+      "name": "Abuse",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "merritt-college"
+      ],
+      "sample_titles": [
+        "CASE MANAGEMENT FOR SUBSTANCE ABUSE PARAPROFESSIONALS",
+        "COUNSELING SKILLS AND SUBSTANCE ABUSE",
+        "MAINTAINING SOBRIETY AND RELAPSE PREVENTION",
+        "Psychology/Pharmacology of Drugs of Abuse",
+        "SOCIAL PSYCHOLOGY OF SUBSTANCE/DRUG ABUSE"
+      ]
+    },
+    {
+      "prefix": "CSFM",
+      "name": "Company",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "COMPANY OFFICER 2A",
+        "COMPANY OFFICER 2D",
+        "CONFINED SPACE-AWARENESS",
+        "INSTRUCTOR 1"
+      ]
+    },
+    {
+      "prefix": "CUST",
+      "name": "Essential",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Customer Service and Sales",
+        "Essential Skills"
+      ]
+    },
+    {
+      "prefix": "DE",
+      "name": "Occupational",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Introduction to Dental Radiology",
+        "Occupational Health and Safety"
+      ]
+    },
+    {
+      "prefix": "ECSN",
+      "name": "ECSN",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Assessment and Delivery System",
+        "Child Health and Safety NC",
+        "Developmental Needs of a Child",
+        "Ethics &amp; Business Contracts NC",
+        "Family Childcare Business NC"
+      ]
+    },
+    {
+      "prefix": "EH",
+      "name": "EH",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "butte-college",
+        "madera-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "Fall Plant Identification",
+        "HOME FOOD PROD",
+        "Intro-Environ Horticult",
+        "Irrigation Pract-Matl",
+        "Plant Propagation-Nursery Prac"
+      ]
+    },
+    {
+      "prefix": "ELDV",
+      "name": "ELDV",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Developmental Needs of A Child",
+        "ELD for Assmt. &amp; Del. Systems",
+        "ELD for Child Health &amp; Safety",
+        "ELD for Ethics &amp; Bus. Contract",
+        "ELD for Family Childcare Bus."
+      ]
+    },
+    {
+      "prefix": "ELTN",
+      "name": "Electronics",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "BASIC ELECTRONICS FOR AUDIO",
+        "DIGITAL AND CONTROL ELECTRONICS",
+        "INTRODUCTION TO ELECTRONICS",
+        "INTRODUCTION TO MICROCONTROLLERS AND EMBEDDED DESIGN",
+        "PRINTED CIRCUIT &amp; ELECTRONIC HARDWARE DESIGN"
+      ]
+    },
+    {
+      "prefix": "EMP",
+      "name": "EMP",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ADAPTABILITY",
+        "COLLABORATION",
+        "COMMUNICATIONS",
+        "DIGITAL FLUENCY",
+        "SELF-AWARENESS"
+      ]
+    },
+    {
+      "prefix": "FMT",
+      "name": "FMT",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Intermediate PLCs",
+        "Intro Facilities Maintenance",
+        "Intro PLC",
+        "Low/High Pressure Boilers"
+      ]
+    },
+    {
+      "prefix": "HR",
+      "name": "Human",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Human Resource Benefits Administration",
+        "Human Resource Compensation Administration",
+        "Human Resource Employment Law",
+        "Human Resource Hiring Process",
+        "Human Resource Management"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "ITEC",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "butte-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Intro to Industrial Trades",
+        "Mechanical Systems",
+        "Occupational Work Experience Education"
+      ]
+    },
+    {
+      "prefix": "JPNS",
+      "name": "Japanese",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "monterey-peninsula-college",
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese",
+        "Elementary Japanese I",
+        "Elementary Japanese II",
+        "Independent Study"
+      ]
+    },
+    {
+      "prefix": "NFOO",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "compton-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "OFF",
+      "name": "Microsoft",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Procedures",
+        "Computer Keyboarding and Document Processing",
+        "Filing and Records Management",
+        "Introduction to Microsoft Office Applications",
+        "Microsoft Excel"
+      ]
+    },
+    {
+      "prefix": "PADM",
+      "name": "PADM",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Ethics in Public Service",
+        "Internship / Work Experience",
+        "Intro to Law and Society",
+        "Intro to Pub. Admin."
+      ]
+    },
+    {
+      "prefix": "PASV",
+      "name": "Code",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Adv Code Enforcement Officer",
+        "Basic Code Enforcement Officer",
+        "Code Enforcement Officer",
+        "Code Enforcement Officer-Super",
+        "Code Enforcement Officr Safety"
+      ]
+    },
+    {
+      "prefix": "PHYN",
+      "name": "PHYN",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Phy Sci for Elem Ed",
+        "Survey of Physical Science",
+        "Weather and Climate"
+      ]
+    },
+    {
+      "prefix": "PHYZ",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Human Physiology",
+        "Introduction to Human Physiology"
+      ]
+    },
+    {
+      "prefix": "PORT",
+      "name": "Portuguese",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "fresno-city-college",
+        "orange-coast-college",
+        "pasadena-city-college",
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "BEG PORTUGUESE",
+        "ELEMENTARY PORTUGUESE - LEVEL 1",
+        "ELEMENTARY PORTUGUESE - LEVEL 2",
+        "Elementary Portuguese 1",
+        "Elementary Portuguese I"
+      ]
+    },
+    {
+      "prefix": "RTV",
+      "name": "RTV",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "BROADCAST WRITING",
+        "INTERM/RADIO/PODCAST PROD",
+        "INTRO/PODCAST/RADIO/PROD",
+        "RADIO/TV WORK EXPER",
+        "SPORTS MEDIA"
+      ]
+    },
+    {
+      "prefix": "SILA",
+      "name": "American",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "American Sign Language 1",
+        "American Sign Language 2",
+        "American Sign Language 3"
+      ]
+    },
+    {
+      "prefix": "SSD",
+      "name": "Adults",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Emp Prep for Dev Disabled",
+        "Ind Living Skills for Adults",
+        "Issues & Concepts for Adults",
+        "Physical Activities for Adults"
+      ]
+    },
+    {
+      "prefix": "WEG",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "WORK EXPERIENCE, GEN"
+      ]
+    },
+    {
+      "prefix": "WMNS",
+      "name": "Studie",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "san-diego-mesa-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to LGBTQ+ Studie",
+        "Introduction to Women's Studie"
+      ]
+    },
+    {
+      "prefix": "ABED",
+      "name": "Reading",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "College Prep English Reading and Writing",
+        "GED/HiSET: Reading",
+        "GED/HiSET: Science",
+        "NOCE Learning Center",
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "ACRV",
+      "name": "Refrigeration",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Basic Refrigeration Controls",
+        "Basic Refrigeration Systems",
+        "Commercial Air Conditioning Controls",
+        "Commercial Air Conditioning Systems",
+        "Commercial Refrigeration Controls"
+      ]
+    },
+    {
+      "prefix": "AGBU",
+      "name": "Leadership",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "college-of-the-desert",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Agricultural Computer Applications",
+        "Agriculture Leadership &amp; Mentor Training Level 1",
+        "Agriculture Leadership &amp; Mentor Training Level 2",
+        "Agriculture Leadership &amp; Mentor Training Level 3",
+        "Agriculture Leadership &amp; Mentor Training Level 4"
+      ]
+    },
+    {
+      "prefix": "AM",
+      "name": "Solid",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "3D Solid Modeling I using CATIA/3DExperience",
+        "3D Solid Modeling I Using Solidworks",
+        "3D Solid Modeling II Using CATIA/3DExperience",
+        "3D Solid Modeling II Using Solidworks",
+        "Introduction to 2D CAD"
+      ]
+    },
+    {
+      "prefix": "BMK",
+      "name": "Marketing",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Advertising, Branding, &amp; Digital Marketing",
+        "Consumer Behavior",
+        "Digital Marketing Tools",
+        "High Tech Selling and Pursuing a Sales Career",
+        "Introduction to Public Relations"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chem",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Chem for Health",
+        "Intro Gen Chem"
+      ]
+    },
+    {
+      "prefix": "CVT",
+      "name": "CVT",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Adv Electrocardiography",
+        "Cardiac Anat/Pathophys",
+        "Echo Clinical Lab 1",
+        "Intro Echocardiog Lab",
+        "Intro Echocardiography"
+      ]
+    },
+    {
+      "prefix": "DDGT",
+      "name": "Digital",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Digital Design Graphics Tech1",
+        "Digital Design Graphics Tech3",
+        "Technical Drawing Fundamental"
+      ]
+    },
+    {
+      "prefix": "DRLTH",
+      "name": "Apprenticeship",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Introduction to Apprenticeship II",
+        "Work Experience Drywall/Lathing Apprenticeship"
+      ]
+    },
+    {
+      "prefix": "DVST",
+      "name": "DVST",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Learning Disability Assessment",
+        "Orient to Col for Stdnts W/Dis",
+        "Study Skills",
+        "Wellness for Students With Dis"
+      ]
+    },
+    {
+      "prefix": "EDUN",
+      "name": "Instructional",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Bilingual Instructional Aide",
+        "Instructional Aide I",
+        "Instructional Aide II"
+      ]
+    },
+    {
+      "prefix": "FOOD",
+      "name": "Food",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Cultural Aspects of Food",
+        "Food Safety and Sanitation",
+        "Food Service Management",
+        "Foods for Fitness (formerly FOOD 060 F)",
+        "Introduction to Foods (formerly FOOD 101AF)"
+      ]
+    },
+    {
+      "prefix": "GEL",
+      "name": "Geology",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "History of the Earth",
+        "Introduction to Geology",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "GENT",
+      "name": "GENT",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Between the Wars (1918-1945)",
+        "Foundations of the Classical World (1200-500 B.C.)",
+        "Prehistory and Earliest Civilizations (To 1200 B.C.)",
+        "The Age of Progress (1815-1870)",
+        "The End of Innocence (1870-1918)"
+      ]
+    },
+    {
+      "prefix": "HEA",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "college-of-the-siskiyous",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Health Educ",
+        "Health in Action"
+      ]
+    },
+    {
+      "prefix": "HLC",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Health Care Implications of Anatomy and Physiology",
+        "Health Careers Institute",
+        "Introduction to Health Careers",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "ITALIAN",
+      "name": "Italian",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "los-angeles-mission-college",
+        "los-angeles-pierce-college",
+        "los-angeles-valley-college"
+      ],
+      "sample_titles": [
+        "Elementary Italian I",
+        "Elementary Italian II",
+        "Intermediate Italian I"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Leadership",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "mt-san-antonio-college",
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Exploring Leadership",
+        "Personal Leadership"
+      ]
+    },
+    {
+      "prefix": "LTAT",
+      "name": "Skills",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Introduction to Individual Peer Tutoring",
+        "Study Skills for Mathematics",
+        "Study Skills for Mathematics II",
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "MFET",
+      "name": "MFET",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "6 Sigma & Lean Implementation",
+        "Automated PCBA Inspection/Test",
+        "Automated PCBAInspect/Test Lab",
+        "Intro to EMS",
+        "Intro to Manufac Engineer Tech"
+      ]
+    },
+    {
+      "prefix": "NRSR",
+      "name": "Nursing",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Adv Med Surg/Matrn-Newbrn Nurs",
+        "Dosage Calculations",
+        "High-Risk Pediatric Nursing",
+        "IV Therapy Techniques",
+        "Med Surg I &amp; Pediatric Nursing"
+      ]
+    },
+    {
+      "prefix": "OTEC",
+      "name": "OTEC",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Computer Basics",
+        "Excel for Business",
+        "Microsoft Outlook Fundamentals",
+        "Office Essentials",
+        "Software Essentials"
+      ]
+    },
+    {
+      "prefix": "PEMA",
+      "name": "Varsity",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "college-of-the-siskiyous"
+      ],
+      "sample_titles": [
+        "Men&#39;s Varsity Basketball",
+        "Men&#39;s Varsity Football",
+        "Men&#39;s Varsity Soccer",
+        "Off-Season Men&#39;s Varsity Baseball",
+        "Off-Season Varsity Softball"
+      ]
+    },
+    {
+      "prefix": "PHSCI",
+      "name": "Survey",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Survey of Chemistry & Physics"
+      ]
+    },
+    {
+      "prefix": "PRJMGT",
+      "name": "Project",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Introduction to Project Management",
+        "Leading Project Teams though Stakeholder and Communications Management",
+        "Managing Procurement and Project Delivery",
+        "Project Organization and Prioritization",
+        "Project Planning"
+      ]
+    },
+    {
+      "prefix": "PSMA",
+      "name": "Public",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Community Approach",
+        "Human Resources",
+        "Intro to Public Safety MGMT",
+        "Leader Communications",
+        "Native American Relations"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "Drone",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "citrus-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Applications in Aerial, Land and Submersible Drone/ROV Systems",
+        "Drone Regulations, Ethics and Crew Resource Management",
+        "Remote Sensing and GIS for Drone Operators",
+        "Uas/Drone Flt Maneuvers & Safe",
+        "Uas/Drone Plan & Payloads"
+      ]
+    },
+    {
+      "prefix": "WRLD",
+      "name": "WRLD",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Between the Wars (1918 - 1945)",
+        "Foundations of the Classical World (1200-500 B.C.)",
+        "Prehistory and the Earliest Civilizations (to 1200 BCE)",
+        "The Age of Progress (1815 - 1870)",
+        "The Classical World (1200 BCE - 14 CE)"
+      ]
+    },
+    {
+      "prefix": "WTRM",
+      "name": "WTRM",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "gavilan-college"
+      ],
+      "sample_titles": [
+        "ADVANCED W T PLANT OPERATION",
+        "BEG WASTEWATER TRT OPS",
+        "BEGINNING W T PLANT OPS",
+        "POLLUTION PREVENTION",
+        "WATER CONSERVATION"
+      ]
+    },
+    {
+      "prefix": "AJLE",
+      "name": "Academy",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Academy Instructor Cert",
+        "Law Academy Physical Training",
+        "Law Enforcement Academy",
+        "PC 832 Arrest Module",
+        "PC 832 Firearms Module"
+      ]
+    },
+    {
+      "prefix": "BSKL",
+      "name": "High",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "High School Equiv Test Prep"
+      ]
+    },
+    {
+      "prefix": "CID",
+      "name": "CID",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Adobe Animate",
+        "Beg Dig Cartoon in Adobe Anima",
+        "Dreamweaver",
+        "HTML 5 & CSS 3 - Web Develop",
+        "Multimedia Integration"
+      ]
+    },
+    {
+      "prefix": "CSL",
+      "name": "Identity",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Identity, Culture, & Education"
+      ]
+    },
+    {
+      "prefix": "DFLM",
+      "name": "Film",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Introduction to Film",
+        "The American Cinema"
+      ]
+    },
+    {
+      "prefix": "DFT",
+      "name": "DFT",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Architectural Drafting",
+        "Beginning AutoCAD",
+        "Building Info Modeling I",
+        "Engineering Graphics I",
+        "Engineering Graphics II"
+      ]
+    },
+    {
+      "prefix": "DMECH",
+      "name": "Diesel",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "college-of-alameda"
+      ],
+      "sample_titles": [
+        "DIESEL ENGINES - LECTURE/LABORATORY",
+        "DIESEL ENGINES I",
+        "DIESEL ENGINES II",
+        "Heavy-Duty Truck Chassis, Transmission, and Drive Axles",
+        "Heavy-Duty Truck’s Electrical System and Brake System"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "hartnell-college",
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Macroeconomics",
+        "Microeconomics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "EMSP",
+      "name": "EMSP",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Life Support",
+        "Anatomy &amp; Physiology for Preho",
+        "Introduction to ECG Rhythm Ana",
+        "Introduction to Pharmacology",
+        "ITPME"
+      ]
+    },
+    {
+      "prefix": "ESTH",
+      "name": "Esthetician",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Esthetician I",
+        "Esthetician II",
+        "Esthetician Salon Success Part II",
+        "Salon Success - Full-time"
+      ]
+    },
+    {
+      "prefix": "ETC",
+      "name": "Emergency",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Emergency Fire Dispatcher",
+        "Emergency Medical Dispatcher",
+        "Emergency Telecom Dispatcher",
+        "Emergency Telecommunications"
+      ]
+    },
+    {
+      "prefix": "GOLF",
+      "name": "Golf",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "FUND & RULES OF GOLF",
+        "GOLF PATHWAYS",
+        "TEACHING/SHORT GAME",
+        "TOURNAMENT ADMIN"
+      ]
+    },
+    {
+      "prefix": "GRFN",
+      "name": "Graphic",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "BASIC GRAPHIC DESIGN - MODULE A",
+        "BASIC GRAPHIC DESIGN - MODULE B"
+      ]
+    },
+    {
+      "prefix": "GRFX",
+      "name": "Design",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Graphic Design I (formerly ART 140 F)",
+        "Graphic Design II (formerly ART 147 F)",
+        "Graphic Design III",
+        "History of Graphic Design (formerly ART 138 F)",
+        "Packaging Design (formerly ART 148 F)"
+      ]
+    },
+    {
+      "prefix": "HELH",
+      "name": "Community",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Community First Aid & Safety",
+        "Health and Social Justice",
+        "Personal & Community Health"
+      ]
+    },
+    {
+      "prefix": "HRMA",
+      "name": "HRMA",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Assessing and Improving Performance",
+        "Compensation",
+        "Employee Relations",
+        "Human Resources, Introduction"
+      ]
+    },
+    {
+      "prefix": "INS",
+      "name": "Peer",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "hartnell-college",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Advanced Peer Tutors and Mentors Training",
+        "Advanced Training for Peer Tutors and Mentors",
+        "Peer Tutor and Mentor Training",
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "LATN",
+      "name": "Latin",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "mt-san-antonio-college",
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "Continuing Elem Latin - Honors",
+        "Continuing Elementary Latin",
+        "Elementary Latin",
+        "Elementary Latin - Honors",
+        "ELEMENTARY LATIN - LEVEL 1"
+      ]
+    },
+    {
+      "prefix": "LCOM",
+      "name": "Lcom",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "LCOM: Individual Connections"
+      ]
+    },
+    {
+      "prefix": "LNT",
+      "name": "LNT",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Intro to Soil Science",
+        "Landscape Construction",
+        "Landscape Design II",
+        "Organic Gardening",
+        "Plant & Horticultural Science"
+      ]
+    },
+    {
+      "prefix": "MEDO",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support (BLS)",
+        "Medical Terminology (Formerly MEOC 104)"
+      ]
+    },
+    {
+      "prefix": "NNA",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "NURSING ASSISTANT"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "Vocational",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Introduction to Vocational Nursing",
+        "Nurse Assistant (Weekdays - AM Course)"
+      ]
+    },
+    {
+      "prefix": "NSC",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Medical Terminology",
+        "Phlebotomy Tech Pract Experien",
+        "Phlebotomy Technician"
+      ]
+    },
+    {
+      "prefix": "OLS",
+      "name": "OLS",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Ana Behavior for Voc Advantage",
+        "Literacy for Career Building",
+        "Mathematics Within Industry",
+        "Occupational Assessment",
+        "Occupational Certification"
+      ]
+    },
+    {
+      "prefix": "PARL",
+      "name": "PARL",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Civil Litigation I",
+        "Contracts",
+        "Criminal Litigation",
+        "Family Law",
+        "Legal Research and Law Office Technology"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "Adapted",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Adapted Cross Training",
+        "Adapted Strength Conditioning"
+      ]
+    },
+    {
+      "prefix": "PHSCBE",
+      "name": "PHSCBE",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Analytic Inquiry",
+        "Application Awareness",
+        "Application Fluency",
+        "Application Reasoning",
+        "Quantitative Reasoning"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "hartnell-college",
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Chicano Politics & Amer Sys",
+        "Comparative Government",
+        "International Films",
+        "International Relations",
+        "Intr to Polit Theory & Thought"
+      ]
+    },
+    {
+      "prefix": "POLT",
+      "name": "Politics",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "American Political Thought",
+        "Identity Politics",
+        "International Politics",
+        "Introduction to Comparative PO",
+        "Model United Nations"
+      ]
+    },
+    {
+      "prefix": "TD",
+      "name": "Commercial",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "CLASS A COMMERCIAL DRIVER TR",
+        "COMMERCIAL DRIVER PERMIT PREP",
+        "ELTD HAZMAT ENDORSEMENT"
+      ]
+    },
+    {
+      "prefix": "VE",
+      "name": "Employment",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Employment Transitions"
+      ]
+    },
+    {
+      "prefix": "VSW",
+      "name": "VSW",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "VS FALL BSKTBALL-WOMEN",
+        "VS GOLF-WOMEN",
+        "VS SOCCER-WOMEN",
+        "VS VOLLEYBALL-WOMEN"
+      ]
+    },
+    {
+      "prefix": "AAT",
+      "name": "Systems",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Brake Systems",
+        "Electrical & Electronic System",
+        "Electronic Systems & Controls",
+        "Engine Performance",
+        "Engine Repair"
+      ]
+    },
+    {
+      "prefix": "ADHS",
+      "name": "ADHS",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "college-of-the-siskiyous"
+      ],
+      "sample_titles": [
+        "Case Management",
+        "Community Outreach and Referral",
+        "Introduction to Chemical Dependency",
+        "Introduction to Human Services",
+        "Law and Ethics for Helping Professions"
+      ]
+    },
+    {
+      "prefix": "APHY",
+      "name": "Anatomy",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology I",
+        "Anatomy and Physiology II"
+      ]
+    },
+    {
+      "prefix": "APIS",
+      "name": "Asian",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Intro to Asian Amer Studies"
+      ]
+    },
+    {
+      "prefix": "ARM",
+      "name": "Industrial",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "clovis-community-college"
+      ],
+      "sample_titles": [
+        "Electricity and Electronics",
+        "Industrial Automation Sys",
+        "Industrial Robotics System",
+        "Industrl Communic Networks",
+        "Instrumenta and Process Contro"
+      ]
+    },
+    {
+      "prefix": "BANK",
+      "name": "BANK",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Intro to Financial Services",
+        "Introduction to Investments",
+        "Mortgage Brokerage and Banking",
+        "Principles of Insurance"
+      ]
+    },
+    {
+      "prefix": "BUSMG",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Human Resource Management",
+        "Introduction to Management Studies",
+        "Managing Diversity in the Workplace",
+        "Practices and Concepts of Supervision",
+        "Small Business Management"
+      ]
+    },
+    {
+      "prefix": "CSPD",
+      "name": "CSPD",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Intro Chinese Language/Culture",
+        "Intro Japanese Lang/Culture",
+        "Introduction to Beekeeping",
+        "Music, Protest and Politics"
+      ]
+    },
+    {
+      "prefix": "DANCFOLK",
+      "name": "Dance",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Beginning Hip-Hop and Break Dance",
+        "Haitian Folkloric Dance I",
+        "Haitian Folkloric Dance II",
+        "Hip Hop Dance Evolution"
+      ]
+    },
+    {
+      "prefix": "DANS",
+      "name": "Dance",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Dance Appreciation",
+        "Dance History",
+        "Salsa & Latin Dance TA",
+        "Salsa & Latin Social Dance II",
+        "Salsa and Latin Social Dance I"
+      ]
+    },
+    {
+      "prefix": "DMD",
+      "name": "Design",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Digital Media Design Princpls",
+        "Graphic Design/Illustration",
+        "Intro to Digital Art &amp; Media",
+        "Typography",
+        "Visual Design (Photoshop)"
+      ]
+    },
+    {
+      "prefix": "EAC",
+      "name": "Strategies",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "citrus-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "College &amp; Life Strategies",
+        "Empowerment for Students with Disabilities",
+        "Strategies for Stress and Anxiety Management",
+        "Study Skills for Higher Education"
+      ]
+    },
+    {
+      "prefix": "FAME",
+      "name": "FAME",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "BLPRNT RDNG and MEASUREMENT",
+        "Electricity",
+        "INDUSTRIAL MATERIALS",
+        "PLCS",
+        "POWER TRANSMISSION"
+      ]
+    },
+    {
+      "prefix": "GES",
+      "name": "Mstr",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "The Mstr Stdnt"
+      ]
+    },
+    {
+      "prefix": "GGR",
+      "name": "Geography",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Intro. to Human Geography",
+        "Physical Geography",
+        "Physical Geography Laboratory"
+      ]
+    },
+    {
+      "prefix": "HRCM",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Introduction to Hospitality Management",
+        "Introduction to Hotel Management",
+        "Maitenance and Housekeeping Management",
+        "Occupational Work Experience Education",
+        "Supervision and Leadership in Hospitality"
+      ]
+    },
+    {
+      "prefix": "HTL",
+      "name": "HTL",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Applied Immunology",
+        "Biochem for Histotechnicians",
+        "Essentials of Hematology",
+        "Ethics &amp; Standards in the Lab",
+        "Forensic Histopathology"
+      ]
+    },
+    {
+      "prefix": "INT",
+      "name": "Interpreting",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Ethics, Decision-Making, &amp; Professionalism for Interpreters",
+        "Interpreting III",
+        "Principles of Sign Language Interpreting",
+        "Translation"
+      ]
+    },
+    {
+      "prefix": "INTDS",
+      "name": "Stem",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "clovis-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "College Success",
+        "PATHWAY STUDY SKILLS",
+        "STEM EDUCATION"
+      ]
+    },
+    {
+      "prefix": "LCI",
+      "name": "Medical",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Advanced Skills and Exam Preparation - Medical",
+        "Consecutive Interpretation-Spanish",
+        "Interpreting for Pediatric Genetic Disorders",
+        "Introduction to Medical Interpreting",
+        "Simultaneous Interpretation-Spanish"
+      ]
+    },
+    {
+      "prefix": "LIBS",
+      "name": "Info",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "san-diego-city-college",
+        "san-diego-mesa-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Info Literacy & Resrch Skills"
+      ]
+    },
+    {
+      "prefix": "LITEC",
+      "name": "LITEC",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "INF/CMPTR LITRCY",
+        "INFO TECHNOLOGY",
+        "INTRO LIB SERV",
+        "LEGAL RESOURCES",
+        "LIB PUBLIC SERV"
+      ]
+    },
+    {
+      "prefix": "LSK",
+      "name": "Skills",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Intro to College Accomo",
+        "Learning Strategies",
+        "Math Skills Dev (Non-STEM)",
+        "Memory Skills"
+      ]
+    },
+    {
+      "prefix": "M/SVN",
+      "name": "Management",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Essentials of Managerial Communications",
+        "Introduction to Management",
+        "Organization and Management",
+        "PSYCHOLOGY OF MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "MANGT",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Conflict Management, Team Development, Leadership",
+        "Introduction to Management",
+        "Making Effective Decisions",
+        "Managing Human Resources",
+        "Mastering Management's Essential Tools"
+      ]
+    },
+    {
+      "prefix": "MATHCE",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "College Prep Essential Math",
+        "College Preparation Algebra"
+      ]
+    },
+    {
+      "prefix": "MDHD",
+      "name": "Diesel",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "DIESEL ELECT",
+        "DIESEL FUEL/EMISS SYS",
+        "DIESEL TECHNOLOGY",
+        "MD/HD BRAKES/PMI",
+        "MD/HD HVAC/ADV ELEC"
+      ]
+    },
+    {
+      "prefix": "METO",
+      "name": "Weather",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Weather &amp; Atmospheric Environ",
+        "Weather &amp; Atmospheric Lab"
+      ]
+    },
+    {
+      "prefix": "MUSCO",
+      "name": "Music",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "clovis-community-college"
+      ],
+      "sample_titles": [
+        "Electronic Music I",
+        "Intro to Music Technology",
+        "Live Sound",
+        "Music Business",
+        "Recording I"
+      ]
+    },
+    {
+      "prefix": "PDS",
+      "name": "PDS",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Attitude in the Workplace",
+        "Conflict Resolution",
+        "Customer Service",
+        "Decision Making Prob Solving",
+        "Team Building"
+      ]
+    },
+    {
+      "prefix": "PLTS",
+      "name": "Plant",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Introduction to Plant Science",
+        "Soils, Soil Management, and Plant Nutrition",
+        "Work Experience in Plant Science"
+      ]
+    },
+    {
+      "prefix": "PROPTX",
+      "name": "Property",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Appraisal of Machinery and Equipment for Property Tax Purposes",
+        "Introduction to Appraising for Property Tax Purposes"
+      ]
+    },
+    {
+      "prefix": "RLS",
+      "name": "Real",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Escrow Procedures",
+        "Real Estate Appraisal",
+        "Real Estate Mortgage Brokerage",
+        "Real Estate Practices",
+        "Real Estate Principles"
+      ]
+    },
+    {
+      "prefix": "WGQS",
+      "name": "Womens",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Honors Introduction to Women's Studies",
+        "Introduction to Gender and Queer Studies",
+        "Introduction to Women's Studies",
+        "Women in the Arts: Multicultural Perspectives",
+        "Women in World Cultures"
+      ]
+    },
+    {
+      "prefix": "AC",
+      "name": "Systems",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Electrical Systems I Lab",
+        "Heating &amp; Control Systems Lab",
+        "HVAC/Refrig II Lab",
+        "Intro Air Con &amp; Ref I Lab",
+        "WEE AC"
+      ]
+    },
+    {
+      "prefix": "AGMA",
+      "name": "Farm",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Farm Power and Machinery",
+        "Intro to Cons Skills for Ag/Nr"
+      ]
+    },
+    {
+      "prefix": "ATGM",
+      "name": "Auto",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "AUTO BRAKING SYS",
+        "AUTO ELEC SYSTMS",
+        "ENGINE PERFORM",
+        "ENGINE THEORY",
+        "SUSPN/STER/ALIGN"
+      ]
+    },
+    {
+      "prefix": "AVMT",
+      "name": "Avmt",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Aviation Airframe Maint III",
+        "Aviation Powerplant Maint I",
+        "AVMT General I",
+        "AVMT General II",
+        "AVMT General IIA"
+      ]
+    },
+    {
+      "prefix": "BC",
+      "name": "BC",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Customer Service Skills (NC)",
+        "HIT Medical Coding 1",
+        "Intro to Windows OS (NC)",
+        "Keyboard/Doc Formatting (NC)",
+        "Keyboarding Basics (Noncredit)"
+      ]
+    },
+    {
+      "prefix": "BEHS",
+      "name": "Behavioral",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Independent Study in Behavioral Sciences"
+      ]
+    },
+    {
+      "prefix": "BLDN",
+      "name": "Building",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "BASIC CONSTRUCTION SKILLS FOR BUILDING TRADES AND CONSTRUCTION INDUSTRY",
+        "INTRODUCTION TO CARPENTRY AND CONSTRUCTION FUNDAMENTALS",
+        "INTRODUCTION TO OCCUPATIONAL SAFETY AND HEALTH FOR THE BUILDING TRADES",
+        "INTRODUCTION TO THE BUILDING TRADES AND CONSTRUCTION INDUSTRY"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "CAD Detailing and Dimension",
+        "CAD Mechanical Design I",
+        "Intermed 3D Model & Animation",
+        "Intro 3D Modeling Animation",
+        "Intro to Cad/Cam Systems"
+      ]
+    },
+    {
+      "prefix": "CI",
+      "name": "CI",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Building Codes I",
+        "Building Plans/Constr. Detail",
+        "Construction Project Mgmt",
+        "Electrical Inspection",
+        "Inspection/Mechanical Constr"
+      ]
+    },
+    {
+      "prefix": "CISGAME",
+      "name": "Game",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Fund of Game Dev II",
+        "Fundamentals of Game Dev",
+        "Game Programming Fundamentals",
+        "Mobile/Web Game Development"
+      ]
+    },
+    {
+      "prefix": "CJA",
+      "name": "CJA",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Basic Police Academy",
+        "Fitness for Law Enforcement",
+        "Pre-Academy",
+        "Pre-Employment Preparation for"
+      ]
+    },
+    {
+      "prefix": "DETT",
+      "name": "DETT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Alternative Fuels, Diesel, Emi",
+        "Diesel Engines",
+        "Diesel-Electric Transport Refr",
+        "Heavy Duty Mobile Hydraulics",
+        "Intro to Preventative Mainten."
+      ]
+    },
+    {
+      "prefix": "DRMA",
+      "name": "Theatre",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "History World Theatre 2",
+        "Introduction to Theatre",
+        "Stage Makeup"
+      ]
+    },
+    {
+      "prefix": "ELECT",
+      "name": "Work",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "american-river-college",
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "National Electrical Code",
+        "Work Experience in Electricians Apprenticeship"
+      ]
+    },
+    {
+      "prefix": "ENVTC",
+      "name": "Water",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Wastewater Treat I",
+        "Water Distribution",
+        "Water Treatment"
+      ]
+    },
+    {
+      "prefix": "ESHP",
+      "name": "ESHP",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Ethics, Responsibility, and Sustainability",
+        "Financial Basics and Cash Flow",
+        "Innovation",
+        "Venture Launch"
+      ]
+    },
+    {
+      "prefix": "ESRM",
+      "name": "Environmental",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "oxnard-college",
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Conservation Natural Resources",
+        "Intro Environmental Science",
+        "Intro to Environmental Issues",
+        "Intro to Environmental Science"
+      ]
+    },
+    {
+      "prefix": "FILI",
+      "name": "Filipino",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "oxnard-college",
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Elementary Filipino 1",
+        "Filipino American Experience"
+      ]
+    },
+    {
+      "prefix": "FLOR",
+      "name": "Retail",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Beginning Floral Design",
+        "Display and Merchandising for Retail Florists",
+        "Flowers to Wear and Carry",
+        "Intermediate Floral Design",
+        "Retail Flower Business Management"
+      ]
+    },
+    {
+      "prefix": "HET",
+      "name": "Heavy",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Introduction to Diesel Engines, Fuel Systems and Emissions",
+        "Introduction to Heavy Equipment Electrical and Diagnostic Procedures",
+        "Introduction to Heavy Equipment Maintenance",
+        "Introduction to Heavy Equipment Mobile Hydraulics",
+        "Introduction to Heavy Equipment Powertrains"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Electronic Health Records",
+        "Healthcare Law/Ethics",
+        "Intro to Health Info Mgmt",
+        "Introduction to Medical Coding",
+        "Reimbursement"
+      ]
+    },
+    {
+      "prefix": "HMONG",
+      "name": "Hmong",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "cosumnes-river-college",
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "BEGINNING HMONG",
+        "Elementary Hmong",
+        "Elementary Hmong II"
+      ]
+    },
+    {
+      "prefix": "HONRS",
+      "name": "Colloquium",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "cabrillo-college"
+      ],
+      "sample_titles": [
+        "Honors Colloquium I",
+        "Honors Colloquium II"
+      ]
+    },
+    {
+      "prefix": "HUMCBE",
+      "name": "HUMCBE",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Artistic Tech Human Express",
+        "Critical Awareness",
+        "Cultural Inquiry",
+        "Ethical Fluency",
+        "Ethical Reasoning"
+      ]
+    },
+    {
+      "prefix": "IETMECH",
+      "name": "Mechatronics",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Introduction to Mechatronics",
+        "Robotics Ops/Programming"
+      ]
+    },
+    {
+      "prefix": "IMEI",
+      "name": "IMEI",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Alternating Current",
+        "Electrical and Instrumentation Test Equipment",
+        "Flow, Pressure, Level and Temperature",
+        "Introduction to Instrument Drawings and Documents",
+        "Process Quantitative Skills"
+      ]
+    },
+    {
+      "prefix": "INDS",
+      "name": "INDS",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Humanities - Ancient and Medieval (same as ENGL 110 C)",
+        "Introduction to the Monterey State Historical Park",
+        "Learning Communities Seminar"
+      ]
+    },
+    {
+      "prefix": "IW",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Work Experience in Ironworkers Apprenticeship"
+      ]
+    },
+    {
+      "prefix": "JFT",
+      "name": "Fire",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "gavilan-college"
+      ],
+      "sample_titles": [
+        "BUILDING CONSTRUCTION FIRE",
+        "EMERGENCY MED TECH",
+        "EMT CLINICAL",
+        "FIRE PREVENTION",
+        "Fire Safety and Survival"
+      ]
+    },
+    {
+      "prefix": "KINAM",
+      "name": "Basketball",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Int Basketball - Men",
+        "Intercollegiate Football"
+      ]
+    },
+    {
+      "prefix": "KNDAN",
+      "name": "Dance",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Advanced Jazz Dance",
+        "Intermediate Jazz Dance",
+        "Introduction to Dance"
+      ]
+    },
+    {
+      "prefix": "LIBST",
+      "name": "Library",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Library and Information Research Skills"
+      ]
+    },
+    {
+      "prefix": "LOGI",
+      "name": "LOGI",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Global Business",
+        "Global Marketing",
+        "Imports/Exports",
+        "Intro to Logistics",
+        "Supply Chain Management"
+      ]
+    },
+    {
+      "prefix": "LRC",
+      "name": "Tutor",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Introduction to Supplemental Instruction",
+        "Introduction to Tutor Training"
+      ]
+    },
+    {
+      "prefix": "LSR",
+      "name": "LSR",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Negotiating the College Web and Assistive Technology Environment",
+        "Strategies for Basic Skills Math",
+        "Writing for LSR Students in English C1000"
+      ]
+    },
+    {
+      "prefix": "MAST",
+      "name": "Assist",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Med Assist Fast Track",
+        "Med Assist Fast Track Lab",
+        "Medical Assisting Basics"
+      ]
+    },
+    {
+      "prefix": "MODL",
+      "name": "Modeling",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "3D Modeling I",
+        "3D Modeling II"
+      ]
+    },
+    {
+      "prefix": "NAST",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant",
+        "Nursing Assistant Lab"
+      ]
+    },
+    {
+      "prefix": "NUT",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Basic Nutrition"
+      ]
+    },
+    {
+      "prefix": "PHDA",
+      "name": "Modified",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "MODIFIED GENERAL CONDITIONING",
+        "MODIFIED RESISTIVE EXERCISE"
+      ]
+    },
+    {
+      "prefix": "TAGA",
+      "name": "Tagalog",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "First Course in Tagalog",
+        "Second Course in Tagalog",
+        "Third Course in Tagalog"
+      ]
+    },
+    {
+      "prefix": "VSM",
+      "name": "VSM",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "VS FALL BSKTBALL-MEN",
+        "VS FOOTBALL-MEN",
+        "VS SOCCER-MEN"
+      ]
+    },
+    {
+      "prefix": "AGAG",
+      "name": "Food",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Food Land Use and Politics -GP"
+      ]
+    },
+    {
+      "prefix": "APCD",
+      "name": "Child",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Apprenticeship Observation",
+        "Child Growth and Development",
+        "Child, Family and Community",
+        "Intro Children Special Populat"
+      ]
+    },
+    {
+      "prefix": "ASLA",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I"
+      ]
+    },
+    {
+      "prefix": "BCI",
+      "name": "Code",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "California Administrative Code",
+        "Electrical Code",
+        "Framing Reqs Bldg Code",
+        "International Residential Code",
+        "Introduction Int&#39;l Bldg Code"
+      ]
+    },
+    {
+      "prefix": "BCTT",
+      "name": "Safety",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Safety Orientation"
+      ]
+    },
+    {
+      "prefix": "BTEC",
+      "name": "Biomanufacturing",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "compton-college"
+      ],
+      "sample_titles": [
+        "Biomanufacturing",
+        "Introduction to Biotechnology",
+        "Quality and Regulatory Practices in Biomanufacturing",
+        "Technical Coms Regltd Envirmnt",
+        "Techniques in Cell and Molecular Biology"
+      ]
+    },
+    {
+      "prefix": "BUSEN",
+      "name": "Entrepreneurship",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurship",
+        "Entrepreneurship: Operating a Business - Noncredit",
+        "Entrepreneurship: Starting a Business - Noncredit"
+      ]
+    },
+    {
+      "prefix": "CHW",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Community Health Resources",
+        "Introduction to Community Health Work",
+        "Prevention and Management of Chronic Conditions",
+        "Social Determinants of Health",
+        "U.S. Healthcare Systems and Third Party Payers"
+      ]
+    },
+    {
+      "prefix": "CIV",
+      "name": "Civil",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Civil Engineering &amp; Construction Fundamentals",
+        "Civil Engineering Drafting and Design",
+        "Introduction to Surveying and GPS",
+        "Introduction to Technical Drawing &amp; Graphics (Same as ARCH 101, ENGT 101)"
+      ]
+    },
+    {
+      "prefix": "COOP",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Work Experience Education"
+      ]
+    },
+    {
+      "prefix": "CORR",
+      "name": "Corrections",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Conflict Resolution for the Correctional Officer",
+        "Control and Supervision in Corrections",
+        "Introduction to Corrections"
+      ]
+    },
+    {
+      "prefix": "CRPSCI",
+      "name": "CRPSCI",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "coalinga-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "California Pest Control Laws and Regulations",
+        "Introduction to Plant Science",
+        "Introduction to Precision Agriculture",
+        "Weeds and Poisonous Plants"
+      ]
+    },
+    {
+      "prefix": "CTMT",
+      "name": "Repair",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "victor-valley-college"
+      ],
+      "sample_titles": [
+        "Electrical Repair",
+        "Plumbing Repair",
+        "Residential Main. & Repair"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "Diesel",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "barstow-community-college"
+      ],
+      "sample_titles": [
+        "Diesel Engine Auxiliary Systems",
+        "Diesel Engine Fundamentals",
+        "Diesel Fuel Injection Systems",
+        "Diesel Starting, Charging, and Electrical Systems",
+        "Steering, Suspension and Brakes"
+      ]
+    },
+    {
+      "prefix": "EDUSP",
+      "name": "Disabilities",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Historical Perspectives of Disabilities and the Law",
+        "Internship in Work Experience Education in EDUSP",
+        "Introduction to Disabilities",
+        "Strategies for Working With Youth and Adults With Special Needs",
+        "Work Experience Education in EDUSP"
+      ]
+    },
+    {
+      "prefix": "ESEC",
+      "name": "Environmental",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Intro Environmental Sci Honors",
+        "Intro to Environmental Science",
+        "Island Ecology"
+      ]
+    },
+    {
+      "prefix": "GPM",
+      "name": "Game",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Game Design Fundamentals",
+        "Game Sys & Mechanics Design",
+        "Introduction to Game Narrative",
+        "Level Design",
+        "Pitch Development & Practice"
+      ]
+    },
+    {
+      "prefix": "HONORS",
+      "name": "HONORS",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "clovis-community-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "HONOR COLLOQUIUM",
+        "HONORS NAT/BIOL SCI",
+        "Honors Seminar: Comm Or Crit T",
+        "HONORS SOC SCI"
+      ]
+    },
+    {
+      "prefix": "HSRV",
+      "name": "Human",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Crisis Interv in Human Servic",
+        "Human Serv Field Internship",
+        "Intro to Human Services",
+        "Social Work & Human Serv Sem",
+        "Work With Diverse Populations"
+      ]
+    },
+    {
+      "prefix": "LBRY",
+      "name": "Methods",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Advanced Research",
+        "Research Methods"
+      ]
+    },
+    {
+      "prefix": "LRNG",
+      "name": "Learning",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Learning Skills-Writing",
+        "Learning Skills-Writing Lab",
+        "Learning Strat for Math",
+        "Learning Strat for Math - Lab",
+        "Life Skills Disabled Student B"
+      ]
+    },
+    {
+      "prefix": "LRSV",
+      "name": "Learning",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Learning Strategies for College and Careers",
+        "Learning Strategies for Writing"
+      ]
+    },
+    {
+      "prefix": "MILSC",
+      "name": "Lead",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "FRESH LEAD LAB I",
+        "INTRO TO U. S. ARMY",
+        "LEADERSHIP/DEC MAKING",
+        "SOPH LEAD LAB I"
+      ]
+    },
+    {
+      "prefix": "MSCM",
+      "name": "MSCM",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Documentary Film",
+        "Mass Media in Modern Society",
+        "Survey of Motion Picture, Radio, and Television"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "Marine",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Intro to Oceanography Lab",
+        "Introduction to Oceanography",
+        "Marine Biology",
+        "Marine Biology Laboratory"
+      ]
+    },
+    {
+      "prefix": "NURX",
+      "name": "Think",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Practicing RN Clinical Skills",
+        "Think Like a Registered Nurse",
+        "Think Like A Vocational Nurse"
+      ]
+    },
+    {
+      "prefix": "OS",
+      "name": "OS",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Advanced Pediatric Practice",
+        "Applying Research to Occupatio",
+        "Community-Based Occupational",
+        "Movement Theory & Analysis",
+        "Therapeutic Approaches to the"
+      ]
+    },
+    {
+      "prefix": "POS",
+      "name": "POS",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Calif State-Local Govt",
+        "Comparative Politics",
+        "International Relations",
+        "Vital Political Problems"
+      ]
+    },
+    {
+      "prefix": "PRNT",
+      "name": "PRNT",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "fullerton-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Early Childhood Care and Dev",
+        "Health Educ for Childcare Prov",
+        "Introduction to Printing"
+      ]
+    },
+    {
+      "prefix": "RELS",
+      "name": "RELS",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "History of Satan",
+        "Introduction to Religious Studies",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "SSCI",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro Social Justice Studies",
+        "Intro to Social Sciences"
+      ]
+    },
+    {
+      "prefix": "STMN",
+      "name": "Skills",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Chemistry Skills Lab",
+        "Pre-Calculus/Calculus Skills L"
+      ]
+    },
+    {
+      "prefix": "VECU",
+      "name": "Solar",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Solar Installation I",
+        "Solar Sales I",
+        "Solar Sales II"
+      ]
+    },
+    {
+      "prefix": "VIT",
+      "name": "Viticulture",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Wine Grape Viticulture",
+        "Introduction to Viticulture, Winemaking, Wines of the World",
+        "Vineyard Pest and Disease Management",
+        "Viticulture: Fall Practices",
+        "Viticulture: Summer Practices"
+      ]
+    },
+    {
+      "prefix": "WGS",
+      "name": "Women",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Global Women's Issues",
+        "Introduction to Women and Gender Studies"
+      ]
+    },
+    {
+      "prefix": "AEROST",
+      "name": "Leadrshp",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "AS 100 LEADRSHP LAB A",
+        "AS 200 LEADRSHP LAB C",
+        "HERITAGE/VALUE A",
+        "TEAM/LEADERSHP A"
+      ]
+    },
+    {
+      "prefix": "AGAB",
+      "name": "Agriculture",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Agriculture Accounting",
+        "Introduction to Agri Business"
+      ]
+    },
+    {
+      "prefix": "AGBUS",
+      "name": "Agriculture",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "coalinga-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Agricultural Accounting",
+        "Computer Application to Agriculture",
+        "Introduction to Agriculture Business",
+        "Introductory Agricultural Economics"
+      ]
+    },
+    {
+      "prefix": "AGNG",
+      "name": "Aging",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Biology of Aging",
+        "Healthy Aging",
+        "Introduction to Aging Studies",
+        "Psychology of Aging"
+      ]
+    },
+    {
+      "prefix": "AIED",
+      "name": "AIED",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "AI for Educators: Curriculum Design &amp; Student Oversight",
+        "AI for Students: Creativity, Ethics, and Efficiency",
+        "Introduction to AI for Everyday Use"
+      ]
+    },
+    {
+      "prefix": "APTE",
+      "name": "Animation",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "3D Animation: Character Animation",
+        "Basic Drafting Skills",
+        "Computer Modeling and Animation",
+        "Introduction to Computer-Aided Drafting"
+      ]
+    },
+    {
+      "prefix": "ARAM",
+      "name": "Aramaic",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "cuyamaca-college",
+        "grossmont-college"
+      ],
+      "sample_titles": [
+        "Aramaic I"
+      ]
+    },
+    {
+      "prefix": "ARB",
+      "name": "Semester",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "First Semester Arab And Culture",
+        "Second Semester Arabic"
+      ]
+    },
+    {
+      "prefix": "BCOT",
+      "name": "Correctional",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "CORRECTIONAL OFCR TRNG",
+        "JUV CORRECTIONAL OFCR TRN"
+      ]
+    },
+    {
+      "prefix": "BPOT",
+      "name": "Ofcr",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "BASIC PCE OFCR M-II",
+        "BASIC PCE OFCR M-III"
+      ]
+    },
+    {
+      "prefix": "BUFI",
+      "name": "Invstmnt",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "INVSTMNT OPPRTUNTIES"
+      ]
+    },
+    {
+      "prefix": "CANT",
+      "name": "Cantonese",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Elementary Cantonese"
+      ]
+    },
+    {
+      "prefix": "CBA",
+      "name": "CBA",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "golden-west-college"
+      ],
+      "sample_titles": [
+        "Internet Basics",
+        "Intro to Computers &amp; Windows",
+        "Intro to MS Office Suite"
+      ]
+    },
+    {
+      "prefix": "CCT",
+      "name": "Systems",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "contra-costa-college"
+      ],
+      "sample_titles": [
+        "Introduction to Information Systems Security",
+        "Introduction to Networks CCNA 1",
+        "Systems and Network Administration"
+      ]
+    },
+    {
+      "prefix": "CHI",
+      "name": "Semester",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "First Semester Chinese",
+        "Second Semester Chinese"
+      ]
+    },
+    {
+      "prefix": "CMUS",
+      "name": "Music",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Introduction to Music Technology",
+        "Songwriting"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "Tutoring",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "College Strategies",
+        "Supervised Tutoring Across Cur",
+        "Tutoring Methods"
+      ]
+    },
+    {
+      "prefix": "CSAR",
+      "name": "CSAR",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Introduction to Etamine Embroi",
+        "Moguel Art &amp; Sewing Art for En",
+        "Stained Glass 101"
+      ]
+    },
+    {
+      "prefix": "CSTN",
+      "name": "CSTN",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "CLEANING AND CONTAMINATION",
+        "DISINFECTION AND STERILIZATION",
+        "FOUNDATIONS CENTRAL STERILE PROCESSING (CSP)",
+        "MATERIALS AND EQUIPMENT MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "DIST",
+      "name": "Online",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cuesta-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Intro To Online",
+        "Larsen M142 Online Exams"
+      ]
+    },
+    {
+      "prefix": "DSST",
+      "name": "Disability",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college",
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Intro to Disability Studies",
+        "The History of Disability in the United States"
+      ]
+    },
+    {
+      "prefix": "EHMT",
+      "name": "Management",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Env Tech Work Exp I",
+        "Intro Hygiene/Occ Health",
+        "Occupational Safety Management",
+        "Waste Management Applications"
+      ]
+    },
+    {
+      "prefix": "EMGT",
+      "name": "Emergency",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Disaster Recovery",
+        "Emergency Preparedness",
+        "Emergency Response",
+        "Intro to Emergency Mgmt"
+      ]
+    },
+    {
+      "prefix": "ENERGY",
+      "name": "Solar",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Electrical and Mechanical Applications for Solar Installers",
+        "Electrical Applications for Solar Installers",
+        "NABCEP Associate Certification Preparation",
+        "Solar Photovoltaic Systems Design, Installation, and Troubleshooting"
+      ]
+    },
+    {
+      "prefix": "ENGI",
+      "name": "Engineering",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Engineering Graphics & Design",
+        "Introduction to Engineering",
+        "Programming with MATLAB",
+        "Properties of Materials"
+      ]
+    },
+    {
+      "prefix": "ESYS",
+      "name": "Industrial",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "ELECTRICAL WIRING",
+        "INDUSTRIAL CALC"
+      ]
+    },
+    {
+      "prefix": "FIL",
+      "name": "Filipino",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Elementary Filipino I",
+        "Elementary Filipino II"
+      ]
+    },
+    {
+      "prefix": "FOT",
+      "name": "Fire",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Fire Inspector 1A",
+        "Fire Inspector 1B: Introduct.",
+        "Fire Inspector 1C: Field Inspe",
+        "Fire Inspector 1D: Field Insp"
+      ]
+    },
+    {
+      "prefix": "FSRV",
+      "name": "Funeral",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Funeral Service Practices and Procedures I",
+        "Introduction to Funeral Service Practice"
+      ]
+    },
+    {
+      "prefix": "GLBL",
+      "name": "Global",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO GLOBAL STUDIES",
+        "ISSUES IN GLOBAL STUDIES"
+      ]
+    },
+    {
+      "prefix": "GSWS",
+      "name": "Womens",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to Women's Studie",
+        "Men and Masculinities"
+      ]
+    },
+    {
+      "prefix": "HLCR",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Introduction to Health Careers"
+      ]
+    },
+    {
+      "prefix": "HMLD",
+      "name": "Emergency",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Foundations of Critical Infrastructure Protection",
+        "Hazard Mitigation in Emergency Management",
+        "Introduction to Emergency Management",
+        "Introduction to Homeland Security"
+      ]
+    },
+    {
+      "prefix": "HSVC",
+      "name": "HSVC",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Crisis Intervention",
+        "Intro to Human Services",
+        "Trtmnt Issues/Substance Abuse"
+      ]
+    },
+    {
+      "prefix": "HUMNT",
+      "name": "World",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Intro to World Literature",
+        "Intro Women, Gender, Sexuality"
+      ]
+    },
+    {
+      "prefix": "INFO",
+      "name": "INFO",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Academic Research and Informat",
+        "AI Literacy",
+        "Library Research Fundamentals"
+      ]
+    },
+    {
+      "prefix": "IRON",
+      "name": "Orientation",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Orientation and Trade Science"
+      ]
+    },
+    {
+      "prefix": "KINAW",
+      "name": "Basketball",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Int Basketball - Women",
+        "Intercollegiate Volleyball"
+      ]
+    },
+    {
+      "prefix": "KNAF",
+      "name": "Beginning",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Beginning Stretch, Flex and",
+        "Beginning Walking/Jogging for"
+      ]
+    },
+    {
+      "prefix": "LASR",
+      "name": "LASR",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "FUNDAMENTALS OF LIGHT AND LASERS",
+        "OPTICAL DEVICES",
+        "QUALITY ASSURANCE OF PRECISION OPTICS"
+      ]
+    },
+    {
+      "prefix": "LDER",
+      "name": "Prinprac",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Prac/App of Leadership Princip",
+        "Prin/Prac Student Government"
+      ]
+    },
+    {
+      "prefix": "MB",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Body Systems and Diseases",
+        "Coding for Medical Insurance",
+        "MB Administrative Procedures",
+        "Medical Billing &amp; Insurance"
+      ]
+    },
+    {
+      "prefix": "MS",
+      "name": "Microsoft",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Microsoft Office, Overview",
+        "Microsoft Word, Intermediate"
+      ]
+    },
+    {
+      "prefix": "NCMA",
+      "name": "Math",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Math Jam for Calculus Preparation",
+        "Math Jam for Statistics",
+        "Math Jam for Transfer Preparation"
+      ]
+    },
+    {
+      "prefix": "NCSP",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Spanish for Medical Professionals - Beginners",
+        "Spanish for Medical Professionals - Intermediate"
+      ]
+    },
+    {
+      "prefix": "NCTU",
+      "name": "Tutor",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "General Tutor Training",
+        "Writing Tutor Training"
+      ]
+    },
+    {
+      "prefix": "NTS",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Intro. to Nutrition Science"
+      ]
+    },
+    {
+      "prefix": "PBLC",
+      "name": "PBLC",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Public Works",
+        "Fundamentals of Storm Water Ma",
+        "Infrastructure Const and Maint",
+        "Introduction to Microsoft Proj"
+      ]
+    },
+    {
+      "prefix": "PHYSCI",
+      "name": "Chemistry",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "coalinga-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Chemistry and Physics for Educators"
+      ]
+    },
+    {
+      "prefix": "QAMD",
+      "name": "Formerly",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Quality Auditing for Medical Devices (Formerly BMGR 660)",
+        "Technical Writing for Bio-Medical Industries (Formerly BMGR 657)"
+      ]
+    },
+    {
+      "prefix": "ROBO",
+      "name": "Robotics",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Intermediate Robotics",
+        "Introduction to Robotics"
+      ]
+    },
+    {
+      "prefix": "SOCS",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Independent Study in Social Science"
+      ]
+    },
+    {
+      "prefix": "SPE",
+      "name": "SPE",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Arg. & Debate",
+        "Intro to Intercultural Communc",
+        "Intro to Speech"
+      ]
+    },
+    {
+      "prefix": "SPMD",
+      "name": "Care",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Back Care and Injury Management",
+        "Care and Prevention of Athletic Injuries",
+        "Sports Medicine-Athletic Training Practicum Fall Sports",
+        "Sports Medicine-Athletic Training Practicum Fall Sports 2"
+      ]
+    },
+    {
+      "prefix": "SPTUT",
+      "name": "Supervised",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "SUCCESS",
+      "name": "Supervised",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Supervised Tutoring"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surgical",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "cosumnes-river-college"
+      ],
+      "sample_titles": [
+        "Basic Sciences for Surgical Technologists",
+        "Introduction to Surgical Technology",
+        "Surgical Patient Care Concepts",
+        "Surgical Skills Lab"
+      ]
+    },
+    {
+      "prefix": "VFOTO",
+      "name": "Drone",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Drone Photography and Video",
+        "How to Fly a Drone"
+      ]
+    },
+    {
+      "prefix": "VOCN",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Nursing of Adults and Children"
+      ]
+    },
+    {
+      "prefix": "WINE",
+      "name": "WINE",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Beginning Wine Sensory Analysis",
+        "Introduction to Enology",
+        "Introduction to Viticulture, Winemaking, Wines of the World"
+      ]
+    },
+    {
+      "prefix": "ACRT",
+      "name": "ACRT",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "ADVANCED ACR",
+        "BASIC ACR",
+        "SPRAY REFINISH"
+      ]
+    },
+    {
+      "prefix": "AGM",
+      "name": "Farm",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Farm Power, Machinery, Safety",
+        "Intro To Ag Mechanics"
+      ]
+    },
+    {
+      "prefix": "ANDI",
+      "name": "Destructive",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Non Destructive Inspection: Eddy Current",
+        "Non Destructive Inspection: Ultrasound Inspection"
+      ]
+    },
+    {
+      "prefix": "ARABC",
+      "name": "Term",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "First Term Arabic",
+        "Second Term Arabic"
+      ]
+    },
+    {
+      "prefix": "ARTV",
+      "name": "Filmvideo",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "monterey-peninsula-college"
+      ],
+      "sample_titles": [
+        "Beginning Video Production",
+        "Introduction to Film/Video"
+      ]
+    },
+    {
+      "prefix": "ARTZ",
+      "name": "Specialized",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Specialized Studio-Art Studies"
+      ]
+    },
+    {
+      "prefix": "BMET",
+      "name": "Biomedical",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Introduction to Biomedical Equipment Networking",
+        "Introduction to Biomedical Equipment Technology",
+        "Introduction to Respiratory Therapy Ventilators"
+      ]
+    },
+    {
+      "prefix": "BNK/F",
+      "name": "Banking",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "BANK MANAGEMENT",
+        "MONEY AND BANKING",
+        "PRINCIPLES OF BANKING"
+      ]
+    },
+    {
+      "prefix": "BSRC",
+      "name": "Mgmt",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "el-camino-community-college-district"
+      ],
+      "sample_titles": [
+        "Cs Mgmt in Plmnry Emrgncy Med",
+        "Rsp Care Mgmt Usng Evd Bsd Med",
+        "Rsp Cre Mgm of Bdg Dv Prsn Iss"
+      ]
+    },
+    {
+      "prefix": "CC",
+      "name": "What",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Sew What You Wish",
+        "Sewing Techniques"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Computer Arch &amp; Org",
+        "Discrete Structures"
+      ]
+    },
+    {
+      "prefix": "CSHE",
+      "name": "CSHE",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Chinese Dumpling Cooking Funda",
+        "Mediterranean Savory Pastry",
+        "Vietnamese Spring Rolls"
+      ]
+    },
+    {
+      "prefix": "CTD",
+      "name": "Commercial",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Commercial Truck Driving: Behind-the-Wheel",
+        "Commercial Truck Driving: Theory and Permit Preparation"
+      ]
+    },
+    {
+      "prefix": "DIET",
+      "name": "Food",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Food Production Management",
+        "Introduction to Nutrition, Dietetics and Food Service",
+        "Sanitation and Safety"
+      ]
+    },
+    {
+      "prefix": "DMC",
+      "name": "Mass",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "coastline-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Mass Communication"
+      ]
+    },
+    {
+      "prefix": "DSS",
+      "name": "Disability",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Disability and Identity",
+        "Disability, Culture, and Equity Lecture Series",
+        "Universal Access: Disability,Technology and Society"
+      ]
+    },
+    {
+      "prefix": "ENER",
+      "name": "Energy",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Energy Science"
+      ]
+    },
+    {
+      "prefix": "EOPS",
+      "name": "Firstgeneration",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "EOP&amp;S Summer Bridge",
+        "First-Generation College Student Seminar"
+      ]
+    },
+    {
+      "prefix": "ESLP",
+      "name": "Pronunciation",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Pronunciation"
+      ]
+    },
+    {
+      "prefix": "GNDR",
+      "name": "Gender",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Gender Communication",
+        "Introduction to Gender Studies"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "clovis-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Health Care & Careers"
+      ]
+    },
+    {
+      "prefix": "HLS",
+      "name": "Security",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Intelligence Analysis and Security Management",
+        "Introduction to Homeland Security",
+        "Transportation and Border Security"
+      ]
+    },
+    {
+      "prefix": "HSW",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "solano-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Human Services and Social Work",
+        "Serving Diverse Populations"
+      ]
+    },
+    {
+      "prefix": "HTM",
+      "name": "Mgmt",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Food & Beverage Business Mgmt",
+        "Hotel and Lodging Management",
+        "Intro Hospitality/Tourism Mgmt"
+      ]
+    },
+    {
+      "prefix": "IMAGE",
+      "name": "Magnetic",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Magnetic Resonance Imaging I",
+        "Magnetic Resonance Imaging II",
+        "Magnetic Resonance Imaging Practicum"
+      ]
+    },
+    {
+      "prefix": "IMTA",
+      "name": "IMTA",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Industrial Manufacturing Technician Apprentice 1",
+        "Mathematics for the Machine Trades",
+        "Transition to Trainer: Your role as a Journey Worker [455-455]"
+      ]
+    },
+    {
+      "prefix": "IMVR",
+      "name": "IMVR",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Advanced 3D Modeling",
+        "AI for Creative Developers",
+        "Intro to Immersive Media AR/VR"
+      ]
+    },
+    {
+      "prefix": "INTR",
+      "name": "Sign",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "golden-west-college"
+      ],
+      "sample_titles": [
+        "Advanced Voice To Sign",
+        "Beginning Voice To Sign",
+        "Intro to Sign Language Interp"
+      ]
+    },
+    {
+      "prefix": "KNFI",
+      "name": "Circuit",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Advanced Circuit Training",
+        "Beginning Circuit Training",
+        "Intermediate Circuit Training"
+      ]
+    },
+    {
+      "prefix": "MITECH",
+      "name": "Cadcam",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "folsom-lake-college"
+      ],
+      "sample_titles": [
+        "Intermediate CAD/CAM Programming",
+        "Introduction to CAD/CAM Programming",
+        "Introduction to Manufacturing and Industrial Technology"
+      ]
+    },
+    {
+      "prefix": "NAT",
+      "name": "Natural",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "citrus-college",
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "Natural History Series - Coastal Mountains and Islands",
+        "Natural History Series - Death Valley",
+        "NURSE ASST THEORY"
+      ]
+    },
+    {
+      "prefix": "NRSA",
+      "name": "Precert",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "sierra-college"
+      ],
+      "sample_titles": [
+        "Precert Nursing Assistant Trng"
+      ]
+    },
+    {
+      "prefix": "NTTR",
+      "name": "Training",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Introduction to Tutoring Training",
+        "Tutor Leadership and Mentorship Training"
+      ]
+    },
+    {
+      "prefix": "OPT",
+      "name": "Optical",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Optical Dispensing Clinical Lab I",
+        "Optical Dispensing Theory I",
+        "Review Course for American Board of Opticianry (ABO) Certification Exam"
+      ]
+    },
+    {
+      "prefix": "ORTH",
+      "name": "Orthopedic",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Introduction to Orthopedic Technology",
+        "Orthopedic Technician Health Assessment",
+        "Orthopedic Technician Practicum"
+      ]
+    },
+    {
+      "prefix": "PM",
+      "name": "Paramedic",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "ventura-college"
+      ],
+      "sample_titles": [
+        "Paramedic Practicum",
+        "WEE Paramedic Studies"
+      ]
+    },
+    {
+      "prefix": "PSPA",
+      "name": "Dispatcher",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Dispatcher Public Safety (Basic)"
+      ]
+    },
+    {
+      "prefix": "SHME",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Work Experience in Sheet Metal Apprenticeship"
+      ]
+    },
+    {
+      "prefix": "STMFT",
+      "name": "STMFT",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "Industrial Rigging",
+        "Steam Systems",
+        "Welding Safety/Plate Welding"
+      ]
+    },
+    {
+      "prefix": "SUAG",
+      "name": "SUAG",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Direct Farm Marketing",
+        "Introduction to Sustainable Agriculture",
+        "Warm Season Crop Production"
+      ]
+    },
+    {
+      "prefix": "TRLN",
+      "name": "Translation",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "LEGAL TRANSLATION AND INTERPRETATION, MODULE A",
+        "LEGAL TRANSLATION AND INTERPRETATION, MODULE B",
+        "MEDICAL TRANSLATION AND INTERPRETATION, MODULE B"
+      ]
+    },
+    {
+      "prefix": "VDMA",
+      "name": "Design",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to Digital Media",
+        "Web Design"
+      ]
+    },
+    {
+      "prefix": "VHOSP",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Career Focus - Hospitality Ser"
+      ]
+    },
+    {
+      "prefix": "WFPR",
+      "name": "Canva",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Canva for Work",
+        "Career Skills and Resource Lab"
+      ]
+    },
+    {
+      "prefix": "WTRT",
+      "name": "Water",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Basic Water Distribution",
+        "Basic Water Treatment"
+      ]
+    },
+    {
+      "prefix": "WWTR",
+      "name": "Wastewater",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Instrumentation and Controls",
+        "Math for Water and Wastewater Technology",
+        "Wastewater Treatment 1"
+      ]
+    },
+    {
+      "prefix": "ZOOL",
+      "name": "Zoology",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "mt-san-antonio-college",
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Zoology",
+        "General Zoology"
+      ]
+    },
+    {
+      "prefix": "ADLT",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Spanish for Daily Life",
+        "Spanish for Travel"
+      ]
+    },
+    {
+      "prefix": "AGEQ",
+      "name": "Horsemanship",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Horsemanship"
+      ]
+    },
+    {
+      "prefix": "AGSA",
+      "name": "Sust",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Intro to Sust AG & Farm Mgmt"
+      ]
+    },
+    {
+      "prefix": "ALM",
+      "name": "Manufacturing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Lean Manufacturing",
+        "Manufacturing Processes and Controls"
+      ]
+    },
+    {
+      "prefix": "APED",
+      "name": "Tutoring",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "School-Age Child Care and Recr",
+        "Tutoring Reading in Elementary"
+      ]
+    },
+    {
+      "prefix": "ARMN",
+      "name": "Armenian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY ARMENIAN - LEVEL 1",
+        "ELEMENTARY ARMENIAN - LEVEL 2"
+      ]
+    },
+    {
+      "prefix": "ATCAD",
+      "name": "Operations",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Aircraft Dispatcher Operations",
+        "Airline Operations and Performance"
+      ]
+    },
+    {
+      "prefix": "ATHM",
+      "name": "Intercollegiate",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Intercollegiate Men's Soccer"
+      ]
+    },
+    {
+      "prefix": "ATHW",
+      "name": "Intercollegiate",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Intercollegiate Women's Soccer"
+      ]
+    },
+    {
+      "prefix": "ATMG",
+      "name": "Automotive",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Automotive Parts Management",
+        "Automotive Planning and Small Business Management"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "Barbering",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "citrus-college"
+      ],
+      "sample_titles": [
+        "Advanced Barbering",
+        "Introduction to Barbering"
+      ]
+    },
+    {
+      "prefix": "BFFA",
+      "name": "Bffa",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "BFFA ACADEMY PART 1"
+      ]
+    },
+    {
+      "prefix": "BIOLFS",
+      "name": "Natural",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Natural History Field Study: Advanced Study of the Mojave Desert",
+        "Natural History Field Study: Mojave Desert"
+      ]
+    },
+    {
+      "prefix": "BLST",
+      "name": "African",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to African Americ"
+      ]
+    },
+    {
+      "prefix": "BRS",
+      "name": "Border",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oxnard-college"
+      ],
+      "sample_titles": [
+        "Intro to Border Studies"
+      ]
+    },
+    {
+      "prefix": "BTNY",
+      "name": "Plant",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "mt-san-antonio-college",
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Plant Biology",
+        "Plant Structure and Diversity"
+      ]
+    },
+    {
+      "prefix": "CHNS",
+      "name": "Chinese",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Elementary Chinese I",
+        "Elementary Chinese II"
+      ]
+    },
+    {
+      "prefix": "CISIWEB",
+      "name": "Wordpress",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "WordPress Web Development"
+      ]
+    },
+    {
+      "prefix": "CISM",
+      "name": "Systems",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mt-san-antonio-college"
+      ],
+      "sample_titles": [
+        "Systems Analysis and Design"
+      ]
+    },
+    {
+      "prefix": "CL",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Computer Literacy"
+      ]
+    },
+    {
+      "prefix": "CMRT",
+      "name": "Commercial",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "bakersfield-college"
+      ],
+      "sample_titles": [
+        "Commercial Layout and Design",
+        "Illustration"
+      ]
+    },
+    {
+      "prefix": "CNC",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Computer Numerical Control (CNC)"
+      ]
+    },
+    {
+      "prefix": "CSMU",
+      "name": "Ukulele",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Ukulele Sing and Strum"
+      ]
+    },
+    {
+      "prefix": "DATA",
+      "name": "Data",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "clovis-community-college",
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Foundtns of Data Science",
+        "Intro to Data Science"
+      ]
+    },
+    {
+      "prefix": "DIGFAB",
+      "name": "Sign",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "Sign Making"
+      ]
+    },
+    {
+      "prefix": "DRONE",
+      "name": "Remote",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "los-medanos-college"
+      ],
+      "sample_titles": [
+        "Basic Drone Piloting",
+        "Remote Pilot Certification Preparation"
+      ]
+    },
+    {
+      "prefix": "DSCI",
+      "name": "Data",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Foundations of Data Science",
+        "Statistics for Data Science"
+      ]
+    },
+    {
+      "prefix": "EART",
+      "name": "Earth",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Earth Science"
+      ]
+    },
+    {
+      "prefix": "ELED",
+      "name": "Teaching",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Field Experience in Elementary Teaching",
+        "Introduction to Elementary Teaching"
+      ]
+    },
+    {
+      "prefix": "ENGN",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Intro to Engineering Design"
+      ]
+    },
+    {
+      "prefix": "ENVR",
+      "name": "Environmental",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Environmental Geology",
+        "Human Ecology"
+      ]
+    },
+    {
+      "prefix": "ES/S",
+      "name": "Adapted",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Adapted Gentle Yoga",
+        "Adapted Personalized Fitness"
+      ]
+    },
+    {
+      "prefix": "FRNH",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "gavilan-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY FRENCH"
+      ]
+    },
+    {
+      "prefix": "GAD",
+      "name": "Game",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Game Concept Design and Visual Development",
+        "Introduction to Game Design"
+      ]
+    },
+    {
+      "prefix": "GBST",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Global Economics"
+      ]
+    },
+    {
+      "prefix": "GEG",
+      "name": "Geography",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Geography & World Affairs"
+      ]
+    },
+    {
+      "prefix": "GEM",
+      "name": "Introductory",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Diamonds",
+        "Introductory Colored Stones"
+      ]
+    },
+    {
+      "prefix": "HOND",
+      "name": "Transmission",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Honda/Acura Automatic Transmission Systems",
+        "Power Train System Service and Transmission Diagnostics"
+      ]
+    },
+    {
+      "prefix": "HSP",
+      "name": "Hospitality",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "HOSPITALITY COST CONTROL",
+        "INTRO TO FOOD & BEVERGE MNGT"
+      ]
+    },
+    {
+      "prefix": "HUS",
+      "name": "Work",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lassen-community-college"
+      ],
+      "sample_titles": [
+        "Human Services Work Exp",
+        "Intr Social Work Human Service"
+      ]
+    },
+    {
+      "prefix": "IETELMT",
+      "name": "Hydraulic",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chaffey-college"
+      ],
+      "sample_titles": [
+        "Hydraulic Fundamentals"
+      ]
+    },
+    {
+      "prefix": "IHSS",
+      "name": "High",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cypress-college",
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "High School Biology A: Molecules to Organisms"
+      ]
+    },
+    {
+      "prefix": "IMT",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "coalinga-college"
+      ],
+      "sample_titles": [
+        "Industrial Core"
+      ]
+    },
+    {
+      "prefix": "INTL",
+      "name": "Global",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Introduction to Global Studies",
+        "Sociology of Globalization and Social Change"
+      ]
+    },
+    {
+      "prefix": "KOREAN",
+      "name": "Korean",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Elementary Korean"
+      ]
+    },
+    {
+      "prefix": "LABR",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "American Labor Movement",
+        "Organizing"
+      ]
+    },
+    {
+      "prefix": "LABST",
+      "name": "Labor",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "AMERICAN LABOR MOVEMENT",
+        "ECONOMICS FOR LABOR AND COMMUNITY LEADERSHIP"
+      ]
+    },
+    {
+      "prefix": "LGL",
+      "name": "Legal Studies",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Intro To Law"
+      ]
+    },
+    {
+      "prefix": "LIBSC",
+      "name": "LIBSC",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Basic Research"
+      ]
+    },
+    {
+      "prefix": "MAN",
+      "name": "Behavior",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Org. Behavior"
+      ]
+    },
+    {
+      "prefix": "MCGS",
+      "name": "Womens",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "butte-college"
+      ],
+      "sample_titles": [
+        "Intro to Women's Studies",
+        "Multicultural/Gender Studies"
+      ]
+    },
+    {
+      "prefix": "MCTL",
+      "name": "Tool",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bakersfield-college",
+        "porterville-college"
+      ],
+      "sample_titles": [
+        "Tool and Equipment Operation"
+      ]
+    },
+    {
+      "prefix": "MESA",
+      "name": "Mesa",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "MESA ORIENTATION"
+      ]
+    },
+    {
+      "prefix": "MIT",
+      "name": "Robotics",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO ROBOTICS"
+      ]
+    },
+    {
+      "prefix": "MTER",
+      "name": "Weather",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Introduction to Weather and Climate",
+        "Weather and Climate Lab"
+      ]
+    },
+    {
+      "prefix": "NCLA",
+      "name": "Supplemental",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "foothill-college"
+      ],
+      "sample_titles": [
+        "SUPPLEMENTAL INSTRUCTION ENGLISH: ESSAY- & PARAGRAPH-LEVEL REVISION"
+      ]
+    },
+    {
+      "prefix": "NCLS",
+      "name": "Desp",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "DESP College Orientation",
+        "Learning Strategies for Writing"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "NDT",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Basic EEG"
+      ]
+    },
+    {
+      "prefix": "NFIR",
+      "name": "Practical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Practical Experience in Fire Suppression"
+      ]
+    },
+    {
+      "prefix": "NHIS",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shasta-college"
+      ],
+      "sample_titles": [
+        "Natural History of California"
+      ]
+    },
+    {
+      "prefix": "NRA",
+      "name": "Certified",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Certified Nurse Assistant"
+      ]
+    },
+    {
+      "prefix": "NTRSC",
+      "name": "Forestry",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "woodland-community-college",
+        "yuba-college"
+      ],
+      "sample_titles": [
+        "Intro to Forestry"
+      ]
+    },
+    {
+      "prefix": "ORN",
+      "name": "Periporative",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Basic Periporative Nursing",
+        "Perioperative Nrs Train'g Lab"
+      ]
+    },
+    {
+      "prefix": "PA",
+      "name": "Theater",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Film Appreciation",
+        "Introduction to Theater"
+      ]
+    },
+    {
+      "prefix": "PDNC",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "College Connect",
+        "College Success Strategies for"
+      ]
+    },
+    {
+      "prefix": "PHE",
+      "name": "Fitness",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "palo-verde-college"
+      ],
+      "sample_titles": [
+        "Adv Golf",
+        "Fitness Center"
+      ]
+    },
+    {
+      "prefix": "PHLT",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Env Health: Legislation, Inspe",
+        "Intro Principles Envrnt Health"
+      ]
+    },
+    {
+      "prefix": "POLSCI",
+      "name": "International",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "coalinga-college",
+        "lemoore-college"
+      ],
+      "sample_titles": [
+        "Comparative Government",
+        "Introduction to International Relations"
+      ]
+    },
+    {
+      "prefix": "PREAPP",
+      "name": "Preapp",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "MC3 PREAPP CORE",
+        "MC3 PREAPP ESSENTIALS"
+      ]
+    },
+    {
+      "prefix": "PSG",
+      "name": "Polysomnography",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Intro to Polysomnography"
+      ]
+    },
+    {
+      "prefix": "PUNJABI",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "fresno-city-college",
+        "madera-community-college"
+      ],
+      "sample_titles": [
+        "BEGINNING PUNJABI"
+      ]
+    },
+    {
+      "prefix": "RBT",
+      "name": "Knowledge",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "RBT: Clinical Applications",
+        "RBT: Knowledge Skills"
+      ]
+    },
+    {
+      "prefix": "RED",
+      "name": "Real",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-the-desert"
+      ],
+      "sample_titles": [
+        "INTRO REAL EST PROF"
+      ]
+    },
+    {
+      "prefix": "SGVT",
+      "name": "Student",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Introduction to Student Government",
+        "Student Leadership I"
+      ]
+    },
+    {
+      "prefix": "STSV",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cypress-college"
+      ],
+      "sample_titles": [
+        "College Orientation"
+      ]
+    },
+    {
+      "prefix": "SURVY",
+      "name": "Survey",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Advanced Survey",
+        "Experimental Offering in Surveying"
+      ]
+    },
+    {
+      "prefix": "T&T",
+      "name": "Agency",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "T&T Agency Operations",
+        "Travel: Western Hemisphere"
+      ]
+    },
+    {
+      "prefix": "TRCK",
+      "name": "Public",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "allan-hancock-college"
+      ],
+      "sample_titles": [
+        "Public Road Truck Driving"
+      ]
+    },
+    {
+      "prefix": "TV",
+      "name": "Digital",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Digital Filimmaking II: Intermediate",
+        "Digital Filmmaking I: Introduction"
+      ]
+    },
+    {
+      "prefix": "VAUTO",
+      "name": "Automotive",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to Automotive"
+      ]
+    },
+    {
+      "prefix": "VFDM",
+      "name": "Fashion",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Beginning Sewing",
+        "Intro to the Fashion Industry"
+      ]
+    },
+    {
+      "prefix": "VMFG",
+      "name": "Machining",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Basic Machining Concepts and"
+      ]
+    },
+    {
+      "prefix": "WDTO",
+      "name": "Water",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "antelope-valley-community-college-district"
+      ],
+      "sample_titles": [
+        "Water Distribution I",
+        "Water Treatment I"
+      ]
+    },
+    {
+      "prefix": "WGSS",
+      "name": "Chicanalatina",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "reedley-college"
+      ],
+      "sample_titles": [
+        "LA CHICANA&LATINA"
+      ]
+    },
+    {
+      "prefix": "WOMS",
+      "name": "Womensgender",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "evergreen-valley-college",
+        "san-jose-city-college"
+      ],
+      "sample_titles": [
+        "Intro Women's/Gender Studies"
+      ]
+    },
+    {
+      "prefix": "WTD",
+      "name": "Drinking",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "clovis-community-college"
+      ],
+      "sample_titles": [
+        "Bas Drinking Watr Treatment",
+        "Drinking Water Math"
+      ]
+    },
+    {
+      "prefix": "WTR",
+      "name": "Water",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Introduction to Water Careers",
+        "Water Treatment Plant Operator"
+      ]
+    },
+    {
+      "prefix": "ZOO",
+      "name": "Zoology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "moorpark-college"
+      ],
+      "sample_titles": [
+        "Introduction to Zoology"
+      ]
+    },
+    {
+      "prefix": "AFS",
+      "name": "African",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "golden-west-college"
+      ],
+      "sample_titles": [
+        "Intro African American Studies"
+      ]
+    },
+    {
+      "prefix": "AGME",
+      "name": "Agricultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Agricultural Machinery and Equipment Skills"
+      ]
+    },
+    {
+      "prefix": "ALLH",
+      "name": "Skills",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Basic Skills Health Careers"
+      ]
+    },
+    {
+      "prefix": "ARLN",
+      "name": "Operations",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Operations, Terms, Safety"
+      ]
+    },
+    {
+      "prefix": "AUDI",
+      "name": "Sound",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "san-diego-miramar-college"
+      ],
+      "sample_titles": [
+        "Sound Reinforcement Systems"
+      ]
+    },
+    {
+      "prefix": "CEST",
+      "name": "Civil",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Civil Drafting Technology"
+      ]
+    },
+    {
+      "prefix": "CFT",
+      "name": "Contemporary",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "orange-coast-college"
+      ],
+      "sample_titles": [
+        "Contemporary Cabinetmaking"
+      ]
+    },
+    {
+      "prefix": "COMDE",
+      "name": "Community",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Independent Studies in Community Leadership Development"
+      ]
+    },
+    {
+      "prefix": "CRES",
+      "name": "Conflict",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "san-diego-city-college"
+      ],
+      "sample_titles": [
+        "Conflict Res"
+      ]
+    },
+    {
+      "prefix": "ELEVA",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "american-river-college"
+      ],
+      "sample_titles": [
+        "Work Experience in Elevator Apprenticeship"
+      ]
+    },
+    {
+      "prefix": "EMTEC",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "EQSC",
+      "name": "Equine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Equine Anatomy and Physiology"
+      ]
+    },
+    {
+      "prefix": "EVNT",
+      "name": "Eventconvention",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southwestern-college"
+      ],
+      "sample_titles": [
+        "Intro to Event/Convention Plng"
+      ]
+    },
+    {
+      "prefix": "FERM",
+      "name": "Beer",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "san-diego-mesa-college"
+      ],
+      "sample_titles": [
+        "Beer Production Laboratory"
+      ]
+    },
+    {
+      "prefix": "FM",
+      "name": "Fashion",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "FASHION MERCH"
+      ]
+    },
+    {
+      "prefix": "HEAV",
+      "name": "Forklift",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bakersfield-college"
+      ],
+      "sample_titles": [
+        "Forklift Certification"
+      ]
+    },
+    {
+      "prefix": "HEBREW",
+      "name": "Hebrew",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "los-angeles-valley-college"
+      ],
+      "sample_titles": [
+        "Elementary Hebrew II"
+      ]
+    },
+    {
+      "prefix": "HLE",
+      "name": "Personal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-rosa-junior-college"
+      ],
+      "sample_titles": [
+        "Personal Health and Wellness"
+      ]
+    },
+    {
+      "prefix": "HNDI",
+      "name": "Hindi",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "de-anza-college"
+      ],
+      "sample_titles": [
+        "Elementary Hindi (Third Quarter)"
+      ]
+    },
+    {
+      "prefix": "HVYEQUI",
+      "name": "Level",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "coalinga-college"
+      ],
+      "sample_titles": [
+        "Level III Heavy Equipment Operations"
+      ]
+    },
+    {
+      "prefix": "KNSM",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sports Medicin"
+      ]
+    },
+    {
+      "prefix": "LIN",
+      "name": "Language",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Introduction to Language and Linguistics"
+      ]
+    },
+    {
+      "prefix": "METE",
+      "name": "Meteorology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Meteorology"
+      ]
+    },
+    {
+      "prefix": "METL",
+      "name": "Metallurgy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "fullerton-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Metallurgy"
+      ]
+    },
+    {
+      "prefix": "MUSCE",
+      "name": "Chorale",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Chorale Music"
+      ]
+    },
+    {
+      "prefix": "NATAM",
+      "name": "Native",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "laney-college"
+      ],
+      "sample_titles": [
+        "NATIVE AMERICAN INDIANS IN CONTEMPORARY SOCIETY"
+      ]
+    },
+    {
+      "prefix": "NATSCI",
+      "name": "Physicschemstry",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "fresno-city-college"
+      ],
+      "sample_titles": [
+        "PHYSICS/CHEMSTRY"
+      ]
+    },
+    {
+      "prefix": "NBSS",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Social Services Career Exploration"
+      ]
+    },
+    {
+      "prefix": "NCAA",
+      "name": "Home",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "west-valley-college"
+      ],
+      "sample_titles": [
+        "Introduction to Home Health Caregiving"
+      ]
+    },
+    {
+      "prefix": "NHSL",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Nursing Skills Lab"
+      ]
+    },
+    {
+      "prefix": "NRES",
+      "name": "Outdoor",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bakersfield-college"
+      ],
+      "sample_titles": [
+        "Outdoor Recreation Management"
+      ]
+    },
+    {
+      "prefix": "NSCI",
+      "name": "Anatomy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Basic Anatomy for Health Care"
+      ]
+    },
+    {
+      "prefix": "OCN",
+      "name": "Oceanography",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hartnell-college"
+      ],
+      "sample_titles": [
+        "Oceanography"
+      ]
+    },
+    {
+      "prefix": "PEDS",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cuesta-college"
+      ],
+      "sample_titles": [
+        "Career Planning: Comprehensive"
+      ]
+    },
+    {
+      "prefix": "PERSN",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "diablo-valley-college"
+      ],
+      "sample_titles": [
+        "First Term Persian"
+      ]
+    },
+    {
+      "prefix": "PHRM",
+      "name": "Pharmacologic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "pasadena-city-college"
+      ],
+      "sample_titles": [
+        "PHARMACOLOGIC AGENTS-COMMON MEDICATIONS"
+      ]
+    },
+    {
+      "prefix": "RDIO",
+      "name": "Radio",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Radio Production"
+      ]
+    },
+    {
+      "prefix": "TCED",
+      "name": "Blueprint",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "rio-hondo-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading for Industry"
+      ]
+    },
+    {
+      "prefix": "TELA",
+      "name": "Tutor",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "sacramento-city-college"
+      ],
+      "sample_titles": [
+        "Independent Studies in Tutor Education and Learning Assistance"
+      ]
+    },
+    {
+      "prefix": "TRN",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mission-college"
+      ],
+      "sample_titles": [
+        "Foundations of Public Service for Transit Workers"
+      ]
+    },
+    {
+      "prefix": "VCNST",
+      "name": "Heatingventilationair",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Heating/Ventilation/Air Cond"
+      ]
+    },
+    {
+      "prefix": "VDOG",
+      "name": "Practical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-ana-college"
+      ],
+      "sample_titles": [
+        "Practical Dog Training"
+      ]
+    },
+    {
+      "prefix": "VESL",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bakersfield-college"
+      ],
+      "sample_titles": [
+        "Work Readiness and Communication Skills Module A"
+      ]
+    },
+    {
+      "prefix": "WOEX",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "napa-valley-college"
+      ],
+      "sample_titles": [
+        "Work Experience"
+      ]
+    }
+  ],
+  "program_titles": [
+    "2025-2026 General Education Courses Common to Associate Degree Requirements and Cal-GETC — Certificate",
+    "3-D Animation Skills Certificate — Level II — Associate in Science",
+    "3D Modeling and Design Certificate of Achievement — Associate of Science",
+    "Academic English Certificate of Completion — Certificate of Completion",
+    "Academic Success - Certificate of Competency — Associate in Science",
+    "Account Clerk Certificate of Proficiency — Associate in Science",
+    "Account Clerk Certificate of Specialization — Associate in Science",
+    "Accounting - Associate in Science — Associate in Arts",
+    "Accounting - Associate in Science — Associate in Science",
+    "Accounting - Bookkeeping (Certificate E0504) — AS",
+    "Accounting - Certificate of Achievement Level 2 — Associate in Science",
+    "Accounting - Computerized (Certificate N0460) — AS",
+    "Accounting - Financial Planning (Certificate N0461) — AS",
+    "Accounting - Managerial (Certificate N0462) — AS",
+    "Accounting - Payroll (Certificate E0505) — AS",
+    "Accounting - Professional Accounting (Certificate T0883) — AS",
+    "Accounting - Tax Preparation (Skills Certificate E0433) — AS",
+    "Accounting - Taxation for Enrolled Agents - Certificate of Achievement — Associate of Science",
+    "Accounting – Certified Bookkeeper – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Accounting — Associate in Arts",
+    "Accounting (AS Degree S0502) — Associate of Science",
+    "Accounting Associate in Science and Certificate of Achievement — Associate in Science",
+    "Accounting Associate in Science Degree — Associate in Science",
+    "Accounting Associate of Arts Degree — Associate of Arts",
+    "Accounting Certificate — Associate in Science",
+    "Accounting Certificate of Achievement",
+    "Accounting Certificate of Achievement — Associate of Arts",
+    "Accounting Clerk Certificate of Achievement",
+    "Accounting, AS",
+    "Acting and Performance Level 1 Certificate — Associate in Science",
+    "Acting and Performance Level 2 Certificate — Associate in Science",
+    "Addiction Counseling (AS Degree S0657) — AS",
+    "Addiction Counseling (Certificate T0658) — AS",
+    "Addiction Studies",
+    "Addiction Studies Certificate of Achievement — Associate of Arts",
+    "Administration Certificate of Specialization — Associate in Science",
+    "Administration of Justice - Associate in Arts — Associate in Arts",
+    "Administration of Justice - Associate in Science — Associate in Arts",
+    "Administration of Justice - Associate In Science for Transfer — Associate in Arts",
+    "Administration of Justice - Associate in Science for Transfer — Associate in Science",
+    "Administration of Justice - Associate in Science Transfer Degree — Associate in Arts",
+    "Administration of Justice - Certificate of Achievement — Associate in Arts",
+    "Administration of Justice - Corrections Associate of Science Degree — Associate of Science",
+    "Administration of Justice - Corrections Certificate of Achievement — Associate of Science",
+    "Administration of Justice - Judicial Administration - Certificate of Achievement Level 2 — Associate in Science",
+    "Administration of Justice - Judicial Administration Associate in Science — Associate in Science",
+    "Administration of Justice - Judicial Administration: Court Management - Certificate of Achievement Level 2 — Associate in Science",
+    "Administration of Justice - Judicial Administration: Court Operations - Certificate of Achievement Level 1 — Associate in Science",
+    "Administration of Justice - Judicial Administration: Supervision/Lead - Certificate of Achievement Level 1 — Associate in Science",
+    "Administration of Justice - Traditional Option - Associate in Science — Associate in Science",
+    "Administration of Justice – Associate in Science Degree for Transfer — Associate of Science",
+    "Administration of Justice – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Administration of Justice — Associate in Science",
+    "Administration of Justice (AS Degree S0404) — AS",
+    "Administration of Justice (AS-T Degree S0362) — Associate in Science",
+    "Administration of Justice (Certificate T0406) — AS",
+    "Administration of Justice AS-T Degree — Associate in Science",
+    "Administration of Justice Associate in Science Degree — Associate in Science",
+    "Administration of Justice Associate in Science Degree for Transfer — Associate in Science",
+    "Administration of Justice Associate in Science for Transfer Degree — Associate of Science",
+    "Administration of Justice Associate of Arts Degree — Associate of Arts",
+    "Administration of Justice Certificate of Achievement — Associate of Science",
+    "Administration of Justice for Transfer (AS-T)",
+    "Administration of Justice for Transfer (AS-T) — Associate in Science",
+    "Administration of Justice Geospatial Literacy Certificate of Proficiency — Associate in Science",
+    "Administration of Justice, AS-T",
+    "Administrative Assistant - Level I (Certificate E0516) — AS",
+    "Administrative Assistant (AS Degree S0514) — AS",
+    "Administrative Assistant Associate in Science and Certificate of Achievement — Associate in Science",
+    "Administrative Assistant Certificate of Achievement — Associate of Science",
+    "Administrative Assistant I Certificate of Achievement",
+    "Administrative Assistant II Certificate of Achievement",
+    "Administrative Assistant, Customer Relations Specialist - Certificate of Achievement — Associate in Arts",
+    "Administrative Assistant, Customer Support - Associate in Science — Associate in Arts",
+    "Administrative Assistant, Customer Support - Certificate of Achievement — Associate in Arts",
+    "Administrative Assistant, Human Resources Support - Associate in Science — Associate in Arts",
+    "Administrative Assistant, Human Resources Support - Certificate of Achievement — Associate in Arts",
+    "Administrative Assistant, Office Support - Associate in Science — Associate in Arts",
+    "Administrative Assistant, Office Support - Certificate of Achievement — Associate in Arts",
+    "Administrative Assistant, Virtual Support - Associate in Science — Associate in Arts",
+    "Administrative Assistant, Virtual Support - Certificate of Achievement — Associate in Arts",
+    "Administrative Executive Assistant Certificate of Achievement",
+    "Administrative Executive Professional/Office Manager, AS",
+    "Adobe for Designers - Certificate of Completion — Associate in Arts",
+    "ADU Remodeling - Certificate of Achievement — Associate in Arts",
+    "Adult High School Diploma — Certificate of Completion",
+    "Adult Learning Skills - Certificate of Competency — Associate in Arts",
+    "Adult Literacy - Certificate of Competency — Associate in Arts",
+    "Advanced Academic English as a Second Language Noncredit Certificate of Competency — Certificate of Competency",
+    "Advanced Automotive Collision Repair and Refinishing Associate of Science Degree — Associate of Science",
+    "Advanced Automotive Collision Repair and Refinishing Certificate of Achievement — Associate of Science",
+    "Advanced Baking & Pastry Arts - Certificate of Achievement — Associate in Arts",
+    "Advanced Bookkeeping Certificate — Associate in Science",
+    "Advanced Commercial Music Certificate of Achievement — Certificate of Achievement",
+    "Advanced Culinary Arts, AS",
+    "Advanced English Certificate of Completion — Certificate of Completion",
+    "Advanced ESL Certificate of Competency",
+    "Advanced Fashion Design Certificate — Associate in Science",
+    "Advanced Film Production Certificate of Achievement — AS",
+    "Advanced Manufacturing — AS",
+    "Advanced Manufacturing and Design Technology - Certificate of Achievement — Associate in Arts",
+    "Advanced Manufacturing Technology - Associate in Science — Associate in Arts",
+    "Advanced Manufacturing Technology - Certificate of Achievement — Associate in Arts",
+    "Advanced Manufacturing Technology Core Skills - Certificate of Achievement — Associate in Arts",
+    "Advanced Manufacturing, Level I, Certificate of Achievement — Associate in Arts",
+    "Advanced Materials Nanotechnology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Advanced Math Certificate of Completion — Certificate of Completion",
+    "Advanced Pharmacy Technician – Occupational Skills Certificate — Associate of Science",
+    "Advanced Sheetfed Offset Presswork Certificate — Associate in Science",
+    "Advanced Taxation - Certificate of Achievement — Associate in Arts",
+    "Advanced Technical Theatre Certificate — Associate in Science",
+    "Advanced Transportation Technologies AS Degree — Associate of Science",
+    "Advanced Transportation Technology - Associate in Science — Associate in Arts",
+    "Advanced Transportation Technology - Certificate of Achievement — Associate in Arts",
+    "Advanced Water Treatment Associate in Science and Certificate of Achievement — Associate in Science",
+    "Advertising and Graphic Design Associate in Arts Degree — Associate in Arts",
+    "Advertising and Graphic Design Certificate — Associate in Arts",
+    "Africana Studies Associate in Arts Degree — Associate in Science",
+    "After Effects Certificate of Completion — Certificate of Completion",
+    "Aging Studies Certificate — Associate in Science",
+    "Agri-Business AS Degree — AS",
+    "Agricultural Entrepreneurship - Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Agricultural Mechatronics",
+    "Agricultural Science and Technology (AS Degree S0853) — AS",
+    "Agriculture — AS",
+    "Agriculture Animal Science (AS-T Degree S0878) — Associate in Science",
+    "Agriculture Animal Science, AS-T",
+    "Agriculture Business - Animal Science Certificate of Achievement",
+    "Agriculture Business - Plant Science Certificate of Achievement",
+    "Agriculture Business Certificate of Achievement",
+    "Agriculture Business for Transfer Degree (AS-T)",
+    "Agriculture Business, AS",
+    "Agriculture Business, AS-T",
+    "Agriculture Engineering Production Plant - Level 1 Safety Certificate of Achievement",
+    "Agriculture Engineering Production Plant - Level 2 Mechanical Certificate of Achievement",
+    "Agriculture Food Safety Certificate of Achievement — Certificate of Achievement",
+    "Agriculture Irrigation Technician Certificate of Achievement — Certificate of Achievement",
+    "Agriculture Mechanics Certificate of Achievement",
+    "Agriculture Office Assistant Certificate of Achievement — Certificate of Achievement",
+    "Agriculture Office Professional Certificate of Achievement — Certificate of Achievement",
+    "Agriculture Pest Management Certificate of Achievement — Certificate of Achievement",
+    "Agriculture Plant Science – Associate in Science Degree for Transfer — Associate of Science",
+    "Agriculture Plant Science (AS-T Degree S0847) — Associate in Science",
+    "Agriculture Plant Science for Transfer (AS-T)",
+    "Agriculture Plant Science, AS-T",
+    "Agriculture Technician Certificate of Achievement — Certificate of Achievement",
+    "AI Literacy - Certificate of Accomplishment — Associate in Arts",
+    "AI Literacy - Certificate of Completion — Associate in Arts",
+    "Aides, Assistants and Caregivers - Certificate of Achievement — Associate in Arts",
+    "Air Conditioning and Refrigeration (AS Degree S0909) — AS",
+    "Air Conditioning and Refrigeration (Certificate T0909) — AS",
+    "Air Conditioning and Refrigeration Technology - Associate in Science — Associate in Science",
+    "Air Conditioning and Refrigeration Technology - Certificate of Achievement Level 2 — Associate in Science",
+    "Air Conditioning and Refrigeration Technology - Certificate of Achievement Level 3 — Associate in Science",
+    "Air Properties & Economizer Performance Certificate of Completion — Certificate of Achievement",
+    "Aircraft Powerplant Maintenance Technology - Day (Certificate T0982) — Associate in Science",
+    "Aircraft Powerplant Maintenance Technology- Evening (Certificate T0952) — Associate in Science",
+    "Airframe and Aircraft Powerplant Maintenance Technology - Day (AS Degree S0911) — Associate in Science",
+    "Airframe and Aircraft Powerplant Maintenance Technology - Evening (AS Degree S0951) — Associate in Science",
+    "Airframe Maintenance Technician Certificate of Achievement — Associate of Science",
+    "Airframe Maintenance Technology - Day (Certificate T0991) — Associate in Science",
+    "Airframe Maintenance Technology - Evening (Certificate T0981) — Associate in Science",
+    "Alcohol and Drug Studies - Addiction and Criminal Justice - Certificate of Specialization — Associate in Science",
+    "Alcohol and Drug Studies - Associate in Arts — Associate in Science",
+    "Alcohol and Drug Studies - Certificate of Achievement Level 2 — Associate in Science",
+    "Alcohol and Drug Studies - Peer Mentor - Certificate of Specialization — Associate in Science",
+    "Alcohol and Drug Studies Certification - Certificate of Achievement Level 3 — Associate in Science",
+    "Alcohol and Drug Studies Peer Mentor - Certificate of Specialization — Associate in Science",
+    "Allied Health — Associate in Science",
+    "Alternative Fuel Vehicles - Certificate of Achievement — Associate in Arts",
+    "Amazon Web Services (AWS) Cloud Computing Certificate of Achievement — Associate of Science",
+    "American Honda - Certificate of Achievement — Associate in Arts",
+    "American Indian and Indigenous Studies Associate in Arts Degree — Associate in Science",
+    "American Language Advanced Proficiency in English for English Language Learners (Certificate M0859) — AS",
+    "American Language Communication for English Language Learners (Certificate M0860) — AS",
+    "American Language Foundational English for English Language Learners (Certificate N0945) — AS",
+    "American Sign Language – Associate in Arts Degree, Certificate of Achievement — Associate of Science",
+    "American Sign Language and Deaf Culture Associate in Arts Degree — Associate in Science",
+    "American Sign Language and Deaf Studies - Associate in Arts — Associate in Arts",
+    "American Sign Language Associate in Arts — Associate in Science",
+    "American Sign Language Associate in Arts and Certificate of Achievement — Associate in Science",
+    "American Sign Language Certificate of Achievement",
+    "American Sign Language Certificate of Achievement — Associate in Science",
+    "American Sign Language, AA",
+    "Android App Developer - Certificate of Accomplishment — Associate in Arts",
+    "Android Application Security Support Specialist Certificate of Achievement — Associate of Science",
+    "Anesthesia Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Animal Science (AS Degree S0854) — AS",
+    "Animal Science Fundamentals (Certificate N0871) — AS",
+    "Animation - Junior Animator Level I (Certificate E0414) — AS",
+    "Animation (AS Degree S1006) — AS",
+    "Animation Certificate of Achievement — Certificate of Achievement",
+    "Anthropology - Associate in Arts for Transfer — Associate in Arts",
+    "Anthropology - Associate in Arts Transfer Degree — Associate in Arts",
+    "Anthropology – Associate in Arts Degree for Transfer — Associate of Science",
+    "Anthropology — Associate in Arts",
+    "Anthropology (AA-T Degree A0668) — Associate in Arts",
+    "Anthropology AA-T Degree — Associate in Arts",
+    "Anthropology Associate in Arts Degree — Associate in Arts",
+    "Anthropology Associate in Arts Degree for Transfer — Associate in Arts",
+    "Anthropology Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Anthropology for Transfer (AA-T) — Associate in Science",
+    "Anthropology, AA-T",
+    "Anthropology, AA-T — Associate in Arts",
+    "Apparel Design, AA",
+    "Apparel Industry Sewing Certificate of Achievement",
+    "Applications and Information Systems AS Degree — AS",
+    "Applied Art and Design — AS",
+    "Applied Artificial Intelligence Associate in Science and Certificate of Achievement — Associate in Science",
+    "Applied Artificial Intelligence Certificate of Proficiency — Associate in Science",
+    "Applied Circuits & Systems – Occupational Skills Certificate — Associate of Science",
+    "Applied Design in Art: 3D Materials and Processes - Certificate of Achievement — Associate in Arts",
+    "Applied Laboratory Science Technology (ALST) (AS Degree S0307) — AS",
+    "Applied Sciences – Associate in Science Degree — Associate of Science",
+    "Apprenticeship - Air Conditioning and Refrigeration Technology — Associate in Science",
+    "Apprenticeship - Air Conditioning Mechanic — Associate in Science",
+    "Apprenticeship - Inside Wireman (formerly General Electrician) — Associate in Science",
+    "Apprenticeship - Non-Destructive Testing (NDT) Technician — Certificate of Achievement",
+    "Apprenticeship - Plumbing and Pipefitting — Associate in Science",
+    "Apprenticeship - Plumbing Technology — Associate in Science",
+    "Apprenticeship - Retail Operations Specialist — Certificate of Achievement",
+    "Apprenticeship - Sheet Metal — Associate in Science",
+    "Apprenticeship - Sound and Communication — Certificate of Achievement",
+    "Apprenticeship - Steamfitting and Pipefitting Technology — Associate in Science",
+    "Apprenticeship - Test, Adjust and Balancing (TAB) Technician — Associate in Science",
+    "Arabic Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Arabic Studies Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Arboriculture Associate in Science and Certificate of Achievement — Associate in Science",
+    "Arborist Technician Certificate of Achievement — Certificate of Achievement",
+    "Archaeological Field Work – Occupational Skills Certificate — Associate of Science",
+    "Archaeology Field Technician - Certificate of Achievement — Associate in Arts",
+    "Architectural CAD Technology Certificate — Associate in Science",
+    "Architectural Design - Associate in Science — Associate in Arts",
+    "Architectural Design - Certificate of Achievement — Associate in Arts",
+    "Architectural Design Concentration (AS Degree S0390) — AS",
+    "Architectural Design Concentration Level l (Certificate N0466) — AS",
+    "Architectural Drafting Certificate of Achievement",
+    "Architectural Drafting, AS",
+    "Architectural Technology Concentration (AS Degree S0392) — AS",
+    "Architecture – Associate in Arts Degree — Associate of Science",
+    "Architecture and Environmental Design Associate of Science Degree — Associate of Science",
+    "Architecture Associate in Science Degree — Associate in Science",
+    "Architecture Foundational Skills (Certificate E0387) — AS",
+    "Architecture Mini CAD Certificate — Associate in Science",
+    "Archives and Digital Collections Assistant – Certificate of Achievement — Associate of Science",
+    "ARE Exam Prep - Certificate of Completion — Associate in Arts",
+    "Art - Associate in Arts — Associate in Arts",
+    "Art - Associate in Arts — Associate in Science",
+    "Art — Associate in Arts",
+    "Art Associate in Arts — Associate in Science",
+    "Art Associate in Arts Degree — Associate in Arts",
+    "Art Associate of Arts Degree — Associate of Arts",
+    "Art emphasis in Drawing and Painting or emphasis in Photography - Associate in Science — Associate in Science",
+    "Art History - Associate in Arts for Transfer — Associate in Science",
+    "Art History - Associate in Arts Transfer Degree — Associate in Arts",
+    "Art History – Associate in Arts Degree for Transfer — Associate of Science",
+    "Art History — Associate in Arts",
+    "Art History (AA-T Degree A0330) — Associate in Arts",
+    "Art History AA-T Degree — Associate in Arts",
+    "Art History Associate in Arts Degree — Associate in Arts",
+    "Art History Associate in Arts Degree for Transfer — Associate in Arts",
+    "Art History for Transfer (AA-T) — Associate in Science",
+    "Art History Museum Studies Associate in Arts Degree — Associate in Arts",
+    "Art History, AA-T",
+    "Art History, AA-T — Associate in Arts",
+    "Art–Animation Associate in Arts — Associate in Science",
+    "Art–Drawing, Painting, and Printmaking Associate in Arts — Associate in Science",
+    "Art–Illustration, Design, and Digital Arts Associate in Arts — Associate in Science",
+    "Art–Visual Communication Design Associate in Arts — Associate in Science",
+    "Art, AA",
+    "Artificial Intelligence — Certificate of Achievement",
+    "Artificial Intelligence (AI) Essential Skills Certificate of Completion — Associate of Science",
+    "Artificial Intelligence Developer Certificate of Completion — Associate in Science",
+    "Artificial Intelligence for Business (AS Degree S0844) — AS",
+    "Artificial Intelligence for Digital Transformation - Associate in Science — Associate in Arts",
+    "Artificial Intelligence Fundamentals Certificate of Completion — Associate in Science",
+    "Artificial Intelligence in Business (Certificate M0671) — AS",
+    "Artistic Glass and Design Certificate of Achievement — Associate of Arts",
+    "Arts Entrepreneurship in Ceramics Certificate of Achievement — Certificate of Achievement",
+    "Arts Entrepreneurship in Sculpture Certificate of Achievement — Certificate of Achievement",
+    "Asian/Pacific Islander American Studies Associate in Arts Degree — Associate in Science",
+    "Assistant Costume Designer Certificate — Associate in Science",
+    "Assistant Stage Management Certificate — Associate in Science",
+    "Associate Teacher Certificate of Proficiency — Associate in Science",
+    "Astronomy",
+    "Astronomy — AS",
+    "Astronomy Associate in Science Degree — Associate in Science",
+    "Astronomy Associate of Science Degree — Associate of Science",
+    "Athletic Coach Certificate — Associate in Science",
+    "Athletic Coaching - Certificate of Accomplishment — Associate in Arts",
+    "Athletic Coaching - Certificate of Achievement — Associate in Arts",
+    "Athletic Trainer Aide I (Certificate E0802) — AS",
+    "Audio Arts (AS Degree S0434) — AS",
+    "Audio Arts Level I (Certificate N0965) — AS",
+    "Audio Broadcasting Certificate of Achievement — Associate of Arts",
+    "Audio Production Associate of Arts Degree — Associate of Arts",
+    "Auto - Drivetrain and Chassis - Associate in Science — Associate in Arts",
+    "Auto - Drivetrain and Chassis - Certificate of Achievement — Associate in Arts",
+    "Auto - Electrical-Engine Performance - Associate in Science — Associate in Arts",
+    "Auto - Electrical-Engine Performance - Certificate of Achievement — Associate in Arts",
+    "Auto Body Advanced Repair and Restoration Certificate of Achievement",
+    "Auto Body Basic Repair and Restoration Certificate of Achievement",
+    "Auto Body Intermediate Repair and Restoration Certificate of Achievement",
+    "AutoCAD Essentials - Certificate of Completion — Associate in Arts",
+    "Automatic and Manual Transmission Associate of Science Degree — Associate of Science",
+    "Automatic and Manual Transmission Certificate of Achievement — Associate of Science",
+    "Automatic Transmission Certificate — Associate in Science",
+    "Automation Fundamentals Certificate — Associate in Science",
+    "Automation Technician - Certificate of Achievement — Associate in Arts",
+    "Automation Technician - Mechatronics Certificate of Achievement",
+    "Automation Technology - Mechatronics, AS",
+    "Automotive Air Conditioning Certificate of Achievement — Certificate of Achievement",
+    "Automotive Alternative Fuels Certificate of Achievement — Certificate of Achievement",
+    "Automotive Basic Maintenance Certificate of Completion — Certificate of Achievement",
+    "Automotive Braking Systems Certificate of Achievement — Certificate of Achievement",
+    "Automotive Chassis Certificate — Associate in Science",
+    "Automotive Clean Vehicle Technology Associate of Science Degree — Associate of Science",
+    "Automotive Clean Vehicle Technology Certificate of Achievement — Associate of Science",
+    "Automotive Electric Technology Certificate of Achievement",
+    "Automotive Electrical Certificate of Achievement — Certificate of Achievement",
+    "Automotive Emission Control Certificate — Associate in Science",
+    "Automotive Emissions Certificate of Achievement — Certificate of Achievement",
+    "Automotive Engine and Transmission Service - Certificate of Achievement — Associate in Arts",
+    "Automotive Engine Management Certificate of Achievement — Certificate of Achievement",
+    "Automotive Engine Performance Associate of Science Degree — Associate of Science",
+    "Automotive Engine Performance Certificate — Associate in Science",
+    "Automotive Engine Performance Certificate of Achievement — Associate of Science",
+    "Automotive Engine Performance Service - Certificate of Achievement — Associate in Arts",
+    "Automotive Fabrication Certificate — Associate in Science",
+    "Automotive Foundational Skills – Certificate of Achievement — Associate in Arts",
+    "Automotive General Service Certificate of Achievement — Certificate of Achievement",
+    "Automotive Hybrid and Electric Vehicle Service - Certificate of Achievement — Associate in Arts",
+    "Automotive Interiors Certificate of Achievement — Associate of Science",
+    "Automotive Interiors Certificate of Completion — Associate of Science",
+    "Automotive Light and Medium Duty Diesel Certificate of Achievement — Certificate of Achievement",
+    "Automotive Light Repair Certificate — Associate in Science",
+    "Automotive Lubrication Technician Certificate of Achievement",
+    "Automotive Maintenance Certificate — Associate in Science",
+    "Automotive Maintenance Service - Certificate of Achievement — Associate in Arts",
+    "Automotive Manual Drive Train Certificate — Associate in Science",
+    "Automotive Manufacturer Certificate of Completion — Certificate of Achievement",
+    "Automotive Master Technician Certificate of Achievement",
+    "Automotive Mechanics Technology Certificate of Achievement",
+    "Automotive Oil Change Certificate of Completion — Certificate of Achievement",
+    "Automotive Preventative Maintenance Technician Certificate of Achievement — Associate of Science",
+    "Automotive Quick Service - Certificate of Accomplishment — Associate in Arts",
+    "Automotive Quick Service - Certificate of Completion — Associate in Arts",
+    "Automotive Quick Service Certificate of Completion — Certificate of Achievement",
+    "Automotive Safety & Sustainability Certificate of Completion — Certificate of Achievement",
+    "Automotive Service Advisor Certificate — Associate in Science",
+    "Automotive Service Management Certificate — Associate in Science",
+    "Automotive Steering, Suspension, & Alignment Certificate of Achievement — Certificate of Achievement",
+    "Automotive Technician Associate of Science Degree — Associate of Science",
+    "Automotive Technician Certificate of Achievement — Associate of Science",
+    "Automotive Technology - Associate in Science — Associate in Arts",
+    "Automotive Technology - Certificate of Achievement — Associate in Arts",
+    "Automotive Technology – All Automotive Systems – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Automotive Technology – Automotive Electrical Systems Technician – Certificate of Achievement — Associate of Science",
+    "Automotive Technology – Automotive Service Councils of California ASCCA Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology – Engine Performance Technician – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Automotive Technology – Ford ASSET Associate in Science — Associate in Science",
+    "Automotive Technology – General Motors ASEP Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology – Powertrain Technician – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Automotive Technology – Undercar Technician – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Automotive Technology — Certificate of Completion",
+    "Automotive Technology AS Degree — AS",
+    "Automotive Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology Associate in Science Degree — Associate in Science",
+    "Automotive Technology Certificate — Associate in Science",
+    "Automotive Technology Chassis Specialist Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology Drivetrain Specialist Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology Electronics and Electric Vehicle Specialist Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology Engine Performance and Smog Technician Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology Engine Repair Specialist Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology Service Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Automotive Technology, AS",
+    "Automotive Terminology Certificate of Completion — Certificate of Achievement",
+    "Automotive Transmission & Axle Certificate of Achievement — Certificate of Achievement",
+    "Automotive Wheel Alignment and Brakes Associate of Science Degree — Associate of Science",
+    "Automotive Wheel Alignment and Brakes Certificate of Achievement — Associate of Science",
+    "Autonomous Systems Certificate — Associate in Science",
+    "Autonomous Systems Development Associate in Science Degree — Associate in Science",
+    "Aviation Maintenance Technician Associate of Science Degree — Associate of Science",
+    "Aviation Maintenance Technician Certificate of Achievement — Associate of Science",
+    "Aviation Science (AS Degree S0910) — AS",
+    "Avionics Technology Associate of Science Degree — Associate of Science",
+    "Avionics Technology Certificate of Achievement — Associate of Science",
+    "Backflow & Cross-Connection Control Associate in Science and Certificate of Achievement — Associate in Science",
+    "Baker Certificate of Completion — Certificate of Achievement",
+    "Baking & Pastry Arts - Associate in Science — Associate in Arts",
+    "Baking & Pastry Arts - Certificate of Achievement — Associate in Arts",
+    "Baking and Pastry - Level I (Certificate N0888) — AS",
+    "Baking and Pastry (AS Degree S0456) — AS",
+    "Baking and Pastry Certificate of Achievement",
+    "Baking and Pastry, AS",
+    "Baking Business Certificate of Achievement — Associate of Arts",
+    "Baking Certificate of Achievement — Associate of Arts",
+    "Banquet Cook Certificate of Achievement — Associate of Science",
+    "Barbering Associate in Science Degree — Associate in Science",
+    "Barbering Certificate — Associate in Science",
+    "Basic Arabic for Healthcare Professionals Certificate of Proficiency — Associate in Science",
+    "Basic Arc Welding - Certificate of Completion — Associate in Arts",
+    "Basic Automotive Collision Repair and Refinishing Associate of Science Degree — Associate of Science",
+    "Basic Automotive Collision Repair and Refinishing Certificate of Achievement — Associate of Science",
+    "Basic Baking Skills - Certificate of Completion — Associate in Arts",
+    "Basic Commercial Music Certificate of Achievement — Certificate of Achievement",
+    "Basic Computer Literacy",
+    "Basic Correctional Officer Certificate of Achievement — Certificate of Achievement",
+    "Basic Culinary Arts Certificate of Achievement — Certificate of Achievement",
+    "Basic Electronics Technician Certificate of Completion",
+    "Basic English Certificate of Completion — Certificate of Completion",
+    "Basic Fire Fighter Certificate of Achievement — Certificate of Achievement",
+    "Basic Gas Tungsten Arc Welding - Certificate of Completion — Associate in Arts",
+    "Basic Math Certificate of Completion — Certificate of Completion",
+    "Basic Ornamental Horticulture Certificate of Specialization — Associate in Science",
+    "Basic Oxy-Acetylene Welding - Certificate of Completion — Associate in Arts",
+    "Basic Peace Officer Academy Certificate of Achievement",
+    "Basic Peace Officer Certificate of Achievement — Certificate of Achievement",
+    "Basic Podcasting and Radio Production Certificate of Achievement — Certificate of Achievement",
+    "Basic Semi-Automatic Welding - Certificate of Completion — Associate in Arts",
+    "Basic Waterworks Certificate of Completion — Associate of Science",
+    "Basic Welding – Occupational Skills Certificate — Associate of Science",
+    "Behavioral Intake and Assessment - Certificate of Achievement — Associate in Arts",
+    "Behavioral Training Certificate of Achievement — Associate in Science",
+    "Big Data Analytics (Certificate M0452) — AS",
+    "Biochemistry — Associate in Science",
+    "Biological Sciences - Associate in Science — Associate in Arts",
+    "Biological Sciences — Associate in Science",
+    "Biological Sciences Associate in Science — Associate in Science",
+    "Biological Sciences: Pre-Allied Health Associate in Science — Associate in Science",
+    "Biological Technician Associate in Science Degree — Associate in Science",
+    "Biological Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Biological Technology – Computational Biology – Certificate of Achievement — Associate of Science",
+    "Biological Technology – Laboratory Assistant – Certificate of Achievement — Associate of Science",
+    "Biological Technology – Laboratory Skills – Certificate of Achievement — Associate of Science",
+    "Biological Technology – Stem Cell Culture – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Biological Technology – Stem Cell-Based Biomanufacturing – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Biology",
+    "Biology - Associate in Arts — Associate in Arts",
+    "Biology - Associate in Science for Transfer — Associate in Arts",
+    "Biology - Associate in Science for Transfer — Associate in Science",
+    "Biology – Associate in Science Degree for Transfer — Associate of Science",
+    "Biology — Associate of Science",
+    "Biology (AS Degree S0652) — AS",
+    "Biology (AS-T Degree S0979) — Associate in Science",
+    "Biology AS-T Degree — Associate in Science",
+    "Biology Associate in Arts Degree — Associate in Science",
+    "Biology Associate in Science Degree — Associate in Science",
+    "Biology Associate in Science Degree for Transfer — Associate in Science",
+    "Biology Associate in Science for Transfer Degree — Associate of Science",
+    "Biology Associate of Science Degree — Associate of Science",
+    "Biology for Transfer (AS-T) — Associate in Science",
+    "Biology for Transfer Degree (AS-T)",
+    "Biotechnology Biomanufacturing Technician Certificate — Associate in Science",
+    "Biotechnology Lab Assistant Skills Certificate — Associate in Science",
+    "Biotechnology Laboratory Technician Certificate — Associate in Science",
+    "BIS - Information Processing Specialist - Certificate of Achievement — Associate in Arts",
+    "BIW I: Office Support and Technologies Certificate of Achievement — Certificate of Achievement",
+    "BIW II: Office Support and Technologies Certificate of Achievement — Certificate of Achievement",
+    "BIW III: Remote Office Support and Technologies Certificate of Achievement — Certificate of Achievement",
+    "BIW IV: Legal Office Specialist Certificate of Achievement — Certificate of Achievement",
+    "BIW IV: Marketing Office Specialist Certificate of Achievement — Certificate of Achievement",
+    "BIW IV: Medical Office Specialist Certificate of Achievement — Certificate of Achievement",
+    "Bookkeeping Certificate of Achievement — Associate in Arts",
+    "Bookkeeping Certificate of Achievement — Associate in Science",
+    "Bookkeeping Certificate of Career Preparation — Associate of Arts",
+    "Bread Baker Certificate of Completion — Certificate of Achievement",
+    "Breastfeeding and Nutrition - Certificate of Completion — Associate in Arts",
+    "Broadcast Journalism – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Broadcast Journalism – Occupational Skills Certificate — Associate of Science",
+    "Broker's License Certificate of Achievement — Associate in Science",
+    "Building & Energy Systems Professionals AS Degree — AS",
+    "Building Automation (AS Degree S0308) — AS",
+    "Building Automation (Certificate T0309) — AS",
+    "Building Automation Control Certificate of Achievement — Certificate of Achievement",
+    "Building Commissioning Technician Certificate of Achievement — Certificate of Achievement",
+    "Building Construction Inspection – Certificate of Achievement — Associate of Science",
+    "Building Construction Project Management – Associate in Science, Certificate of Achievement — Associate of Science",
+    "Building Energy Consultant Certificate of Achievement — Certificate of Achievement",
+    "Building Industries — AS",
+    "Building Information and 3D Modeling Certificate of Achievement — Associate of Science",
+    "Building Information Management (BIM) Certificate of Achievement — Associate of Science",
+    "Building Information Modeling (BIM) - Certificate of Achievement — Associate in Arts",
+    "Building Information Modeling (BIM) Coordinator - Certificate of Achievement — Associate in Arts",
+    "Building Inspection Technology Certificate of Achievement — Certificate of Achievement",
+    "Business - Entrepreneurship - Associate in Science — Associate in Science",
+    "Business - Management - Associate in Science — Associate in Science",
+    "Business - Marketing - Associate in Science — Associate in Science",
+    "Business – Associate in Science Degree — Associate of Science",
+    "Business – General Associate in Science and Certificate of Achievement — Associate in Science",
+    "Business — Associate in Science",
+    "Business Administration",
+    "Business Administration - Associate in Arts — Associate in Arts",
+    "Business Administration – Entrepreneurship – Certificate of Achievement — Associate of Science",
+    "Business Administration – Entrepreneurship and Small Business Management – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration – Financial Investments – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration – Human Resource Management – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration – International Business – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration – Management – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration – Marketing Management – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration – Retail Management – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Administration — Associate in Arts",
+    "Business Administration 2.0 - Associate in Science for Transfer — Associate in Arts",
+    "Business Administration 2.0 - Associate in Science for Transfer — Associate in Science",
+    "Business Administration 2.0 - Associate in Science Transfer Degree — Associate in Arts",
+    "Business Administration 2.0 – Associate in Science Degree for Transfer — Associate of Science",
+    "Business Administration 2.0 (AS-T S0872) — Associate in Science",
+    "Business Administration 2.0 AS-T Degree — Associate in Science",
+    "Business Administration 2.0 Associate in Science for Transfer Degree — Associate of Arts",
+    "Business Administration 2.0 for Transfer (AS-T)",
+    "Business Administration 2.0 for Transfer (AS-T) — Associate in Science",
+    "Business Administration 2.0, AS-T",
+    "Business Administration 2.0, AS-T — Associate in Science",
+    "Business Administration Associate in Arts Degree — Associate in Arts",
+    "Business Administration Associate in Science and Certificate of Achievement — Associate in Science",
+    "Business Administration Associate in Science Degree for Transfer 2.0 — Associate in Arts",
+    "Business Administration Associate of Arts Degree — Associate of Arts",
+    "Business Administration Certificate of Achievement — Associate of Arts",
+    "Business Administration for Transfer 2.0 (AS-T) — Associate in Science",
+    "Business and Data Analytics - Certificate of Achievement Level 1 — Associate in Science",
+    "Business Calculus Preparation Certificate of Competency — Certificate of Competency",
+    "Business Certificate of Achievement",
+    "Business Communications and Marketing - Certificate of Achievement — Associate in Arts",
+    "Business Data Analytics – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Data Analytics Certificate — Associate in Arts",
+    "Business Economics Certificate — Associate in Arts",
+    "Business Emphasis (AA Degree A8981) — AS",
+    "Business Information Technology – Administrative Assistant – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Information Technology – Business Information Worker – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Information Technology – Business Information Worker II – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Information Technology – Business Software Specialist – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Information Technology – Office Assistant – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Business Information Worker - Real Estate Specialist — Certificate of Achievement",
+    "Business Information Worker Certificate of Achievement — Associate in Science",
+    "Business Management Associate in Science Degree — Associate in Arts",
+    "Business Management Certificate — Associate in Arts",
+    "Business Networking and Sales Certificate — Associate in Arts",
+    "Business Office Technology Administrative Assistant Associate in Science and Certificate of Achievement — Associate in Science",
+    "Business Office Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Business Office Technology Executive Assistant Associate in Science and Certificate of Achievement — Associate in Science",
+    "Business Office Technology-Information Processing",
+    "Business Skills Certificate — Associate in Arts",
+    "Business Workplace Essential Skills Certificate of Completion — Associate of Arts",
+    "Business–General Associate in Science and Certificate of Achievement — Associate in Science",
+    "Business, AS",
+    "Business: Accounting - Certificate of Achievement — Associate in Arts",
+    "Business: Accounting Concentration - Associate in Arts — Associate in Arts",
+    "Business: Business Economics - Certificate of Accomplishment — Associate in Arts",
+    "Business: Entrepreneurship - Certificate of Achievement Level 2 — Associate in Science",
+    "Business: Entrepreneurship - Certificate of Achievement Level 3 — Associate in Science",
+    "Business: Foundations of Accounting - Certificate of Accomplishment — Associate in Arts",
+    "Business: Foundations of Business - Certificate of Accomplishment — Associate in Arts",
+    "Business: Foundations of International Business - Certificate of Accomplishment — Associate in Arts",
+    "Business: Foundations of Management - Certificate of Accomplishment — Associate in Arts",
+    "Business: Foundations of Marketing - Certificate of Accomplishment — Associate in Arts",
+    "Business: General Business - Certificate of Achievement — Associate in Arts",
+    "Business: General Business Concentration - Associate in Arts — Associate in Arts",
+    "Business: Global Trade and Logistics – Certificate of Achievement — Associate in Arts",
+    "Business: Global Trade and Logistics Concentration - Associate in Arts — Associate in Arts",
+    "Business: Human Resource Management - Level I (Certificate E0531) — AS",
+    "Business: International - Level I (Certificate E0527) — AS",
+    "Business: Logistics - Certificate of Accomplishment — Associate in Arts",
+    "Business: Management - Certificate of Achievement — Associate in Arts",
+    "Business: Management - Certificate of Achievement Level 2 — Associate in Science",
+    "Business: Management - Certificate of Achievement Level 3 — Associate in Science",
+    "Business: Management - Level I (Certificate E0525) — AS",
+    "Business: Management (AS Degree S0506) — AS",
+    "Business: Management Concentration - Associate in Arts — Associate in Arts",
+    "Business: Marketing - Certificate of Achievement — Associate in Arts",
+    "Business: Marketing - Certificate of Achievement Level 2 — Associate in Science",
+    "Business: Marketing - Certificate of Achievement Level 3 — Associate in Science",
+    "Business: Marketing Concentration - Associate in Arts — Associate in Arts",
+    "Business: Money and Banking - Certificate of Accomplishment — Associate in Arts",
+    "Business: Retail Management - Level I (Certificate E0500) — AS",
+    "Business: Retail Management (AS Degree S0509) — AS",
+    "Business: Small Business Management - Level I (Certificate E0529) — AS",
+    "Business: Small Business Management (AS S0508) — AS",
+    "CAD Designer – Mechanical Design and Fabrication – Level 2 – Associate in Science, Certificate of Achievement — Associate of Science",
+    "CAD Technician – Mechanical Design and Fabrication – Level 1 – Certificate of Achievement — Associate of Science",
+    "CAD Technician (Certificate E0426) — AS",
+    "CAD/BIM Designer – Building Design and Environment – Level 2 – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "CAD/BIM Modeler – Building Design and Fabrication – Certificate of Achievement — Associate of Science",
+    "CAD/BIM Technician – Building Design and Environment – Level 1 – Certificate of Achievement — Associate of Science",
+    "CADD - Computer Aided Drafting and Design (CADD) - Associate in Science — Associate in Arts",
+    "CADD Technology: Building Design Industry Associate in Science and Certificate of Achievement — Associate in Science",
+    "CADD Technology: Manufacturing Industry Associate in Science and Certificate of Achievement — Associate in Science",
+    "CADD/Manufacturing Technology Certificate of Specialization — Associate in Science",
+    "Cake Decorating Techniques - Certificate of Completion — Associate in Arts",
+    "Cal-GETC Certificate of Achievement Level 3 — Associate in Science",
+    "Calgetc",
+    "California Building Codes Certificate of Completion — Certificate of Achievement",
+    "California Building/Fire Codes Certificate of Completion — Certificate of Achievement",
+    "California Electrical Codes Certificate of Completion — Certificate of Achievement",
+    "California Energy Codes Certificate of Completion — Certificate of Achievement",
+    "California General Education Transfer Curriculum (Cal-GETC) — Certificate",
+    "California General Education Transfer Curriculum (Cal-GETC) Certificate of Achievement",
+    "California Mechanical Codes Certificate of Completion — Certificate of Achievement",
+    "California Plumbing Codes Certificate of Completion — Certificate of Achievement",
+    "California Residential Codes Certificate of Completion — Certificate of Achievement",
+    "Cannabis - Level 1 (Certificate N0892) — AS",
+    "Cannabis Management Certificate — Associate in Arts",
+    "Cannabis Operations (AS Degree S0891) — AS",
+    "Cannabis Studies Associate in Arts Degree — Associate in Science",
+    "Cardiovascular Technology Associate in Science — Associate in Science",
+    "Career Essentials for the Business World Certificate of Completion — Associate of Arts",
+    "Career Exploration Certificate of Completion — Certificate of Completion",
+    "Career Preparedness - Certificate of Competency — Associate in Science",
+    "Carpentry - Certificate of Achievement — Associate in Arts",
+    "Case Management in the Public Sector Certificate of Achievement — Associate of Arts",
+    "Catering & Mobile Food Operations - Certificate of Completion — Associate in Arts",
+    "Catering: Banquets & Buffets Certificate of Completion — Certificate of Achievement",
+    "Caterpillar Dealer Engine Technician Apprenticeship Certificate of Achievement",
+    "Caterpillar Dealer Service Technician Apprenticeship Certificate of Achievement",
+    "Caterpillar Dealer Service Technician Apprenticeship, AS",
+    "CCNP Routing & Switching Preparation – Occupational Skills Certificate — Associate of Science",
+    "CDECE: Assistant Teacher - Certificate of Accomplishment — Associate in Arts",
+    "CDECE: Associate Teacher - Certificate of Accomplishment — Associate in Arts",
+    "CDECE: Family Development - Certificate of Accomplishment — Associate in Arts",
+    "Certified Baker – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Certified Culinarian – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Certified Dietary Manager (CDM) Board Exam Preparation - Certificate of Completion — Associate in Arts",
+    "Certified Hospitality Entrepreneur – Certificate of Achievement — Associate of Science",
+    "Certified Nursing Assistant – Occupational Skills Certificate — Associate of Science",
+    "Chemistry - Associate in Arts — Associate in Arts",
+    "Chemistry - Associate in Arts — Associate in Science",
+    "Chemistry – Associate in Science for Transfer — Associate in Arts",
+    "Chemistry — Associate in Science",
+    "Chemistry Associate in Arts Degree — Associate in Arts",
+    "Chemistry Associate in Science — Associate in Science",
+    "Chemistry Associate in Science and Certificate of Achievement — Associate in Science",
+    "Chemistry Associate in Science Degree — Associate in Arts",
+    "Chemistry Associate in Science Degree for Transfer — Associate in Arts",
+    "Chemistry Associate in Science Degree for UC Transfer — Associate in Science",
+    "Chemistry Associate of Science Degree — Associate of Science",
+    "Chemistry for Transfer Degree (AS-T)",
+    "Chicanx and Latinx Studies Associate in Arts Degree — Associate in Science",
+    "Child and Adolescent Development - Associate in Arts for Transfer — Associate in Arts",
+    "Child and Adolescent Development - Associate in Arts for Transfer — Associate in Science",
+    "Child and Adolescent Development – Associate in Arts Degree for Transfer — Associate of Science",
+    "Child and Adolescent Development (AA-T Degree A0940) — Associate in Arts",
+    "Child and Adolescent Development AA-T Degree — Associate in Arts for Transfer",
+    "Child and Adolescent Development Associate in Arts Degree for Transfer — Associate in Science",
+    "Child and Adolescent Development Associate in Arts for Transfer Degree — Associate of Arts",
+    "Child and Adolescent Development for Transfer (AA-T) — Associate in Science",
+    "Child and Adolescent Development, AA-T — Associate in Arts",
+    "Child Development - Associate Teacher Certificate of Achievement — Associate of Arts",
+    "Child Development - Classroom Curriculum (Certificate M0937) — AS",
+    "Child Development - Early Childhood Teacher (Certificate T0865) — AS",
+    "Child Development - Early Intervention and Inclusion (AS Degree S0936) — Associate in Science",
+    "Child Development - Early Intervention and Inclusion (Certificate T0458) — AS",
+    "Child Development - Early Intervention and Inclusion Associate of Arts Degree — Associate of Arts",
+    "Child Development - Early Intervention and Inclusion Certificate of Achievement — Associate of Arts",
+    "Child Development - Family Child Care Provider Certificate of Achievement — Associate of Arts",
+    "Child Development - Infant and Toddler Certificate of Achievement — Associate of Arts",
+    "Child Development - Infant/Toddler Care Teacher (Certificate N0864) — AS",
+    "Child Development - Level I (Certificate M0663) — AS",
+    "Child Development - Master Teacher Certificate of Achievement — Associate of Arts",
+    "Child Development - Program Administration (Certificate T0863) — AS",
+    "Child Development - School-Age Certificate of Achievement — Associate of Arts",
+    "Child Development - School-Age Child (Certificate N0862) — AS",
+    "Child Development - Site Supervisor Certificate of Achievement — Associate of Arts",
+    "Child Development - Teacher Certificate of Achievement — Associate of Arts",
+    "Child Development – Administration – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Early Intervention – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Infant/Toddler – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Language & Literacy – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Multicultural Awareness – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Music & Movement Education for Young Children – Occupational Skills Certificate — Associate of Science",
+    "Child Development – School Age Instructional Assistant – Occupational Skills Certificate — Associate of Science",
+    "Child Development – Science and Math Integration – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Special Education – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Child Development – Special Education Assistant – Occupational Skills Certificate — Associate of Science",
+    "Child Development — Associate in Arts",
+    "Child Development (AS Degree S1315) — AS",
+    "Child Development and Educational Studies Associate in Arts Degree — Associate in Science",
+    "Child Development Associate of Arts Degree — Associate of Arts",
+    "Child Development Instructional Assistant – Occupational Skills Certificate — Associate of Science",
+    "Child Development Master Teacher Associate in Science and Certificate of Achievement — Associate in Science",
+    "Child Development Site Supervisor Associate in Science and Certificate of Achievement — Associate in Science",
+    "Child Development: Early Childhood Education - Associate in Arts — Associate in Arts",
+    "Child Development: Early Childhood Education - Certificate of Achievement — Associate in Arts",
+    "Child Development: Permit Specialization Area – Child Health and Safety - Certificate of Accomplishment — Associate in Arts",
+    "Child Development: Permit Specialization Area – Children with Exceptional Needs - Certificate of Accomplishment — Associate in Arts",
+    "Child Development: Permit Specialization Area – Curriculum in Early Childhood Education - Certificate of Accomplishment — Associate in Arts",
+    "Child Development: Permit Specialization Area – Early Literacy - Certificate of Accomplishment — Associate in Arts",
+    "Child Development: Permit Specialization Area – Family Child Care - Certificate of Accomplishment — Associate in Arts",
+    "Child Development: Permit Specialization Area – Infant/Toddler - Certificate of Accomplishment — Associate in Arts",
+    "Child Development: Special Education Assistant - Associate in Arts — Associate in Arts",
+    "Child Development: Special Education Assistant - Certificate of Achievement — Associate in Arts",
+    "Child Nutrition Management - Certificate of Achievement — Associate in Arts",
+    "Children’s Book Illustration Certificate — Associate in Arts",
+    "Chinese – Associate in Arts Degree — Associate of Science",
+    "Cinema – Cinema Production/Filmmaking – Occupational Skills Certificate — Associate of Science",
+    "Cinema – Cinematography – Occupational Skills Certificate — Associate of Science",
+    "CIS - Computer Programming - Associate in Science — Associate in Science",
+    "CIS - General Networking - Associate in Science — Associate in Science",
+    "CIS - MCSE - Associate in Science — Associate in Science",
+    "CIS - UNIX Networks - Associate in Science — Associate in Science",
+    "CIS - Web Developer - Associate in Science — Associate in Science",
+    "CIS Cloud Computing for Amazon Web Services (Certificate M0672) — AS",
+    "CIS Professional in C++ Programming (Certificate E0714) — AS",
+    "CIS Professional in Information and Operating Systems Security (Certificate M0814) — AS",
+    "CIS Professional in Java Programming (Certificate M0689) — AS",
+    "CIS Professional in LINUX (Certificate M0816) — AS",
+    "CIS Professional in Network Security (Certificate M0688) — AS",
+    "CIS Professional in Networking (Certificate M0809) — AS",
+    "CIS Professional in Object-Oriented Design & Programming (Certificate M0813) — AS",
+    "CIS Professional in Python Programming (Certificate M0675) — AS",
+    "CIS Professional in SQL (Certificate M0811) — AS",
+    "CIS Professional in Telecommunications (Certificate M0810) — AS",
+    "CIS Professional in Web Programming (Certificate M0812) — AS",
+    "CIS Professional in Windows Operating System Administration (Certificate E0720) — AS",
+    "Cisco Certified Network",
+    "Cisco Certified Network Associate Certificate of Career Preparation — Associate of Science",
+    "Cisco Certified Network Associate Certificate of Specialization — Associate in Science",
+    "CISCO Certified Network Installation Associate - Certificate of Achievement — Associate in Arts",
+    "CISCO Enterprise Network Associate – Occupational Skills Certificate — Associate of Science",
+    "CIT - Management Information Systems Associate of Science Degree — Associate of Science",
+    "CIT - Management Information Systems Certificate of Achievement — Associate of Science",
+    "CIT - Office Technology Associate of Arts Degree — Associate of Arts",
+    "Civil Engineering - Certificate of Achievement — Associate in Arts",
+    "Civil Engineering Associate in Science — Associate in Science",
+    "Cloud and Network Cyber Security Administration (AS Degree S0884) — Associate in Science",
+    "Cloud Computing - Associate in Science — Associate in Arts",
+    "Cloud Computing - Certificate of Achievement — Associate in Arts",
+    "Cloud Computing and Security Skills Certificate — Associate in Arts",
+    "Cloud Computing Certificate — Associate in Arts",
+    "CNC Operator Certificate — Associate in Science",
+    "CNC Technician (Certificate E0431) — AS",
+    "CNG Essentials Certificate of Completion — Certificate of Achievement",
+    "CNG Inspection Certificate of Completion — Certificate of Achievement",
+    "CNG Installation Essentials Certificate of Completion — Certificate of Achievement",
+    "Coaching (Certificate E0804) — AS",
+    "College Mathematics Preparation Certificate of Competency — Certificate of Competency",
+    "Commercial Driver's License (CDL) Orientation and Training Certificate of Achievement — Associate of Science",
+    "Commercial Drone Imaging — certificate",
+    "Commercial Flight (AS Degree S0912) — AS",
+    "Commercial Gas Heating Certificate of Achievement — Certificate of Achievement",
+    "Commercial Interior Design Certificate — Associate in Science",
+    "Commercial Music - Certificate of Achievement — Associate in Arts",
+    "Commercial Music – Occupational Skills Certificate — Associate of Science",
+    "Commercial Music (AS Degree S0876) — AS",
+    "Commercial Music (Certificate T0874) — AS",
+    "Commercial Music Associate in Arts Degree — Associate in Science",
+    "Commercial Photography Certificate — Associate in Science",
+    "Communication Arts – Associate in Arts Degree — Associate of Science",
+    "Communication Associate in Arts — Associate in Science",
+    "Communication Emphasis (AA Degree A8982) — AS",
+    "Communication Studies - Associate in Arts — Associate in Arts",
+    "Communication Studies - Certificate of Achievement — Associate in Arts",
+    "Communication Studies — Associate in Arts",
+    "Communication Studies 2.0 - Associate in Arts for Transfer — Associate in Science",
+    "Communication Studies 2.0 - Associate in Arts Transfer Degree — Associate in Arts",
+    "Communication Studies 2.0 – Associate in Arts Degree for Transfer — Associate of Science",
+    "Communication Studies 2.0 – Associate in Arts for Transfer — Associate in Arts",
+    "Communication Studies 2.0 (AA-T Degree A0976) — Associate in Arts",
+    "Communication Studies 2.0 AA-T Degree — Associate in Arts",
+    "Communication Studies 2.0 Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Communication Studies 2.0 for Transfer (AA-T) — Associate in Science",
+    "Communication Studies 2.0 for Transfer Degree (AA-T)",
+    "Communication Studies 2.0, AA-T",
+    "Communication Studies 2.0, AA-T — Associate in Arts",
+    "Communication Studies and Mass Media - Certificate of Achievement Level 1 — Associate in Science",
+    "Communication Studies Associate in Arts Degree for Transfer 2.0 — Associate in Science",
+    "Communication Studies for Transfer 2.0 (AA-T) — Associate in Science",
+    "Community Advocacy and Engagement - Certificate of Achievement — Associate in Arts",
+    "Community Health Worker - Certificate of Achievement — Associate in Arts",
+    "Community Health Worker - Certificate of Completion-Noncredit — Associate in Science",
+    "Community Health Worker — Associate Degree for Transfer",
+    "Community Health Worker: Children and Families Certificate of Achievement — Certificate of Achievement",
+    "Community Service Officer - Certificate of Achievement — Associate in Arts",
+    "Computed Tomography - Certificate of Accomplishment — Associate in Arts",
+    "Computed Tomography (Certificate N0687) — AS",
+    "Computer - Database Management Systems (AS Degree S0706) — AS",
+    "Computer Aided Design - Mechanical - Associate in Science — Associate in Arts",
+    "Computer Aided Design - Mechanical - Certificate of Achievement — Associate in Arts",
+    "Computer Aided Manufacturing (CAM) Certificate — Associate in Science",
+    "Computer and Networking Technology (AS Degree S0725) — AS",
+    "Computer and Networking Technology (Certificate T0960) — AS",
+    "Computer Animation/Multi Media Certificate — Associate in Science",
+    "Computer Engineering - Certificate of Achievement — Associate in Arts",
+    "Computer Game Design Certificate — Associate in Science",
+    "Computer Game Programming Skills Certificate — Associate in Science",
+    "Computer Graphics Certificate — Associate in Science",
+    "Computer Hardware Technician - Certificate of Achievement — Associate in Arts",
+    "Computer Hardware Technician - Certificate of Completion — Associate in Arts",
+    "Computer Information Competency - Certificate of Completion — Associate in Arts",
+    "Computer Information Systems – Computer Retail Sales & Support – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Information Systems – Cybersecurity – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Information Systems – Full Stack Web Development – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Information Systems – Help Desk/User Support – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Information Systems – Software Development – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Information Systems – System and Network Administration – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Information Systems Associate in Science Degree — Associate in Science",
+    "Computer Information Systems Certificate — Associate in Science",
+    "Computer Information Systems, AS",
+    "Computer Information Systems: CCNA - Certificate of Achievement Level 2 — Associate in Science",
+    "Computer Information Systems: Computer Programming - Certificate of Achievement Level 2 — Associate in Science",
+    "Computer Information Systems: Computer Programming - Certificate of Achievement Level 3 — Associate in Science",
+    "Computer Information Systems: General Networking - Certificate of Achievement Level 1 — Associate in Science",
+    "Computer Information Systems: MCSA - Certificate of Achievement Level 2 — Associate in Science",
+    "Computer Information Systems: MCSE - Certificate of Achievement Level 2 — Associate in Science",
+    "Computer Information Systems: UNIX Networks - Certificate of Achievement Level 1 — Associate in Science",
+    "Computer Information Systems: Web Developer - Certificate of Achievement Level 2 — Associate in Science",
+    "Computer Information Systems: Web Developer - Certificate of Achievement Level 3 — Associate in Science",
+    "Computer Network Security Technician Certificate of Achievement",
+    "Computer Network Security Technician, AS",
+    "Computer Network Support Specialist Certificate of Achievement — Associate of Science",
+    "Computer Network Technician Certificate of Achievement",
+    "Computer Network Technician, AS",
+    "Computer Networking Software Certificate of Achievement",
+    "Computer Networking Technician - Certificate of Accomplishment — Associate in Arts",
+    "Computer Networking Technology Fundamentals (Certificate M0682) — AS",
+    "Computer Networking Technology Industry Certification (M0849) — AS",
+    "Computer Numerical Control (CNC) Certificate — Associate in Science",
+    "Computer Numerical Control (CNC) Machine Tool Operator – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Computer Numerical Control (CNC) Machining Associate of Science Degree — Associate of Science",
+    "Computer Numerical Control (CNC) Machining Certificate of Achievement — Associate of Science",
+    "Computer Numerical Control (CNC) Operator/Programmer Certificate of Achievement",
+    "Computer Programming - Certificate of Achievement — Associate in Arts",
+    "Computer Programming (AS Degree S7302) — AS",
+    "Computer Programming Associate in Science and Certificate of Achievement — Associate in Science",
+    "Computer Programming Certificate of Achievement",
+    "Computer Programming Certificate of Specialization — Associate in Science",
+    "Computer Programming Competence Certificate of Achievement",
+    "Computer Science - Associate in Science — Associate in Arts",
+    "Computer Science - Associate in Science Degree for Transfer — Associate of Science",
+    "Computer Science - Associate in Science for Transfer — Associate in Arts",
+    "Computer Science - Associate in Science for Transfer — Associate in Science",
+    "Computer Science - Certificate of Achievement — Associate in Arts",
+    "Computer Science — Associate in Science",
+    "Computer Science AS-T Degree — Associate in Science",
+    "Computer Science Associate in Science Degree — Associate in Science",
+    "Computer Science Associate in Science for Transfer Degree — Associate of Science",
+    "Computer Science Associate of Science Degree — Associate of Science",
+    "Computer Science Certificate of Achievement",
+    "Computer Science Certificate of Achievement — Associate of Science",
+    "Computer Science for Transfer (AS-T) — Associate in Science",
+    "Computer Science, AS",
+    "Computer Science, AS-T",
+    "Computer Science, AS-T — Associate in Science",
+    "Computer Security and Networking - Associate in Science — Associate in Arts",
+    "Computer Security and Networking - Certificate of Achievement — Associate in Arts",
+    "Computer Support Certificate of Achievement",
+    "Computer Support Specialist Certificate of Achievement — Associate of Science",
+    "Computer Support Technician Certificate of Specialization — Associate in Science",
+    "Computer Technician Analyst Certificate — Associate in Science",
+    "Computer Technician Apprentice Skills Certificate — Associate in Science",
+    "Computer Technology - Associate in Science — Associate in Arts",
+    "Computer Technology - Certificate of Achievement — Associate in Arts",
+    "Computer Web Developer Technician Certificate of Achievement",
+    "Construction Apprenticeship Readiness - Certificate of Achievement — Associate in Arts",
+    "Construction Apprenticeship Readiness - Certificate of Completion — Associate in Arts",
+    "Construction Estimating Skills Certificate — Associate in Science",
+    "Construction Inspection - Associate in Science — Associate in Arts",
+    "Construction Inspection - Certificate of Achievement — Associate in Arts",
+    "Construction Inspection Associate in Science Degree — Associate in Science",
+    "Construction Inspection Certificate — Associate in Science",
+    "Construction Management - Associate in Science — Associate in Arts",
+    "Construction Management - Certificate of Achievement — Associate in Arts",
+    "Construction Management - Level I (Certificate M0873) — AS",
+    "Construction Management - Level II (Certificate N0880) — AS",
+    "Construction Management (AS Degree S0881) — AS",
+    "Construction Management Associate in Science Degree — Associate in Science",
+    "Construction Management Fundamentals - Certificate of Completion — Associate in Arts",
+    "Construction Technology - Associate in Arts — Associate in Science",
+    "Construction Technology - Associate in Science — Associate in Arts",
+    "Construction Technology - Associate in Science — Associate in Science",
+    "Construction Technology - Certificate of Achievement — Associate in Arts",
+    "Construction Technology - Certificate of Achievement Level 3 — Associate in Science",
+    "Construction Technology Associate in Science Degree — Associate in Science",
+    "Construction Technology Career Preparation Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Certificate — Associate in Science",
+    "Construction Technology Concrete and Masonry Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Drywall Installation and Finish Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Electrical Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Exterior Finishes Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Finish Carpentry Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Framing Carpentry Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Introduction Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Plumbing Certificate of Completion — Certificate of Achievement",
+    "Construction Technology Site Preparation and Layout Certificate of Completion — Certificate of Achievement",
+    "Construction technology: Residential Carpentry Technology - Certificate of Achievement Level 1 — Associate in Science",
+    "Construction technology: Residential Maintenance - Certificate of Achievement Level 2 — Associate in Science",
+    "Construction Welding – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Consumer Affairs - Accredited Financial Counselor (Certificate N0938) — AS",
+    "Consumer Affairs (AS Degree S0939) — AS",
+    "Consumer Relations (Certificate M0479) — AS",
+    "Control Systems Technician Certificate of Completion",
+    "Conversational Programming Skills Certificate — Associate in Science",
+    "Correctional Science Certificate of Achievement",
+    "Correctional Science, AS",
+    "Corrections Associate in Science and Certificate of Achievement — Associate in Science",
+    "Cosmetology - Associate in Science — Associate in Science",
+    "Cosmetology - Certificate of Achievement Level 3 — Associate in Science",
+    "Cosmetology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Cosmetology Associate in Science Degree — Associate in Science",
+    "Cosmetology Associate in Science Degree (1000 hours) — Associate in Science",
+    "Cosmetology Certificate — Associate in Science",
+    "Cosmetology Certificate (1000 hours) — Associate in Science",
+    "Cosmetology Instructor Associate in Science Degree — Associate in Science",
+    "Cost Accounting Certificate — Associate in Science",
+    "Costume Cutter, Draper, and Stitcher Certificate — Associate in Science",
+    "Costume Technician Certificate of Achievement",
+    "Costume Wardrobe Skills Certificate — Associate in Science",
+    "Craft Industries Entrepreneurship Certificate of Specialization — Associate in Science",
+    "Creative Writing Certificate of Achievement",
+    "Crime Scene Investigation Certificate — Associate in Science",
+    "Criminal Forensics - Certificate of Achievement — Associate in Arts",
+    "Criminal Law Specialty Certificate — Associate in Science",
+    "Cross-Cultural Communication Skills Certificate of Proficiency — Associate in Science",
+    "Cross-Cultural Competence Certificate of Proficiency — Associate in Science",
+    "Cross-Cultural Skills, with Conversational-Level Second Language Certificate of Proficiency — Associate in Science",
+    "Cruiseline Sector Hospitality Leadership – Certificate of Achievement — Associate of Science",
+    "Cryptocurrency Fundamentals - Certificate of Accomplishment — Associate in Arts",
+    "Cryptocurrency Fundamentals - Certificate of Completion — Associate in Arts",
+    "CSIS - Digital Web & Mobile Development",
+    "CSIS-Mobile Development Option",
+    "CSIS-Web Development Option",
+    "Culinary - Advanced (Certificate T0457) — AS",
+    "Culinary Arts - Associate in Science — Associate in Arts",
+    "Culinary Arts - Certificate of Achievement — Associate in Arts",
+    "Culinary Arts - Level I (Certificate E0887) — AS",
+    "Culinary Arts Associate in Science and Certificate of Achievement — Associate in Science",
+    "Culinary Arts Certificate of Achievement",
+    "Culinary Arts Management (AS Degree S0448) — associate in science",
+    "Culinary Arts, AA",
+    "Culinary Catering Certificate of Completion — Certificate of Achievement",
+    "Culinary Entrepreneurship Associate in Science and Certificate of Achievement — Associate in Science",
+    "Culinary Management and Operations – Associate in Science, Certificate of Achievement — Associate of Science",
+    "Culinary Menu Planning Certificate of Completion — Certificate of Achievement",
+    "Culinary Procurement and Cost Control Certificate of Completion — Certificate of Achievement",
+    "Culinary Safety & Sanitation Certificate of Completion — Certificate of Achievement",
+    "Cultural Diversity and Awareness - Certificate of Achievement — Associate in Arts",
+    "Customer Service – Occupational Skills Certificate — Associate of Science",
+    "Cyber Security - Certificate of Achievement — Associate in Arts",
+    "Cyber Security Analyst Certificate — Associate in Science",
+    "Cyber Security Associate in Science Degree — Associate in Science",
+    "Cyber Security Master Certificate — Associate in Science",
+    "Cyber Security Specialist Certificate of Specialization — Associate in Science",
+    "Cyber Security Technician Certificate — Associate in Science",
+    "Cybersecurity and Networking Associate in Science and Certificate of Achievement — Associate in Science",
+    "Dance - Associate in Arts — Associate in Arts",
+    "Dance - Associate in Arts — Associate in Science",
+    "Dance - Certificate of Achievement — Associate in Arts",
+    "Dance – Associate in Arts Degree — Associate of Science",
+    "Dance – Certificate of Achievement — Associate in Arts",
+    "Dance Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Dance Associate in Arts Degree — Associate in Science",
+    "Dance Emphasis (AA Degree A0444) — AS",
+    "Dance Teacher (Certificate N0649) — AS",
+    "Dance Teaching - Certificate of Achievement Level 1 — Associate in Science",
+    "Dance Teaching Certificate — Associate in Science",
+    "Dance, AA",
+    "Data Analytics - Associate in Science — Associate in Arts",
+    "Data Analytics - Certificate of Achievement — Associate in Arts",
+    "Data Science - Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Data Science Certificate of Achievement — Associate in Science",
+    "Database Administrator Specialist - Certificate of Accomplishment — Associate in Arts",
+    "Deaf Studies — AA",
+    "Deaf Studies (AA Degree A0944) — AS",
+    "Deaf Studies (Certificate T0943) — AS",
+    "Dental Assisting - Associate in Science — Associate in Science",
+    "Dental Assisting - Certificate of Achievement Level 3 — Associate in Science",
+    "Dental Hygiene – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Dental Hygiene — diploma",
+    "Desert Ecologist Certificate of Achievement — Certificate of Achievement",
+    "Design and Technical Theatre Certificate of Achievement — Associate in Arts for Transfer",
+    "Design Basics - Certificate of Achievement — Associate in Arts",
+    "Design Introduction - Certificate of Completion — Associate in Arts",
+    "Design Management- Associate in Science — Associate in Arts",
+    "Design Media Art – Animation & Motion Arts – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Design Media Art – Design/Media Arts Foundation – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Design Media Art – Game Design & Development – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Design Media Art – Graphic Design – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Design Media Art – Interactive Art & Design – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Design Media Art – Web Design & Development – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Design/Build - Certificate of Completion — Associate in Arts",
+    "Designing with Rhinoceros - Certificate of Completion — Associate in Arts",
+    "Developmental Disabilities Specialist - Certificate of Achievement Level 1 — Associate in Science",
+    "Diagnostic Medical Imaging (Radiologic Technology) - Associate in Science — Associate in Arts",
+    "Diagnostic Medical Imaging (Radiologic Technology) - Certificate of Achievement — Associate in Arts",
+    "Diagnostic Medical Sonography — Associate in Science",
+    "Diesel Automotive Equipment Technician Certificate of Achievement",
+    "Diesel Bus Technician Certificate of Achievement",
+    "Diesel Equipment Technician Certificate of Achievement",
+    "Diesel Equipment Technician, AS",
+    "Dietary Manager Certificate — Associate in Science",
+    "Dietetic Aide Certificate of Achievement — Associate in Science for Transfer",
+    "Dietetic Service Supervisor - Associate in Arts — Associate in Arts",
+    "Dietetic Service Supervisor - Certificate of Achievement — Associate in Arts",
+    "Dietetic Service Supervisor Certificate of Achievement — Associate in Science for Transfer",
+    "Digital and Social Media - Certificate of Achievement — Associate in Arts",
+    "Digital Arts",
+    "Digital Fashion Design - Certificate of Completion — Associate in Arts",
+    "Digital Forensics Certificate of Achievement — Associate of Science",
+    "Digital Image Editing – Occupational Skills Certificate — Associate of Science",
+    "Digital Imaging Certificate of Completion",
+    "Digital Marketing Certificate — Associate in Arts",
+    "Digital Marketing Certificate of Achievement — Associate of Arts",
+    "Digital Media Content Entrepreneurship Certificate of Completion",
+    "Digital Media with Emphasis in Audio Certificate of Achievement",
+    "Digital Media with Emphasis in Video Certificate of Achievement",
+    "Digital Media, AA",
+    "Digital Media: Comics & Animation - Certificate of Achievement — Associate in Arts",
+    "Digital Media: Graphic Design - Certificate of Achievement — Associate in Arts",
+    "Digital Media: Multimedia Interaction & Game Design - Certificate of Achievement — Associate in Arts",
+    "Digital Photography Certificate of Specialization — Associate in Science",
+    "Digital Publication Certificate — Associate in Science",
+    "Digital/In-Plant Graphics Certificate — Associate in Science",
+    "Digitization Skills for Libraries and Cultural Heritage Institutions – Certificate of Achievement — Associate of Science",
+    "Directing for Theatre, Film and Television Certificate — Associate in Science",
+    "DRE Exam Preparation - Certificate of Completion — Associate in Arts",
+    "Dressmaking-Alterations Certificate — Associate in Science",
+    "Drone and Autonomous Systems Associate in Science Degree — Associate in Science",
+    "Drone Business and Entrepreneurship Certificate — Associate in Science",
+    "Drone Camera Operator (AS Degree S0449) — AS",
+    "Drone Cinematography Certificate of Proficiency — Associate in Science",
+    "Drone Journalism Certificate — Associate in Science",
+    "Drone Mapping Certificate of Proficiency — Associate in Science",
+    "Early Childhood Education",
+    "Early Childhood Education - Associate in Science — Associate in Science",
+    "Early Childhood Education - Associate in Science for Transfer — Associate in Science",
+    "Early Childhood Education - Associate in Science Transfer Degree — Associate in Arts",
+    "Early Childhood Education - Associate Teacher - Certificate of Achievement Level 1 — Associate in Science",
+    "Early Childhood Education - Certificate of Achievement Level 2 — Associate in Science",
+    "Early Childhood Education - Inclusion Specialist - Certificate of Achievement Level 2 — Associate in Science",
+    "Early Childhood Education - Master Teacher - Certificate of Achievement Level 3 — Associate in Science",
+    "Early Childhood Education – Associate in Science Degree for Transfer to CSU — Associate of Science",
+    "Early Childhood Education (AS-T Degree S0401) — Associate in Science",
+    "Early Childhood Education Administration Certificate — Associate in Science",
+    "Early Childhood Education Associate in Arts Degree — Associate in Science",
+    "Early Childhood Education Associate in Science Degree for Transfer — Associate in Science",
+    "Early Childhood Education Associate in Science for Transfer Degree — Associate of Arts",
+    "Early Childhood Education Associate Teacher Certificate of Achievement",
+    "Early Childhood Education Associate Teacher Certificate of Achievement — Certificate of Achievement",
+    "Early Childhood Education for Transfer (AS-T) — Associate in Science",
+    "Early Childhood Education Master Teacher Certificate of Achievement",
+    "Early Childhood Education Master Teacher Certificate of Achievement — Certificate of Achievement",
+    "Early Childhood Education Site Supervisor Certificate of Achievement",
+    "Early Childhood Education Site Supervisor Certificate of Achievement — Certificate of Achievement",
+    "Early Childhood Education Teacher Certificate — Associate in Science",
+    "Early Childhood Education Teacher Certificate of Achievement",
+    "Early Childhood Education Teacher Certificate of Achievement — Certificate of Achievement",
+    "Early Childhood Education, AA",
+    "Early Childhood Education, AS-T",
+    "Early Childhood Education, AS-T — Associate in Science",
+    "Early Childhood Education: Teacher - Certificate of Achievement Level 2 — Associate in Science",
+    "Early Childhood Intervention Certificate of Specialization — Associate in Science",
+    "Earth Science — Associate in Science",
+    "Earth Science Associate in Science Degree — Associate in Science",
+    "ECE Administration and Adult Supervision Add On Certificate of Achievement",
+    "Economics - Associate in Arts for Transfer — Associate in Arts",
+    "Economics - Associate in Arts for Transfer — Associate in Science",
+    "Economics - Associate in Arts Transfer Degree — Associate in Arts",
+    "Economics - Certificate of Achievement — Associate in Arts",
+    "Economics – Associate in Arts Degree for Transfer — Associate of Science",
+    "Economics — Associate in Arts",
+    "Economics AA-T Degree — Associate in Arts",
+    "Economics Associate in Arts — Associate in Science",
+    "Economics Associate in Arts Degree — Associate in Science",
+    "Economics Associate in Arts Degree for Transfer — Associate in Science",
+    "Economics Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Economics for Transfer (AA-T) — Associate in Science",
+    "Economics for Transfer Degree (AA-T)",
+    "Economics, AA-T — Associate in Arts",
+    "EDGE Certificate of Completion — Certificate of Completion",
+    "eDiscovery and Litigation Support (Certificate M0885) — Associate in Science",
+    "eDiscovery and Technology Specialty Certificate — Associate in Science",
+    "Education — Associate in Arts",
+    "Education, Society, and Human Development Associate of Arts Degree — Associate of Arts",
+    "Educational Aide - Certificate of Achievement — Associate of Science",
+    "Educational Aide I - Certificate of Achievement — Associate in Arts",
+    "Educational Aide II - Certificate of Achievement — Associate in Arts",
+    "Educational Paraprofessional (Instructional Assistant) (AS Degree S0375) — AS",
+    "Educator Workforce Preparation - Certificate of Competency — Associate in Arts",
+    "Educators Global Awareness Certificate of Proficiency — Associate in Science",
+    "EKG Technician – Occupational Skills Certificate — Associate of Science",
+    "Elder Care – Occupational Skills Certificate — Associate of Science",
+    "Electric & Hybrid Vehicles - Certificate of Achievement — Associate in Arts",
+    "Electric Power Technology Associate of Science Degree — Associate of Science",
+    "Electric Power Technology Certificate of Achievement — Associate of Science",
+    "Electric Vehicle Service (Tesla Start), Certificate of Achievement — Associate in Arts",
+    "Electrical and Computer Engineering Associate in Science — Associate in Science",
+    "Electrical Apprenticeship Preparation - Certificate of Achievement — Associate in Arts",
+    "Electrical Engineering - Certificate of Achievement — Associate in Arts",
+    "Electrical Program Preparation - Certificate of Completion — Associate in Arts",
+    "Electrical Technology - Apprenticeship Certificate of Achievement",
+    "Electrical Technology - Apprenticeship, AS",
+    "Electrical Technology - Electrical Maintenance Certificate of Achievement",
+    "Electrical Technology - General Electrician Trainee Certificate of Achievement",
+    "Electrical Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Electrical Technology, AS",
+    "Electrical Technology, Automation Technician - Associate in Science — Associate in Arts",
+    "Electrical Technology, Automation Technician - Certificate of Achievement — Associate in Arts",
+    "Electrical Technology, CISCO Certified Network Installation Associate - Associate in Science — Associate in Arts",
+    "Electrical Technology, CISCO Certified Network Installation Associate - Certificate of Achievement — Associate in Arts",
+    "Electrical Technology, General Industrial Electrician - Associate in Science — Associate in Arts",
+    "Electrical Technology, General Industrial Electrician - Certificate of Achievement — Associate in Arts",
+    "Electrical Technology, High Voltage Test Technician - Associate in Science — Associate in Arts",
+    "Electrical Technology, High Voltage Test Technician - Certificate of Achievement — Associate in Arts",
+    "Electrical Technology, Solar Installation and Maintenance - Associate in Science — Associate in Arts",
+    "Electrical Technology, Solar Installation and Maintenance - Certificate of Achievement — Associate in Arts",
+    "Electrical Technology, Traffic Signal Technician - Associate in Science — Associate in Arts",
+    "Electrical Technology, Traffic Signal Technician - Certificate of Achievement — Associate in Arts",
+    "Electro-Mechanical Technician Certificate — Associate in Science",
+    "Electron Microscopy - Biological Concentration Advanced Sample Preparation Certificate of Achievement",
+    "Electron Microscopy - Biological Concentration Basic Sample Preparation",
+    "Electron Microscopy - Biological Concentration, AS",
+    "Electron Microscopy - Crystalline Materials Advanced Training Certificate of Achievement",
+    "Electron Microscopy - Crystalline Materials Basic Imaging",
+    "Electron Microscopy - Field Service Technician Basic Training",
+    "Electron Microscopy - Materials, AS",
+    "Electron Microscopy: Field Service Technician Advanced Training",
+    "Electronic Assembly and Fabrication (Certificate E0929) — AS",
+    "Electronic Communications (Certificate N0973) — AS",
+    "Electronic Imaging Certificate — Associate in Science",
+    "Electronics and Computer Engineering Technology (AS Degree S0906) — AS",
+    "Electronics and Computer Engineering Technology (Certificate T0906) — AS",
+    "Electronics Engineering Technology (AS Degree S0681) — AS",
+    "Electronics Technology - Level 1 (Certificate M0679) — AS",
+    "Electronics Technology - Level 2 (Certificate N0680) — AS",
+    "Electronics Technology – Basic Digital Technician – Certificate of Achievement — Associate of Science",
+    "Electronics Technology Certificate of Achievement",
+    "Elementary Education Associate in Arts — Associate in Science",
+    "Elementary Teacher Assistant Special Education Certificate of Achievement — Certificate of Achievement",
+    "Elementary Teacher Assistant Special Education, Bilingual Certificate of Achievement — AA-T",
+    "Elementary Teacher Education Associate in Arts Degree for Transfer — Associate in Science",
+    "Elementary Teacher Education for Transfer (AA-T)",
+    "Elementary Teacher Education for Transfer (AA-T) — Associate in Science",
+    "Elementary Teacher Education, AA-T",
+    "Elementary Teacher Education, AA-T — Associate in Arts",
+    "Elementary Teacher Education: Integrated Programs - Associate in Arts Transfer Degree — Associate in Arts",
+    "Elementary Teacher Education: Integrated Programs – Associate in Arts Degree for Transfer — Associate of Science",
+    "Elementary Teacher Education: Integrated Programs AA-T Degree — Associate in Arts",
+    "Elementary Teacher Education: Integrated Programs Associate in Arts for Transfer Degree — Associate of Arts",
+    "Emergency Medical Responder Certificate of Completion — Certificate of Achievement",
+    "Emergency Medical Responder, Intermediate Certificate of Completion — Certificate of Achievement",
+    "Emergency Medical Services - Paramedic (AS Degree S1210) — Associate in Science",
+    "Emergency Medical Services Technology - Certificate of Specialization — Associate in Science",
+    "Emergency Medical Technician - Certificate of Accomplishment — Associate in Arts",
+    "Emergency Medical Technician – Certificate of Achievement — Associate of Science",
+    "Emergency Medical Technician — Certificate of Achievement",
+    "Emergency Medical Technician Basic Certificate of Achievement — Certificate of Achievement",
+    "Emerging Tech Entrepreneurship - Certificate of Achievement Level 1 — Associate in Science",
+    "Emerging Tech Entrepreneurship - Certificate of Achievement Level 2 — Associate in Science",
+    "Employment Preparation: Entry Cook Certificate of Completion — Certificate of Achievement",
+    "Employment Preparation: Line Cook Certificate of Completion — Certificate of Achievement",
+    "Engineering",
+    "Engineering - Associate in Arts — Associate in Arts",
+    "Engineering - Associate in Arts — Associate in Science",
+    "Engineering - Associate in Science — Associate in Arts",
+    "Engineering - Civil, AS",
+    "Engineering - Computer, AS",
+    "Engineering - Electrical, AS",
+    "Engineering - Mechanical, Aeronautical, and Manufacturing, AS",
+    "Engineering — AS",
+    "Engineering — Associate in Science",
+    "Engineering and Construction Technology (AS Degree S0430) — AS",
+    "Engineering and Construction Technology Level I (Certificate E0423) — AS",
+    "Engineering AS Degree — Associate of Science",
+    "Engineering Associate in Science Degree — Associate in Science",
+    "Engineering Automation Technology - Certificate of Achievement — Associate in Arts",
+    "Engineering Computer Aided Drafting, AS",
+    "Engineering Computer-Aided Drafter Certificate of Achievement",
+    "Engineering Fundamentals",
+    "Engineering Fundamentals (Certificate N0846) — AS",
+    "Engineering Fundamentals 1 - Certificate of Achievement — Associate in Arts",
+    "Engineering Fundamentals 2 — Associate in Arts",
+    "Engineering Fundamentals Certificate of Achievement",
+    "Engineering Technology - Associate in Science — Associate in Arts",
+    "Engineering Technology - Certificate of Achievement — Associate in Arts",
+    "Engineering Technology Advanced - Certificate of Achievement — Associate in Arts",
+    "Engineering Technology Certificate — Associate in Science",
+    "Engineering Technology Certificate of Achievement",
+    "Engineering Technology, AS",
+    "Engineering with Emphasis in Chemical and Materials Engineering Applications (AS Degree S0829) — AS",
+    "Engineering with Emphasis in Civil Engineering Applications (AS Degree S0832) — AS",
+    "Engineering with Emphasis in Electrical Engineering Applications (AS Degree S0835) — AS",
+    "Engineering with Emphasis in Mechanical Engineering Applications (AS Degree S0838) — AS",
+    "Engineering with Emphasis in Software Engineering Applications (AS Degree S0841) — AS",
+    "Engineering: Civil Engineering Emphasis – Associate in Science Degree — Associate of Science",
+    "Engineering: Electrical Engineering Emphasis – Associate in Science Degree — Associate of Science",
+    "Engineering: Mechanical, Aerospace, and Manufacturing Engineering Emphasis – Associate in Science Degree — Associate of Science",
+    "English - Associate in Arts for Transfer — Associate in Arts",
+    "English - Associate in Arts for Transfer — Associate in Science",
+    "English - Associate in Arts Transfer Degree — Associate in Arts",
+    "English – Associate in Arts Degree for Transfer — Associate of Science",
+    "English — Associate in Arts",
+    "English — Associate in Arts for Transfer",
+    "English AA-T Degree — Associate in Arts",
+    "English As a Second Language - Intermediate Noncredit ESL, Certificate of Competency — Associate in Arts",
+    "English As a Second Language - Low-Intermediate Noncredit ESL, Certificate of Competency — Associate in Arts",
+    "English as a Second Language — Certificate of Competency",
+    "English as a Second Language Advanced Academic Credit Certificate of Proficiency — Certificate of Competency",
+    "English Associate in Arts and Certificate of Achievement — Associate in Science",
+    "English Associate in Arts Degree — Associate in Science",
+    "English Associate in Arts Degree for Transfer — Associate in Science",
+    "English Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "English for Every Day – Level 1 - Certificate of Competency — Associate in Arts",
+    "English for Every Day – Level 2 - Certificate of Competency — Associate in Arts",
+    "English for Every Day – Level 3 - Certificate of Competency — Associate in Arts",
+    "English for Transfer (AA-T)",
+    "English for Transfer (AA-T) — Associate in Science",
+    "English Literature – Associate in Arts Degree — Associate of Science",
+    "English Proficiency Certificate of Completion: Life & Work Skills — Certificate of Completion",
+    "English Proficiency Level High-Intermediate Certificate of Specialization — Associate in Science",
+    "English, AA-T",
+    "English, AA-T — Associate in Arts",
+    "English, Creative Writing - Associate in Arts — Associate in Arts",
+    "English, Language and Literature - Associate in Arts — Associate in Arts",
+    "Entertainment Arts Certificate — Associate in Science",
+    "Entertainment Design and Technical Theatre - Advanced — Certificate of Achievement",
+    "Entertainment Design and Technical Theatre - Basic — Certificate of Achievement",
+    "Entrepreneurship - Certificate of Achievement — Associate in Arts",
+    "Entrepreneurship - General Certificate of Achievement — Associate of Arts",
+    "Entrepreneurship - Real Estate Certificate of Achievement — Associate of Arts",
+    "Entrepreneurship - Tax Certificate of Achievement — Associate of Arts",
+    "Entrepreneurship Associate in Science Degree — Associate in Arts",
+    "Entrepreneurship Certificate — Associate in Arts",
+    "Entrepreneurship Certificate of Achievement",
+    "Entrepreneurship Skills Certificate — Associate in Arts",
+    "Entrepreneurship-Small Business Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Entry-Level Accounting Certificate — Associate in Science",
+    "Entry-Level Dental Assistant - Occupational Skills Certificate — Associate of Science",
+    "Environmental Horticulture and Design — Associate in Science",
+    "Environmental Management Associate in Science — Associate in Science",
+    "Environmental Science - Associate in Science for Transfer — Associate in Science",
+    "Environmental Science AS-T Degree — Associate in Science for Transfer",
+    "Environmental Science Associate in Science for Transfer Degree — Associate of Science",
+    "Environmental Science Associate of Science Degree — Associate of Science",
+    "Environmental Science for Transfer (AS-T)",
+    "Environmental Science, AS-T — Associate in Science",
+    "Environmental Sciences and Sustainability — Associate in Science",
+    "Environmental Sciences Associate in Science Degree — Associate in Science",
+    "Environmental Studies Emphasis (AA Degree A0411) — AS",
+    "Environmental Sustainability Associate in Arts Degree — Associate in Science",
+    "Environmental Technician Certificate of Achievement — Associate in Science",
+    "ESL Certificate of Proficiency in Academic English — Associate in Science",
+    "ESL In Career and College: intermediate - Certificate of Competency — Associate in Science",
+    "ESL Integrated Skills - Beginning Certificate of Competency — Certificate of Competency",
+    "ESL Literacy - Certificate of Competency — Associate in Arts",
+    "ESL Milestone - Pathway to Transfer - Business Success Certificate of Achievement — Associate in Science",
+    "ESL Milestone - Pathway to Transfer: Health Sciences Certificate of Achievement — Associate in Science",
+    "ESL Milestone - Pathway to Transfer: Language and Communication Certificate of Achievement — Associate in Science",
+    "ESL Milestone - Pathway to Transfer: Science, Technology, Engineering, and Math (STEM) Certificate of Achievement — Associate in Science",
+    "ESL Milestone - Pathway to Transfer: Social and Behavioral Sciences Certificate of Achievement — Associate in Science",
+    "ESL Milestone - Pathway to Transfer: The Humanities — Associate in Science",
+    "ESL Milestone - Pathway to Transfer: Visual and Performing Arts Certificate of Achievements — Associate in Science",
+    "ESL Milestone Certificate of Achievement: Pathway to Transfer - Written and Oral Communication — Associate in Science",
+    "ESL Milestone for Multilingual Speakers: Pathway to Business Certificate of Achievement",
+    "ESL Milestone for Multilingual Speakers: Pathway to Electrical Technology Certificate of Achievement",
+    "ESL Milestone for Multilingual Speakers: Pathway to Health Careers Certificate of Achievement",
+    "ESL Pathway Behavioral and Social Sciences Certificate of Achievement — Associate in Science",
+    "ESL Pathway Business and Professional Studies Certificate of Achievement — Associate in Science",
+    "ESL Pathway Culture, People, and Ideas Certificate of Achievement — Associate in Science",
+    "ESL Pathway Environmental and Applied Technology Certificate of Achievement — Associate in Science",
+    "ESL Pathway Health Sciences Certificate of Achievement — Associate in Science",
+    "ESL Pathway Language and Communication Certificate of Achievement — Associate in Science",
+    "ESL Pathway STEM Certificate of Achievement — Associate in Science",
+    "ESL Pathway Visual and Performing Arts Certificate of Achievement — Associate in Science",
+    "ESL Reading for Citizenship - Certificate of Competency — Associate in Arts",
+    "Esthetician Certificate — Associate in Science",
+    "Esthetics - Certificate of Achievement Level 2 — Associate in Science",
+    "Ethnic Studies - Associate in Arts — Associate in Arts",
+    "Ethnic Studies — Associate in Arts",
+    "Ethnic Studies — Associate in Arts for Transfer",
+    "Ethnic Studies AA Degree — AA",
+    "Ethnic Studies Associate in Arts — Associate in Science",
+    "Ethnic Studies Associate in Arts Degree — Associate in Science",
+    "Ethnic Studies for Educators Discipline Emphasis Certificate — Associate in Science",
+    "Ethnic Studies for Educators Foundations Certificate — Associate in Science",
+    "Executive Assistant Associate in Science and Certificate of Achievement — Associate in Science",
+    "Exercise Science and Wellness Associate in Science and Certificate of Achievement — Associate in Science",
+    "Exercise Science Associate in Science — Associate in Science",
+    "Exhibition Concept, Design, and Production (Certificate N0659) — AS",
+    "Exploring Welding and Metal Fabrication - Certificate of Completion — Associate in Arts",
+    "FAA Aircraft Dispatcher (Certificate E0408) — AS",
+    "Facilities Maintenance - Associate in Science — Associate in Science",
+    "Facilities Maintenance - Certificate of Achievement Level 3 — Associate in Science",
+    "Facilities Operations Technician Certificate of Achievement — Certificate of Achievement",
+    "Family and Consumer Sciences, AS",
+    "Family Child Care Certificate of Achievement — Certificate of Achievement",
+    "Family Child Care Management - Certificate of Completion — Associate in Arts",
+    "Family Violence Specialist - Certificate of Achievement — Associate in Arts",
+    "Fashion – Design – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Fashion — AS",
+    "Fashion Assistant – Certificate of Achievement — Associate of Science",
+    "Fashion Computer-Aided Design (Certificate E0383) — AS",
+    "Fashion Design - Associate in Science — Associate in Arts",
+    "Fashion Design - Certificate of Achievement — Associate in Arts",
+    "Fashion Design - Level I (Certificate N0482) — AS",
+    "Fashion Design – Advanced Apparel Construction - Certificate of Completion — Associate in Arts",
+    "Fashion Design – Industrial Sewing and Factory Production Methods - Certificate of Completion — Associate in Arts",
+    "Fashion Design – Swimwear Construction - Certificate of Completion — Associate in Arts",
+    "Fashion Design – Textile Surface Design - Certificate of Completion — Associate in Arts",
+    "Fashion Design and Technologies (AS Degree S1320) — AS",
+    "Fashion Design Associate in Arts Degree — Associate in Science",
+    "Fashion Design Certificate — Associate in Science",
+    "Fashion Design Certificate of Achievement",
+    "Fashion Design: Custom Apparel Design - Certificate of Achievement — Associate in Arts",
+    "Fashion Design: Patternmaker/Technical Design - Certificate of Achievement — Associate in Arts",
+    "Fashion Design: Wardrobe Designer/Stylist - Certificate of Achievement — Associate in Arts",
+    "Fashion Historical Costuming (Certificate M0674) — AS",
+    "Fashion Illustration Certificate — Associate in Science",
+    "Fashion Merchandising - Associate in Science — Associate in Arts",
+    "Fashion Merchandising - Certificate of Achievement — Associate in Arts",
+    "Fashion Merchandising - Level I (Certificate N0484) — AS",
+    "Fashion Merchandising (AS Degree S1308) — AS",
+    "Fashion Merchandising Associate in Arts Degree — Associate in Science",
+    "Fashion Merchandising Certificate — Associate in Science",
+    "Fashion Merchandising Certificate of Achievement",
+    "Fashion Merchandising, AS",
+    "Fashion Retailing Fundamentals Online (Certificate M0676) — AS",
+    "Fashion Skills Certificate — Associate in Science",
+    "Fashion Stylist Certificate — Associate in Science",
+    "FCC Amateur Radio Technician Preparation - Certificate of Completion — Associate in Arts",
+    "Field Ranger Certificate of Achievement — Certificate of Achievement",
+    "Film Associate of Arts Degree — Associate of Arts",
+    "Film Post-Production Certificate of Achievement — Certificate of Achievement",
+    "Film Production - Certificate of Achievement — Associate in Arts",
+    "Film Production AS Degree — Associate of Science",
+    "Film Production Management Certificate of Achievement — Certificate of Achievement",
+    "Film Production Scheduling and Budgeting Certificate of Completion — Certificate of Achievement",
+    "Film, Television & Electronic Media – Associate in Science Degree for Transfer — Associate of Science",
+    "Film, Television, and Electronic Media - Associate in Science Transfer Degree — Associate in Arts",
+    "Film, Television, and Electronic Media — Associate Degree for Transfer",
+    "Film, Television, and Electronic Media AS-T Degree — Associate in Science",
+    "Film, Television, and Electronic Media Associate in Science Degree for Transfer — Associate in Science",
+    "Film, Television, and Electronic Media Associate in Science for Transfer Degree — Associate of Arts",
+    "Film, Television, and Electronic Media, AS-T — Associate in Science",
+    "Finance Certificate — Associate in Arts",
+    "Finance Skills Certificate — Associate in Arts",
+    "Financial Accounting Certificate — Associate in Science",
+    "Financial Literacy - Certificate of Competency — Associate in Arts",
+    "Fine Arts Emphasis (AA Degree A8983) — AS",
+    "Fire Academy Preparation - Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Fire Officer Certification (Certificate E0381) — AS",
+    "Fire Science - Associate in Science — Associate in Arts",
+    "Fire Science - Certificate of Achievement — Associate in Arts",
+    "Fire Technology — AS",
+    "Fire Technology (AS Degree S2105) — AS",
+    "Fire Technology (Certificate N0486) — AS",
+    "First Line Supervisor",
+    "First Time Hospitality Manager - Certificate of Achievement — Associate of Science",
+    "Fitness Specialist Certificate of Achievement",
+    "Fitness Specialist Certificate of Achievement — Associate of Arts",
+    "Fitness Specialist Certificate of Achievement — Certificate of Achievement",
+    "Fitness Specialist Certification, Certificate of Proficiency — Associate in Science",
+    "Fitness Specialist/Personal Trainer (Certificate E0808) — AS",
+    "Flexography Skills Certificate — Associate in Science",
+    "Flight Operations - Professional Pilot Associate of Science Degree — Associate of Science",
+    "Flight Operations - Professional Pilot Certificate of Achievement — Associate of Science",
+    "Flight Operations and Management Associate of Science Degree — Associate of Science",
+    "Flight Operations Certificate of Achievement — Associate of Science",
+    "Flight Operations Certificate of Completion — Associate of Science",
+    "Floral Design Associate in Science and Certificate of Achievement — Associate in Science",
+    "Fluid Power and Automation Technology Certificate of Achievement",
+    "Fluid Power and Automation Technology, AS",
+    "Flux Cored Arc Welding (FCAW) Certificate of Achievement — Associate of Science",
+    "Food Safety in the Workplace — Certificate of Achievement",
+    "Foreign Language – Advanced – Occupational Skills Certificate — Associate of Science",
+    "Foreign Language – Basic – Occupational Skills Certificate — Associate of Science",
+    "Foreign Language – Intermediate – Occupational Skills Certificate — Associate of Science",
+    "Foreign Language Associate in Arts Degree — Associate in Science",
+    "Forensic Technician Certificate — Associate in Science",
+    "Forensic Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Forklift Fundamentals - Certificate of Completion — Associate in Arts",
+    "Formula Room Technician - Certificate of Achievement — Associate in Arts",
+    "Foundational Chemistry – Certificate of Achievement — Associate in Arts",
+    "Foundational Skills - Certificate of Competency — Associate in Arts",
+    "Foundations for Accessibility Certificate of Achievement — Certificate of Achievement",
+    "Foundations in Academic Research - Certificate of Competency — Associate in Arts",
+    "Foundations of Entrepreneurship - Certificate of Accomplishment — Associate in Arts",
+    "Foundations of Geospatial Data and Programming - Certificate of Accomplishment — Associate in Arts",
+    "French - Associate in Arts — Associate in Arts",
+    "French - Certificate of Achievement — Associate in Arts",
+    "French – Associate in Arts Degree — Associate of Science",
+    "French – Certificate of Achievement — Associate of Science",
+    "French Associate in Arts and Certificate of Achievement — Associate in Science",
+    "French Language, AA",
+    "Front End Web Developer - Certificate of Achievement — Associate in Arts",
+    "Front Office / Receptionist Certificate of Proficiency — Associate in Science",
+    "Front Office Receptionist Certificate of Specialization — Associate in Science",
+    "Gas Metal Arc Welding (GMAW) Certificate of Achievement — Associate of Science",
+    "Gas Metal Arc Welding (GMAW)/Flux Core Arc Welding (FCAW) Certificate of Achievement",
+    "Gas Metal Arc Welding Certificate — Certificate of Achievement",
+    "Gas Tungsten & Gas Metal Welding – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Gas Tungsten Arc Welding (GTAW) - Certificate of Achievement — Associate in Arts",
+    "Gas Tungsten Arc Welding (GTAW) Certificate of Achievement",
+    "Gas Tungsten Arc Welding (GTAW) Certificate of Achivement — Associate of Science",
+    "Gas Tungsten Arc Welding Certificate — Certificate of Achievement",
+    "Gender and Sexuality Studies - Certificate of Achievement — Associate in Arts",
+    "Gender, Ethnicity, and Multicultural Studies – Associate in Arts Degree — Associate of Science",
+    "General Agriculture AS Degree — Associate of Science",
+    "General Business (AS Degree S0501) — AS",
+    "General Education Requirements: Cal-GETC — Associate Degree for Transfer",
+    "General Education Requirements: Local — AS",
+    "General Electrician Certificate of Achievement — Associate of Science",
+    "General Industrial Electrician - Certificate of Achievement — Associate in Arts",
+    "General Studies AA - Humanities and Fine Arts — Associate in Science",
+    "General Studies AA - Social and Behavioral Sciences — Associate in Science",
+    "General Studies AA - Wellness and Self-Development — Associate in Science",
+    "General Studies AS - Science and Quantitative Reasoning — Associate in Science",
+    "General Studies with Emphasis in Astronomy - Associate in Arts — Associate in Arts",
+    "General Studies with Emphasis in Health Science - Associate in Arts — Associate in Arts",
+    "General Studies with Emphasis in Natural Science - Associate in Arts — Associate in Arts",
+    "General Studies with Emphasis in Sociology - Associate in Arts — Associate of Arts",
+    "General Studies with Emphasis in Women and Gender Studies - Associate in Arts — Associate in Arts",
+    "General Studies: Arts and Humanities",
+    "General Studies: Business and Technology — Associate in Science",
+    "General Studies: Communication and Language Arts — Associate in Science",
+    "General Studies: Humanities and Fine Arts — Associate in Science",
+    "General Studies: Lifelong Health, Well-Being and Self-Development — Associate in Science",
+    "General Studies: Science — Associate in Science",
+    "General Studies: Science and Mathematics — Associate in Science",
+    "General Studies: Social and Behavioral Sciences",
+    "General Studies: Social and Behavioral Sciences — Associate in Science",
+    "General Studies: Social Science — Associate in Arts",
+    "General Studies: STEM",
+    "Geographic Information Systems – Certificate of Achievement — Associate of Science",
+    "Geographic Information Systems (GIS) (AS Degree S0851) — AS",
+    "Geographic Information Systems (GIS) (Certificate N0850) — AS",
+    "Geographic Information Systems and Technology – Associate in Science, Certificate of Achievement — Associate of Science",
+    "Geographic Information Systems Certificate of Achievement — Certificate of Achievement",
+    "Geographic Information Systems Data Acquisition Certificate of Completion — Certificate of Achievement",
+    "Geographic Information Systems Essentials Certificate of Completion — Certificate of Achievement",
+    "Geographic Information Systems for Business Certificate of Completion — Certificate of Achievement",
+    "Geographic Information Systems Literacy Certificate of Proficiency — Associate in Science",
+    "Geographic Information Systems Spatial Analysis Certificate of Completion — Certificate of Achievement",
+    "Geographic Information Systems Technology — Associate in Science",
+    "Geography - Associate in Arts for Transfer — Associate in Science",
+    "Geography - Associate in Arts Transfer Degree — Associate in Arts",
+    "Geography – Associate in Arts Degree for Transfer — Associate of Science",
+    "Geography — Associate in Arts",
+    "Geography — Associate in Science",
+    "Geography (AA-T Degree A0356) — Associate in Arts",
+    "Geography AA-T Degree — Associate in Arts",
+    "Geography Associate in Arts Degree — Associate in Science",
+    "Geography Associate in Arts Degree for Transfer — Associate in Science",
+    "Geography Associate in Arts for Transfer Degree — Associate of Science",
+    "Geography Associate in Science — Associate in Science",
+    "Geography Associate of Science Degree — Associate of Science",
+    "Geography for Transfer (AA-T) — Associate in Science",
+    "Geography, AA-T — Associate in Arts",
+    "Geology – Associate in Science Degree for Transfer — Associate of Science",
+    "Geology (AS-T Degree S0670) — Associate in Science",
+    "Geology AS-T Degree — Associate in Science",
+    "Geology Associate in Science — Associate in Science",
+    "Geology Associate in Science Degree — Associate in Science",
+    "Geology Associate in Science Degree for Transfer — Associate in Science",
+    "Geology Associate in Science for Transfer Degree — Associate in Science for Transfer",
+    "Geology for Transfer (AS-T) — Associate in Science",
+    "Geology for Transfer Degree (AS-T)",
+    "Geology, AS-T",
+    "Geospatial Technologies Certificate — Associate in Science",
+    "Geotech (Certificate T0677) — AS",
+    "German – Associate in Arts Degree — Associate of Science",
+    "German Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Gerontology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Global Awareness and Appreciation Certificate of Proficiency — Associate in Science",
+    "Global Studies - Associate in Arts for Transfer — Associate in Science",
+    "Global Studies - Associate in Arts Transfer Degree — Associate in Arts",
+    "Global Studies – Associate in Arts Degree for Transfer — Associate of Science",
+    "Global Studies AA-T Degree — Associate in Arts",
+    "Global Studies Associate in Arts Degree for Transfer — Associate in Science",
+    "Global Studies Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Global Studies Certificate of Achievement Level 1 — Associate in Science",
+    "Global Studies for Transfer (AA-T) — Associate in Science",
+    "Global Studies, AA-T — Associate in Arts",
+    "Global Trade and Logistics - Certificate of Achievement — Associate of Science",
+    "Global Trade Operations, Supply Chain Management Certificate of Achievement — Associate in Science",
+    "Golf Course and Sports Turf Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Google IT Support Professional - Certificate of Achievement — Associate in Science",
+    "Graphic and Interactive Design — Associate in Arts",
+    "Graphic Arts - Print Production Certificate of Achievement",
+    "Graphic Arts Certificate of Achievement",
+    "Graphic Arts, AA",
+    "Graphic Design - Associate in Arts — Associate in Science",
+    "Graphic Design & Marketing AA Degree — AA",
+    "Graphic Design Associate in Science and Certificate of Achievement — Associate in Science",
+    "Graphic Design Associate of Arts Degree — Associate of Arts",
+    "Graphic Design Certificate — Associate in Arts",
+    "Graphic Design Certificate of Achievement — Associate of Arts",
+    "Graphic Design Certificate of Achievement — Certificate of Achievement",
+    "Graphic Design Level I (Certificate N0487) — AS",
+    "Green HVAC Commercial Certificate of Achievement — Certificate of Achievement",
+    "Green HVAC Residential Certificate of Achievement — Certificate of Achievement",
+    "Green Technician Certificate of Career Preparation — Associate of Science",
+    "Greenhouse and Nursery Production Certificate — Associate in Science",
+    "Health Education — Associate in Science",
+    "Health Education and Promotion - Certificate of Achievement — Associate in Arts",
+    "Health Science AS Degree — Associate of Science",
+    "Health Science, AS",
+    "Health Sciences - Associate in Arts — Associate in Science",
+    "Health Sciences - Certificate of Achievement Level 2 — Associate in Science",
+    "Health Sciences – Associate in Science Degree — Associate of Science",
+    "Health Sciences — Associate of Science",
+    "Health Sciences Preparation for Transfer Certificate — Associate in Science",
+    "Heat Pumps Certificate of Achievement — Certificate of Achievement",
+    "Heating and Air Conditioning Certificate of Achievement",
+    "Heating and Air Conditioning, Refrigeration, AS",
+    "Heating, Ventilation, Air Conditioning and Refrigeration Associate of Science Degree — Associate of Science",
+    "Heating, Ventilation, Air Conditioning and Refrigeration Certificate of Achievement — Associate of Science",
+    "Heavy Equipment Mechanic Certificate of Achievement",
+    "Heavy Equipment Technician Certificate of Achievement",
+    "Heavy Equipment Technician, AS",
+    "Heavy/Medium Duty Clean Vehicle Technology Associate of Science Degree — Associate of Science",
+    "Heavy/Medium Duty Clean Vehicle Technology Certificate of Achievement — Associate of Science",
+    "Heavy/Medium Duty Truck Engine and Fuel Injection Technology Certificate of Achievement — Associate of Science",
+    "Heavy/Medium Duty Truck Engine and Fuel Injection Technology Certificate of Completion — Associate of Science",
+    "Heavy/Medium Duty Truck Technology Associate of Science Degree — Associate of Science",
+    "Heavy/Medium Duty Truck Technology Certificate of Achievement — Associate of Science",
+    "High Voltage Test Technician - Certificate of Achievement — Associate in Arts",
+    "High-Intermediate ESL Certificate of Competency",
+    "Historical Costume Making – Occupational Skills Certificate — Associate of Science",
+    "Historical Documentary Production Certificate of Achievement — Associate of Arts",
+    "History - Associate in Arts for Transfer — Associate in Arts",
+    "History - Associate in Arts for Transfer — Associate in Science",
+    "History - Associate in Arts Transfer Degree — Associate in Arts",
+    "History – Associate in Arts Degree for Transfer — Associate of Science",
+    "History — Associate in Arts",
+    "History — Associate in Arts for Transfer",
+    "History (AA-T Degree A0334) — Associate in Arts",
+    "History AA-T Degree — Associate in Arts",
+    "History Associate in Arts — Associate in Science",
+    "History Associate in Arts Degree — Associate in Science",
+    "History Associate in Arts Degree for Transfer — Associate in Science",
+    "History Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "History for Transfer (AA-T) — Associate in Science",
+    "History, AA",
+    "History, AA-T",
+    "History, AA-T — Associate in Arts",
+    "Histotechnician Training (AS Degree S0961) — AS",
+    "Histotechnology (BS Degree BS0962) — AS",
+    "Home Health Aide - Certificate of Accomplishment — Associate in Arts",
+    "Home Remodeling - Certificate of Achievement — Associate in Arts",
+    "Home Remodeling - Certificate of Completion — Associate in Arts",
+    "Honda PACT - Certificate of Achievement — Associate of Science",
+    "Horse Ranch Management - Level I (Certificate M0869) — AS",
+    "Horse Ranch Management (AS Degree S0102) — AS",
+    "Horticulture - Associate in Science — Associate in Arts",
+    "Horticulture - Certificate of Achievement — Associate in Arts",
+    "Horticulture - Irrigation Technician Certificate of Achievement",
+    "Horticulture - Landscape Arborist Certificate of Achievement",
+    "Horticulture - Nursery Management Certificate of Achievement",
+    "Horticulture - Sustainable Landscape Management Certificate of Achievement",
+    "Horticulture Science (Certificate N0489) — AS",
+    "Horticulture, AS",
+    "Hospitality and Restaurant Management (AS Degree S1307) — Associate of Science",
+    "Hospitality and Tourism Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Hospitality Front of House Essentials Certificate of Achievement",
+    "Hospitality Front of House Service Operations Certificate of Achievement",
+    "Hospitality Management - Associate in Science Transfer Degree — Associate in Arts",
+    "Hospitality Management – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Hospitality Management – Associate of Science Degree for Transfer — Associate of Science",
+    "Hospitality Management (AS-T Degree S0451) — Associate in Science",
+    "Hospitality Management Associate in Science for Transfer Degree — Associate of Arts",
+    "Hospitality Service Leadership – Certificate of Achievement — Associate of Science",
+    "Hospitality: Event Planning and Catering (Certificate E0379) — AS",
+    "Hospitality: Food Services (Certificate E1390) — AS",
+    "Hospitality: Hospitality Management - Level I (Certificate E1332) — AS",
+    "Hospitality: Restaurant Management - Level I (Certificate E1333) — AS",
+    "Hospitality/Culinary Arts Associate of Arts Degree — Associate of Arts",
+    "Hospitality/Culinary Arts Certificate of Achievement — Associate of Arts",
+    "Human Development and Family — Associate in Science",
+    "Human Prosection (Certificate N0450) — AS",
+    "Human Resource Generalist Certificate of Achievement — Certificate of Achievement",
+    "Human Resource Management (AS Degree S0530) — AS",
+    "Human Resources Essentials - Certificate of Achievement — Associate in Arts",
+    "Human Resources Management - Certificate of Achievement — Associate in Arts",
+    "Human Resources Management Certificate — Associate in Arts",
+    "Human Services Associate of Arts Degree — Associate of Arts",
+    "Human Services Certificate of Achievement — Associate of Arts",
+    "Humanities – Associate in Arts Degree — Associate of Science",
+    "Humanities — AA",
+    "Humanities — Associate in Arts",
+    "Humanities Associate in Arts — Associate in Science",
+    "Humanities Emphasis ( AA Degree A8984) — AS",
+    "Hybrid, Fuel-Cell, & Electric Vehicle Certificate of Achievement — Certificate of Achievement",
+    "Illustration Certificate — Associate in Arts",
+    "Illustration Level 1 (Certificate N0969) — AS",
+    "Illustrator Skills Certificate of Completion — Certificate of Completion",
+    "InDesign Certificate of Completion — Certificate of Completion",
+    "Individual Taxation Certificate — Associate in Science",
+    "Industrial Automation Certificate of Achievement — Associate of Science",
+    "Industrial Design - Associate in Science — Associate in Arts",
+    "Industrial Design – Occupational Skills Certificate — Associate of Science",
+    "Industrial Design Engineering - Level I (Certificate N0651) — AS",
+    "Industrial Design Engineering (AS Degree S0331) — AS",
+    "Industrial Drafting — Level I Certificate — Associate in Science",
+    "Industrial Drafting — Level II Certificate — Associate in Science",
+    "Industrial Drafting Associate in Science Degree — Associate in Science",
+    "Industrial Fabricator – Occupational Skills Certificate — Associate of Science",
+    "Industrial Maintenance Technician Certificate — Associate in Science",
+    "Industrial Technology - Electrical Apprenticeship Certificate of Achievement",
+    "Industrial Technology - Level I Certificate of Achievement",
+    "Industrial Technology - Level II - Mechanical Certificate of Achievement",
+    "Industrial Technology - Maintenance Apprenticeship Certificate of Achievement",
+    "Industrial Technology - Mechanical Apprenticeship Certificate of Achievement",
+    "Industrial Technology - Operations Apprenticeship Certificate of Achievement",
+    "Industrial Technology Associate in Science Degree — Associate in Science",
+    "Infant and Toddler Teacher Certificate — Associate in Science",
+    "Infants and Toddlers Associate in Science and Certificate of Achievement — Associate in Science",
+    "Information Security and Cyber Defense Certificate of Achievement — Associate of Science",
+    "Information Systems and Technology Associate of Science Degree — Associate of Science",
+    "Information Technology — AS",
+    "Information Technology Cybersecurity - Associate in Science — Associate in Arts",
+    "Information Technology Cybersecurity - Certificate of Achievement — Associate in Arts",
+    "Information Technology Emphasis (AA degree A8985) — AS",
+    "Information Technology Emphasis (AA Degree A8985) — AS",
+    "Information Technology Emphasis, AA Liberal Arts and Sciences (Degree A8985) — AS",
+    "Information Technology Support Specialist Associate in Science and Certificate of Achievement — Associate in Science",
+    "Information Technology Technician Certificate of Proficiency — Associate in Science",
+    "Insurance Services Certificate of Proficiency — Associate in Science",
+    "Integers Certificate of Competency — Certificate of Competency",
+    "Integrated Behavioral Health - Certificate of Specialization — Associate in Science",
+    "Integrated Pest Management (AS Degree S0311) — AS",
+    "Intercollegiate Athletics",
+    "Interdisciplinary Studies, Arts, Humanities, and Social Sciences Option, AA",
+    "Interdisciplinary Studies, Business Option, AA",
+    "Interdisciplinary Studies, Mathematics and Science Option, AS",
+    "Interdisciplinary Studies: Emphasis in Arts and Human Expression Associate in Arts Degree — Associate in Science",
+    "Interdisciplinary Studies: Emphasis in Science and Mathematics Associate in Arts Degree — Associate in Science",
+    "Interdisciplinary Studies: Emphasis in Social Behavior and Self-Development Associate in Arts — Associate in Science",
+    "Interdisciplinary Studies: Emphasis in Social Sciences Associate in Arts Degree — Associate in Science",
+    "Interfaith Religious Literacy Certificate of Achievement — Associate in Science",
+    "Interior Design - Associate in Science — Associate in Arts",
+    "Interior Design - Certificate of Achievement — Associate in Arts",
+    "Interior Design - Kitchen and Bath (AS Degree S1302) — Associate of Science",
+    "Interior Design - Level I (Certificate E0364) — AS",
+    "Interior Design – Occupational Skills Certificate — Associate of Science",
+    "Interior Design (AS Degree S1301) — Associate of Science",
+    "Interior Design Assistant Certificate — Associate in Science",
+    "Interior Design Associate in Science Degree — Associate in Science",
+    "Interior Design Certificate of Achievement",
+    "Interior Design, AA",
+    "Interior Landscaping (Certificate N0621) — AS",
+    "Intermediate Culinary Arts Certificate of Achievement — Certificate of Achievement",
+    "Intermediate Grammar - Certificate of Competency — Associate in Arts",
+    "Intermediate Oral Skills - Certificate of Competency — Associate in Arts",
+    "Intermediate Reading and Writing - Certificate of Competency — Associate in Arts",
+    "International Business (AS Degree S0507) — AS",
+    "International Business Associate in Science and Certificate of Achievement — Associate in Science",
+    "International Business Certificate of Achievement",
+    "International Business Management Associate in Science Degree — Associate in Arts",
+    "International Business Management Certificate — Associate in Arts",
+    "International Business Skills Certificate — Associate in Arts",
+    "Introduction to Computer Information Technology (Certificate E0712) — AS",
+    "Introduction to Computer Information Technology (Certificate M0818) — AS",
+    "Introduction to Computers - Certificate of Completion — Associate in Arts",
+    "Introduction to Film Certificate of Completion — Certificate of Achievement",
+    "Introduction to Gas Tungsten Arc Welding (GTAW) - Certificate of Achievement — Associate in Arts",
+    "Introduction to Screenwriting Certificate of Completion — Certificate of Achievement",
+    "Introduction to Shielded Metal Arc Welding (SMAW) - Certificate of Achievement — Associate in Arts",
+    "Introduction to Urban Planning - Certificate of Accomplishment — Associate in Arts",
+    "iOS Application Security Support Specialist Certificate of Achievement — Associate of Science",
+    "IPC-620 Wire Harness Assembly and Inspection - Certificate of Completion — Associate in Arts",
+    "Irrigation Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Italian – Associate in Arts Degree — Associate of Science",
+    "Italian – Certificate of Achievement — Associate of Science",
+    "Japanese – Associate in Arts Degree — Associate of Science",
+    "Japanese — Associate in Arts",
+    "Japanese Associate in Arts — Associate in Science",
+    "Jazz Piano Teaching Certificate — Associate in Science",
+    "Jewelry Design Certificate of Achievement — Associate in Science",
+    "Jewelry Entrepreneurship - Certificate of Achievement — Associate in Arts",
+    "Jewelry/Metalworking – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Job Readiness Skills Certificate of Completion — Certificate of Completion",
+    "Journalism - Associate in Arts — Associate in Arts",
+    "Journalism - Associate in Arts for Transfer — Associate in Science",
+    "Journalism - Associate in Arts Transfer Degree — Associate in Arts",
+    "Journalism – Associate in Arts Degree for Transfer — Associate of Science",
+    "Journalism – Photojournalism – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Journalism – Printed Media – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Journalism AA-T Degree — Associate in Arts",
+    "Journalism Associate in Arts Degree — Associate in Science",
+    "Journalism Associate in Arts Degree for Transfer — Associate in Science",
+    "Journalism Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Journalism Certificate — Associate in Science",
+    "Journalism Certificate of Achievement — Associate in Arts for Transfer",
+    "Journalism for Transfer (AA-T) — Associate in Science",
+    "Journalism, AA-T",
+    "Junior Game Designer - Level I (Certificate E0886) — AS",
+    "Killer Robots, Drugs, and Mirror Molecules: Ethical Decision-Making in a Rapidly Changing World Certificate of Achievement — Associate in Science",
+    "Kinesiology",
+    "Kinesiology - Associate in Arts — Associate in Arts",
+    "Kinesiology - Associate in Arts for Transfer — Associate in Arts",
+    "Kinesiology - Associate in Arts for Transfer — Associate in Science",
+    "Kinesiology - Associate in Arts Transfer Degree — Associate in Arts",
+    "Kinesiology - Certificate of Achievement Level 2 — Associate in Science",
+    "Kinesiology – Associate in Arts Degree for Transfer — Associate of Science",
+    "Kinesiology — Associate in Arts",
+    "Kinesiology — Associate of Science",
+    "Kinesiology (AA-T Degree A0454) — Associate in Arts",
+    "Kinesiology & Wellness – Associate in Arts Degree — Associate of Science",
+    "Kinesiology AA-T Degree — Associate in Arts",
+    "Kinesiology and Wellness Emphasis (AA Degree A8986) — AS",
+    "Kinesiology Associate in Arts Degree for Transfer — Associate in Science",
+    "Kinesiology Associate in Arts for Transfer Degree — Associate of Arts",
+    "Kinesiology Associate of Arts Degree — Associate of Arts",
+    "Kinesiology for Transfer (AA-T)",
+    "Kinesiology for Transfer (AA-T) — Associate in Science",
+    "Kinesiology, AA-T",
+    "Kinesiology, AA-T — Associate in Arts",
+    "Kumeyaay Studies Associate in Arts — Associate in Science",
+    "Kumeyaay Studies Certificate of Achievement — Associate in Science",
+    "Laboratory Occupational Safety and Health Technician Certificate of Achievement — Associate in Science",
+    "Landscape & Irrigation Technician Certificate of Achievement — Certificate of Achievement",
+    "Landscape and Park Maintenance (Certificate N0623) — AS",
+    "Landscape Architecture Associate in Science and Certificate of Achievement — Associate in Science",
+    "Landscape Construction (Certificate N0624) — AS",
+    "Landscape Design - Level I (Certificate N0625) — AS",
+    "Landscape Design/Management Certificate — Associate in Science",
+    "Landscape Horticulture Certificate — Associate in Science",
+    "Landscape Irrigation (Certificate N0627) — AS",
+    "Landscape Management Associate in Science Degree — Associate in Science",
+    "Landscape Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Language and Thought Certificate of Competency — Certificate of Competency",
+    "Language Arts Emphasis (AA Degree A8987) — AS",
+    "Laser Technology - Certificate of Achievement Level 1 — Associate in Science",
+    "Laser Technology – Associate in Science, Certificate of Achievement — Associate of Science",
+    "Laser Technology Essentials– Certificate of Achievement — Associate of Science",
+    "Latin American Studies Associate in Arts — Associate in Science",
+    "Latin-American Studies Associate in Arts Degree — Associate in Science",
+    "Law Enforcement Associate in Science and Certificate of Achievement — Associate in Science",
+    "Law Enforcement Certificate of Achievement",
+    "Law Enforcement, AS",
+    "Law School First-Year Prep Specialty Certificate — Associate in Science",
+    "Law, Public Policy and Society - Associate in Arts for Transfer — Associate in Arts",
+    "Law, Public Policy and Society (AA-T)",
+    "Law, Public Policy and Society Associate in Arts Degree for Transfer — Associate in Science",
+    "Law, Public Policy, and Society - Associate in Arts for Transfer — Associate in Science",
+    "Law, Public Policy, and Society – Associate in Arts Degree for Transfer — Associate of Science",
+    "Law, Public Policy, and Society, AA-T",
+    "Leadership Certificate of Achievement — Associate of Arts",
+    "Learning in New Media Classrooms — Certificate of Achievement",
+    "Lesbian, Gay, Bisexual and Transgender Studies — AA",
+    "Liberal Arts - Biological and Physical Sciences Associate of Arts Degree — Associate of Arts",
+    "Liberal Arts - Humanities and Fine Arts Associate of Arts Degree — Associate of Arts",
+    "Liberal Arts - Social and Behavioral Sciences Associate of Arts Degree — Associate of Arts",
+    "Liberal Arts — AA",
+    "Liberal Arts AA Degree with Emphasis in Arts, Humanities, and Communication Studies — AA",
+    "Liberal Arts AA Degree with Emphasis in Business and Technology — AA",
+    "Liberal Arts AA Degree with Emphasis in Math and Science — AA",
+    "Liberal Arts AA Degree with Emphasis in Social and Behavioral Sciences — AA",
+    "Liberal Arts: Arts and Humanities - Associate in Arts — Associate in Science",
+    "Liberal Arts: Pathway to Health Sciences",
+    "Liberal Arts: Scientific Inquiry and Quantitative Reasoning - Associate in Arts — Associate in Science",
+    "Liberal Arts: Social and Behavioral Sciences - Associate in Arts — Associate in Science",
+    "Library Technician - Associate in Science — Associate in Arts",
+    "Library Technician - Certificate of Achievement — Associate in Arts",
+    "Library Technician - Certificate of Completion — Associate in Arts",
+    "Library Technician Basic Digitization - Certificate of Completion — Associate in Arts",
+    "Library Technician Public Services - Certificate of Completion — Associate in Arts",
+    "Library Technician School & Youth Services - Certificate of Completion — Associate in Arts",
+    "Library Technician Technical Services - Certificate of Completion — Associate in Arts",
+    "Library Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Library Technology Associate of Arts Degree — Associate of Arts",
+    "Library Technology Certificate of Achievement — Associate of Arts",
+    "Light-Duty Diesel Generator Engine Maintenance - Certificate of Completion — Associate in Arts",
+    "Lighting and Controls Technology Certificate of Achievement — Certificate of Achievement",
+    "Lighting Technician Certificate — Associate in Science",
+    "Line Cook Certificate of Achievement — Associate of Science",
+    "Linguistics - Associate in Arts — Associate in Arts",
+    "Linguistics – Associate in Arts Degree — Associate of Science",
+    "Livestock Production Management (Certificate M0870) — AS",
+    "Logistics and Transportation Supervisor Certificate of Achievement",
+    "Logistics and Transportation, AS",
+    "Los Angeles Structural Welding License – Certificate of Achievement — Associate of Science",
+    "Low-Intermediate ESL Certificate of Competency",
+    "LVN to RN Career Ladder - Associate in Science — Associate in Arts",
+    "Machine Shop Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Machine Technology - Associate in Science — Associate in Science",
+    "Machine Technology Level I Certificate — Associate in Science",
+    "Machine Technology Level II Certificate — Associate in Science",
+    "Machine Technology: CNC Machine Operator - Certificate of Achievement Level 2 — Associate in Science",
+    "Machine Technology: CNC, CAD/CAM Machininist - Certificate of Achievement Level 3 — Associate in Science",
+    "Machine Technology: Entry Level Machinist - Certificate of Achievement Level 2 — Associate in Science",
+    "Machining Technology, AS",
+    "Magnetic Resonance Imaging Technologist - Certificate of Accomplishment — Associate in Arts",
+    "Makerspace Basic Skills — Certificate of Achievement",
+    "Mammography (Certificate E0398) — AS",
+    "Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Manual Machining Certificate of Achievement",
+    "Manufacturing Engineering Technician – Certificate of Achievement — Associate of Science",
+    "Manufacturing Foundation (Certificate E0421) — AS",
+    "Manufacturing Technology (AS Degree S0918) — Associate in Science",
+    "Manufacturing Technology (Certificate T0918) — AS",
+    "Manufacturing Technology Associate in Science Degree — Associate in Science",
+    "Marine Biology Associate in Science — Associate in Science",
+    "Marketing Associate in Science and Certificate of Achievement — Associate in Science",
+    "Marketing Management (AS Degree S0510) — AS",
+    "Marketing Management (Certificate N0626) — AS",
+    "Marketing Management Associate in Science Degree — Associate in Science",
+    "Marketing Management Certificate — Associate in Science",
+    "Marketing Management Skills Certificate — Associate in Science",
+    "MasterCAM (Certificate E0927) — AS",
+    "Mastercam Certificate — Associate in Science",
+    "Mastercam Skills Certificate — Associate in Science",
+    "Mathematics - Associate in Science — Associate in Arts",
+    "Mathematics - Associate in Science for Transfer — Associate in Arts",
+    "Mathematics – Associate in Science Degree for Transfer — Associate of Science",
+    "Mathematics — Associate in Science",
+    "Mathematics — Associate in Science for Transfer",
+    "Mathematics (AS-T Degree S0333) — Associate in Science",
+    "Mathematics 2.0 - Associate in Science Transfer Degree — Associate in Arts",
+    "Mathematics Associate in Science — Associate in Science",
+    "Mathematics Associate in Science and Certificate of Achievement — Associate in Science",
+    "Mathematics Associate in Science Degree — Associate in Science",
+    "Mathematics Associate in Science Degree for Transfer — Associate in Science",
+    "Mathematics Associate in Science for Transfer Degree — Associate in Science for Transfer",
+    "Mathematics Emphasis (AA Degree A8989) — AS",
+    "Mathematics for Transfer (AS-T) — Associate in Science",
+    "Mathematics for Transfer Degree (AS-T)",
+    "Mathematics Study Skills Certificate of Completion — Certificate of Competency",
+    "Mathematics, AS-T",
+    "Mathematics, AS-T — Associate in Science",
+    "Mechanical and Aerospace Engineering Associate in Science — Associate in Science",
+    "Mechanical Engineering - Certificate of Achievement — Associate in Arts",
+    "Mechanical Engineering Technician – Certificate of Achievement — Associate of Science",
+    "Mechatronics — AS",
+    "Mechatronics Certificate of Achievement — Associate in Science",
+    "Media Communications Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Media Development Certificate of Achievement — Associate of Arts",
+    "Media Programming & Management – Occupational Skills Certificate — Associate of Science",
+    "Medical Administrative Assistant Certificate of Achievement",
+    "Medical Assistant - Front Office - Certificate of Achievement — Associate in Arts",
+    "Medical Assisting – Administrative and Clinical – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Medical Assisting – Medical Scribe Specialist – Occupational Skills Certificate — Associate of Science",
+    "Medical Assisting – Patient Intake Specialist – Occupational Skills Certificate — Associate of Science",
+    "Medical Assisting: Administrative - Associate in Science — Associate in Science",
+    "Medical Assisting: Administrative - Certificate of Achievement Level 3 — Associate in Science",
+    "Medical Assisting: Administrative Option - Certificate of Achievement — Associate in Arts",
+    "Medical Assisting: Clinical - Associate in Science — Associate in Science",
+    "Medical Assisting: Clinical - Certificate of Achievement Level 3 — Associate in Science",
+    "Medical Assisting: Clinical Option - Certificate of Achievement — Associate in Arts",
+    "Medical Assisting: Combined Administrative/Clinical - Associate in Science — Associate in Arts",
+    "Medical Assisting: Combined Administrative/Clinical - Certificate of Achievement — Associate in Arts",
+    "Medical Career Preparation - Certificate of Completion-Noncredit — Associate in Science",
+    "Medical Coding and Billing Certificate of Achievement — Associate of Science",
+    "Medical Insurance Billing - Certificate of Accomplishment — Associate in Arts",
+    "Medical Office Assistant Certificate of Achievement — Associate in Science",
+    "Medical Sector Hospitality Food And Beverage Leadership – Certificate of Achievement — Associate of Science",
+    "Mental Health Specialist Certificate of Achievement",
+    "Mental Health Technology - Psychiatric Technician (AS Degree S1208) — Associate in Science",
+    "Mental Health Technology - Psychiatric Technician (Certificate T1279) — Associate in Science",
+    "Merchandising Certificate of Achievement",
+    "Metal Fabrication Technology - Associate in Science — Associate in Arts",
+    "Metal Fabrication Technology - Certificate of Achievement — Associate in Arts",
+    "Metal Fabrication Technology - Certificate of Completion — Associate in Arts",
+    "Meteorology Associate in Science Degree — Associate in Science",
+    "Metrology Certificate — Associate in Science",
+    "Metrology Mini Skills Certificate — Associate in Science",
+    "Microbiology Associate in Science Degree — Associate in Science",
+    "Microcomputer Productivity Software (Certificate N0660) — AS",
+    "Microsoft Access for Windows - Certificate of Completion — Associate in Arts",
+    "Microsoft Essentials - Certificate of Achievement — Associate in Arts",
+    "Microsoft Excel - Certificate of Completion — Associate in Arts",
+    "Microsoft Office - Certificate of Completion — Associate in Arts",
+    "Microsoft Outlook - Certificate of Completion — Associate in Arts",
+    "Microsoft PowerPoint - Certificate of Completion — Associate in Arts",
+    "Microsoft Windows Networking Technician - Certificate of Achievement — Associate in Arts",
+    "Microsoft Word for Windows - Certificate of Completion — Associate in Arts",
+    "Middle East Studies Certificate of Proficiency — Associate in Science",
+    "Mindfulness Certificate — Associate in Science",
+    "Mobile Applications Entrepreneur Certificate — Associate in Arts",
+    "Modern Languages — Associate in Arts for Transfer",
+    "Modern Policing, AS",
+    "Motion Graphic Design - Associate In Science — Associate in Science",
+    "Motion Graphic Design - Certificate of Achievement - Level 2 — Associate in Science",
+    "Multimedia Certificate of Achievement",
+    "Multimedia Journalism Certificate — Associate in Science",
+    "Multimedia, AA",
+    "Municipal Clerk Certificate of Achievement",
+    "Museum Assistant Certificate — Associate in Arts",
+    "Music - Associate in Arts — Associate in Arts",
+    "Music - Associate in Arts for Transfer — Associate in Arts",
+    "Music - Associate in Arts Transfer Degree — Associate in Arts",
+    "Music – Associate in Arts Degree — Associate of Science",
+    "Music – Associate in Arts Degree for Transfer — Associate of Science",
+    "Music – Certificate of Achievement — Associate of Science",
+    "Music — Associate in Arts",
+    "Music (AA-T Degree A0347) — Associate in Arts",
+    "Music AA-T Degree — Associate in Arts",
+    "Music Associate in Arts — Associate in Science",
+    "Music Associate in Arts Degree — Associate in Science",
+    "Music Associate in Arts Degree for Transfer — Associate in Science",
+    "Music Associate in Arts for Transfer Degree — Associate of Arts",
+    "Music Associate of Arts Degree — Associate of Arts",
+    "Music Education Associate in Arts — Associate in Science",
+    "Music Education Certificate of Achievement — Associate in Science",
+    "Music Entrepreneurship – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Music for Transfer (AA-T)",
+    "Music for Transfer (AA-T) — Associate in Science",
+    "Music Industry Studies Associate in Arts — Associate in Science",
+    "Music Recording and Production Certificate — Associate in Science",
+    "Music Studies - Level I (Certificate N0889) — AS",
+    "Music Technology — Associate in Arts",
+    "Music Technology Recording - Certificate of Achievement - Level 2 — Associate in Science",
+    "Music, AA",
+    "Music, AA-T",
+    "Music: General — Associate in Arts",
+    "Musical Theatre Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Musical Theatre Certificate of Achievement — Certificate of Achievement",
+    "Musical Theatre Level 1 Certificate — Associate in Science",
+    "Natural Resources AS Degree (transfer preparation) — Associate of Science",
+    "Natural Science — AS",
+    "Natural Sciences – Associate in Science Degree — Associate of Science",
+    "Natural Sciences Emphasis (AA Degree A8988) — AS",
+    "Network and Cybersecurity Technician Certificate of Proficiency — Associate in Science",
+    "Network Cabling Specialist - Certificate of Accomplishment — Associate in Arts",
+    "Networking Certificate — Associate in Science",
+    "Networking Fundamentals - Certificate of Completion — Associate in Arts",
+    "Networking Skills Certificate — Associate in Science",
+    "Networking, Security and System Administration - Enterprise Networking Associate in Science and Certificate of Achievement — Associate in Science",
+    "Networking, Security and System Administration - Enterprise System Administration Associate in Science and Certificate of Achievement — Associate in Science",
+    "New World of Work Adaptability Certificate of Completion — Certificate of Completion",
+    "New World of Work Analysis/Solution Mindset Certificate of Completion — Certificate of Completion",
+    "New World of Work Collaboration on the Job Certificate of Completion — Certificate of Completion",
+    "New World of Work Communication on the Job Certificate of Completion — Certificate of Completion",
+    "New World of Work Digital Fluency Certificate of Completion — Certificate of Completion",
+    "New World of Work Empathy on the Job Certificate of Completion — Certificate of Completion",
+    "New World of Work Entrepreneurial Mindset Certificate of Completion — Certificate of Completion",
+    "New World of Work Resilience on the Job Certificate of Completion — Certificate of Completion",
+    "New World of Work Self-Awareness Certificate of Completion — Certificate of Completion",
+    "New World of Work Social Diversity Awareness Certificate of Completion — Certificate of Completion",
+    "Non-Credit: 12-Lead ECG Interpretation — Certificate of Completion",
+    "Non-Credit: Bridge to College ESL Pathway — Certificate of Competency",
+    "Non-Credit: Bridge to College Level English — Certificate of Competency",
+    "Non-Credit: Bridge to College Level Mathematics — Certificate of Completion",
+    "Non-Credit: Commercial Photography — Certificate of Completion",
+    "Non-Credit: Emergency Medical Technician (formerly Emergency Medical Technology) — Certificate of Completion",
+    "Non-Credit: English as a Second Language for College and Careers (Advanced) — Certificate of Competency",
+    "Non-Credit: English as a Second Language for College and Careers (High-Intermediate) — Certificate of Competency",
+    "Non-Credit: English as a Second Language for Food Service Workers — Certificate of Completion",
+    "Non-Credit: English as a Second Language-Beginning — Certificate of Competency",
+    "Non-Credit: English as a Second Language-Intermediate — Certificate of Competency",
+    "Non-Credit: Photography — Associate in Arts",
+    "Non-Credit: Theatre Costume and Makeup — Certificate of Completion",
+    "Non-Credit: Theatre Production Organization — Certificate of Completion",
+    "Non-Credit: Theatre Technology — Certificate of Completion",
+    "Noncredit ESL Milestone for Multilingual Speakers - Introduction to Health Careers",
+    "Noncredit ESL Milestone for Multilingual Speakers - Pathway to Digital Media",
+    "Noncredit ESL Milestone for Multilingual Speakers - Pathway to Health Careers Certificate of Completion",
+    "Nurse Assistant and Home Health Aide Certificate of Completion",
+    "Nursery Management (Certificate N0628) — AS",
+    "Nursery Management Associate in Arts Degree — Associate in Science",
+    "Nursery Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Nursing - Associate in Science — Associate of Science",
+    "Nursing - Licensed Psychiatric Technician (LPT) to Registered Nurse (RN) Option (AS Degree S0959) — Associate in Science",
+    "Nursing - Licensed Vocational Nurse (LVN) 30-Unit Option - Nondegree — Associate in Science",
+    "Nursing - Licensed Vocational Nurse (LVN) to Registered Nurse (RN) Option (AS Degree S0957) — Associate in Science",
+    "Nursing - Registered Nursing (RN) Generic Option (AS Degree S0958) — Associate in Science",
+    "Nursing – Registered Nursing – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Nursing — Associate of Science",
+    "Nursing Assistant - Certificate of Accomplishment — Associate in Arts",
+    "Nursing Assistant — Certificate",
+    "Nursing Associate in Science — Associate in Science",
+    "Nursing Associate of Science Degree — Associate of Science",
+    "Nursing-Registered Nursing",
+    "Nursing-Vocational Nursing",
+    "Nursing, AS",
+    "Nursing, Registered — AA",
+    "Nursing: Vocational/Practical - Associate in Science — Associate in Arts",
+    "Nursing: Vocational/Practical - Certificate of Achievement — Associate in Arts",
+    "Nursing: Vocational/Practical — Associate of Science",
+    "Nutrition (Certificate N0453) — AS",
+    "Nutrition and Dietetics - Associate in Science for Transfer — Associate in Science",
+    "Nutrition and Dietetics - Associate in Science Transfer Degree — Associate in Arts",
+    "Nutrition and Dietetics – Associate in Science Degree for Transfer — Associate of Science",
+    "Nutrition and Dietetics (AS-T Degree S0422) — Associate in Science",
+    "Nutrition and Dietetics AS-T Degree — Associate in Science",
+    "Nutrition and Dietetics Associate in Science Degree for Transfer — Associate in Science",
+    "Nutrition and Dietetics Associate in Science for Transfer Degree — Associate in Science for Transfer",
+    "Nutrition and Dietetics-Associate in Science for Transfer — Associate in Arts",
+    "Nutrition and Dietetics, AS-T — Associate in Science",
+    "Nutrition and Fitness Education - Certificate of Achievement — Associate in Arts",
+    "Nutrition and Food Science — Associate in Science",
+    "Nutrition and Foods Associate in Arts Degree — Associate in Science",
+    "Nutrition and Foods Certificate — Associate in Science",
+    "Nutrition and Technology - Certificate of Achievement — Associate in Arts",
+    "Nutrition and Wellness for Healthy Aging - Certificate of Achievement — Associate in Arts",
+    "Nutrition Assistant - Associate in Science — Associate in Arts",
+    "Nutrition Associate in Science and Certificate of Achievement — Associate in Science",
+    "Nutrition, Wellness, and Healthy Cooking - Certificate of Achievement — Associate in Arts",
+    "Occupational Safety and Health (OSH) Management Associate in Science — Associate in Science",
+    "Occupational Safety and Health (OSH) Technician Certificate of Achievement — Associate in Science",
+    "Occupational Therapy Assistant Associate in Science — Associate in Science",
+    "Oceanography Associate in Science — Associate in Science",
+    "Oceanography Associate in Science Degree — Associate in Science",
+    "Office Administration: Management - Associate in Science — Associate in Arts",
+    "Office Applications Apprentice Certificate — Associate in Science",
+    "Office Applications Technician Certificate — Associate in Science",
+    "Office Assistant Level I Certificate of Specialization — Associate in Science",
+    "Office Assistant Level II Certificate of Specialization — Associate in Science",
+    "Office Assistant, Level I Certificate of Proficiency — Associate in Science",
+    "Office Assistant, Level II Certificate of Proficiency — Associate in Science",
+    "Office Professional Certificate of Proficiency — Associate in Science",
+    "Office Professional Certificate of Specialization — Associate in Science",
+    "Office Software Specialist Level I Certificate of Specialization — Associate in Science",
+    "Office Software Specialist Level II Certificate of Specialization — Associate in Science",
+    "Office Software Specialist, Level I Certificate of Proficiency — Associate in Science",
+    "Office Software Specialist, Level II Certificate of Proficiency — Associate in Science",
+    "Office Technologies – Job Search Skills - Certificate of Completion — Associate in Arts",
+    "Office Technologies – Microsoft Access - Certificate of Completion — Associate in Arts",
+    "Office Technologies – Microsoft Excel - Certificate of Completion — Associate in Arts",
+    "Office Technologies – Microsoft Outlook - Certificate of Completion — Associate in Arts",
+    "Office Technologies – Microsoft PowerPoint - Certificate of Completion — Associate in Arts",
+    "Office Technologies – Microsoft Word - Certificate of Completion — Associate in Arts",
+    "Office Technology Fundamentals Certificate of Completion — Associate of Science",
+    "Online Teaching and Educational Technology - Certificate of Achievement — Associate in Arts",
+    "Organization Certificate of Competency — Certificate of Competency",
+    "Ornamental Horticulture (AS Degree S0119) — AS",
+    "Ornamental Horticulture Associate in Science Degree — Associate in Science",
+    "Ornamental Horticulture Certificate — Associate in Science",
+    "Orthodontic Assistant – Occupational Skills Certificate — Associate of Science",
+    "Orthopedic Technology Associate in Science and Certificate of Achievement — Associate in Science",
+    "Oxy-Fuel Processes and Shielded Metal Arc Welding (SMAW) Certificate of Achievement",
+    "Paralegal Studies - Associate in Arts — Associate in Arts",
+    "Paralegal Studies - Associate in Science — Associate in Arts",
+    "Paralegal Studies - Certificate of Achievement — Associate in Arts",
+    "Paralegal Studies – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Paralegal Studies Associate in Science — Associate in Science",
+    "Paralegal Studies Associate in Science Degree — Associate in Science",
+    "Paralegal Studies Certificate — Associate of Arts",
+    "Paralegal/Legal Assistant (AS Degree S0310) — AS",
+    "Paralegal/Legal Assistant (Certificate T0968) — AS",
+    "Paralegal/Legal Assistant Studies Certificate of Achievement",
+    "Paralegal/Legal Assistant Studies, AS",
+    "Paramedic — Associate in Science",
+    "Paramedic (Certificate T0425) — AS",
+    "Paraprofessional Preparation Certificate of Achievement",
+    "Parent Educator - Certificate of Completion — Associate in Arts",
+    "Park and Sports Turf Management (AS Degree S0116) — AS",
+    "Park Management (Certificate N0629) — AS",
+    "Pastry Arts Associate in Science and Certificate of Achievement — Associate in Science",
+    "Pastry Cook Certificate of Achievement — Associate of Science",
+    "Patient Navigator - Certificate of Achievement Level 1 — Associate in Science",
+    "Payroll Accounting Certificate — Associate in Science",
+    "Peer Leader Training - Certificate of Specialization — Associate in Science",
+    "Performing Arts — Associate of Arts",
+    "Personal Financial Planning - Certificate of Accomplishment — Associate in Arts",
+    "Personal Trainer - Certificate of Achievement — Associate in Arts",
+    "Personal Trainer — Certificate of Achievement",
+    "Personal Trainer Certificate — Associate in Science",
+    "Personal Trainer Certificate of Achievement — Certificate of Achievement",
+    "Pest Management Certificate — Associate in Science",
+    "Pest Management Technician Certificate of Achievement — Certificate of Achievement",
+    "Pet Science (Certificate N0630) — AS",
+    "Pharmacy Technician — Associate in Science",
+    "Pharmacy Technician Certificate of Achievement — Certificate of Achievement",
+    "Pharmacy Technology — Associate of Science",
+    "Pharmacy Technology Associate of Science Degree — Associate of Science",
+    "Pharmacy Technology Certificate of Achievement — Associate of Science",
+    "Philosophy - Associate in Arts Transfer Degree — Associate in Arts",
+    "Philosophy – Associate in Arts Degree for Transfer — Associate of Science",
+    "Philosophy – Associate in Arts for Transfer — Associate in Arts",
+    "Philosophy — Associate in Arts",
+    "Philosophy (AA-T Degree A0424) — Associate in Arts",
+    "Philosophy AA-T Degree — Associate in Arts",
+    "Philosophy Associate in Arts — Associate in Science",
+    "Philosophy Associate in Arts Degree — Associate in Science",
+    "Philosophy Associate in Arts Degree for Transfer — Associate in Science",
+    "Philosophy Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Philosophy for Transfer (AA-T) — Associate in Science",
+    "Philosophy, AA-T — Associate in Arts",
+    "Phlebotomy - Certificate of Accomplishment — Associate in Arts",
+    "Photography",
+    "Photography - Associate in Arts — Associate in Arts",
+    "Photography - Certificate of Achievement — Associate in Arts",
+    "Photography - Level I (Certificate N0631) — AS",
+    "Photography – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Photography — AS",
+    "Photography — Associate in Arts",
+    "Photography (AS Degree S1002) — AS",
+    "Photography Associate in Arts — Associate in Science",
+    "Photography Associate in Arts Degree — Associate in Science",
+    "Photography Certificate of Achievement",
+    "Photography Certificate of Achievement — Associate in Science",
+    "Photography Certificate of Achievement — Certificate of Achievement",
+    "Photography Digital Technician (Certificate N0632) — AS",
+    "Photography Video Production (Certificate N0633) — AS",
+    "Photography, AA",
+    "Photojournalism - Certificate of Achievement — Associate in Arts",
+    "Photoshop Skills Certificate of Completion — Certificate of Completion",
+    "Photovoltaic Design & Installation – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "PHP Web Programmer - Certificate of Achievement — Associate in Arts",
+    "Physical Education — Associate in Arts",
+    "Physical Education — Fitness Associate in Science Degree — Associate in Science",
+    "Physical Education Associate in Arts Degree — Associate in Science",
+    "Physical Education, AS",
+    "Physical Sciences - Associate in Science — Associate in Arts",
+    "Physical Therapist Assistant AS Degree — AS",
+    "Physics - Associate in Science for Transfer — Associate in Arts",
+    "Physics – Associate in Science Degree for Transfer — Associate of Science",
+    "Physics — Associate in Science",
+    "Physics 2.0 Associate in Science for Transfer Degree — Associate of Science",
+    "Physics AS-T Degree — Associate in Science",
+    "Physics Associate in Science — Associate in Science",
+    "Physics Associate in Science Degree for Transfer — Associate in Science",
+    "Physics Associate in Science Degree for UC Transfer — Associate in Science",
+    "Physics Associate of Science Degree — Associate of Science",
+    "Physics for Transfer (AS-T) — Associate in Science",
+    "Physics, AS-T",
+    "Piano Teaching Certificate — Associate in Science",
+    "Pilates Certificate — Associate in Science",
+    "Pilates Professional Teacher Training: Cadillac, Chair, Auxiliary (Certificate N0665) — AS",
+    "Pilates Professional Teacher Training: Mat and Reformer (Certificate N0667) — AS",
+    "Pipe Welding Certificate of Achievement — Associate of Science",
+    "Police Science, AS",
+    "Political Science - Associate in Arts for Transfer — Associate in Arts",
+    "Political Science - Associate in Arts for Transfer — Associate in Science",
+    "Political Science - Associate in Arts Transfer Degree — Associate in Arts",
+    "Political Science – Associate in Arts Degree for Transfer — Associate of Science",
+    "Political Science — Associate in Arts",
+    "Political Science (AA-T Degree A0345) — Associate in Arts",
+    "Political Science AA-T Degree — Associate in Arts",
+    "Political Science Associate in Arts — Associate in Science",
+    "Political Science Associate in Arts Degree for Transfer — Associate in Science",
+    "Political Science Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Political Science for Transfer (AA-T)",
+    "Political Science for Transfer (AA-T) — Associate in Science",
+    "Political Science, AA-T",
+    "Political Science, AA-T — Associate in Arts",
+    "Popular Music - Associate in Arts Degree — Associate of Science",
+    "Post-Production Certificate of Achievement — Associate of Arts",
+    "Power Generation and Distribution Certificate of Achievement — Certificate of Achievement",
+    "Power Generation Technician - Electrical - Certificate of Completion — Associate in Arts",
+    "Power Performance and Data Collecting Certificate of Achievement",
+    "Powerplant Maintenance Technician Certificate of Achievement — Associate of Science",
+    "Practical Entrepreneurship Certificate of Completion — Associate of Arts",
+    "Practical Politics Certificate — Associate in Science",
+    "Pre-Law Studies Certificate of Achievement",
+    "Pre-Nursing Associate in Science Degree — Associate in Science",
+    "Premier Pro Certificate of Completion — Certificate of Completion",
+    "Prep Cook Certificate of Achievement — Associate of Science",
+    "Prep Cook Certificate of Completion — Certificate of Achievement",
+    "Preschool Children Associate in Science and Certificate of Achievement — Associate in Science",
+    "Printing Technology (General) Certificate — Associate in Science",
+    "Printing Technology Associate in Science Degree — Associate in Science",
+    "Printmaking (Certificate N0653) — AS",
+    "Product Design – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Product Design – Graphics – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Product Design – Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Production Certificate of Achievement — Associate of Arts",
+    "Professional Baking and Management Associate of Arts Degree — Associate of Arts",
+    "Professional Photography Certificate — Associate in Science",
+    "Programmable Logic Controllers Certificate of Achievement — Associate in Science",
+    "Programming Certificate — Associate in Science",
+    "Programming In C++ (Certificate N0634) — AS",
+    "Programming Skills Certificate — Associate in Science",
+    "Project Management - Certificate of Achievement Level 1 — Associate in Science",
+    "Project Management Certificate of Achievement — Certificate of Achievement",
+    "Proper HVAC Systems Preperation and Systems Charging Certificate of Completion — Certificate of Achievement",
+    "Psychiatric Technician Certificate of Achievement",
+    "Psychiatric Technology — Associate of Science",
+    "Psychiatric Technology Associate of Science Degree — Associate of Science",
+    "Psychiatric Technology Certificate of Achievement — Associate of Science",
+    "Psychiatric Technology, AS",
+    "Psychology - Associate in Arts for Transfer — Associate in Arts",
+    "Psychology - Associate in Arts for Transfer — Associate in Science",
+    "Psychology - Associate in Arts Transfer Degree — Associate in Arts",
+    "Psychology – Associate in Arts Degree for Transfer — Associate of Science",
+    "Psychology — Associate in Arts",
+    "Psychology (AA-T Degree A0324) — Associate in Arts",
+    "Psychology AA-T Degree — Associate in Arts",
+    "Psychology Associate in Arts Degree — Associate in Science",
+    "Psychology Associate in Arts Degree for Transfer — Associate in Science",
+    "Psychology Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Psychology for Transfer (AA-T)",
+    "Psychology for Transfer (AA-T) — Associate in Science",
+    "Psychology, AA",
+    "Psychology, AA-T",
+    "Psychology, AA-T — Associate in Arts",
+    "Public Health - Associate in Science for Transfer — Associate in Science",
+    "Public Health - Associate in Science Transfer Degree — Associate in Arts",
+    "Public Health – Associate in Science Degree for Transfer — Associate of Science",
+    "Public Health (AS Degree S0428) — Associate of Science",
+    "Public Health (AS-T Degree S0857) — Associate in Science",
+    "Public Health AS-T Degree — Associate in Science",
+    "Public Health Associate in Science for Transfer Degree — Associate of Arts",
+    "Public Health for Transfer (AS-T) — Associate in Science",
+    "Public Health for Transfer Degree (AS-T)",
+    "Public Health, AS-T — Associate in Science",
+    "Public Relations Certificate — Associate in Science",
+    "Public Relations Certificate of Achievement",
+    "Public Safety Certificate of Achievement — Certificate of Achievement",
+    "Public Safety Dispatcher Certificate of Completion",
+    "Public Services: Transportation Security Administration Associate - Certificate of Accomplishment — Associate in Arts",
+    "Public Works/Landscape Management (Certificate M0635) — AS",
+    "Quickbooks Training - Certificate of Achievement — Certificate of Achievement",
+    "Radio and Television/Video Production Certificate — Associate in Science",
+    "Radio Broadcast News Associate in Arts Degree — Associate in Science",
+    "Radio Broadcast News Certificate — Associate in Science",
+    "Radio Broadcasting Associate in Arts Degree — Associate in Science",
+    "Radio Broadcasting Certificate — Associate in Science",
+    "Radio Production Associate in Arts Degree — Associate in Science",
+    "Radiologic Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Radiologic Technology — Associate in Science",
+    "Radiologic Technology (AS Degree S1206) — Associate of Science",
+    "Radiologic Technology Certificate of Achievement",
+    "Rational Numbers Certificate of Competency — Certificate of Competency",
+    "Reading Certificate of Completion — Certificate of Completion",
+    "Reading in the Health Sciences - Certificate of Completion — Associate in Arts",
+    "Reading Skills for ESL Students – Level 1 - Certificate of Competency — Associate in Arts",
+    "Reading Skills for ESL Students – Level 2 - Certificate of Competency — Associate in Arts",
+    "Reading Skills for ESL Students – Level 3 - Certificate of Competency — Associate in Arts",
+    "Real Estate - Associate in Science — Associate in Science",
+    "Real Estate - Certificate of Achievement Level 2 — Associate in Science",
+    "Real Estate (AS Degree S0512) — AS",
+    "Real Estate Associate in Science and Certificate of Achievement — Associate in Science",
+    "Real Estate Associate of Arts Degree — Associate of Arts",
+    "Real Estate Broker - Certificate of Accomplishment — Associate in Arts",
+    "Real Estate Broker (Certificate N0638) — AS",
+    "Real Estate Broker Certificate of Achievement",
+    "Real Estate Brokers Certificate — Associate in Science",
+    "Real Estate Certificate of Achievement",
+    "Real Estate Certificate of Achievement — Associate of Arts",
+    "Real Estate Development Certificate of Achievement — Certificate of Achievement",
+    "Real Estate Law Specialty Certificate — Associate in Science",
+    "Real Estate Management Associate in Science Degree — Associate in Science",
+    "Real Estate Management Certificate — Associate in Science",
+    "Real Estate Sales (Certificate M0954) — AS",
+    "Real Estate Sales Skills Certificate — Associate in Science",
+    "Real Estate Salesperson - Certificate of Accomplishment — Associate in Arts",
+    "Real Estate Salesperson Certificate of Achievement",
+    "Real Estate Styling and Staging (Certificate M0974) — AS",
+    "Real Estate, AS",
+    "Recreation Management — Associate in Science",
+    "Recreational Leadership–School-Based Programs Certificate of Specialization — Associate in Science",
+    "Refrigerant Management & EPA-608 Preparation Certificate of Completion — Certificate of Achievement",
+    "Refrigeration Certificate of Achievement",
+    "Registered Dental Assisting - Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Registered Nursing AS Degree — AS",
+    "Registered Nursing Program for Licensed Vocational Nurses, Licensed Psychiatric Technicians, and Military Experience to RN — Associate in Science",
+    "Registered Veterinary Technology (AS Degree S0105) — Associate in Science",
+    "Religious Studies Associate in Arts Degree — Associate of Arts",
+    "Research and Argument Certificate of Competency — Certificate of Competency",
+    "Research Fundamentals Skills Certificate — Associate in Science",
+    "Reserve Police Officer Certificate of Achievement — Certificate of Achievement",
+    "Residential Gas Heating Certificate of Achievement — Certificate of Achievement",
+    "Residential Interior Design Certificate — Associate in Science",
+    "Residential Solar Certificate of Achievement — Certificate of Achievement",
+    "Residential Solar Installation Certificate of Completion — Certificate of Achievement",
+    "Residential Solar Surveying and Planning Certificate of Completion — Certificate of Achievement",
+    "Respiratory Care",
+    "Respiratory Care — Associate in science",
+    "Respiratory Therapy — Associate in Science",
+    "Respiratory Therapy (AS Degree S1205) — Associate in Science",
+    "Respiratory Therapy Associate in Science — Associate in Science",
+    "Restaurant Service Certificate of Achievement — Associate of Arts",
+    "Restorative Dental Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Retail Management and Merchandising, AS",
+    "Retail Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Retail Management Certificate — Associate in Arts",
+    "Retail Management Certificate of Achievement",
+    "Retail Management Certificate of Achievement — Associate of Arts",
+    "Retail Management Certificate of Achievement — Certificate of Achievement",
+    "REVIT Essentials - Certificate of Completion — Associate in Arts",
+    "Robotic Welding Automation - Certificate of Achievement — Associate in Arts",
+    "Robotics Exploration - Certificate of Completion — Associate in Arts",
+    "Russian – Associate in Arts Degree — Associate of Science",
+    "Russian Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Sales Engineering (AS Degree S0852) — AS",
+    "San Joaquin Delta College Associate Degree General Education Pattern",
+    "Scenic Artist Certificate — Associate in Science",
+    "Scenic Artist Certificate of Achievement",
+    "Scenic Technician Certificate of Achievement",
+    "Scoring, Music Production and Sound Design Certificate — Associate in Science",
+    "Screen Printing Certificate — Associate in Science",
+    "Sculptural Design: 3D Materials and Processes - Certificate of Achievement — Associate in Arts",
+    "Secondary Education (GED) Certificate of Completion — Certificate of Completion",
+    "Security Guard Training - Certificate of Completion — Associate in Arts",
+    "Security Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Semi-Automatic Welding - Certificate of Achievement — Associate in Arts",
+    "Semiconductor Process Engineering — Associate in Science",
+    "Sentence Certificate of Competency — Certificate of Competency",
+    "Shielded Metal Arc Welding (SMAW) - Certificate of Achievement — Associate in Arts",
+    "Shielded Metal Arc Welding (SMAW) Certificate of Achievement — Associate of Science",
+    "Shielded Metal Arc Welding Certificate — Certificate of Achievement",
+    "Show Business – Commercials, Voice-Over, Film Acting - Certificate of Achievement — Associate in Arts",
+    "Sign Language Interpreting (AS S0801) — Associate of Science",
+    "Sign Language Interpreting (Certificate T0801) — Associate of Science",
+    "SketchUp Essentials - Certificate of Completion — Associate in Arts",
+    "Skills for Professional Helpers - Certificate of Completion — Associate in Arts",
+    "Sleep Disorders, Diagnostic Procedures, and Treatment Certificate of Proficiency — Associate in Science",
+    "Small Business Bookkeeping Certificate — Associate in Science",
+    "Small Business Certificate of Achievement",
+    "Small Business Certificate of Achievement — Certificate of Achievement",
+    "Small Farm",
+    "Social & Behavioral Sciences Emphasis (AA Degree A8991) — AS",
+    "Social and Behavioral Sciences – Associate in Arts Degree — Associate of Science",
+    "Social Competency Skills - Certificate of Completion — Associate in Arts",
+    "Social Justice Studies - Associate in Arts Transfer Degree — Associate in Arts",
+    "Social Justice Studies - Ethnic Studies Associate in Arts Degree for Transfer — Associate in Science",
+    "Social Justice Studies - Gender Studies Associate in Arts Degree for Transfer — Associate in Science",
+    "Social Justice Studies-African American Studies – Associate in Arts for Transfer — Associate in Arts",
+    "Social Justice Studies-Asian American Studies – Associate in Arts for Transfer — Associate in Arts",
+    "Social Justice Studies-Chicano Studies – Associate in Arts for Transfer — Associate in Arts",
+    "Social Justice Studies-Ethnic Studies – Associate in Arts for Transfer — Associate in Arts",
+    "Social Justice Studies-Gender Studies - Associate in Arts for Transfer — Associate in Arts",
+    "Social Justice Studies, AA-T",
+    "Social Justice Studies, AA-T — Associate in Arts",
+    "Social Justice Studies: Ethnic Studies Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Social Justice Studies: General – Associate in Arts Degree for Transfer — Associate of Science",
+    "Social Justice Studies: General (AA-T Degree A0978) — Associate in Arts",
+    "Social Justice Studies: General Associate in Arts Degree for Transfer — Associate in Science",
+    "Social Justice, Advocacy, and Community Associate of Arts Degree — Associate of Arts",
+    "Social Media Application Development - Certificate of Accomplishment — Associate in Arts",
+    "Social Media Certificate of Achievement",
+    "Social Media Content Creator - Level I (Certificate N0955) — AS",
+    "Social Media Marketing (Certificate M0877) — AS",
+    "Social Media Marketing Certificate of Achievement — Certificate of Achievement",
+    "Social Media Production Certificate of Achievement — Associate of Arts",
+    "Social Media Strategy Certificate of Completion",
+    "Social Work - Associate in Arts — Associate in Arts",
+    "Social Work - Certificate of Achievement — Associate in Arts",
+    "Social Work and Human Services - Associate in Arts Transfer Degree — Associate in Arts",
+    "Social Work and Human Services Assistant Certificate of Achievement — Associate of Arts",
+    "Social Work and Human Services Associate in Arts for Transfer Degree — Associate of Arts",
+    "Social Work and Human Services, AA-T — Associate in Arts",
+    "Social Work Associate in Arts — Associate in Science",
+    "Social Work Certificate of Achievement — Associate in Science",
+    "Sociology - Associate in Arts for Transfer — Associate in Science",
+    "Sociology - Associate in Arts Transfer Degree — Associate in Arts",
+    "Sociology – Associate in Arts Degree for Transfer — Associate of Science",
+    "Sociology — Associate in Arts",
+    "Sociology (AA-T Degree A0419) — Associate in Arts",
+    "Sociology AA-T Degree — Associate in Arts",
+    "Sociology Associate in Arts Degree for Transfer — Associate in Science",
+    "Sociology Associate in Arts for Transfer Degree — Associate of Arts",
+    "Sociology for Transfer (AA-T)",
+    "Sociology for Transfer (AA-T) — Associate in Science",
+    "Sociology, AA-T — Associate in Arts",
+    "Solar Battery Storage Installation and Maintenance Certificate of Completion — Certificate of Achievement",
+    "Solar Installation and Maintenance - Certificate of Achievement — Associate in Arts",
+    "Solar Photovoltaic Installation Technician Certificate of Achievement",
+    "Solar Site Planning Project Certificate of Completion — Certificate of Achievement",
+    "Solidworks Essentials - Certificate of Completion — Associate in Arts",
+    "Sound Technician Certificate — Associate in Science",
+    "Spanish - Associate in Arts for Transfer — Associate in Science",
+    "Spanish - Associate in Arts Transfer Degree — Associate in Arts",
+    "Spanish - Certificate of Achievement — Associate in Arts",
+    "Spanish – Associate in Arts Degree — Associate of Science",
+    "Spanish – Associate in Arts Degree for Transfer — Associate of Science",
+    "Spanish — Associate in Arts",
+    "Spanish AA-T Degree — Associate of Arts",
+    "Spanish Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Spanish Associate in Arts Degree for Transfer — Associate in Science",
+    "Spanish Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Spanish for Medical Professionals - Certificate of Accomplishment — Associate in Arts",
+    "Spanish for Medical Professionals - Certificate of Achievement — Associate in Arts",
+    "Spanish for Medical Professions, Certificate of Achievement",
+    "Spanish for Medical Professions, Certificate of Completion",
+    "Spanish for Transfer (AA-T) — Associate in Science",
+    "Spanish Language Media Certificate — Associate in Science",
+    "Spanish Language, AA",
+    "Spanish Translation and Interpreting - Certificate of Achievement — Associate in Arts",
+    "Spanish, AA-T",
+    "Spanish, AA-T — Associate in Arts",
+    "Special Education Certificate — Associate in Science",
+    "Special Education Paraprofessional - Certificate of Achievement — Associate in Arts",
+    "Speech Communication – Associate in Arts Degree — Associate of Science",
+    "Speech Language Pathology Assistant Advanced Placement Certificate of Achievement",
+    "Speech Language Pathology Assistant, AS",
+    "Speech-Language Pathology Assistant – Associate in Science Degree — Associate of Science",
+    "Sports Broadcasting Certificate — Associate in Science",
+    "Sports Medicine — Associate in Science",
+    "Sports Medicine AS Degree — Associate of Science",
+    "Sports Nutrition Certificate — Associate in Science",
+    "Sports Turf Management (Certificate N0639) — AS",
+    "SQL Programmer Specialist - Certificate of Accomplishment — Associate in Arts",
+    "Stage and Screen Combat Level 1 Certificate — Associate in Science",
+    "Stage and Screen Combat Level 2 Certificate — Associate in Science",
+    "Stage Electrician Certificate of Achievement",
+    "Stage Makeup Technician Certificate of Achievement",
+    "Stage Management Certificate — Associate in Science",
+    "Stagecraft Certificate of Achievement",
+    "Storyboarding Certificate — Associate in Arts",
+    "Street Rod Construction Certificate of Achievement — Associate of Science",
+    "Street Rod Construction Certificate of Completion — Associate of Science",
+    "Studio Art – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Studio Art — Associate in Arts for Transfer",
+    "Studio Art for Transfer (AA-T) — Associate in Science",
+    "Studio Art, AA-T",
+    "Studio Arts - Associate in Arts — Associate in Arts",
+    "Studio Arts - Associate in Arts for Transfer — Associate in Arts",
+    "Studio Arts - Associate in Arts for Transfer — Associate in Science",
+    "Studio Arts - Associate in Arts Transfer Degree — Associate in Arts",
+    "Studio Arts – Associate in Arts Degree for Transfer — Associate of Science",
+    "Studio Arts (AA-T Degree A0395) — Associate in Arts",
+    "Studio Arts AA-T Degree — Associate in Arts",
+    "Studio Arts Associate in Arts Degree for Transfer — Associate in Arts",
+    "Studio Arts Associate in Arts for Transfer Degree — Associate of Arts",
+    "Studio Arts for Transfer (AA-T)",
+    "Studio Arts for Transfer (AA-T) — Associate in Science",
+    "Studio Arts, AA-T — Associate in Arts",
+    "Substance Abuse Counselor Certificate of Achievement",
+    "Supermarket Refrigeration (AS Degree S0967) — AS",
+    "Supervision and Management Certificate of Achievement",
+    "Supply Chain Management – Certificate of Achievement — Associate of Science",
+    "Supply Chain Management (Certificate M0645) — AS",
+    "Supply Chain Management Certificate — Associate in Arts",
+    "Surfcam Skills Certificate — Associate in Science",
+    "Surveying Associate in Science and Certificate of Achievement — Associate in Science",
+    "Surveying Engineering Technology (Certificate T0879) — AS",
+    "Surveying Technology (Certificate N0868) — AS",
+    "Sustainability - Certificate of Achievement — Associate in Arts",
+    "Sustainable Building Construction – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Sustainable Crop Management",
+    "Sustainable Design Certificate of Achievement — Associate of Science",
+    "Sustainable Design/Build - Certificate of Completion — Associate in Arts",
+    "Sustainable Urban Landscapes Associate in Science and Certificate of Achievement — Associate in Science",
+    "Swiss Lathe Certificate — Associate in Science",
+    "Tax Preparation Certificate of Achievement",
+    "TEAS Preparation - Certificate of Competency — Associate in Arts",
+    "Technical Sales (Certificate N0856) — AS",
+    "Technical Theater (Certificate T0446) — AS",
+    "Technical Theatre Certificate — Associate in Science",
+    "Telecommuting Fundamentals - Certificate of Achievement — Associate in Arts",
+    "Telecommuting Fundamentals - Certificate of Completion — Associate in Arts",
+    "Telemetry / ECG Technician Certificate of Achievement — Associate in Science",
+    "Telemetry Technician - Certificate of Achievement — Associate of Science",
+    "Television and Film Associate in Arts Degree — Associate in Science",
+    "Television and Film Production Certificate — Associate in Science",
+    "Television and Radio – Radio Production – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Television and Radio – Video Post-Production – Certificate of Achievement — Associate of Science",
+    "Television Associate of Arts Degree — Associate of Arts",
+    "Television Broadcast News - Associate in Arts — Associate in Arts",
+    "Television Broadcast News - Certificate of Achievement — Associate in Arts",
+    "Television Multimedia Production - Certificate of Achievement — Associate in Arts",
+    "Television Operations – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Television Performance - Associate in Arts — Associate in Arts",
+    "Television Performance - Certificate of Achievement — Associate in Arts",
+    "Television Post Production – Occupational Skills Certificate — Associate of Science",
+    "Television Producer - Associate in Arts — Associate in Arts",
+    "Television Producer - Certificate of Achievement — Associate in Arts",
+    "Television Production – Occupational Skills Certificate — Associate of Science",
+    "Television Production (AS Degree S0602) — Associate in Science",
+    "Television Sports Broadcasting - Associate in Arts — Associate in Arts",
+    "Television Sports Broadcasting - Certificate of Achievement — Associate in Arts",
+    "Textiles and Clothing Associate in Arts Degree — Associate in Science",
+    "The Business of Art Certificate — Associate in Arts",
+    "Theater Arts (AA-T Degree A0346) — Associate in Arts",
+    "Theater Performance (Certificate N0855) — AS",
+    "Theatre Arts - Acting, AA",
+    "Theatre Arts - Associate in Arts for Transfer — Associate in Science",
+    "Theatre Arts - Associate in Arts Transfer Degree — Associate in Arts",
+    "Theatre Arts - Technical Theatre, AA",
+    "Theatre Arts – Associate in Arts Degree for Transfer — Associate of Science",
+    "Theatre Arts – Associate in Arts for Transfer — Associate in Arts",
+    "Theatre Arts — Associate in Arts",
+    "Theatre Arts AA-T Degree — Associate in Arts",
+    "Theatre Arts Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Theatre Arts Associate in Arts Degree — Associate in Science",
+    "Theatre Arts Associate in Arts Degree for Transfer — Associate in Science",
+    "Theatre Arts Associate in Arts for Transfer Degree — Associate in Arts for Transfer",
+    "Theatre Arts For Transfer (AA-T) — Associate in Science",
+    "Theatre Arts Technical Training Program Associate in Arts and Certificate of Achievement — Associate in Science",
+    "Theatre Arts, AA-T",
+    "Theatre Arts, AA-T — Associate in Arts",
+    "Theatre Arts: Acting and Performance Associate in Arts Degree — Associate in Science",
+    "Theatre Arts: Technical Theatre Associate in Arts Degree — Associate in Science",
+    "Theatre Technology – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Theatre Technology — Associate in Arts",
+    "Theatre-Acting Academy - Associate in Arts — Associate in Arts",
+    "Theatre-General - Associate in Arts — Associate in Arts",
+    "Theme Park Technician Certificate — Associate in Science",
+    "Theme Park Technology Specialist Certificate — Associate in Science",
+    "Traffic Shipping and Receiving Technician Certificate of Achievement",
+    "Traffic Signal Technician - Certificate of Achievement — Associate in Arts",
+    "Transfer Studies: Cal-GETC — Certificate of Achievement",
+    "Transfer Studies: CSU GE — Associate Degree for Transfer",
+    "Transfer Studies: IGETC — Certificate of Achievement",
+    "Transitioning to Higher Learning - Certificate of Completion — Associate in Arts",
+    "Trauma Studies - Associate in Science — Associate in Arts",
+    "Trauma Studies - Certificate of Achievement — Associate in Arts",
+    "Trauma-Informed Early Childhood Certificate of Achievement — Associate in Science",
+    "Tree Care and Maintenance (Certificate N0641) — AS",
+    "Turfgrass Management Technician Certificate of Achievement — Certificate of Achievement",
+    "UC 7 Course Pattern Certificate of Achievement — Certificate of Achievement",
+    "UCTP in Physics - Associate in Science UC Transfer Degree — Associate in Arts",
+    "Uncrewed Aerial Systems Piloting Certificate — Associate in Science",
+    "University Studies - Business and Economics (AA) — Associate in Science",
+    "University Studies - Communication and Language Arts (AA) — Associate in Science",
+    "University Studies - Humanities and Fine Arts (AA) — Associate in Science",
+    "University Studies - Mathematics and Natural Science and Computer Science (AS) — Associate in Science",
+    "University Studies - Social and Behavioral Sciences (AA) — Associate in Science",
+    "University Studies: Business and Economics — Associate in Science",
+    "University Studies: Communication and Language Arts — Associate in Science",
+    "University Studies: Humanities and Fine Arts — Associate in Science",
+    "University Studies: Science and Mathematics — Associate in Science",
+    "University Studies: Social and Behavioral Sciences — Associate in Science",
+    "UNIX Network Administrator - Certificate of Achievement — Associate in Arts",
+    "Unmanned Aerial System (Drone) Technologies Certificate of Specialization — Associate in Science",
+    "Unmanned Aircraft Systems (Certificate M0662) — AS",
+    "Urban Forestry - Associate in Science, Certificate of Achievement — Associate of Science",
+    "Urban Planning - Associate in Science — Associate in Arts",
+    "Urban Planning Certificate of Achievement — Associate of Science",
+    "User Experience and Interaction Design - Associate in Science — Associate in Science",
+    "User Experience and Interaction Design - Certificate of Achievement Level 2 — Associate in Science",
+    "Veterinary Technology — Associate in Science",
+    "Video Broadcasting Certificate of Achievement — Associate of Arts",
+    "Video Engineering (Certificate N0650) — AS",
+    "Video Operations – Occupational Skills Certificate — Associate of Science",
+    "Video Post Production Certificate of Achievement — Certificate of Achievement",
+    "Video Production – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Vietnamese Translation & Interpreting - Certificate of Achievement — Associate in Arts",
+    "Virtual Office Assistant Certificate of Proficiency — Associate in Science",
+    "Virtual Production in Cinema - Associate in Science, Certificate of Achievement — Associate of Science",
+    "Virtual Reality Designer (Certificate N0644) — AS",
+    "Vocational ESLN Certificate of Completion — Certificate of Completion",
+    "Vocational Nursing Program Preparation - Certificate of Competency — Associate in Arts",
+    "Volunteer Services Skills Certificate — Associate in Science",
+    "VVC General Education — AS",
+    "War on Drugs Certificate of Achievement — Associate in Science",
+    "Wastewater Collection Systems Associate in Science and Certificate of Achievement — Associate in Science",
+    "Wastewater Collection Systems Certificate of Specialization — Associate in Science",
+    "Wastewater Collection Systems, Advanced Wastewater Collection Systems Certificate of Specialization — Associate in Science",
+    "Wastewater Collection Systems, Water & Wastewater Fundamentals Certificate of Specialization — Associate in Science",
+    "Wastewater Technology Certificate of Completion — Associate of Science",
+    "Wastewater Treatment Operations Associate in Science and Certificate of Achievement — Associate in Science",
+    "Wastewater Treatment Operations Certificate of Specialization — Associate in Science",
+    "Wastewater Treatment Operations, Advanced Wastewater Treatment Operations Certificate of Specialization — Associate in Science",
+    "Wastewater Treatment Operations, Water & Wastewater Fundamentals Certificate of Specialization — Associate in Science",
+    "Water and Wastewater Technology - Certificate of Achievement — Associate in Arts",
+    "Water Distribution Operations Associate in Science and Certificate of Achievement — Associate in Science",
+    "Water Distribution Operations Certificate of Specialization — Associate in Science",
+    "Water Distribution Operations, Advanced Water Distribution Operations Certificate of Specialization — Associate in Science",
+    "Water Distribution Operations, Water & Wastewater Fundamentals Certificate of Specialization — Associate in Science",
+    "Water Resources Management Associate in Science and Certificate of Achievement — Associate in Science",
+    "Water Supply Technology Certificate of Achievement — Associate of Science",
+    "Water Technology Associate of Science Degree — Associate of Science",
+    "Water Treatment Plant Operations Associate in Science and Certificate of Achievement — Associate in Science",
+    "Water Treatment Plant Operations Certificate of Specialization — Associate in Science",
+    "Water Treatment Plant Operations, Advanced Water Treatment Plant Operations Certificate of Specialization — Associate in Science",
+    "Water Treatment Plant Operations, Water & Wastewater Fundamentals Certificate of Specialization — Associate in Science",
+    "Water Use Specialist Certificate of Completion — Associate of Science",
+    "Web and Multimedia Design Certificate of Achievement — Associate of Arts",
+    "Web Application Security Support Specialist Certificate of Achievement — Associate of Science",
+    "Web Design and Development Associate in Science and Certificate of Achievement — Associate in Science",
+    "Web Design Certificate — Associate in Science",
+    "Web Design Certificate of Achievement — Certificate of Achievement",
+    "Web Design Certificate of Specialization — Associate in Science",
+    "Web Design Skills Certificate — Associate in Science",
+    "Web Development - Associate in Science — Associate in Arts",
+    "Web Development Associate in Science and Certificate of Achievement — Associate in Science",
+    "Web Development-Full Stack - Certificate of Achievement — Associate in Arts",
+    "Web Graphics Certificate of Specialization — Associate in Science",
+    "Web Programming Certificate of Specialization — Associate in Science",
+    "Welder - Automotive Welding, Cutting & Modification (Certificate N0648) — AS",
+    "Welder - Gas Tungsten Arc Welding (Certificate T0932) — AS",
+    "Welder - Licensed (Certificate N0643) — AS",
+    "Welding – Semiautomatic Arc Welding (Certificate T0933) — AS",
+    "Welding (AS Degree S0919) — AS",
+    "Welding (Certificate E0919) — AS",
+    "Welding Fabrication – Associate in Science Degree, Certificate of Achievement — Associate of Science",
+    "Welding Inspection Technology Certificate of Achievement — Associate of Science",
+    "Welding Job Readiness Certificate of Completion — Associate of Science",
+    "Welding Technology",
+    "Welding Technology - Associate in Science — Associate in Arts",
+    "Welding Technology - Certificate of Achievement — Associate in Arts",
+    "Welding Technology — AS",
+    "Welding Technology Associate of Science Degree — Associate of Science",
+    "Welding Technology Certificate — Associate in Science",
+    "Welding Technology Certificate of Achievement",
+    "Welding Technology Certificate of Achievement — Associate of Science",
+    "Welding Technology SENSE Entry-Level Welder Certificate of Achievement — Certificate of Achievement",
+    "Whole Numbers Certificate of Competency — Certificate of Competency",
+    "Wildland Fire Academy - Occupational Skills Certificate — Associate of Science",
+    "Wildland Fire Technology - Certificate of Achievement — Associate of Science",
+    "Wildland Fire Technology (AS Degree S0890) — AS",
+    "Wildland Fire Technology (Certificate T0882) — AS",
+    "Winery Event Coordinator Certificate of Achievement",
+    "Winery Sales and Marketing Certificate of Achievement",
+    "Winery Tasting Room Associate Certificate of Achievement",
+    "Women and Gender Studies — AA",
+    "Women's Studies — Associate in Arts",
+    "Workforce Literacy Skills Certificate of Completion — Certificate of Completion",
+    "Workplace Language Skills for ESL – Level 1 - Certificate of Competency — Associate in Arts",
+    "Workplace Language Skills for ESL – Level 2 - Certificate of Competency — Associate in Arts",
+    "Workplace Language Skills for ESL – Level 3 - Certificate of Competency — Associate in Arts",
+    "World Languages & Global Studies Emphasis (AA Degree A0429) — Associate of Arts",
+    "World Languages and Global Studies, AA",
+    "Writing for Film, Television & Radio – Occupational Skills Certificate — Associate of Science",
+    "Yoga Instructor Training – Certificate of Achievement — Associate of Science",
+    "Yoga Teacher Skills Certificate — Associate in Science",
+    "Yoga Teacher Training - Certificate of Achievement — Associate in Arts",
+    "Yoga Teacher Training Certificate of Achievement — Certificate of Achievement",
+    "Zero Net Energy Certificate of Achievement — Associate of Science"
+  ]
+}

--- a/data/co/subject-vocab.json
+++ b/data/co/subject-vocab.json
@@ -1,0 +1,3801 @@
+{
+  "state": "co",
+  "generated_at": "2026-06-06T15:41:40.047Z",
+  "subjects": [
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 36,
+      "section_count": 2481,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Algebraic Literacy",
+        "Algebraic Literacy Support",
+        "Calculus I: GT-MA1",
+        "Calculus II: GT-MA1",
+        "Calculus III with Engineering Applications: GT-MA1"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 20,
+      "section_count": 1554,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Capstone",
+        "Composition and Reading",
+        "Creative Writing I: GT-AH1",
+        "Creative Writing II",
+        "English Composition I : GT-CO1"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 55,
+      "section_count": 1390,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv Music Audio Production",
+        "Audio Post Production I",
+        "Capstone",
+        "Computer Music Applications I",
+        "Computer Music Applications II"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 25,
+      "section_count": 1294,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Human Anatomy",
+        "Aquatic Entomology",
+        "Basic Anatomy and Physiology",
+        "Bioinformatics Capstone",
+        "​​Biology Foundations: Prep for Anatomy & Physiology and Microbiology​​"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 26,
+      "section_count": 1193,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Brain and Behavior",
+        "Child Abuse and Neglect",
+        "Child Development: GT-SS3",
+        "Cognitive Psychology",
+        "Educational Psychology"
+      ]
+    },
+    {
+      "prefix": "WEL",
+      "name": "Welding",
+      "course_count": 48,
+      "section_count": 1007,
+      "colleges": [
+        "aims-community-college",
+        "colorado-mountain-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "2G Horizontal Pipe A.P.I.",
+        "5G Vertical Down A.P.I.",
+        "Adv CAD/CAM Cutting Processes",
+        "Advanced Gas Metal Arc Welding",
+        "Advanced Robotic Welding"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 64,
+      "section_count": 852,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "3-D Design",
+        "4-D Design: Time-Based Art",
+        "Advanced Figure Drawing",
+        "Art Appreciation GT-AH1",
+        "Art Hist 1900 to Present: AH1"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 24,
+      "section_count": 820,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "20th Century World History: GT-HI1",
+        "African American History: GT-HI1",
+        "American Environmental History",
+        "American Indian History: HI1",
+        "Colorado History:GT-HI1"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 25,
+      "section_count": 800,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Basic Workplace Skills",
+        "Bus Research & Data Analytics",
+        "Business Communications & Report Writing",
+        "​​Business Ethics and Sustainability​​",
+        "Business Law and Ethics"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 13,
+      "section_count": 780,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Argumentation and Debate: AH1",
+        "Career Communication",
+        "Communication and Popular Culture: GT-AH1",
+        "Communication in Healthcare",
+        "Conflict Resolution"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 27,
+      "section_count": 681,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Administration of Early Childhood Care and Education Programs",
+        "Administration:Human Relations for Early Childhood Education",
+        "Assessment Process in ECE",
+        "Capstone:Early Childhood Ed",
+        "Creativity and the Young Child"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 11,
+      "section_count": 668,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Business Ethics: GT-AH3",
+        "Comparative Religions: GT-AH3",
+        "Environmental Ethics: GT-AH3",
+        "Ethics: GT-AH3",
+        "Introduction to Philosophy: GT-AH3"
+      ]
+    },
+    {
+      "prefix": "HPR",
+      "name": "HPR",
+      "course_count": 25,
+      "section_count": 644,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced ECG Interpretations",
+        "Advanced Phlebotomy",
+        "AHA Hrtsvr First Aid CPR & AED",
+        "Anatomical Kinesiology",
+        "Basic EKG Interpretation"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 23,
+      "section_count": 540,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Automated Project Management",
+        "Capstone",
+        "Complete Presentation Graphics",
+        "Complete Spreadsheets: (Software package)",
+        "Complete Word Processing (software package)"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 26,
+      "section_count": 538,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Accounting Principles I",
+        "Accounting Principles II",
+        "Advanced Auditing Topics",
+        "Business Taxation",
+        "Capstone"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 53,
+      "section_count": 490,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "community-college-of-aurora",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced EMS Simulation Lab",
+        "Advanced Paramedic Trauma Care",
+        "Advced Paramedic Medical Care",
+        "AEMT Clinical Internship",
+        "AEMT Fundamentals"
+      ]
+    },
+    {
+      "prefix": "MGD",
+      "name": "MGD",
+      "course_count": 65,
+      "section_count": 489,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "2D Animation Production",
+        "3D Animation I",
+        "3D Modeling I",
+        "3DAnimation II",
+        "Adobe Illustrator I"
+      ]
+    },
+    {
+      "prefix": "CNG",
+      "name": "CNG",
+      "course_count": 48,
+      "section_count": 475,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "A+ Certification Preparation",
+        "Active Cyber Defense",
+        "Bus Continuity/Disaster Recov",
+        "CCNA Security",
+        "CISCO CCNA Network Assc I"
+      ]
+    },
+    {
+      "prefix": "MAN",
+      "name": "Management",
+      "course_count": 34,
+      "section_count": 448,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Aligning Tech w/ Business Stgy",
+        "Contemporary Management",
+        "Corporate Ethics & Social Resp",
+        "Crit Issues-Marketing/Mgmt",
+        "Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 10,
+      "section_count": 429,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Contemp. Social Problems: SS3",
+        "Environmental Sociology: SS3",
+        "Principles of Sociology: GT-SS3",
+        "Sociolgy of Famly Dynamcs:SS3",
+        "Sociology of Death & Dying: SS3"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 23,
+      "section_count": 411,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Constitutional Law",
+        "Correctional Process",
+        "Crime Scene Investigation",
+        "Criminal Investigation I",
+        "Criminal Profiling"
+      ]
+    },
+    {
+      "prefix": "ASE",
+      "name": "ASE",
+      "course_count": 49,
+      "section_count": 399,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "front-range-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv Automatic Trans/Transax",
+        "Adv Drivability/Diagnosis/Repr",
+        "Adv Electric Vehicles HEV",
+        "Adv Manual Transm/Transa",
+        "Advanced Engine Diagnosis"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 25,
+      "section_count": 395,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "3D Game Programming",
+        "Advanced C# Programming",
+        "Advanced Computer Architecture",
+        "Advanced Python Programming",
+        "C Programming: Platform"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 15,
+      "section_count": 366,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "American Literature After the Civil War: GT-AH2",
+        "American Literature to Civil War: GT-AH2",
+        "British Lit Since 1770: GT-AH2",
+        "British Lit to 1770: GT-AH2",
+        "Celtic Literature: AH2"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 7,
+      "section_count": 350,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Conceptual Physics with Lab: GT-SC1",
+        "PHY Calc-Base III: Modern",
+        "Physics for CTE Occupations",
+        "Physics: Algebra-Based I with Lab: GT-SC1",
+        "Physics: Algebra-Based II with Lab: GT-SC1"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 7,
+      "section_count": 340,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Humanities: Early Civilization:GT-AH2",
+        "Humanities: Medieval-- Modern: GT-AH2",
+        "Humanities: Modern World: GT-AH2",
+        "Introduction to Film Art: GT-AH2",
+        "Special Topics"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 46,
+      "section_count": 334,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv Concepts Med-Surg NSG II",
+        "Adv Concepts of Med/Surg NSG I",
+        "Advancement into Practical Nur",
+        "Alterations in Adult Health I",
+        "Alterations in Adult Health II"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 7,
+      "section_count": 324,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "General College Chemistry I with Lab: GT-SC1",
+        "General College Chemistry II with Lab: GT-SC1",
+        "General, Organic, and Biochemistry",
+        "Intro to Chemistry II/Lab: SC1",
+        "Introduction to Chemistry I with Lab: GT-SC1"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 307,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Econ for Managerial Decisions",
+        "Econ Of Social Issues:SS1",
+        "Environmental Economics: GT-SS1",
+        "Principles of Macroeconomics: GT-SS1",
+        "Principles of Microeconomics: GT-SS1"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "Gtss",
+      "course_count": 6,
+      "section_count": 278,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "American Government: GT-SS1",
+        "American, State, and Local Government: GT-SS1",
+        "Comparative Government: SS1",
+        "Current Political Issues: GT-SS1",
+        "International Relations: GT-SS1"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Anthropology",
+      "course_count": 9,
+      "section_count": 273,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Anthropology of Religion GT:SS3",
+        "Arch. of World Rock Art: SS3",
+        "Biological Anthropology with Laboratory: GT:SC1",
+        "Cultural Anthropology: GT-SS3",
+        "Intro Forensc Anthrp w/Lab:SC1"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 10,
+      "section_count": 272,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Conversational Spanish I",
+        "Conversational Spanish II",
+        "Conversational Spanish III",
+        "Span Lang-Heritage Spkrs: AH4",
+        "Spanish for the Professional I"
+      ]
+    },
+    {
+      "prefix": "HWE",
+      "name": "HWE",
+      "course_count": 17,
+      "section_count": 256,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Applied Nutrition to Whole Food Cooking",
+        "Capstone: Athletic Trainer",
+        "Certified Personal Trainer Preparatory Course",
+        "Community First Aid and CPR",
+        "Exercise, Nutrition and Body Composition"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 26,
+      "section_count": 246,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv II Disinfec/Sanitat/Safety",
+        "Advanced Chemical Texture",
+        "Advanced Hair Coloring",
+        "Advanced Hair Cutting",
+        "Advanced Hair Styling"
+      ]
+    },
+    {
+      "prefix": "ABM",
+      "name": "ABM",
+      "course_count": 57,
+      "section_count": 229,
+      "colleges": [
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college"
+      ],
+      "sample_titles": [
+        "Advance Business Manage VI",
+        "Advanced Business Manage I",
+        "Advanced Business Manage II",
+        "Advanced Business Manage III",
+        "Advanced Business Manage IV"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 7,
+      "section_count": 216,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Careers/Rsrch in Geosciences",
+        "Global Climate Change: GT-SC2",
+        "Human Geography: GT-SS2",
+        "Phys Geo:Clim & Eco w/Lab: SC1",
+        "Physical Geography: Landforms with Lab: GT-SC1"
+      ]
+    },
+    {
+      "prefix": "MAR",
+      "name": "Marketing",
+      "course_count": 15,
+      "section_count": 206,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Business Practical Marketing",
+        "Consumer Behavior",
+        "Contemporary Marketing",
+        "Customer Service",
+        "Digital Marketing"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 28,
+      "section_count": 192,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "3D Printing",
+        "3D Scanning and Modeling",
+        "3DS Max",
+        "Advanced 3D Printing",
+        "Advanced Creo"
+      ]
+    },
+    {
+      "prefix": "NUA",
+      "name": "Nurse",
+      "course_count": 6,
+      "section_count": 192,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Acute Care Nurse Aide Skills",
+        "Adv. Nurse Aid Clinical Exp.",
+        "Certification Exam Prep",
+        "Nurse Aide Clinical Experience",
+        "Nurse Aide Health Care Skills"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 6,
+      "section_count": 156,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Astrobiology: SC2",
+        "Astronomy of Ancient Cultures:GT-SC2",
+        "Astronomy with Lab: Planetary Systems: GT-SC1",
+        "Astronomy with Lab: Stars and Galaxies: GT-SC1",
+        "Colorado Night Sky I"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "PED",
+      "course_count": 29,
+      "section_count": 143,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Aerobics I",
+        "Archery",
+        "Basketball",
+        "Body Sculpting and Toning",
+        "Cardio Kickboxing Aerobic I"
+      ]
+    },
+    {
+      "prefix": "RTE",
+      "name": "RTE",
+      "course_count": 31,
+      "section_count": 143,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Adv CT Protocols, Procedures",
+        "Adv MRI Protocols, Procedures",
+        "Advanced Clinical (Specialty) Advanced Clinical MR III",
+        "Advanced Medical Imaging",
+        "Clinical I: Mammography"
+      ]
+    },
+    {
+      "prefix": "DEH",
+      "name": "Dental",
+      "course_count": 35,
+      "section_count": 134,
+      "colleges": [
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Careers in Dental Hygiene",
+        "Advanced Clinical Skills",
+        "Advanced Concepts in Oral Health Promotion and Community Planning",
+        "Applied Dental Hygiene Research Methodologies",
+        "Applied Dental Pharmacology"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 32,
+      "section_count": 130,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adult Learning and Teaching",
+        "Applied Teaching Methods",
+        "Behavioral Supports",
+        "Capstone",
+        "Classroom Management"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 2,
+      "section_count": 126,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Environmental Science with Lab: GT-SC1",
+        "Natural Disasters: GT-SC2"
+      ]
+    },
+    {
+      "prefix": "AAA",
+      "name": "Student",
+      "course_count": 4,
+      "section_count": 115,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Academic Achievement",
+        "College 101:Student Experience",
+        "Semester Survival",
+        "ST: Student Success Seminar"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 22,
+      "section_count": 114,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Advanced Playwriting",
+        "Auditioning-Musical Theater",
+        "Basic Costume/Apparel Const"
+      ]
+    },
+    {
+      "prefix": "GEY",
+      "name": "Geology",
+      "course_count": 8,
+      "section_count": 108,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Environmental Geol w/Lab: SC1",
+        "Field Paleontology",
+        "General Oceanography w/Lab:SC1",
+        "Geology of Minerals and Gems",
+        "Geology of U.S. National Parks: GT: SC2"
+      ]
+    },
+    {
+      "prefix": "FVM",
+      "name": "FVM",
+      "course_count": 48,
+      "section_count": 107,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "16mm/HD Production",
+        "Acting for the Screen",
+        "Art Direction",
+        "Camera Techniques",
+        "Cinematography"
+      ]
+    },
+    {
+      "prefix": "MAP",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 107,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Internship",
+        "Medical Assistant Internship",
+        "Medical Assisting Clinical Skills",
+        "Medical Assisting Laboratory",
+        "Medical Office Administration"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Integrated",
+      "course_count": 3,
+      "section_count": 107,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Integrated Sci I w/Lab: SC1",
+        "Integrated Sci II w/Lab: SC1",
+        "Science in Society: SC2"
+      ]
+    },
+    {
+      "prefix": "PAR",
+      "name": "PAR",
+      "course_count": 25,
+      "section_count": 103,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Administrative Law",
+        "Bankruptcy Law",
+        "Business Organization Law",
+        "Capstone",
+        "Civil Litigation"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "ACT",
+      "course_count": 37,
+      "section_count": 94,
+      "colleges": [
+        "aims-community-college",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Adv Struct Damage Diag/Repair",
+        "Auto Air Brushing & Murals",
+        "Auto Collision Repr Internsp I",
+        "Auto Collision Tech Lab Exp I",
+        "Auto Collision Tech Lab II"
+      ]
+    },
+    {
+      "prefix": "AEC",
+      "name": "AEC",
+      "course_count": 31,
+      "section_count": 92,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Arch Design & Modeling",
+        "Architectural Drawing Theory",
+        "Architectural Graphics",
+        "Basic Architectural Drafting",
+        "Building Electrical/Mech Sys"
+      ]
+    },
+    {
+      "prefix": "VET",
+      "name": "VET",
+      "course_count": 35,
+      "section_count": 92,
+      "colleges": [
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Anesthesiology",
+        "Animal Nutrition",
+        "Applied Companion Animal Behavior",
+        "Assistant Large Animal Nursing",
+        "Clinical Competency Evaluation"
+      ]
+    },
+    {
+      "prefix": "BEH",
+      "name": "Health",
+      "course_count": 12,
+      "section_count": 89,
+      "colleges": [
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "​Applied Therapeutic Communication Skills​",
+        "Behavioral Health Case Management and Clinical Documentation​",
+        "Behavioral Health Practicum",
+        "Child, Adult, and Family Advocacy​",
+        "Cultural Comp in Beh Health"
+      ]
+    },
+    {
+      "prefix": "JOU",
+      "name": "Journalism",
+      "course_count": 9,
+      "section_count": 85,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Feature and Magazine Writing",
+        "Interm Newswriting & Editing",
+        "Internship",
+        "Introduction to Mass Media: GT-SS3",
+        "Introduction to Public Relations"
+      ]
+    },
+    {
+      "prefix": "LEA",
+      "name": "Enforcement",
+      "course_count": 10,
+      "section_count": 84,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "front-range-community-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Arrest Control Techniques",
+        "Basic Law",
+        "Basic Law Enforcement Acad I",
+        "Basic Law Enforcement Acad II",
+        "Basic Law Enforcement Acad III"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "FST",
+      "course_count": 24,
+      "section_count": 82,
+      "colleges": [
+        "aims-community-college",
+        "colorado-mountain-college",
+        "community-college-of-aurora",
+        "northeastern-junior-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Building Construction for Fire",
+        "Clinical I",
+        "Fire Behavior & Combustion",
+        "Fire Co Superv and Leadership",
+        "Fire Department Administration"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 19,
+      "section_count": 79,
+      "colleges": [
+        "colorado-mountain-college",
+        "community-college-of-aurora",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Adv. English Language Skills",
+        "Advanced Composition",
+        "Advanced Grammar",
+        "Advanced Language Skills",
+        "Advanced Reading"
+      ]
+    },
+    {
+      "prefix": "AVT",
+      "name": "Flight",
+      "course_count": 35,
+      "section_count": 78,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Systems A&P",
+        "AT Ops & Career Development",
+        "ATC Advanced Tower Simulation",
+        "ATC Phraseology",
+        "ATC Tower Simulation"
+      ]
+    },
+    {
+      "prefix": "STE",
+      "name": "Surgical",
+      "course_count": 19,
+      "section_count": 74,
+      "colleges": [
+        "aims-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "CST Exam Review Course",
+        "Fundamentals of Surgical Technology",
+        "Internship I",
+        "Internship II",
+        "Internship III"
+      ]
+    },
+    {
+      "prefix": "FRE",
+      "name": "French",
+      "course_count": 6,
+      "section_count": 70,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Conversational French I",
+        "French Language I: GT-AH4",
+        "French Language II: GT-AH4",
+        "French Language III: GT-AH4",
+        "French Language IV: GT-AH4"
+      ]
+    },
+    {
+      "prefix": "MAC",
+      "name": "MAC",
+      "course_count": 26,
+      "section_count": 64,
+      "colleges": [
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Inspection Techniques",
+        "Advanced Machining Operations",
+        "CAD CAM 2D Lab",
+        "CAD/CAM 2D",
+        "CADCAM 3D"
+      ]
+    },
+    {
+      "prefix": "IHP",
+      "name": "IHP",
+      "course_count": 35,
+      "section_count": 61,
+      "colleges": [
+        "front-range-community-college",
+        "morgan-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "A & P Integrative Therapies",
+        "Adv. Health/Wellness Coaching",
+        "Applied Aromatherapy",
+        "Applied Herbalism",
+        "Bach Flower Essences"
+      ]
+    },
+    {
+      "prefix": "CWB",
+      "name": "CWB",
+      "course_count": 6,
+      "section_count": 59,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Client-side Script: Javascript",
+        "Introduction to Web Authoring",
+        "Tech Foundations E-Commerce",
+        "Web App Dev: (Dev Tool(s))",
+        "Web Content Management Syst"
+      ]
+    },
+    {
+      "prefix": "CSL",
+      "name": "CSL",
+      "course_count": 17,
+      "section_count": 53,
+      "colleges": [
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Addiction Counseling Skills",
+        "Adv Motivational Interview",
+        "Advanced Case Conceptualization and Documentation",
+        "Advanced Pharmacology",
+        "Advanced Professional and Ethical Practice"
+      ]
+    },
+    {
+      "prefix": "EGG",
+      "name": "Engineering",
+      "course_count": 13,
+      "section_count": 52,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Engineering Data Analysis",
+        "Engineering Mechanics II (Dynamics)",
+        "Engineering Methodologies",
+        "Engineering Projects",
+        "Engr Mechanics I - Statics"
+      ]
+    },
+    {
+      "prefix": "DPM",
+      "name": "DPM",
+      "course_count": 25,
+      "section_count": 51,
+      "colleges": [
+        "community-college-of-aurora",
+        "northeastern-junior-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Basic Heavy Duty Electricity",
+        "Diesel Air Induction & Exhaust",
+        "Diesel Engine Cooling Systems",
+        "Diesel Engines I",
+        "Diesel Engines II"
+      ]
+    },
+    {
+      "prefix": "NAT",
+      "name": "Nail",
+      "course_count": 9,
+      "section_count": 50,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv Mani/Pedi/Arti Nails",
+        "Adv Nail Technician Studies",
+        "Advanced Nail Care",
+        "Inter I: Nail Care",
+        "Inter Mani/Pedi/Arti Nails"
+      ]
+    },
+    {
+      "prefix": "ASC",
+      "name": "ASC",
+      "course_count": 16,
+      "section_count": 47,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Animal Science Lab",
+        "Animal Sciences",
+        "Elementary Western Equitation",
+        "Farm Animal Anatomy&Physiology",
+        "Feeds and Feeding"
+      ]
+    },
+    {
+      "prefix": "EIC",
+      "name": "EIC",
+      "course_count": 31,
+      "section_count": 47,
+      "colleges": [
+        "arapahoe-community-college",
+        "front-range-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "AC Circuit Fundamentals",
+        "Advanced Industrial Controls",
+        "Basics Of Indust. Electricity",
+        "DC Circuit Fundamentals",
+        "Electrical Code Calculations"
+      ]
+    },
+    {
+      "prefix": "RTV",
+      "name": "RTV",
+      "course_count": 27,
+      "section_count": 46,
+      "colleges": [
+        "aims-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Television Production",
+        "Basic Video Production",
+        "Beginning Television",
+        "Broadcast Announcing",
+        "Broadcast Management"
+      ]
+    },
+    {
+      "prefix": "BAR",
+      "name": "Hair",
+      "course_count": 18,
+      "section_count": 43,
+      "colleges": [
+        "lamar-community-college",
+        "otero-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Adv Facial Massage/Skin Care",
+        "Adv Perm Waves/Chem Relaxers",
+        "Adv Shaving/Honing/Stropping",
+        "Advanced Hair and Scalp",
+        "Advanced Hair Coloring"
+      ]
+    },
+    {
+      "prefix": "CUA",
+      "name": "CUA",
+      "course_count": 29,
+      "section_count": 43,
+      "colleges": [
+        "colorado-mountain-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Adv Cuisine & Garde Manger",
+        "Advanced Baking",
+        "Advanced Line Prep and Cookery",
+        "Baking:Decorating/Presentation",
+        "Baking:Interm Bread Prep"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 17,
+      "section_count": 43,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "front-range-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "pueblo-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv Programmable Logic Control",
+        "Automation Control Circuits",
+        "Capstone: Automated Systems",
+        "Digital Devices I",
+        "Electronic Assembly"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 15,
+      "section_count": 43,
+      "colleges": [
+        "arapahoe-community-college",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Anatomical Kinesiology Lab",
+        "Anatomy and Kinesiology",
+        "Basic Patient Care in PT",
+        "Internship I:",
+        "Neurological Assess/Mgt"
+      ]
+    },
+    {
+      "prefix": "CIE",
+      "name": "Level",
+      "course_count": 10,
+      "section_count": 42,
+      "colleges": [
+        "aims-community-college"
+      ],
+      "sample_titles": [
+        "English Pre-Literacy",
+        "ESL Level 1A",
+        "ESL Level 1B",
+        "ESL Level 2A",
+        "ESL Level 2B"
+      ]
+    },
+    {
+      "prefix": "WST",
+      "name": "Gtss",
+      "course_count": 4,
+      "section_count": 41,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Goddesses And Women In The Ancient World: GT-SS3",
+        "​Introduction to Women’s and Gender Studies​: GT-SS3",
+        "Women and Social Action: GT-SS3",
+        "Women's Sexuality: SS3"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 6,
+      "section_count": 40,
+      "colleges": [
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Humn Behavr in the Socl Env I",
+        "Humn Behavr in the Socl Env II",
+        "Intro to SWK Practice",
+        "Introduction to Social Work",
+        "Social Welfare and Community Agencies with Service Learning"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 6,
+      "section_count": 39,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Applied Finance",
+        "Consumer Economics",
+        "Entrepreneurial Finance",
+        "Essentials of Finance",
+        "Introduction to Finance"
+      ]
+    },
+    {
+      "prefix": "HVA",
+      "name": "HVAC",
+      "course_count": 24,
+      "section_count": 39,
+      "colleges": [
+        "front-range-community-college",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Air Conditioning",
+        "Air Conditioning",
+        "Air Conditioning Systems",
+        "Air Conditioning&Refrigeration",
+        "Basic Electricity"
+      ]
+    },
+    {
+      "prefix": "IND",
+      "name": "Design",
+      "course_count": 20,
+      "section_count": 39,
+      "colleges": [
+        "arapahoe-community-college",
+        "front-range-community-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Capstone",
+        "Commercial Design I",
+        "Design Production",
+        "Estimating Interior Materials",
+        "Graphic Communication"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "Sign",
+      "course_count": 8,
+      "section_count": 38,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III",
+        "American Sign Language V: AH4",
+        "ASL Linguistics"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 21,
+      "section_count": 38,
+      "colleges": [
+        "arapahoe-community-college",
+        "front-range-community-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Cancer Registry Operations",
+        "Certification Test Preparation",
+        "Cncr Registry Structure & Mgmt",
+        "CPT Coding Basic Principles",
+        "Health Info Mgmt Science"
+      ]
+    },
+    {
+      "prefix": "EST",
+      "name": "Skin",
+      "course_count": 7,
+      "section_count": 37,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Skin Care",
+        "Disinfection, Sanitation",
+        "Hair Removal",
+        "Int Disinfection, Sanitation",
+        "Intermediate I: Skin Care"
+      ]
+    },
+    {
+      "prefix": "DEA",
+      "name": "Dental",
+      "course_count": 13,
+      "section_count": 36,
+      "colleges": [
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Dental Assist Natl Bd Review",
+        "Dental Materials I",
+        "Dental Radiography",
+        "Dental Science I",
+        "Dental Science II"
+      ]
+    },
+    {
+      "prefix": "MOT",
+      "name": "MOT",
+      "course_count": 14,
+      "section_count": 36,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-mountain-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Internship",
+        "Adv Insurance Billing/Coding",
+        "Basic Medical Sciences I",
+        "Basic Medical Sciences II",
+        "Basic Medical Sciences III"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 26,
+      "section_count": 35,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Drawing",
+        "Aircraft Mat and Process",
+        "AMT Preparation",
+        "AMT Regs and Publications",
+        "Aviation Electricity"
+      ]
+    },
+    {
+      "prefix": "CAR",
+      "name": "CAR",
+      "course_count": 17,
+      "section_count": 35,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "otero-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Adv Clinical Const Lab I",
+        "Adv Clinical Const Lab II",
+        "Basic Safety",
+        "Carpentry Basics",
+        "Clinical: Construction Lab I"
+      ]
+    },
+    {
+      "prefix": "FIW",
+      "name": "FIW",
+      "course_count": 25,
+      "section_count": 35,
+      "colleges": [
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Bending and Laminations",
+        "Classical Guitar Construction",
+        "CNC Laser I",
+        "CNC Woodworking Router I",
+        "Contemporary Furniture Making"
+      ]
+    },
+    {
+      "prefix": "PHO",
+      "name": "PHO",
+      "course_count": 17,
+      "section_count": 34,
+      "colleges": [
+        "arapahoe-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Lighting Technique",
+        "Architectural Photography",
+        "Business of Photography",
+        "Color Management",
+        "Digital Capture Processing I"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "DMS",
+      "course_count": 24,
+      "section_count": 33,
+      "colleges": [
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography I",
+        "Abdominal Sonography II",
+        "Abdominal Ultrasound I",
+        "Adult Cardiac Anatomy",
+        "Adult Cardiac Physiology"
+      ]
+    },
+    {
+      "prefix": "PTE",
+      "name": "Care",
+      "course_count": 3,
+      "section_count": 33,
+      "colleges": [
+        "arapahoe-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "App. of Behavioral Health Care",
+        "Intro to Behavioral Health Care and Wellness",
+        "Theoretical Concepts of Psychiatric Care II"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 18,
+      "section_count": 32,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "front-range-community-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Database For GIS",
+        "Capstone",
+        "GIS Applications",
+        "GIS for Natural Sciences",
+        "Global Positioning Sys for GIS"
+      ]
+    },
+    {
+      "prefix": "HLT",
+      "name": "Health",
+      "course_count": 13,
+      "section_count": 32,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college",
+        "front-range-community-college",
+        "pueblo-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Annuals, Bulbs, and Grasses",
+        "Herbaceous Perennials",
+        "Horticulture Science",
+        "Internship",
+        "Introduction to Horticulture"
+      ]
+    },
+    {
+      "prefix": "OUT",
+      "name": "OUT",
+      "course_count": 24,
+      "section_count": 32,
+      "colleges": [
+        "colorado-mountain-college",
+        "front-range-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Avalanche Safety I",
+        "Backcountry Navigation",
+        "Backpacking",
+        "Basic Search and Rescue",
+        "Cooperative Education Internsh"
+      ]
+    },
+    {
+      "prefix": "NRE",
+      "name": "NRE",
+      "course_count": 19,
+      "section_count": 30,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Avian Conservation/Ornithology",
+        "Backcountry Travel Nat Res Pro",
+        "Colorado Wildlife",
+        "Ecology:Field Study",
+        "​​Field Skills for NR​"
+      ]
+    },
+    {
+      "prefix": "AGE",
+      "name": "Agriculture",
+      "course_count": 4,
+      "section_count": 28,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "pueblo-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Agricultural Finance",
+        "Agriculture Economics: GT-SS1",
+        "Agriculture Marketing",
+        "Farm and Ranch Management"
+      ]
+    },
+    {
+      "prefix": "PHT",
+      "name": "PHT",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "colorado-mountain-college",
+        "front-range-community-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Certification Review",
+        "Clinical: Community",
+        "Clinical: Institutional",
+        "Community Pharmacy",
+        "Institutional Pharmacy"
+      ]
+    },
+    {
+      "prefix": "DAN",
+      "name": "Dance",
+      "course_count": 22,
+      "section_count": 27,
+      "colleges": [
+        "aims-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Ballet II",
+        "Ballet III",
+        "Ballroom Dance",
+        "Ballroom Dance II"
+      ]
+    },
+    {
+      "prefix": "ENP",
+      "name": "Entrepreneurship",
+      "course_count": 4,
+      "section_count": 27,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurship Business Plan",
+        "Entrepreneurship Fin Topics",
+        "Entrepreneurship Legal Issues",
+        "Intro to Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "Rodeo",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "aims-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Ag Communication",
+        "Applied Info in Tech in Ag",
+        "Freshman Ag. Orientation",
+        "Precision AG Operations",
+        "Precision Farming Hardware"
+      ]
+    },
+    {
+      "prefix": "ZOO",
+      "name": "ZOO",
+      "course_count": 19,
+      "section_count": 25,
+      "colleges": [
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Advance Exhibitory Techniques",
+        "Animal Behavior",
+        "Apes",
+        "Avian Conservation",
+        "Biodiversity and Conservation"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 11,
+      "section_count": 23,
+      "colleges": [
+        "arapahoe-community-college",
+        "otero-college"
+      ],
+      "sample_titles": [
+        "Clinical Chemistry II",
+        "Clinical Microbiology",
+        "Hematology I",
+        "Hematology II",
+        "Intern-II Hemat/Coag/Urinalys"
+      ]
+    },
+    {
+      "prefix": "ESA",
+      "name": "Emerg",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Capstone: Emerg Service Admin",
+        "Designing Safer Communities",
+        "Elements of Emerg Ser Admin",
+        "Emgcy Publ Info & Media Traing",
+        "Ldshp for Emerg Executives"
+      ]
+    },
+    {
+      "prefix": "AGP",
+      "name": "Cattle",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "aims-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college"
+      ],
+      "sample_titles": [
+        "Animal Health",
+        "Artificial Insemination Mgt",
+        "Beef Cattle Calving Management",
+        "Beef Cattle Management I",
+        "Cattle Reproduction Lab"
+      ]
+    },
+    {
+      "prefix": "HOS",
+      "name": "HOS",
+      "course_count": 11,
+      "section_count": 20,
+      "colleges": [
+        "colorado-mountain-college",
+        "colorado-northwestern-community-college",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Capstone: Work Experience",
+        "Hospitality HR Management",
+        "Hotel Operations",
+        "Internship",
+        "Introduction to Food and Bever"
+      ]
+    },
+    {
+      "prefix": "PAS",
+      "name": "PAS",
+      "course_count": 20,
+      "section_count": 20,
+      "colleges": [
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Practice Seminar",
+        "Clinical Anatomy with Lab I",
+        "Clinical Decision Making I",
+        "Clinical Decision Making II",
+        "Clinical Medicine I"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "UAS",
+      "course_count": 7,
+      "section_count": 20,
+      "colleges": [
+        "aims-community-college",
+        "front-range-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Unmanned Aircraft Sys",
+        "UAS Design and Fabrication I",
+        "UAS Design and Fabrication II",
+        "UAS Field Applications",
+        "UAS Flight Training"
+      ]
+    },
+    {
+      "prefix": "CON",
+      "name": "Construction",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "colorado-mountain-college",
+        "morgan-community-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Build Material/Environ Impact",
+        "Construction Ethics",
+        "Construction Technology",
+        "Flooring, Tile and Wood",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "EQM",
+      "name": "Equine",
+      "course_count": 14,
+      "section_count": 19,
+      "colleges": [
+        "lamar-community-college",
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Equine Business Planning",
+        "Equine Health",
+        "Equine Health Lab",
+        "Equine Management",
+        "Equine Management Capstone"
+      ]
+    },
+    {
+      "prefix": "GUN",
+      "name": "GUN",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Machine Shop",
+        "Basic Machine Shop",
+        "Basic Precision Welding",
+        "Blueing",
+        "Color Case Hardening"
+      ]
+    },
+    {
+      "prefix": "MOR",
+      "name": "MOR",
+      "course_count": 7,
+      "section_count": 19,
+      "colleges": [
+        "arapahoe-community-college"
+      ],
+      "sample_titles": [
+        "Embalming Theory I w/ Lab",
+        "Funeral Merchandising",
+        "Internship",
+        "Intro to Funeral Service",
+        "Mortuary Law and Compliance"
+      ]
+    },
+    {
+      "prefix": "SPI",
+      "name": "Sterile",
+      "course_count": 4,
+      "section_count": 19,
+      "colleges": [
+        "aims-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Internship: Sterile Processing Technology",
+        "Seminar",
+        "Sterile Instrument Lab Skills",
+        "Sterile Instrument Processing"
+      ]
+    },
+    {
+      "prefix": "TRI",
+      "name": "Interpretation",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "community-college-of-aurora"
+      ],
+      "sample_titles": [
+        "Business of Trans and Interp",
+        "Consecutive Interpretation I",
+        "Consecutive Interpretation II",
+        "Ethics for Trans. & Interpr.",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "HPE",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "aims-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Athletic Training Practicum I",
+        "Care/Prevent Athletic Injuries",
+        "Intro to Physical Ed & Sport",
+        "Intro to Sports Medicine",
+        "Introduction to Coaching"
+      ]
+    },
+    {
+      "prefix": "RCA",
+      "name": "RCA",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Apps of Science in RCA",
+        "Basic Techs in Respire Care",
+        "Cadiopulmonary A and P",
+        "Clinical I",
+        "Clinical II"
+      ]
+    },
+    {
+      "prefix": "GUS",
+      "name": "Firearms",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "CNC I",
+        "Comprehensive Skills Evals",
+        "Custom Revolversmithing",
+        "Firearms Bench Metal",
+        "Firearms Conversions"
+      ]
+    },
+    {
+      "prefix": "RUS",
+      "name": "Russian",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "morgan-community-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Conversational Russian I",
+        "Russian Language I"
+      ]
+    },
+    {
+      "prefix": "AGB",
+      "name": "Agribusiness",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "aims-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Agri-Business Capstone",
+        "Agri-Business Internship I",
+        "Agri-Business Management",
+        "Agricultural Salesmanship",
+        "Computerized Farm Records"
+      ]
+    },
+    {
+      "prefix": "AIMS",
+      "name": "AIMS",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "aims-community-college"
+      ],
+      "sample_titles": [
+        "College Boost",
+        "First-Year Seminar",
+        "GED",
+        "Math Brush-Up"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "morgan-community-college",
+        "otero-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "German Language I: GT-AH4"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Conversational Japanese I",
+        "Japanese Language I",
+        "Japanese Language II",
+        "Japanese Language III : AH4",
+        "Japanese Language IV: AH4"
+      ]
+    },
+    {
+      "prefix": "BTE",
+      "name": "Word",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "community-college-of-denver",
+        "morgan-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Keyboarding Applications I",
+        "Ten-Key by Touch",
+        "Word Processing Techniques I",
+        "Word Processing Techniques II"
+      ]
+    },
+    {
+      "prefix": "OTE",
+      "name": "Optics",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Adv Fab of Prec Optics",
+        "Fabrication of Prec Optics",
+        "Introduction to Optics",
+        "Optics Elec Inst & Fiber Optc",
+        "Optics Technology"
+      ]
+    },
+    {
+      "prefix": "MTE",
+      "name": "Manufacturing",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Applied Comm/Tmwrk in Industry",
+        "Design for Manufacturability",
+        "Fluid Power Control",
+        "Introduction to Manufacturing",
+        "Lean Manufacturing Prac/Proc"
+      ]
+    },
+    {
+      "prefix": "PET",
+      "name": "PET",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "aims-community-college"
+      ],
+      "sample_titles": [
+        "Internship",
+        "Oil and Gas Production I",
+        "Petroleum Fundamentals"
+      ]
+    },
+    {
+      "prefix": "DAT",
+      "name": "Data",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "arapahoe-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Intro to Machine Learning",
+        "Introduction to Data Science",
+        "Visualizing Data"
+      ]
+    },
+    {
+      "prefix": "PRA",
+      "name": "PRA",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "colorado-northwestern-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Independent Study",
+        "Intro to Park Ranger Tech",
+        "NPS Academy PRA 100 Park Ranger II",
+        "NPS Academy PRA 103",
+        "NPS Academy PRA 104"
+      ]
+    },
+    {
+      "prefix": "ETH",
+      "name": "ETH",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "aims-community-college",
+        "community-college-of-aurora",
+        "community-college-of-denver",
+        "northeastern-junior-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "African-American Studies",
+        "Intro to Chicano Studies",
+        "Introduction To Ethnic Studies: GT-SS3"
+      ]
+    },
+    {
+      "prefix": "HSE",
+      "name": "Human",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "colorado-mountain-college",
+        "community-college-of-denver"
+      ],
+      "sample_titles": [
+        "GED Preparation",
+        "Human Services for Groups",
+        "Human Services Practicum I",
+        "Interviewing Principles and Practices",
+        "Introduction to Social Welfare"
+      ]
+    },
+    {
+      "prefix": "PRO",
+      "name": "PRO",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "aims-community-college"
+      ],
+      "sample_titles": [
+        "Instrumentation I",
+        "Internship",
+        "Quality in Process Technology",
+        "Safety, Health and Environment"
+      ]
+    },
+    {
+      "prefix": "BCI",
+      "name": "Creative",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Capstone",
+        "Creative Strategy and Planning",
+        "Creative Tools and Technology",
+        "Design Thinking and Research",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "CHI",
+      "name": "Chinese",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Chinese Language I",
+        "Chinese Language II"
+      ]
+    },
+    {
+      "prefix": "EGT",
+      "name": "Engineering Technology",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "aims-community-college",
+        "community-college-of-denver",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Applied Dimension & Tolerance",
+        "Geometric Dimension/Tolerance",
+        "IDEA: Introduction to Design and Engineering Applications",
+        "Mechanical Design I",
+        "Mechanical Design III"
+      ]
+    },
+    {
+      "prefix": "FSW",
+      "name": "Wildland",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "front-range-community-college",
+        "northeastern-junior-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "S-130 Firefighting Training",
+        "S-190 Intro to Wildland Fire",
+        "S-212 Wildfire Chain Saws",
+        "Wildland Fire Practitioner Lab"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "arapahoe-community-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Data Use & Mgmt in Healthcare",
+        "Health Information Governance",
+        "Health Law and Compliance",
+        "HIM Capstone Course",
+        "Hlth Data Analytics and Visual"
+      ]
+    },
+    {
+      "prefix": "HMS",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "colorado-mountain-college"
+      ],
+      "sample_titles": [
+        "Human Services Internship",
+        "Intro to Human Services"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "App to Neuro Impairments",
+        "Basic OT Frames of Refer/Docum",
+        "Internship",
+        "Intro to Occupational Therapy",
+        "Occup. Disrupt./Activ. Analy."
+      ]
+    },
+    {
+      "prefix": "REE",
+      "name": "Real",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "aims-community-college",
+        "colorado-mountain-college",
+        "community-college-of-aurora",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Real Estate Brokers I",
+        "Real Estate Brokers II"
+      ]
+    },
+    {
+      "prefix": "SUS",
+      "name": "Permaculture",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "colorado-mountain-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sustainability",
+        "Ldrship, Ethics, Social Change",
+        "Permaculture Design I",
+        "Permaculture Design II"
+      ]
+    },
+    {
+      "prefix": "WQM",
+      "name": "Water",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Basic Water Quality Analyses",
+        "Disinfect Tech-Water Qual Syst",
+        "Introduction to Water Quality",
+        "Senior Capstone",
+        "Senior Internship"
+      ]
+    },
+    {
+      "prefix": "AIR",
+      "name": "Leadership",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "arapahoe-community-college",
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Heritage & Values II",
+        "Military Leadership Lab I",
+        "Military Leadership Lab III",
+        "Teams & Leadership Fund I"
+      ]
+    },
+    {
+      "prefix": "AME",
+      "name": "AME",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "aims-community-college",
+        "colorado-northwestern-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Agricultural Machinery",
+        "Basic Ag Mechanic Skills",
+        "Farm Carpentry",
+        "Fundamentals of Welding"
+      ]
+    },
+    {
+      "prefix": "EQT",
+      "name": "Training",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "lamar-community-college",
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Colt Training",
+        "Applied Horsemanship",
+        "Beginning Colt Training",
+        "Intermediate Colt Training",
+        "Introduction to Horse Training"
+      ]
+    },
+    {
+      "prefix": "HSD",
+      "name": "Adult",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "colorado-mountain-college"
+      ],
+      "sample_titles": [
+        "Adult HS Diploma"
+      ]
+    },
+    {
+      "prefix": "SBM",
+      "name": "Business",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "otero-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Financing a Small Business",
+        "Legal Aspects-Small Business",
+        "Managing a Small Business",
+        "Marketing for a Small Business",
+        "Recordkeeping-Small Business"
+      ]
+    },
+    {
+      "prefix": "ESS",
+      "name": "Tropical",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "colorado-mountain-college"
+      ],
+      "sample_titles": [
+        "Independent Research in ESS",
+        "Internship Ecosystem Science",
+        "Tropical Conservation",
+        "Tropical Ecology"
+      ]
+    },
+    {
+      "prefix": "GUR",
+      "name": "GUR",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Beg Coaching Clinic Rifle",
+        "NRA Basic Instruction Training",
+        "NRA Basic Rifle Shooting",
+        "NRA CCW Basic Course",
+        "NRA CCW Instructor Course"
+      ]
+    },
+    {
+      "prefix": "HEQ",
+      "name": "HEQ",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "colorado-mountain-college",
+        "lamar-community-college"
+      ],
+      "sample_titles": [
+        "Engine Operation & Drive Train",
+        "Front End Loaders",
+        "Heavy Equipment Operations I",
+        "Hydraulic Excavator",
+        "Jobsite Safety and Skills"
+      ]
+    },
+    {
+      "prefix": "IPP",
+      "name": "Interpreting",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "aims-community-college",
+        "front-range-community-college",
+        "pikes-peak-state-college"
+      ],
+      "sample_titles": [
+        "ASL to English Interpreting",
+        "Aspects of Interpreting I",
+        "Deaf People in Society",
+        "English to ASL Interpreting",
+        "Specialized & Technical Comm"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Meteorology",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "arapahoe-community-college",
+        "colorado-northwestern-community-college",
+        "front-range-community-college",
+        "pikes-peak-state-college",
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Gen Meteorology w/Lab: SC1"
+      ]
+    },
+    {
+      "prefix": "REC",
+      "name": "Outdoor",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "front-range-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "red-rocks-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Intro to Sport Management",
+        "Outdoor Leadership",
+        "Outdoor Recreation Programming",
+        "Principles Outdoor Recreation",
+        "Recreational Skills"
+      ]
+    },
+    {
+      "prefix": "AGY",
+      "name": "Soil",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "aims-community-college",
+        "lamar-community-college",
+        "morgan-community-college",
+        "northeastern-junior-college",
+        "otero-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "General Crop Production",
+        "Intro to Soil Science: SC1"
+      ]
+    },
+    {
+      "prefix": "EMP",
+      "name": "EMP",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "pikes-peak-state-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Business Emergency Management",
+        "Developing Volunteer Resources",
+        "Effective Communication",
+        "Emergency Management",
+        "Exercise Design Evaluation"
+      ]
+    },
+    {
+      "prefix": "HCI",
+      "name": "Healthcare",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "community-college-of-denver"
+      ],
+      "sample_titles": [
+        "Analytics for Healthcare",
+        "Capstone",
+        "Healthcare Systems and Organizations",
+        "Internship",
+        "Legal and Ethical Issues in Health Informatics"
+      ]
+    },
+    {
+      "prefix": "HNR",
+      "name": "Colloquium",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "northeastern-junior-college",
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Capstone: Honors-",
+        "Honors Colloquium I:",
+        "Honors Colloquium II:",
+        "Honors Seminar:",
+        "Special Topics"
+      ]
+    },
+    {
+      "prefix": "HTM",
+      "name": "Training",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lamar-community-college"
+      ],
+      "sample_titles": [
+        "Basic Care and Training",
+        "Internship",
+        "Introduction to Internship",
+        "Specialized Training"
+      ]
+    },
+    {
+      "prefix": "MLS",
+      "name": "Clinical",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "arapahoe-community-college"
+      ],
+      "sample_titles": [
+        "Adv Urinalysis & Bodily Fluids",
+        "Advanced Clinical Chemistry",
+        "Advanced Clinical Microbiology",
+        "Advanced Hematology",
+        "Clinical Immunology & Virology"
+      ]
+    },
+    {
+      "prefix": "OSH",
+      "name": "Industry",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "lamar-community-college",
+        "morgan-community-college",
+        "otero-college",
+        "pueblo-community-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "10HR Constructn Industry Stnds",
+        "10HR OSHA Voluntary Compliance",
+        "General Industry Standards"
+      ]
+    },
+    {
+      "prefix": "IBD",
+      "name": "IBD",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Detailing for Fabrication",
+        "Materials and Spec Writing",
+        "Programming & Site Analysis",
+        "Project Planning Methods",
+        "Regional Landscape & Design"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "Engines I",
+        "Hi Perfo Suspsn/Chassis Setup",
+        "Hi Perform Suspsn/Chassis Dsn",
+        "High Performance Brake Systems",
+        "Intro to Racecar Chassis Fab"
+      ]
+    },
+    {
+      "prefix": "WTG",
+      "name": "WTG",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Wind Technician Capstone",
+        "WTG Power & Control Systems",
+        "WTG Troubleshooting & Repair"
+      ]
+    },
+    {
+      "prefix": "ENY",
+      "name": "Energy",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "aims-community-college",
+        "lamar-community-college",
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Alternative Energy Systems",
+        "Intro to Energy Technologies",
+        "Solar Lab"
+      ]
+    },
+    {
+      "prefix": "IMA",
+      "name": "Industrial",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "arapahoe-community-college",
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Fluid Power",
+        "Industrial Rotating Equipment",
+        "Intro Industrial Maintenance"
+      ]
+    },
+    {
+      "prefix": "LTN",
+      "name": "Library",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "pueblo-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Cataloging/Classific",
+        "Intro to Library Services",
+        "Library Circulation",
+        "Library/Media Center Mgmt/PR"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "Massage",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Massage Clinical I",
+        "Massage Therapy Fundamentals"
+      ]
+    },
+    {
+      "prefix": "SKB",
+      "name": "Marketing",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "colorado-mountain-college"
+      ],
+      "sample_titles": [
+        "SIA Marketing",
+        "SIA Promotions",
+        "SIA Sales Representative",
+        "SKB Marketing & Media"
+      ]
+    },
+    {
+      "prefix": "PBH",
+      "name": "Public",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "aims-community-college",
+        "arapahoe-community-college",
+        "community-college-of-denver"
+      ],
+      "sample_titles": [
+        "Introduction to Public Health: GT-SS3"
+      ]
+    },
+    {
+      "prefix": "RAM",
+      "name": "Range",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "northeastern-junior-college",
+        "otero-college",
+        "trinidad-state-college"
+      ],
+      "sample_titles": [
+        "Range Management"
+      ]
+    },
+    {
+      "prefix": "ADE",
+      "name": "Small",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "colorado-northwestern-community-college"
+      ],
+      "sample_titles": [
+        "Small Gasoline Engines"
+      ]
+    },
+    {
+      "prefix": "CSO",
+      "name": "Endocannabinoid",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "community-college-of-denver"
+      ],
+      "sample_titles": [
+        "Endocannabinoid System and Pharmacology",
+        "Public Health and Cannabis Use"
+      ]
+    },
+    {
+      "prefix": "FLD",
+      "name": "Introductory",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Capstone",
+        "Introductory Floral Design"
+      ]
+    },
+    {
+      "prefix": "MIL",
+      "name": "Lifting",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Lifting Devices"
+      ]
+    },
+    {
+      "prefix": "BIS",
+      "name": "Management",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "colorado-mountain-college"
+      ],
+      "sample_titles": [
+        "Management Systems"
+      ]
+    },
+    {
+      "prefix": "HWY",
+      "name": "Highway",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "front-range-community-college"
+      ],
+      "sample_titles": [
+        "Highway Maintenance Management"
+      ]
+    },
+    {
+      "prefix": "PLU",
+      "name": "International",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "red-rocks-community-college"
+      ],
+      "sample_titles": [
+        "International Plumbing Code"
+      ]
+    },
+    {
+      "prefix": "PSM",
+      "name": "Terrorism",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "community-college-of-denver"
+      ],
+      "sample_titles": [
+        "Terrorism, Intelligence and Justice"
+      ]
+    },
+    {
+      "prefix": "REA",
+      "name": "Appliedtech",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northeastern-junior-college"
+      ],
+      "sample_titles": [
+        "Applied/Tech Reading"
+      ]
+    },
+    {
+      "prefix": "RFM",
+      "name": "Intern",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lamar-community-college"
+      ],
+      "sample_titles": [
+        "Intern Placement"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/hi/subject-vocab.json
+++ b/data/hi/subject-vocab.json
@@ -1,0 +1,1937 @@
+{
+  "state": "hi",
+  "generated_at": "2026-06-06T15:41:40.058Z",
+  "subjects": [
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 33,
+      "section_count": 132,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "College Reading Skills",
+        "Composition I",
+        "Composition I Supplement",
+        "Composition I TRIO",
+        "Composition Supplement"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 51,
+      "section_count": 121,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Algebraic Foundations",
+        "Calculus for Business, Social and Environmental Sciences",
+        "Calculus I",
+        "Calculus II",
+        "Calculus III"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 49,
+      "section_count": 98,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health Care II",
+        "Child Health Nursing",
+        "Child Health Nursing Lab",
+        "Clinical Immersion I",
+        "Fam Hlth I-Mat/Newbn Lab"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 66,
+      "section_count": 96,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "3D Computer Graphics I",
+        "3D Computer Graphics III",
+        "Adv Printmkg: Intaglio",
+        "Advanced Painting",
+        "Corporate Identity"
+      ]
+    },
+    {
+      "prefix": "CULN",
+      "name": "CULN",
+      "course_count": 48,
+      "section_count": 67,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Culinary Experiences - Bean to Bar Coffee Experience",
+        "American &amp; Sustainable Cuisine",
+        "Artisan Breads and Pastries",
+        "Asia Pacific Cuisine",
+        "Asian Pacific Cuisine"
+      ]
+    },
+    {
+      "prefix": "ICS",
+      "name": "ICS",
+      "course_count": 39,
+      "section_count": 63,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Computing Literacy &amp; Applications",
+        "Computing Literacy and Applications",
+        "Cooperative Education",
+        "Cooperative Education/Internship/Practicum",
+        "Digital Tools for Info World"
+      ]
+    },
+    {
+      "prefix": "PHYL",
+      "name": "Human",
+      "course_count": 20,
+      "section_count": 62,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Human Anatomy and Physiology I",
+        "Human Anatomy and Physiology I Lab",
+        "Human Anatomy and Physiology II",
+        "Human Anatomy and Physiology II Lab",
+        "Human Anatomy/Physio II Lab"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 33,
+      "section_count": 57,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology",
+        "Anatomy and Physiology Lab",
+        "Biology and Society",
+        "Biology and Society Lab",
+        "Biology and Society Laboratory"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 30,
+      "section_count": 55,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Chemistry and Society Lab",
+        "Cosmetic Chemistry",
+        "Elementary Survey of Chemistry",
+        "Elementary Survey of Chemistry Laboratory",
+        "General Chemistry I"
+      ]
+    },
+    {
+      "prefix": "HWST",
+      "name": "Hawaiian",
+      "course_count": 34,
+      "section_count": 55,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "&#39;Aikapu: Hawai&#39;i Culture I",
+        "H-Hawai`i:Center ofthe Pacific",
+        "Hawai&#39;i: Center of the Pacific",
+        "Hawaiian Ethnozoology",
+        "Hawaiian Music History &amp; Ethnography I"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 29,
+      "section_count": 37,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Brake Systems",
+        "Advanced Suspension and Steering Systems",
+        "Automatic Transmission and Transaxle",
+        "Automatic Transmissions and Transaxles",
+        "Automatic Transmissions/Transaxles"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 19,
+      "section_count": 37,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Basic Rescue in the Fire Service",
+        "Emergency Medical Resp",
+        "Emergency Medical Tech",
+        "Emergency Medical Technician",
+        "Emergency Medical Technician-Basic"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "IS",
+      "course_count": 16,
+      "section_count": 37,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Bldg Bridges to Self/Community",
+        "Career Exploration",
+        "Collaborative Storytelling And Leadership Through Role-Playing Games",
+        "Exploration in Health Careers",
+        "Foundation Coll. Success Lab"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 15,
+      "section_count": 34,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Conflict Resolution &amp; Mediation",
+        "Developmental Psychology",
+        "Introduction to Clinical Psychology",
+        "Psychology of Personality",
+        "Social Psychology"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 23,
+      "section_count": 32,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "&#39;Ukulele 1",
+        "Applied Music, Western (Piano)",
+        "Beginning Ukulele",
+        "Class Piano I",
+        "Cntmp Isle Mus (ʻUkulele)"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 27,
+      "section_count": 32,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "College Physics I Lab",
+        "College Physics I Laboratory",
+        "College Physics II",
+        "College Physics II Laboratory"
+      ]
+    },
+    {
+      "prefix": "MICR",
+      "name": "Microbiology",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Gen Microbiology Lab",
+        "General Microbiology",
+        "General Microbiology Lab",
+        "General Microbiology Laboratory",
+        "RI-General Microbiology Lab"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 16,
+      "section_count": 27,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Civilizations of Asia II",
+        "Hawai&#39;i and the World I",
+        "WI-American History II",
+        "WI-National Cinemas",
+        "WI-Writing Personal History"
+      ]
+    },
+    {
+      "prefix": "SP",
+      "name": "Public",
+      "course_count": 10,
+      "section_count": 27,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communication",
+        "Introduction to Nonverbal Communication",
+        "Organizational Communication",
+        "Personal and Public Speech",
+        "Principles of Effective Public Speaking"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 18,
+      "section_count": 23,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Business Income Tax Preparation",
+        "Individual Income Tax Preparation",
+        "Intro to Financial Accounting",
+        "Introduction to Financial Accounting",
+        "Introduction to Managerial Accounting"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Veterinary",
+      "course_count": 14,
+      "section_count": 23,
+      "colleges": [
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology of Domestc Animals",
+        "Anatomy of Domestic Animals Laboratory",
+        "Anesthesiology and Surgical Nursing for Veterinary Technicians Lab",
+        "Applied Pharmacology for Veterinary Technicians",
+        "Clinical Laboratory Techniques II"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 21,
+      "section_count": 23,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Applied Theatre",
+        "Beginning Acting 1",
+        "Beginning Acting I"
+      ]
+    },
+    {
+      "prefix": "HOST",
+      "name": "HOST",
+      "course_count": 17,
+      "section_count": 22,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Airline Reservations and Pricing",
+        "Career and Customer Service Skills",
+        "Events Management",
+        "Front Office Management",
+        "Hospitality Management"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "Intensive",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Advanced ESOL (Summer)",
+        "Beginning English for Speakers of Other Languages",
+        "Intensive English 1A",
+        "Intensive English 1B",
+        "Intensive English 2A"
+      ]
+    },
+    {
+      "prefix": "HAW",
+      "name": "Hawaiian",
+      "course_count": 10,
+      "section_count": 21,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Hawai&#39;i Language I",
+        "Elementary Hawaiian I",
+        "Elementary Hawaiian II",
+        "Intermediate Hawaiian I"
+      ]
+    },
+    {
+      "prefix": "DMED",
+      "name": "DMED",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Editing &amp; Audio",
+        "Advanced Film &amp; Video Storytelling &amp; Scriptwriting",
+        "Animation &amp; Special Effects",
+        "Character Animation",
+        "Digital Media Marketing and Online Distribution"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "AG",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "3 hour lecture 3 hour lab",
+        "Agriculture Business Mgmt",
+        "Agroforestry",
+        "Agroforestry Lab",
+        "Greenhouse Production"
+      ]
+    },
+    {
+      "prefix": "CSNT",
+      "name": "CSNT",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Computer Networking IA",
+        "Computer Networking IB",
+        "Computer Networking II",
+        "Database Systems I",
+        "ICT Support I"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Disease and Disability for Rehabilitation",
+        "Kinesiology",
+        "Kinesiology Lab",
+        "Soft Tissue Mobilization",
+        "Soft Tissue Mobilization Lab"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "Cosmetology",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cosmetology Clinic",
+        "Advanced Cosmetology Skills",
+        "Advanced Cosmetology Theory",
+        "Basic Hair, Skin and Nail Care Skills",
+        "Cosmetology Instructor Training"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Child, Family and Community",
+        "Developmentally Appropriate Practices",
+        "Early Childhood Development: Theory into Practice",
+        "Early Childhood Development: Theory Into Practice",
+        "Early Childhood Laboratory"
+      ]
+    },
+    {
+      "prefix": "ITS",
+      "name": "ITS",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Business PC System Maintenance, Support and OS Installation",
+        "Computer Hardware Support",
+        "Cyber Security Fundamentals",
+        "Database Administration I: Introduction to Data Analytics and R",
+        "Introduction to Databases"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Stem",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Science (Biological Science)",
+        "Introduction to Science Lab (Biological Science)",
+        "STEM Research - Experiential Learning in Food Biosecurity",
+        "STEM Research Exp in Env Sci",
+        "STEM Research Experience in Botany"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "honolulu-community-college",
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Fabrication Techniques",
+        "Introduction to Arc I",
+        "Introduction to Arc II",
+        "Introduction to Arc III",
+        "Introduction to Arc IV"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "RESP",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Cardiopulmonary Pathophysiology",
+        "Case and Disease Management in Cardiopulmonary Care",
+        "Clinical Practice III",
+        "Clinical Practice IV"
+      ]
+    },
+    {
+      "prefix": "ERTH",
+      "name": "Geology",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Dynamic Earth Laboratory",
+        "Geology of Hawaiian Islands",
+        "Intro to Physical Geology Lab",
+        "Introduction to Geology Lab",
+        "Natural Disasters and Human History"
+      ]
+    },
+    {
+      "prefix": "MELE",
+      "name": "MELE",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Audio Engineering I",
+        "Concert and Event Production",
+        "Introduction to Music Theory &amp; Songwriting",
+        "Music Supervision",
+        "Public Relations &amp; Media Tools"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "Radiologic",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Radiologic Positioning",
+        "Advanced Radiologic Positioning Laboratory",
+        "Applied Radiologic Principles",
+        "Introduction to Radiologic Technology",
+        "Introduction to Radiologic Technology Lab"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "BOT",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Ethnobotanical Pharmacognosy",
+        "Ethnobotany",
+        "General Botany Lab",
+        "RI-General Botany Laboratory",
+        "RI-S-Plants in Hawʻn Env Lab"
+      ]
+    },
+    {
+      "prefix": "FT",
+      "name": "Design",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Apparel Draft Design",
+        "Art and Design in Fashion",
+        "Basic Apparel Construction",
+        "Block Pattern Design I",
+        "Cutting Room Functions"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Assisting I",
+        "Basic Nutrition for the Medical Assistant",
+        "Clinical Medical Assisting I",
+        "Clinical Medical Assisting Lab I",
+        "Communication in the Medical Office"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "Physical",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Assistive Technology Lab",
+        "Critique: Fieldwork Level I: Physical Dysfunction and Developmental/Education",
+        "Fieldwork Level I: Physical Dysfunction/Development/Educational",
+        "Fundamentals of Assistive Technology",
+        "OT Adult Neurological Lab"
+      ]
+    },
+    {
+      "prefix": "AJ",
+      "name": "Justice",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Constitutional Law",
+        "Correctional Process",
+        "Criminal Justice System Reports and Communications",
+        "Criminology",
+        "Introduction to Administration of Justice"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Digital Earth",
+        "Geography &amp; Contemp Society",
+        "Geography and Contemporary Society",
+        "Introduction to GIS",
+        "S-The Natural Environment"
+      ]
+    },
+    {
+      "prefix": "HDFS",
+      "name": "Human",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Human Development",
+        "Working with People"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "MECH",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits",
+        "Electro-Hydraulics and Pneumatics (Fluid Power Systems)",
+        "Industrial Safety Health and Environment",
+        "Mechanical Drive Systems",
+        "Metallurgy"
+      ]
+    },
+    {
+      "prefix": "MICT",
+      "name": "Paramed",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Paramed I - Oahu A",
+        "Clinical Paramed V HILO A",
+        "Fund of Paramed I - Oahu A",
+        "Paramedic Intern IV-Oahu A"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to the World&#39;s Major Religions",
+        "Introduction to World&#39;s Major Religions",
+        "Religion and the Meaning of Existence",
+        "Sp Topic: Viking Religion",
+        "Understanding Hawaiian Religion"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "Carpentry",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Basic Carpentry I",
+        "Basic Carpentry II",
+        "Blueprint Reading for Carpenters",
+        "Carpentry Basics",
+        "Carpentry I"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Dental Materials",
+        "Dental Materials Lab",
+        "Dental Radiography",
+        "Dental Radiography Lab",
+        "Dental Sciences"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Principles of Economics I: Microeconomics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics",
+        "S-Principles of Economics/Micr"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "Education",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Bilingual Interpreting and Translation in Education",
+        "Classroom Management in the Instructional Process",
+        "Developing Language and Literacy I",
+        "Foundations of Education",
+        "Introduction to Multicultural Education"
+      ]
+    },
+    {
+      "prefix": "ETRO",
+      "name": "Electronics",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "hawaii-community-college",
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis I",
+        "Cisco Networking 1",
+        "Digital Electronics",
+        "Digital Electronics Laboratory",
+        "Electronic Technology 1"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "honolulu-community-college",
+        "kauai-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "E-Intro Politics in Hawai&#39;i",
+        "HCC-E-Intro American Politics",
+        "Introduction to American Government",
+        "Introduction to Hawaiian Politics",
+        "Introduction to Political Science"
+      ]
+    },
+    {
+      "prefix": "AEC",
+      "name": "AEC",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Basic Design Studio I",
+        "Construction Graphics and Conventions",
+        "Introduction to Construction Management",
+        "Land Surveying I",
+        "Planning and Scheduling"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Humanity",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Culture and Humanity",
+        "Emerging Humanity",
+        "S-Polynesian Surf Culture",
+        "S-Surf Culture Field Lab"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "hawaii-community-college",
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Advanced English as a Second Language",
+        "College Reading/Writing Skills II",
+        "Composition I",
+        "Essentials of English Grammar",
+        "Grammar II"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Human Relations in Management",
+        "Human Resource Management",
+        "Integrated Topics in Management",
+        "Organizational Behavior",
+        "Principles of Management"
+      ]
+    },
+    {
+      "prefix": "OESM",
+      "name": "Safety",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education",
+        "Electrical Safety",
+        "Introduction to Environmental Health",
+        "Introduction to Ergonomics",
+        "Introduction to Industrial Hygiene"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "E-Intro to Philosophy",
+        "Ethics in Health Care",
+        "HCC-E-Morals and Society",
+        "Intro to Inductive Logic",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "QM",
+      "name": "Methods",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "hawaii-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "QM for Transportation Tech",
+        "Quant Methods in AMT",
+        "Quantitative Methods Companion",
+        "Quantitative Methods for CULN",
+        "Quantitative Methods for the Trades"
+      ]
+    },
+    {
+      "prefix": "DNCE",
+      "name": "Beginning",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Ballet Technique",
+        "Beginning Contemporary Dance Technique",
+        "Continuing Contemporary Dance Technique",
+        "Hatha Yoga: Beginning",
+        "Hip Hop Dance"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I",
+        "Elementary Japanese I-SSP",
+        "Elementary Japanese II"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Clinical",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Biochemistry I",
+        "Clinical Biochemistry II",
+        "CLINICAL MICROBIOLOGY II",
+        "Hematology II",
+        "IMMUNOHEMATOLOGY"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Maintenance",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Advanced General Aircraft Maintenance II",
+        "Airframe Maintenance II",
+        "Airframe Maintenance III",
+        "General Aircraft Maintenance I",
+        "Powerplant Maintenance II"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "hawaii-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy Undergraduate Research Project",
+        "Survey of Astronomy",
+        "Survey of Astronomy Laboratory"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "kapiolani-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Applied Mathematics in Business",
+        "Business Information Systems",
+        "Principles of Business"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "hawaii-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Business Calculations",
+        "Career Success",
+        "Intro to Bus Computing",
+        "Word Processing for Business"
+      ]
+    },
+    {
+      "prefix": "CHW",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker Fundamentals",
+        "Health Promotion and Disease Prevention",
+        "Introduction to Counseling and Interviewing",
+        "WI-CHW Fundatmentals"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "ENGT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "hawaii-community-college"
+      ],
+      "sample_titles": [
+        "Geom &amp; Land Surveying II",
+        "Intro to Wastewater Mgmt",
+        "Introduction to GIS",
+        "Res Contract Dwgs &amp; Codes",
+        "UAS Flight"
+      ]
+    },
+    {
+      "prefix": "OCN",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "hawaii-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Intro to MOP",
+        "Introduction to Marine Option Program",
+        "Science of the Sea",
+        "Science of the Sea Laboratory"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Clinical Education",
+        "Measurement for the PTA",
+        "Measurement for the PTA - Lab",
+        "Professional Issues Seminar I",
+        "Therapeutic Modalities"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Basic Circuit Analysis I",
+        "Basic Circuit Analysis II",
+        "Programming for Engineers",
+        "Sophomore Project"
+      ]
+    },
+    {
+      "prefix": "EIMT",
+      "name": "Commercial",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "hawaii-community-college",
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Commercial Installation Lab",
+        "Commercial Installation Theory",
+        "Commercial Wiring",
+        "Interior Wiring",
+        "Renewable Energy PV"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Basic Accounting for Entrepreneurs",
+        "Introduction to Entrepreneurship",
+        "Marketing for Business",
+        "Staring a Business",
+        "Starting a Business"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "honolulu-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sociology of Food",
+        "Survey of General Sociology"
+      ]
+    },
+    {
+      "prefix": "ZOOL",
+      "name": "Zoology",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "honolulu-community-college",
+        "kauai-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Hawaiian Ethnozoology",
+        "Marine Biology Lab",
+        "Principles of Zoology",
+        "Principles of Zoology Lab"
+      ]
+    },
+    {
+      "prefix": "BLPR",
+      "name": "Blpr",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "hawaii-community-college",
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "BLPR for Carpenters",
+        "BLPR for Electricians",
+        "Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "CE",
+      "name": "Mechanics",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "honolulu-community-college",
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Applied Mechanics I"
+      ]
+    },
+    {
+      "prefix": "DISL",
+      "name": "DISL",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Operator Orientation",
+        "Preventative Maintenance",
+        "R &amp; R Components",
+        "Technical Practices"
+      ]
+    },
+    {
+      "prefix": "DRAM",
+      "name": "Stagecraft",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "hawaii-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Theatre Practicum",
+        "Basic Stagecraft",
+        "Basic Stagecraft Laboratory",
+        "Beginning Acting I"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emerg",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Emerg Med Tech - ALS Assist",
+        "Emerg Med Tech - ALS Pract",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "FSHE",
+      "name": "Science",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "The Science of Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "MWIM",
+      "name": "Welding",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "hawaii-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Welding",
+        "Intro to Arc Welding",
+        "Intro to Machine &amp; Welding",
+        "Lathe Facing and Knurling"
+      ]
+    },
+    {
+      "prefix": "SMP",
+      "name": "Processes",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Fabrication Processes (Architectural)",
+        "Hand Tool and Machine Processes",
+        "Introduction to Surface Development",
+        "Shop Problems"
+      ]
+    },
+    {
+      "prefix": "BIOC",
+      "name": "Biochemistry",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Biochemistry"
+      ]
+    },
+    {
+      "prefix": "BLAW",
+      "name": "Wilegal",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "E-Legal Envir of Business",
+        "WI-Legal Environment of Bus"
+      ]
+    },
+    {
+      "prefix": "CM",
+      "name": "CM",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "hawaii-community-college",
+        "kauai-community-college",
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Digital Video",
+        "WI-Games &amp; Gaming in Society",
+        "WI-Writing for Media"
+      ]
+    },
+    {
+      "prefix": "FIL",
+      "name": "FIL",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Filipino I",
+        "WI-E-Phl Food, Story, and Comm",
+        "WI-Filipino Cinema"
+      ]
+    },
+    {
+      "prefix": "HSER",
+      "name": "HSER",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "hawaii-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Exploration of Self in Society",
+        "Individual Counseling",
+        "Intro to Human Services"
+      ]
+    },
+    {
+      "prefix": "LSK",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "College Success Strategies"
+      ]
+    },
+    {
+      "prefix": "PACS",
+      "name": "Shpacific",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "S,H-Pacific Worlds"
+      ]
+    },
+    {
+      "prefix": "ABRP",
+      "name": "Collision",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "hawaii-community-college"
+      ],
+      "sample_titles": [
+        "Collision Repair",
+        "Panel &amp; Glass Replacement Tech"
+      ]
+    },
+    {
+      "prefix": "ESS",
+      "name": "Wellness",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Wellness and Fitness"
+      ]
+    },
+    {
+      "prefix": "FENG",
+      "name": "Facility",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Facility Safety and Accident Prevention"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Health Data, Information, Law, and Ethics",
+        "Healthcare Delivery Systems"
+      ]
+    },
+    {
+      "prefix": "KOR",
+      "name": "Korean",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "kapiolani-community-college",
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Korean I"
+      ]
+    },
+    {
+      "prefix": "LING",
+      "name": "Language",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "hawaii-community-college",
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Language",
+        "WI-H-Language in HAP"
+      ]
+    },
+    {
+      "prefix": "MARE",
+      "name": "Marine",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Marine Biology I",
+        "Introduction to Marine Biology Laboratory I"
+      ]
+    },
+    {
+      "prefix": "NREM",
+      "name": "Calculus",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Applied Calculus for Management, Life Sciences, and Human Resources",
+        "S-Principles of Sustainability"
+      ]
+    },
+    {
+      "prefix": "PART",
+      "name": "Senior",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "hawaii-community-college"
+      ],
+      "sample_titles": [
+        "Senior Project",
+        "Senior Seminar"
+      ]
+    },
+    {
+      "prefix": "PH",
+      "name": "Public",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "kauai-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Public Health",
+        "Public Health Issues in Hawaiʻi"
+      ]
+    },
+    {
+      "prefix": "RAC",
+      "name": "Refrigeration",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning I",
+        "Basic Refrigeration"
+      ]
+    },
+    {
+      "prefix": "AMST",
+      "name": "Hindigenous",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "H-Indigenous Studies"
+      ]
+    },
+    {
+      "prefix": "AQUA",
+      "name": "Sthe",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "S-The Hawai`i Fishpond Lab"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "ASL",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Elementary ASL II"
+      ]
+    },
+    {
+      "prefix": "CHN",
+      "name": "Chinese",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Chinese Lang &amp; Culture"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "WI-Intro to Communication"
+      ]
+    },
+    {
+      "prefix": "DIMC",
+      "name": "Diesel",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hawaii-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Diesel Engines"
+      ]
+    },
+    {
+      "prefix": "ES",
+      "name": "Shwiintro",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "S,H,WI-Intro to Ethnic Studies"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "UM Research in Sustainability"
+      ]
+    },
+    {
+      "prefix": "IEDB",
+      "name": "Blueprint",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "honolulu-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "Sthe",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "S-The Hawai&#39;i Legal System"
+      ]
+    },
+    {
+      "prefix": "LLL",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "Global Education Experience"
+      ]
+    },
+    {
+      "prefix": "ME",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Engineering Design"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "OEST",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "leeward-community-college"
+      ],
+      "sample_titles": [
+        "Natural Hazards"
+      ]
+    },
+    {
+      "prefix": "SLT",
+      "name": "Wilanguage",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "WI-Language Learning"
+      ]
+    },
+    {
+      "prefix": "SUST",
+      "name": "Sprinciples",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kapiolani-community-college"
+      ],
+      "sample_titles": [
+        "S-Principles of Sustainability"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Withe",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "windward-community-college"
+      ],
+      "sample_titles": [
+        "WI-The Field of Social Work"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/id/subject-vocab.json
+++ b/data/id/subject-vocab.json
@@ -1,0 +1,2540 @@
+{
+  "state": "id",
+  "generated_at": "2026-06-06T15:41:40.067Z",
+  "subjects": [
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 27,
+      "section_count": 361,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Business Writing",
+        "Creative Writing Fiction",
+        "Creative Writing Nonfiction",
+        "Creative Writing Poetry",
+        "Creative Writing: Nonfiction"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 35,
+      "section_count": 284,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Advanced Prep Math",
+        "Analytic Geometry & Calc II",
+        "Analytic Geometry and Calc III",
+        "Business Mathematics",
+        "Calculus I"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 33,
+      "section_count": 241,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Biology 2 Lab",
+        "Biology I",
+        "Biology I Lab",
+        "Biology II",
+        "Biology II Lab"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 21,
+      "section_count": 171,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Argumentation and Debate",
+        "Communicating Thru Web Design",
+        "Communication and Culture",
+        "Communication Capstone",
+        "Communication Internship"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 40,
+      "section_count": 82,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "ACE Personal Trainer Cert",
+        "Athletic Injuries-Sports Med",
+        "Beginning Fly Fishing",
+        "Beginning Golf",
+        "Beginning Rock Climbing"
+      ]
+    },
+    {
+      "prefix": "BUSA",
+      "name": "Business",
+      "course_count": 22,
+      "section_count": 79,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Analytics for Managers",
+        "Big Data & Business Analytics",
+        "Business Analytics",
+        "Business Capstone",
+        "Business Comm & Professionalsm"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 14,
+      "section_count": 75,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Child & Adolescent Development",
+        "Child Development",
+        "Developmental Psychology",
+        "Drug Use and Misuse"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 20,
+      "section_count": 73,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Carbon Compounds",
+        "Concepts of Chemistry",
+        "Concepts of Chemistry Lab",
+        "Essntls of Organic & Biochem",
+        "Esstl of Organic & Biochem Lab"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 9,
+      "section_count": 71,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "AI and Ethics",
+        "Belief and Reality",
+        "Ethics in Health Care",
+        "Introduction to Ethics",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "WEMF",
+      "name": "Welding",
+      "course_count": 22,
+      "section_count": 63,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Blueprint Read & Layout VII",
+        "Blueprint Read & Layout VIII",
+        "Blueprint Read for Welders I",
+        "Blueprint Read for Welders II",
+        "Blueprint Read for Welders III"
+      ]
+    },
+    {
+      "prefix": "MUSA",
+      "name": "MUSA",
+      "course_count": 42,
+      "section_count": 59,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Cello",
+        "Clarinet",
+        "Classical Guitar",
+        "Composition",
+        "Euphonium"
+      ]
+    },
+    {
+      "prefix": "CWI",
+      "name": "Connecting",
+      "course_count": 2,
+      "section_count": 58,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Connecting With Ideas",
+        "General Studies Capstone"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 11,
+      "section_count": 51,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Historian's Craft",
+        "History Through Biography",
+        "Intro to the Study of History",
+        "Themes in Western History",
+        "U.S. Military History"
+      ]
+    },
+    {
+      "prefix": "CAOT",
+      "name": "CAOT",
+      "course_count": 22,
+      "section_count": 41,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Administrative Support Intern",
+        "AI Essentials for Workplace",
+        "Business Editing & Proofread",
+        "Career Leadership",
+        "Computer Fundamentals for Tech"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 23,
+      "section_count": 40,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "2-D/Design Foundations",
+        "Adobe Photoshop and Lightroom",
+        "Art Hist Da Vinci to Digital",
+        "Art History Caves to Cathedral",
+        "Beginning Painting I"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Health",
+      "course_count": 8,
+      "section_count": 39,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Determinants of Health",
+        "Fundamentals of Nutrition",
+        "Global Health",
+        "Intro to Health Data Analytics",
+        "Intro to Health Systems"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 6,
+      "section_count": 37,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Global Issues",
+        "Intro to Ethnic Studies",
+        "Introduction to Sociology",
+        "Marriage and Family",
+        "Social Problems"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 23,
+      "section_count": 36,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Adv Med/Surg Health Nursing",
+        "Adv Medical Nursing Lab/Clinic",
+        "Basic Med/Surg Nursing Clinic",
+        "Basic Medical Surgical Nursing",
+        "Basic Pharmacology Nursing"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 10,
+      "section_count": 36,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Elem Astronomy Lab",
+        "Elementary Astronomy",
+        "Fundamentals Physical Science",
+        "General Physics I",
+        "General Physics I Lab"
+      ]
+    },
+    {
+      "prefix": "AMET",
+      "name": "AMET",
+      "course_count": 13,
+      "section_count": 35,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "AC Circuits and Application",
+        "Analog Circuits",
+        "Applied Mechatronics",
+        "Auto Controls/Instrumentation",
+        "DC Circuits and Application"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 6,
+      "section_count": 34,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "American Constitutional Fndtns",
+        "American National Government",
+        "International Politics/Problem",
+        "Intro to Comparative Politics",
+        "Intro to Political Science"
+      ]
+    },
+    {
+      "prefix": "CLC",
+      "name": "CLC",
+      "course_count": 7,
+      "section_count": 33,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Academic Pathways Exploration",
+        "Career Readiness",
+        "College Study Skills",
+        "Designing Your NIC Experience",
+        "Dual Credit Transition Seminar"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "SURG",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Clinical Experience I",
+        "Clinical Experience II",
+        "Disease Process and Pharm",
+        "Fundamentals of ST I",
+        "Fundamentals of ST I Lab"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 23,
+      "section_count": 31,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Lab III",
+        "Auto Electrical Systems I",
+        "Auto Electrical Systems II",
+        "Auto Foundations & Safety",
+        "Auto Maintenance"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 3,
+      "section_count": 30,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Economic Issues",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "MMBS",
+      "name": "Introductory",
+      "course_count": 3,
+      "section_count": 30,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Introductory Microbiology",
+        "Introductory Microbiology Lab",
+        "Making Sense of Microbiotic Me"
+      ]
+    },
+    {
+      "prefix": "ARN",
+      "name": "Nurs",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Adv Foundations Nurs Prac",
+        "Adv Foundations Nurs Prac Lab",
+        "Advanced Fund Course & Lab",
+        "Clinical Preceptorship",
+        "Concepts of Med Surg Nurs I"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 5,
+      "section_count": 28,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Intermediate Spanish I",
+        "Spanish for Health Professions",
+        "Spanish for Health Providers"
+      ]
+    },
+    {
+      "prefix": "PTAE",
+      "name": "PTAE",
+      "course_count": 11,
+      "section_count": 25,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Clinical Affiliation I",
+        "Clinical Pathology",
+        "Data Collections",
+        "Data Collections Lab",
+        "Kinesiology"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 7,
+      "section_count": 24,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Anthropology Internship",
+        "Biological Anthropology",
+        "Cultural Anthropology",
+        "Indigenous Mythology & Rituals",
+        "Intro to Anthropology"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "CNT",
+      "course_count": 16,
+      "section_count": 24,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Computer Essentials",
+        "Emerging Trends Cybersecurity",
+        "Fundamentals in Network Sec",
+        "Intrusion Detection",
+        "Leadership 1"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Accounting for Managers",
+        "Accounting Internship",
+        "Foundations of Accounting Prof",
+        "Income Tax Fundamentals",
+        "Intro to Financial Accounting"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Adv Dental Assisting Practicum",
+        "Advanced Instrumentation",
+        "Community Dental Health",
+        "Dental Clinical Skills I",
+        "Dental Hygiene Clinic III"
+      ]
+    },
+    {
+      "prefix": "MACH",
+      "name": "MACH",
+      "course_count": 16,
+      "section_count": 22,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "CNC Lab",
+        "CNC Machining Center Lab",
+        "CNC Machining Center Theory",
+        "CNC Turning Center Lab"
+      ]
+    },
+    {
+      "prefix": "TTEC",
+      "name": "TTEC",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Basic Electrical",
+        "Diesel Engines",
+        "Electrical/Electronic Systems",
+        "Fuel, Air, and Emissions",
+        "HD Truck Technologies"
+      ]
+    },
+    {
+      "prefix": "CRIJ",
+      "name": "Justice",
+      "course_count": 9,
+      "section_count": 21,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Criminal Justice Capstone",
+        "Criminal Justice Internship",
+        "Criminology",
+        "Intro to Corrections",
+        "Intro to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Dinosaurs",
+        "Historical Geology",
+        "Historical Geology Lab",
+        "Physical Geology",
+        "Physical Geology Lab"
+      ]
+    },
+    {
+      "prefix": "BSN",
+      "name": "Business",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Advanced Business Statistics",
+        "Business Internship",
+        "Business Statistics",
+        "Comp Productivity Applications",
+        "Introduction to Business"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Diversity in the Schools",
+        "Education Around the World",
+        "Education Capstone",
+        "Educational Technology",
+        "Educational Technology I"
+      ]
+    },
+    {
+      "prefix": "HTEC",
+      "name": "HTEC",
+      "course_count": 15,
+      "section_count": 17,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Basic Engines",
+        "Basic Powertrains",
+        "CAN Bus/System Troubleshoot",
+        "DC Circuit & Basic Electrical",
+        "Electronically Managed Systems"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Digital Design Tools",
+        "Drawing I",
+        "Intro to 2-D Art Foundations",
+        "Intro to 3-D Art Foundations",
+        "Painting I"
+      ]
+    },
+    {
+      "prefix": "CHD",
+      "name": "Child Development",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Child Development Practicum I",
+        "Child Development Practicum II",
+        "Chld Hlth, Safety, Nutrition",
+        "Early Childhood Curriculum",
+        "Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "CITE",
+      "name": "CITE",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Comp Info Tech Essentials Proj",
+        "Computer IT Essentials",
+        "Cybersecurity Internship",
+        "Data Management",
+        "Desktop Commodity OS Projects"
+      ]
+    },
+    {
+      "prefix": "CSEC",
+      "name": "Cybersecurity",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Advanced Cybersecurity",
+        "Cybersecurity Capstone",
+        "Cybersecurity Essentials",
+        "Fundamentals of Linux",
+        "Intro to Information Security"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Child Development & Guidance",
+        "Child Growth & Development",
+        "Early Childhood Curriculum I",
+        "Early Childhood Ed Pract Lab",
+        "Early Childhood Educ Capstone"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Circuits I",
+        "Circuits I Lab",
+        "Engineering Analysis",
+        "Engineering Capstone",
+        "Engineering Graphics"
+      ]
+    },
+    {
+      "prefix": "MICR",
+      "name": "Microbiology",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Microbiology Lab",
+        "Introduction to Microbiology"
+      ]
+    },
+    {
+      "prefix": "HRTC",
+      "name": "HRTC",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Annuals and Perennials",
+        "Horticulture Busnss Mgmt Prctm",
+        "Horticulture Intern & Seminar",
+        "Integrated Pest Management",
+        "Interior & Floral Plant Design"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "MEDA",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Ethics for Med Professionals",
+        "Human Relations in Healthcare",
+        "Integrated Med Office Software"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "Music",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Introduction to Music",
+        "Surv Amer Popular Music",
+        "Survey of Jazz & Pop Music",
+        "Survey of World Music"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "Animal",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Agricultural Science Capstone",
+        "Animal Anatomy & Phys Lab",
+        "Animal Anatomy and Physiology",
+        "Farm & Agribusiness Management",
+        "Global Food Perspectives"
+      ]
+    },
+    {
+      "prefix": "ASE",
+      "name": "ASE",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Automotive I Lab",
+        "Automotive I Theory",
+        "Automotive II Lab",
+        "Automotive II Theory",
+        "Automotive/Diesel Basic HVAC"
+      ]
+    },
+    {
+      "prefix": "INTR",
+      "name": "INTR",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Common Read",
+        "Death and Dying",
+        "Health Benefits of Nature",
+        "Intr. Bus. and Value Creation",
+        "Leadership in Healthcare"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "Radiographic",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Clinical Radiography II",
+        "Clinical Radiography III",
+        "Introduction to Radiography",
+        "Introduction to Radiology Lab",
+        "Prin Radiation Bio & Prtct"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Advanced SMAW Practical",
+        "Advanced Welding Theory",
+        "Autobody & Paint Tech Welding",
+        "Blueprint Reading for Welders",
+        "Layout/Mechanical Drawing"
+      ]
+    },
+    {
+      "prefix": "GDES",
+      "name": "Design",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustr - Vector Graphic",
+        "Adobe InDesign and Prepress",
+        "AI for Designers",
+        "Design Projects",
+        "Digital Video & Comp Animation"
+      ]
+    },
+    {
+      "prefix": "SIGL",
+      "name": "Sign",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III",
+        "Americn Sign Language Capstone",
+        "Fingerspelling and Numbers"
+      ]
+    },
+    {
+      "prefix": "CPSC",
+      "name": "Computer",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Computer Science I",
+        "Computer Science II",
+        "Intro to Full Stack Web Dev.",
+        "Intro to Python Programming",
+        "Intro to Version Control"
+      ]
+    },
+    {
+      "prefix": "EXHS",
+      "name": "Kinesiology",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Applied Kinesiology",
+        "Health & Wellness",
+        "Intro to Kinesiology",
+        "Motor Learning",
+        "Motor Learning Lab"
+      ]
+    },
+    {
+      "prefix": "HCT",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Cultivating Pro Resil & Wlns",
+        "Intro to Health Professions",
+        "Medical - Intro to Ethics",
+        "Medical Terminology",
+        "Nutrition for Health Care Pros"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Adult Physical Dysfunction",
+        "Adult Rehabilitation Lab",
+        "Fieldwork Level I: Placement I",
+        "Fieldwork Lvl I: Placement III",
+        "Geriatric Occupational Therapy"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "Care",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Care of Adults Clinical",
+        "Comprehensive Care of Adults",
+        "Nurs. Care of Elderly Clinical",
+        "Nursing Care Developing Family",
+        "Nursing Care of the Elderly"
+      ]
+    },
+    {
+      "prefix": "SCIE",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Ethics in Science",
+        "Foundations of Science",
+        "STEM Capstone",
+        "Vertically Integrated Projects"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Food Safety and Sanitation",
+        "Food Science",
+        "Intro to Customer Service",
+        "Intro to Customer Service Lab",
+        "Professional Kitchen 1"
+      ]
+    },
+    {
+      "prefix": "ENVI",
+      "name": "Environmental",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Environmental Science Lab",
+        "General Ecology",
+        "General Ecology Lab"
+      ]
+    },
+    {
+      "prefix": "GEOS",
+      "name": "GEOS",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Earth's Natural Resources",
+        "Field Geology",
+        "Geosciences Internship",
+        "Global Climate Change",
+        "Hazards and Disasters Lab"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "Hospitality",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Careers in Hospitality",
+        "Food Safety and Sanitation",
+        "Hospitality Field Exp II",
+        "Hospitality Field Exp III",
+        "Intro Hospitality and Tourism"
+      ]
+    },
+    {
+      "prefix": "ACRR",
+      "name": "Collision",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Collision Repair Lab I",
+        "Collision Repair Lab II",
+        "Damage Analysis & Small Dent",
+        "Exterior & Interior Renovation",
+        "Fundamentals Collision Repair"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "Computer",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Computer Science I",
+        "Computer Science I Lab",
+        "Computer Science II",
+        "Computer Science II Lab",
+        "Intro to Programming"
+      ]
+    },
+    {
+      "prefix": "DSLT",
+      "name": "DSLT",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Adv Tune-Up/Comptr Engines Lab",
+        "Adv Tune-Up/Computer Engines",
+        "Diesel Engine Elec Systems Lab",
+        "Diesel Engines",
+        "Diesel Lab"
+      ]
+    },
+    {
+      "prefix": "FINA",
+      "name": "Finance",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Pers. Finance & Business Math",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Accounting Essentials",
+        "Business Lab I",
+        "Business Lab II",
+        "Financial Management",
+        "Human Resource Management"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "college-of-eastern-idaho",
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Basics of Performance I",
+        "Introduction to the Theatre",
+        "Scene Design I",
+        "Stage Makeup",
+        "Theatre Practice"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Blueprint Reading for Welders",
+        "Cutting Operations Lab I",
+        "Safety and Leadership",
+        "SMAW Practical",
+        "Welding Fabrication Lab"
+      ]
+    },
+    {
+      "prefix": "BOAA",
+      "name": "Business",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "10-Key Skill Building",
+        "Book/Acctg Assist Intership",
+        "Current Business Taxes",
+        "Fraud Investigation",
+        "QuickBooks"
+      ]
+    },
+    {
+      "prefix": "CMGT",
+      "name": "Construction",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Drawings, Specs, and Codes",
+        "Intro to Construction Mgmt"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "Dental",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Dental Anat, Embry & Histology",
+        "Dental Hygiene Clinic I",
+        "Dental Materials",
+        "Dental Materials Lab",
+        "Dental Radiology"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Global Climate Change",
+        "Physical Geography",
+        "Physical Geography Lab",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "HVACR Electrical",
+        "HVACR Heating",
+        "HVACR Lab I",
+        "HVACR Principles",
+        "HVACR Systems"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "Beginning",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Beginning Admin-Skills for MA",
+        "Beginning Clinical Skills MA",
+        "Beginning Phlebotomy",
+        "Intern/Externship II",
+        "Phlebotomy Clinical Experience"
+      ]
+    },
+    {
+      "prefix": "MSCL",
+      "name": "Leadership",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Applied Tactical Leadership",
+        "Applied Tactical Leadershp Lab",
+        "Corps Physical Fitness",
+        "Leadership & Personal Devlpmnt",
+        "Leadrshp & Personl Dvlpmnt Lab"
+      ]
+    },
+    {
+      "prefix": "MUSP",
+      "name": "MUSP",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Cardinal Chamber Orchestra",
+        "Cardinal Voices",
+        "Chamber Singers",
+        "NIC Cardinal Chorale",
+        "NIC Jazz Ensemble"
+      ]
+    },
+    {
+      "prefix": "SWDV",
+      "name": "SWDV",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Advanced Web App Development",
+        "Capstone Internship",
+        "Collaborative Development",
+        "Fund of Database Systems",
+        "Intermediate Programming"
+      ]
+    },
+    {
+      "prefix": "BACT",
+      "name": "Microbiology",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "General Microbiology",
+        "General Microbiology Lab"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Corrections in America",
+        "Drugs and Society",
+        "Intro to Criminal Justice",
+        "Introduction to Criminology"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "Drafting",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Civil Drafting and Math",
+        "Const Materials & Processes",
+        "Drafting Basics",
+        "Intro to AutoCAD",
+        "Intro to Revit"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Fire Fighter",
+        "Fire Prevention",
+        "Fire Service Capstone",
+        "Physical Fitness- Firefighters",
+        "Principles Emergency Services"
+      ]
+    },
+    {
+      "prefix": "PLEG",
+      "name": "Legal",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Criminal Law and Procedure",
+        "Fundamentals of Legal Support",
+        "Introduction to Law",
+        "Legal Research and Writing I",
+        "Legal Terminology"
+      ]
+    },
+    {
+      "prefix": "PSER",
+      "name": "PSER",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Adv Electrical & Diagnostics",
+        "Engine Mgmt & Adv Fuel Systems",
+        "Foundations of Safety",
+        "Fuel Systems/OPE Maintenance",
+        "Industry Practicum"
+      ]
+    },
+    {
+      "prefix": "RRM",
+      "name": "RRM",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Event Planning and Management",
+        "Outdoor Navigation",
+        "Outdoor Programming/Leadership",
+        "Risk Mgmt in Resort Industry",
+        "Swift Water Rescue"
+      ]
+    },
+    {
+      "prefix": "SOCW",
+      "name": "Social",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Foundations of Social Work",
+        "Social Work and Social Welfare",
+        "Social Work Capstone"
+      ]
+    },
+    {
+      "prefix": "ADMS",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Adv Office Information Systems",
+        "Business Editing",
+        "Business English",
+        "Business Writing",
+        "Office Procedures"
+      ]
+    },
+    {
+      "prefix": "AICC",
+      "name": "Cloud",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "AI and Cloud Computing",
+        "Computer Vision",
+        "Intro to AI",
+        "Linux for AI and Cloud",
+        "Machine Learning"
+      ]
+    },
+    {
+      "prefix": "CEI",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "CEI: Career Exploration",
+        "College, Experience, & Ideas"
+      ]
+    },
+    {
+      "prefix": "COMJ",
+      "name": "Media",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Introduction to Media Writing",
+        "Mass Media in a Free Society",
+        "The Sentinel"
+      ]
+    },
+    {
+      "prefix": "CSSA",
+      "name": "Network",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Email and Clustering",
+        "Fund of Windows Operating Syst",
+        "Hybrid Infrastructure",
+        "Network Design and Security",
+        "Network Fundamentals & Cert."
+      ]
+    },
+    {
+      "prefix": "DFA",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Data Analytics Internship",
+        "Database Management",
+        "Intro to Cyber Operations",
+        "Intro to Digital Forensics",
+        "Project Management"
+      ]
+    },
+    {
+      "prefix": "LAWE",
+      "name": "LAWE",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Arrest Control and POST Chall",
+        "Basic Police and Orientatn II",
+        "Enforcement and Field Skills",
+        "Introduction to POST and Law",
+        "Law Enforcement I"
+      ]
+    },
+    {
+      "prefix": "LSPT",
+      "name": "LSPT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Civil Litigation",
+        "Const Law, Rights & Resp",
+        "Criminal Law",
+        "Intro to Law Lab",
+        "Introduction to Law"
+      ]
+    },
+    {
+      "prefix": "MDET",
+      "name": "MDET",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Advanced SW Techniques",
+        "Geo Dimension and Tolerancing",
+        "Machining Technology Lab I",
+        "Machining Technology Theory I",
+        "SolidWorks Basic"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Immunology and Lab Operations",
+        "Medical Lab Chemistry",
+        "Medical Lab Microbiology",
+        "MLT Student Lab Practice",
+        "Parasitology and Virology"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Harmony and Theory I",
+        "Harmony and Theory I Lab",
+        "Harmony and Theory III",
+        "Harmony and Theory III Lab",
+        "Music Convocation"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "NRS",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Essen Fundmntls of Nrsing Lab",
+        "Essential Fndmntls of Nursing",
+        "Foundations of Med/Surg II",
+        "Foundations of Med/Surg Nrs I",
+        "Introduction to Maternal/Child"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "Photography",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Digital Photography I",
+        "Event Photography",
+        "Land & Arch Photo",
+        "Portrait Photography",
+        "Still Life Photography"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "Essentials",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "CCNA Cyber Ops",
+        "Intro to Networks",
+        "IT Essentials",
+        "Linux Essentials",
+        "Virtualization Technologies"
+      ]
+    },
+    {
+      "prefix": "CSSP",
+      "name": "CSSP",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Adv Network & Troubleshoot",
+        "Fundamentals of Computing",
+        "IT & Cloud Fundamentals",
+        "Principles of Networking",
+        "Surv Peripheral Technologies"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "college-of-western-idaho",
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Intermediate French I"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Introduction to Humanities I"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "World",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "World Humanities"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "MET",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Fluid and Pneumatic Principles",
+        "Human Machine Interface",
+        "Mechanical Principles",
+        "PLC & VFD Fundamental Sys Lab",
+        "Robotics 1"
+      ]
+    },
+    {
+      "prefix": "MM",
+      "name": "Industrial",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Industrial Blueprints",
+        "Industrial Mechanics I",
+        "Industrial Mechanics III",
+        "Industrial Mechanics Lab I",
+        "Industrial Mechanics Lab III"
+      ]
+    },
+    {
+      "prefix": "BOOK",
+      "name": "Accounting",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Applied Accounting",
+        "Computerized Accounting",
+        "Fundamental Accountng Concepts"
+      ]
+    },
+    {
+      "prefix": "CRT",
+      "name": "Collision",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Adv Collision Repair/Refinish",
+        "Basic Collision Repair",
+        "Refinishing - Collision Repair",
+        "Safety and Welding"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Education Technology",
+        "Families, Communities, Culture",
+        "Field Experience",
+        "Foundations of Education"
+      ]
+    },
+    {
+      "prefix": "ENSI",
+      "name": "Environmental",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Environmental Science Lab",
+        "Intro to Environmental Science"
+      ]
+    },
+    {
+      "prefix": "MCTE",
+      "name": "Technical",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Comp Skills Allied Health",
+        "Technical Math for MACH/CADT",
+        "Technical Mathematics"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "Marketing",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Marketing",
+        "Marketing Communctns Capstone",
+        "Principles of Management"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "Practical",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Practical Nursing Lab 1",
+        "Practical Nursing Lab III",
+        "Practical Nursing Theory I",
+        "Practical Nursing Theory III"
+      ]
+    },
+    {
+      "prefix": "SFA",
+      "name": "Surgical",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Advanced Surgical Anatomy",
+        "Advanced Surgical Procedures",
+        "Clinical Practicum I",
+        "Clinical Practicum II"
+      ]
+    },
+    {
+      "prefix": "SRT",
+      "name": "Surgical",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Pharm for Surg Technologist",
+        "Surgical Clinic I",
+        "Surgical Procedures I",
+        "Surgical Techniques I"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "Flight",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Digital Imagery Fundamentals",
+        "Flight Lab I",
+        "Flight Theory - Ground School",
+        "Intro to GPS"
+      ]
+    },
+    {
+      "prefix": "ZOOL",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Human Biology Lab",
+        "Introduction to Human Biology"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Financial Accounting",
+        "Intro to Managerial Accounting"
+      ]
+    },
+    {
+      "prefix": "BLDR",
+      "name": "BLDR",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Customer Service",
+        "Leadership",
+        "Supervisory Management"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Applied Tech Inter Algebra",
+        "Electrical Theory",
+        "Electronic Lab"
+      ]
+    },
+    {
+      "prefix": "ENTP",
+      "name": "ENTP",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Bus. Development & Planning",
+        "Entrepreneurship Skills",
+        "Small Business Financial Manag"
+      ]
+    },
+    {
+      "prefix": "EXHA",
+      "name": "Stress",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Stress Management",
+        "Walking for Health and Fitness"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "Film",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Film Studies",
+        "Movies Around the World"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Fundamentals of GIS",
+        "Web GIS"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Introduction to the Humanities"
+      ]
+    },
+    {
+      "prefix": "IRAA",
+      "name": "IRAA",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "AC/DC Electrical Concepts",
+        "Indst Networks & Cybersecurity",
+        "Introduction to PLCs"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Digital Marketing",
+        "Sales and Customer Service"
+      ]
+    },
+    {
+      "prefix": "MSA",
+      "name": "MSA",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Army Standard Phys Fit Train I",
+        "Intro to Military Science",
+        "Leadership Lab"
+      ]
+    },
+    {
+      "prefix": "PRMG",
+      "name": "Project",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Project Controls",
+        "Intro to Project Management"
+      ]
+    },
+    {
+      "prefix": "SMT",
+      "name": "Nanofabrication",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Nanofabrication I",
+        "Nanofabrication II",
+        "Prog. for Semiconductor Mfg."
+      ]
+    },
+    {
+      "prefix": "ACLS",
+      "name": "Cardiac",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support"
+      ]
+    },
+    {
+      "prefix": "BTNY",
+      "name": "Botany",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "General Botany",
+        "General Botany Lab"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Business Computer App Lab",
+        "Business Computer Applications"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Law & Justice"
+      ]
+    },
+    {
+      "prefix": "CULP",
+      "name": "Culinary",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Culinary Fundamentals Lab",
+        "Proteins and Modern Techniques"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Latin Social Dance",
+        "Social/Swing Dance"
+      ]
+    },
+    {
+      "prefix": "DUSK",
+      "name": "Durable",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Communication",
+        "Durable Skills Critical Think"
+      ]
+    },
+    {
+      "prefix": "ENVS",
+      "name": "Environmental Science",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Environmental Science Lab"
+      ]
+    },
+    {
+      "prefix": "ESE",
+      "name": "Engineering",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Engineering Tech Orient Lab",
+        "Engineering Technology Orient"
+      ]
+    },
+    {
+      "prefix": "FERM",
+      "name": "Fermented",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Fermented Food"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Management Internship"
+      ]
+    },
+    {
+      "prefix": "MTD",
+      "name": "Autodiesel",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Auto/Diesel Tech Fund & Safety",
+        "Mechanics Technical Math"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Introduction to Nursing"
+      ]
+    },
+    {
+      "prefix": "PHAR",
+      "name": "Pharmacology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Introduction to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Work",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Intro to Social Work",
+        "Soc Work Generalist Practice"
+      ]
+    },
+    {
+      "prefix": "WOCU",
+      "name": "Contemporary",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Contemporary World Cultures"
+      ]
+    },
+    {
+      "prefix": "AIST",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "American Indian Studies"
+      ]
+    },
+    {
+      "prefix": "ALTH",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Communication for Health Prof"
+      ]
+    },
+    {
+      "prefix": "ATEC",
+      "name": "Occupational",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Occupational Rlatns/Job Search"
+      ]
+    },
+    {
+      "prefix": "BMGT",
+      "name": "Mgmt",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Bus Mgmt Internship"
+      ]
+    },
+    {
+      "prefix": "CINA",
+      "name": "Film",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Film and Culture"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Introduction to Engineering"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "ESL Speaking and Listening"
+      ]
+    },
+    {
+      "prefix": "GDEM",
+      "name": "Game",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Game Design Theory"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Elementary German I"
+      ]
+    },
+    {
+      "prefix": "HCIT",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Medical Law and Ethics"
+      ]
+    },
+    {
+      "prefix": "HON",
+      "name": "HON",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Honors"
+      ]
+    },
+    {
+      "prefix": "HRA",
+      "name": "Recruit",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-idaho-college"
+      ],
+      "sample_titles": [
+        "Recruit, Selection & Retention"
+      ]
+    },
+    {
+      "prefix": "MADM",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Health Insurance and Billing"
+      ]
+    },
+    {
+      "prefix": "MSCI",
+      "name": "Materials",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-western-idaho"
+      ],
+      "sample_titles": [
+        "Intro to Materials Science"
+      ]
+    },
+    {
+      "prefix": "OCR",
+      "name": "Occupational",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Occupational Relations"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-eastern-idaho"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/il/subject-vocab.json
+++ b/data/il/subject-vocab.json
@@ -1,0 +1,13396 @@
+{
+  "state": "il",
+  "generated_at": "2026-06-06T15:41:40.193Z",
+  "subjects": [
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 137,
+      "section_count": 1563,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "college-of-dupage",
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Addt'l Topics-Vector Calculus",
+        "Advanced Math",
+        "Algebra Essentials",
+        "Algebraic Literacy with Geometry",
+        "Applied Mathematical Concepts"
+      ]
+    },
+    {
+      "prefix": "BIOLOGY",
+      "name": "Biology",
+      "course_count": 20,
+      "section_count": 1359,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Biochemistry",
+        "Biology I",
+        "Biology II",
+        "Biology Of Human Sexuality",
+        "Environmental Biology"
+      ]
+    },
+    {
+      "prefix": "ENGLISH",
+      "name": "Writing",
+      "course_count": 17,
+      "section_count": 1060,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Aligned Reading and Composition",
+        "Business Writing",
+        "College Newspaper",
+        "Communications Skills",
+        "Composition"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 168,
+      "section_count": 999,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "college-of-dupage",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lewis-and-clark-community-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "2D Game Development",
+        "2D Game Scripting",
+        "3D Game Development",
+        "3D Modeling I",
+        "Active Server Pages"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 214,
+      "section_count": 972,
+      "colleges": [
+        "frontier-community-college",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Ableton Electronic Music Ensem",
+        "An Intro to American Music",
+        "APPL MUSC BAR HORN",
+        "APPL MUSIC BASS",
+        "APPL MUSIC BASSOON"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 110,
+      "section_count": 897,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "morton-college",
+        "oakton-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Algebra Concepts",
+        "Applied Calculus for Bus & Soc",
+        "APPLIED MATH I",
+        "Applied Mathematics I",
+        "Business and Consumer Mathematics"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 190,
+      "section_count": 880,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "college-of-dupage",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lewis-and-clark-community-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "prairie-state-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "2-D Design",
+        "2-D Design Foundations",
+        "2-D Foundations Studio",
+        "3-Dimensional Foundatn Studio",
+        "Adv Ceramics I"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 67,
+      "section_count": 862,
+      "colleges": [
+        "frontier-community-college",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "prairie-state-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Adv Tech Writing/Comm",
+        "AMER LIT 1860-PRES",
+        "Analytical Mechanics (Dynamics)",
+        "Analytical Mechanics (Statics)",
+        "Basic Composition"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 72,
+      "section_count": 636,
+      "colleges": [
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology (therapie",
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology II",
+        "Anatomy and Physiology",
+        "Anatomy and Physiology I"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 26,
+      "section_count": 603,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Chemistry and Society",
+        "Chemistry I Laboratory",
+        "Fundamentals of Chemistry",
+        "Gen, Organic & Biochemistry",
+        "General Chem I - Recitation"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 65,
+      "section_count": 593,
+      "colleges": [
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "ABNORMAL PSYCH",
+        "Abnormal Psychology",
+        "Abnrml Child & Adolescnc Psych",
+        "Adolescent Psychology",
+        "ADOLESCENT PSYCHOLOGY"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 48,
+      "section_count": 476,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "frontier-community-college",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Analysis of Juvenile Delinquen",
+        "Consumer Culture",
+        "Criminology",
+        "Cultural Diversity",
+        "Cultural Diversity in America"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 98,
+      "section_count": 432,
+      "colleges": [
+        "frontier-community-college",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "prairie-state-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Accounting for Entrepreneurs",
+        "Bookkeeping",
+        "BUS APPLICTNS MATH",
+        "Bus/Organizatnl Ethics",
+        "BUSINESS COMM SKILLS"
+      ]
+    },
+    {
+      "prefix": "PSYCH",
+      "name": "Psychology",
+      "course_count": 26,
+      "section_count": 417,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psych",
+        "Abnormal Psychology",
+        "Adult Development And Aging",
+        "Behavioral Research Methods",
+        "Black Psychology"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 55,
+      "section_count": 394,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "parkland-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Asian Humanities",
+        "Comparative Mythology",
+        "Contemporary Culture and the Arts",
+        "Cult Val - Eastern World",
+        "Cultural Values in the Estrn W"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 67,
+      "section_count": 390,
+      "colleges": [
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-trail-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health Clinical II",
+        "Adult Health Clinical III",
+        "Adult Health Concepts I",
+        "Adult Health Concepts II",
+        "Adult Health Concepts III"
+      ]
+    },
+    {
+      "prefix": "CHLD DV",
+      "name": "CHLD DV",
+      "course_count": 15,
+      "section_count": 380,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college"
+      ],
+      "sample_titles": [
+        "Administration and Supervision of Early Childhood Settings",
+        "Child, Family & Community Relations",
+        "Creative Activities For Young Children",
+        "Development of Exceptional Child",
+        "Health Safety And Nutrition"
+      ]
+    },
+    {
+      "prefix": "ENGLI",
+      "name": "ENGLI",
+      "course_count": 27,
+      "section_count": 380,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Approach Coll Writing II ALP",
+        "Argumentative Writing",
+        "British Literature to 1800",
+        "Children's Literature",
+        "Documentary Cinema"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 67,
+      "section_count": 375,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "moraine-valley-community-college",
+        "olney-central-college",
+        "south-suburban-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Algebra for Business and Social Science",
+        "Algebra Foundations I",
+        "Algebra Foundations II",
+        "APPLIED CALCULUS",
+        "Applied Practical Math"
+      ]
+    },
+    {
+      "prefix": "MUSIC",
+      "name": "MUSIC",
+      "course_count": 117,
+      "section_count": 364,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "American Music",
+        "Appl Music-Soph Lvl II",
+        "Appld Music: Non-Major",
+        "Applied Music II: Music Major",
+        "Applied Music-Elective Level"
+      ]
+    },
+    {
+      "prefix": "BUSINES",
+      "name": "BUSINES",
+      "course_count": 37,
+      "section_count": 361,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Auditing",
+        "Business Communications",
+        "Business Law I",
+        "Business Mathematics"
+      ]
+    },
+    {
+      "prefix": "332TECH",
+      "name": "332TECH",
+      "course_count": 43,
+      "section_count": 351,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Advanced Welding",
+        "Arc Welding",
+        "Basic Arc Welding",
+        "Basic Electrical Theory",
+        "Basic Hand Tools"
+      ]
+    },
+    {
+      "prefix": "EGL",
+      "name": "EGL",
+      "course_count": 37,
+      "section_count": 298,
+      "colleges": [
+        "lincoln-land-community-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "&quot;Non-Native Speakers: Composition I&quot;",
+        "&quot;Non-Native Speakers: Composition II&quot;",
+        "Academic Reading and Study Skills for the Non-Native Speaker I",
+        "Academic Reading and Study Skills for the Non-Native Speaker II",
+        "Academic Reading and Study Skills for the Non-Native Speaker III"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 46,
+      "section_count": 288,
+      "colleges": [
+        "college-of-dupage",
+        "danville-area-community-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Arc Welding",
+        "Advanced Arc Welding/GTAW",
+        "Advanced Flux Cored Welding",
+        "Advanced Gas Metal Arc Welding",
+        "Advanced Gas Tungsten Arc Weld"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 47,
+      "section_count": 277,
+      "colleges": [
+        "frontier-community-college",
+        "joliet-junior-college",
+        "lincoln-trail-college",
+        "morton-college",
+        "parkland-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "Academic English I",
+        "Advanced Esl",
+        "ADVANCED ESL READING",
+        "Applications in ESL II",
+        "Applications in ESL III"
+      ]
+    },
+    {
+      "prefix": "PHYSICS",
+      "name": "Physics",
+      "course_count": 11,
+      "section_count": 272,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Dynamics",
+        "Electricity, Light and Modern Physics",
+        "Engineering Physics I: Mechanics & Wave Motion",
+        "Engineering Physics II: Electricity & Magnetism",
+        "Engineering Physics III: Heat light and Modern Physics"
+      ]
+    },
+    {
+      "prefix": "340MFGT",
+      "name": "340MFGT",
+      "course_count": 28,
+      "section_count": 271,
+      "colleges": [
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Automated Fabrication I",
+        "AUTOMATED FABRICATION II",
+        "Automated Metrology-Quality Assurance",
+        "CAD I",
+        "CAD II Detailing"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 36,
+      "section_count": 243,
+      "colleges": [
+        "kishwaukee-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "A+ Certification",
+        "Advanced Audio Production",
+        "Business and Technical Writing",
+        "Business Computer Systems",
+        "COM-Bridge"
+      ]
+    },
+    {
+      "prefix": "ELA",
+      "name": "ELA",
+      "course_count": 8,
+      "section_count": 243,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advanced ESL I",
+        "Advanced ESL II",
+        "ESL Literacy I",
+        "ESL Literacy II",
+        "High Beginning ESL"
+      ]
+    },
+    {
+      "prefix": "SPEECH",
+      "name": "Communication",
+      "course_count": 8,
+      "section_count": 239,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Advanced Public Speaking",
+        "Fundamentals of Speech Communication",
+        "Group Communication",
+        "Intercultural Communication",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 60,
+      "section_count": 220,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Afr-Amer Hist to 1865",
+        "African-American History",
+        "American History From 1865",
+        "American History I",
+        "American History II"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 56,
+      "section_count": 206,
+      "colleges": [
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Accounting & Bookkeeping",
+        "Accounting Information Systems",
+        "Accounting Internship",
+        "ACCOUNTING INTERNSHIP",
+        "Accounting Procedures"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 34,
+      "section_count": 197,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Adult Nursing",
+        "Advanced Care Concepts",
+        "Advanced Nursing I",
+        "Advanced Nursing II",
+        "Basic Care Concepts"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Philosophy",
+      "course_count": 20,
+      "section_count": 196,
+      "colleges": [
+        "kishwaukee-college",
+        "oakton-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Ancient and Medieval Philosophy",
+        "Asian Philosophy",
+        "Environmental Ethics",
+        "Ethics",
+        "Honors: Ethics"
+      ]
+    },
+    {
+      "prefix": "CRM JUS",
+      "name": "CRM JUS",
+      "course_count": 12,
+      "section_count": 182,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Administration of Criminal Justice",
+        "Administration of Juvenile Justice",
+        "Constitutional Law",
+        "Criminal Law & Procedure",
+        "Intro To Investigation"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 76,
+      "section_count": 182,
+      "colleges": [
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "ADM CHILDHOOD FACILITIES",
+        "Admin of Day Care Center",
+        "Administration",
+        "Assist Chld Care Setting",
+        "Care Infants/Toddlers"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 43,
+      "section_count": 179,
+      "colleges": [
+        "danville-area-community-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology I Lab",
+        "Anatomy & Physiology II",
+        "Anatomy & Physiology II Lab",
+        "Anatomy and Physiology I"
+      ]
+    },
+    {
+      "prefix": "CEMU",
+      "name": "CEMU",
+      "course_count": 43,
+      "section_count": 179,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Baritone Horn",
+        "Bassoon",
+        "Cello",
+        "Clarinet",
+        "Concert Choir"
+      ]
+    },
+    {
+      "prefix": "RHT",
+      "name": "Comp",
+      "course_count": 5,
+      "section_count": 179,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "College Reading and Writing",
+        "Companion-Eng RHT & Comp I",
+        "Creative Writing",
+        "English Rhetoric and Comp I",
+        "English Rhetoric and Comp II"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 17,
+      "section_count": 174,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Contemp Moral Problems-Ethics",
+        "Critical Thinking",
+        "Enlightenment To Present",
+        "Ethics",
+        "Greek Philo To Renaissance"
+      ]
+    },
+    {
+      "prefix": "SPE",
+      "name": "SPE",
+      "course_count": 10,
+      "section_count": 174,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Argumentation",
+        "Basic Sign Language",
+        "FUND. OF EFFECTIVE SPEAKING",
+        "Honors: Effective Speech"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 35,
+      "section_count": 173,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Biochemistry",
+        "CHEM AND SOCIETY",
+        "Chemistry (Univ. Oriented) I",
+        "Chemistry (Univ. Oriented) II",
+        "Chemistry and Qualitative Analysis"
+      ]
+    },
+    {
+      "prefix": "AUTOTEC",
+      "name": "AUTOTEC",
+      "course_count": 26,
+      "section_count": 167,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-olive-harvey-college"
+      ],
+      "sample_titles": [
+        "Auto Body Reconstruction I",
+        "Auto Body Reconstruction II",
+        "Auto Body Repainting I",
+        "Auto Body Repainting II",
+        "Auto Body Repainting III"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 9,
+      "section_count": 165,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Macroeconomics",
+        "Microeconomics",
+        "Prin Econ I-Macro",
+        "Prin Econ II-Micro",
+        "Principles of Economics"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 22,
+      "section_count": 161,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Accelerated Writing Instr.",
+        "Advanced English I",
+        "Advanced English II",
+        "Basic English",
+        "Basic Writing"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 27,
+      "section_count": 158,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adult Development and Aging",
+        "Child Psychology",
+        "Educ Psychology",
+        "General Psychology"
+      ]
+    },
+    {
+      "prefix": "BIS",
+      "name": "Biology",
+      "course_count": 13,
+      "section_count": 155,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Biology of Humans",
+        "Environmental Biology",
+        "Functional Human Anatomy I",
+        "Functional Human Anatomy II",
+        "General Biology"
+      ]
+    },
+    {
+      "prefix": "MCROBIO",
+      "name": "Microbiology",
+      "course_count": 1,
+      "section_count": 154,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "General Microbiology"
+      ]
+    },
+    {
+      "prefix": "432CMGT",
+      "name": "Construction",
+      "course_count": 9,
+      "section_count": 145,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Blueprint and Specifications",
+        "Building Materials and Testing",
+        "Construction Contracting Specs",
+        "Construction Cost Estimating",
+        "Construction Safety II"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 17,
+      "section_count": 141,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Elements of Economics",
+        "INTRO ECONOMICS",
+        "Intro to Macroeconomics",
+        "Introduction to Economics",
+        "Introduction to Microeconomics"
+      ]
+    },
+    {
+      "prefix": "NURSING",
+      "name": "Nursing",
+      "course_count": 16,
+      "section_count": 140,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Surgical",
+        "Fundamentals of Nursing",
+        "Gerontologic Nursing",
+        "Intermediate Medical-Surgical Nursing",
+        "Introduction to Medical-Surgical"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 49,
+      "section_count": 135,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college",
+        "college-of-dupage",
+        "kishwaukee-college",
+        "oakton-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CPT Coding",
+        "Anat & Pharm Med Code & Bill",
+        "Cancer Disease Coding and Staging",
+        "Cancer Registry Clinical Practicum",
+        "CPT & HCPCS Coding Med Biller"
+      ]
+    },
+    {
+      "prefix": "SPEEC",
+      "name": "Communication",
+      "course_count": 7,
+      "section_count": 133,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Applied Forensics",
+        "Fundmntls Speech Communication",
+        "Intercultural Communication",
+        "Interpersonal Communication",
+        "Intro Business Communication"
+      ]
+    },
+    {
+      "prefix": "SPANISH",
+      "name": "Spanish",
+      "course_count": 9,
+      "section_count": 132,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "First Course Spanish",
+        "Fourth Course Spanish",
+        "Intro To Modern Literature Spanish",
+        "Readings In Literature Spanish",
+        "Second Course Spanish"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 68,
+      "section_count": 129,
+      "colleges": [
+        "college-of-dupage",
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Adv Princ of Weight Training",
+        "Advanced First Aid, CPR & AED",
+        "Aikido I",
+        "Aikido II",
+        "Applied Kinesiology"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 42,
+      "section_count": 128,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "App Physics: Heat/Electr",
+        "College Physics I",
+        "College Physics II",
+        "Concepts of Physics",
+        "Concepts of Physics Laboratory"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 12,
+      "section_count": 127,
+      "colleges": [
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Appl Forensics III",
+        "Appl. Forensics I",
+        "Appl. Forensics II",
+        "Appl. Forensics IV",
+        "Career Writing"
+      ]
+    },
+    {
+      "prefix": "COMPSFI",
+      "name": "COMPSFI",
+      "course_count": 9,
+      "section_count": 127,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Cyber Forensics",
+        "Cybercrime and Incident Response",
+        "Ethical Hacking",
+        "Info Security Program Management",
+        "Information Security Domain"
+      ]
+    },
+    {
+      "prefix": "PHY SCI",
+      "name": "Physical",
+      "course_count": 4,
+      "section_count": 126,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Current Public Issues in Physical Science",
+        "General Course I Physical Science",
+        "General Course II Physical Science",
+        "General Course Physical Science"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "Music",
+      "course_count": 30,
+      "section_count": 123,
+      "colleges": [
+        "danville-area-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Applied Music for Non-Majors",
+        "Applied Music I",
+        "Applied Music II",
+        "Applied Music III",
+        "Applied Music IV"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 43,
+      "section_count": 121,
+      "colleges": [
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "oakton-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "2D Animation",
+        "3D Computer Animation III",
+        "3D Computer Animation IV",
+        "C++ Computer Science I",
+        "C++ Programming for Engineers"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 42,
+      "section_count": 120,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "moraine-valley-community-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "triton-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "American Literature from the Civil War to the 20th Century",
+        "American Literature I",
+        "American Literature II",
+        "Children's Literature",
+        "Contemporary African American Literature"
+      ]
+    },
+    {
+      "prefix": "HISTORY",
+      "name": "History",
+      "course_count": 13,
+      "section_count": 114,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "African History - Modern Period",
+        "African History to Colonial Period",
+        "Afro-American History Since 1865",
+        "American Civil Rights Movement",
+        "Hist World Civiliz Frm 1500"
+      ]
+    },
+    {
+      "prefix": "AFRO AM",
+      "name": "AFRO AM",
+      "course_count": 3,
+      "section_count": 109,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Contemporary Conversations in Africana Studies",
+        "Hip Hop: Culture and Politics",
+        "Introduction to African-American Studies"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 35,
+      "section_count": 104,
+      "colleges": [
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "ADULT LEARNING IN HIGHER ED",
+        "ADVANCED PEDAGOGICAL PRACTICES",
+        "AI FOR EDUCATION",
+        "BASIC PEDAGOGICAL PRACTICES",
+        "CHILDREN EXCEPTION"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 35,
+      "section_count": 103,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "American Education",
+        "Assessment of the Second Language Learner",
+        "Bilingual and ESL Practicum",
+        "Childrens Literature",
+        "Classroom Tools and Resources"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 23,
+      "section_count": 103,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking",
+        "Ethics: Morality & Contemp Val",
+        "INTRO ETHICS",
+        "INTRO LOGIC",
+        "INTRO PHILOSOPHY"
+      ]
+    },
+    {
+      "prefix": "DENTHYG",
+      "name": "Dental",
+      "course_count": 26,
+      "section_count": 99,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Clinical Dental Hygiene IV",
+        "Community Dental Health I"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 9,
+      "section_count": 99,
+      "colleges": [
+        "danville-area-community-college",
+        "kankakee-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Contemporary Health",
+        "First Aid and Personal Safety",
+        "General Medical Terminology",
+        "Medical Terminology",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "MEDASST",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 98,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Fundamentals of Ambulatory Billing and Coding",
+        "Medical Assisting Clinical Procedures I",
+        "Medical Assisting Clinical Procedures II",
+        "Medical Assisting Practicum"
+      ]
+    },
+    {
+      "prefix": "CECE",
+      "name": "CECE",
+      "course_count": 25,
+      "section_count": 96,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Art",
+        "Basic Exercise",
+        "Computers-How to",
+        "Cooking",
+        "Current Events"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 52,
+      "section_count": 94,
+      "colleges": [
+        "college-of-dupage",
+        "danville-area-community-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "4-Cycle Small Engine Repair",
+        "Adv Automotive Drivetrains",
+        "Advanced Chassis Systems",
+        "Air Conditioning and Heating",
+        "Alignment Steering Suspension"
+      ]
+    },
+    {
+      "prefix": "INTDSP",
+      "name": "College",
+      "course_count": 7,
+      "section_count": 92,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Career Development and Decision Making",
+        "College Success Seminar",
+        "College Success: Special Topics",
+        "Interdisciplinary Studies and Service",
+        "Interdisciplinary Study and Service"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "ANT",
+      "course_count": 15,
+      "section_count": 90,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college",
+        "oakton-college",
+        "parkland-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "ARCH FIELD SCHL",
+        "Field Archaeology",
+        "Honors: Introduction to Social and Cultural Anthropology",
+        "Intro Anthropol",
+        "INTRO ANTHROPOLOGY"
+      ]
+    },
+    {
+      "prefix": "COSMET",
+      "name": "Technology",
+      "course_count": 12,
+      "section_count": 88,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Advanced Cosmetology",
+        "Basic Chemical Technology",
+        "Basic Styling Technology",
+        "Basic Teaching Skills for Career Education Instructors",
+        "Cosmetology Summative Seminar"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 49,
+      "section_count": 87,
+      "colleges": [
+        "lincoln-land-community-college",
+        "moraine-valley-community-college",
+        "shawnee-community-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Adv Auto Heatng & Air Conditng",
+        "Adv Automatic Trans & Repair",
+        "Advanced Automotive Electronic",
+        "Advanced Brakes and Suspension Systems",
+        "Advanced Engine Control Systems"
+      ]
+    },
+    {
+      "prefix": "AHL",
+      "name": "AHL",
+      "course_count": 10,
+      "section_count": 84,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Bas Pharmacolgy-Allied Hth Pro",
+        "Comprehensive Med Terminology",
+        "Comprehensive Medical Ethics",
+        "Drug Calculations",
+        "Electrocardiography"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 24,
+      "section_count": 80,
+      "colleges": [
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "parkland-college",
+        "prairie-state-college",
+        "south-suburban-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Basic Emergency Med Tech",
+        "Emergency Medical Responder",
+        "Emergency Medical Tech.-Basic",
+        "Emergency Medical Technician",
+        "EMT Work Practicum"
+      ]
+    },
+    {
+      "prefix": "NURSI",
+      "name": "NURSI",
+      "course_count": 13,
+      "section_count": 80,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Complex Health Problems",
+        "Decision Making Practicum",
+        "Family Health Concepts I",
+        "Family Health Concepts II",
+        "Health and Illness Concepts I"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 30,
+      "section_count": 79,
+      "colleges": [
+        "college-of-dupage",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Apple Mac Operating Systems",
+        "Cloud Computing Serv & Admin",
+        "Commercial Building Systems",
+        "Computer Forensics I",
+        "Computr & Hardware Maintenance"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 53,
+      "section_count": 78,
+      "colleges": [
+        "college-of-dupage",
+        "joliet-junior-college",
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "4-Cycle Small Engine Repair",
+        "Applied Plant Taxonomy",
+        "Arboriculture",
+        "Cannabis & Indust Hemp Product",
+        "Entomology"
+      ]
+    },
+    {
+      "prefix": "PHILO",
+      "name": "Ethics",
+      "course_count": 12,
+      "section_count": 77,
+      "colleges": [
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Biomedical Ethics",
+        "Business Ethics",
+        "Critical Thinking",
+        "Early Modern Philosophy",
+        "Environmental Ethics"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 41,
+      "section_count": 75,
+      "colleges": [
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "olney-central-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "APPLIED CLINICAL RADIOLOGY I",
+        "APPLIED CLINICAL RADIOLOGY III",
+        "APPLIED CLINICAL RADIOLOGY IV",
+        "Clinical Education 1",
+        "Clinical Education 2"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "Cosmetology",
+      "course_count": 41,
+      "section_count": 74,
+      "colleges": [
+        "olney-central-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Advanced Cosmetology",
+        "Advanced Cosmetology Practices",
+        "Basic Haircutting",
+        "Basic Hairstyling",
+        "Chemical Services I"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 26,
+      "section_count": 74,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Am. Republic: Beginning-1877",
+        "Hist/Civilization I",
+        "Hist/CivilizationII",
+        "Hist/US 1865-Presnt",
+        "History of Africa"
+      ]
+    },
+    {
+      "prefix": "ADN",
+      "name": "Nursing",
+      "course_count": 21,
+      "section_count": 73,
+      "colleges": [
+        "lincoln-land-community-college",
+        "shawnee-community-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Advanced Med Surgical Nursing",
+        "Behavioral Health Nursing",
+        "Childbearing Family & Children",
+        "Fundamentals of Nursing",
+        "Healthcare Diversity"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 37,
+      "section_count": 73,
+      "colleges": [
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "parkland-college",
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "ADV FABR TECHNIQUES",
+        "Adv Gas Tungsten Arc Weld",
+        "Advanced Gas Metal Arc Welding",
+        "Advanced SMAW & Cutting I",
+        "Basic Arc/Gas Welding I"
+      ]
+    },
+    {
+      "prefix": "NET TEC",
+      "name": "Internetworking",
+      "course_count": 7,
+      "section_count": 72,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Client-Server Database I",
+        "Cloud Computing and Services",
+        "Internetworking I",
+        "Internetworking II",
+        "Internetworking III"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "PED",
+      "course_count": 23,
+      "section_count": 72,
+      "colleges": [
+        "oakton-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Aquacize",
+        "Boxing for Fitness",
+        "Coaching Certification in Illinois",
+        "Conditioning I",
+        "Conditioning II"
+      ]
+    },
+    {
+      "prefix": "BIOLO",
+      "name": "BIOLO",
+      "course_count": 6,
+      "section_count": 69,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Environmental Biology",
+        "Fundamentals of Biotechnology",
+        "Introduction to Genetics",
+        "Principle Biological Scienc II",
+        "Principle Biological Science"
+      ]
+    },
+    {
+      "prefix": "RADIOGR",
+      "name": "RADIOGR",
+      "course_count": 31,
+      "section_count": 69,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Anatomy, Physiology and Procedures",
+        "Applied Radiographic Techniques",
+        "Attitudes In Patient Care",
+        "Basic Prins Of Image Produc",
+        "Computed Tomography Clinical Education I"
+      ]
+    },
+    {
+      "prefix": "SOCIO",
+      "name": "SOCIO",
+      "course_count": 12,
+      "section_count": 69,
+      "colleges": [
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Contemp Social Iss",
+        "Health & Illness",
+        "Intro to Social Work",
+        "Introduction to Data Science",
+        "Introduction to Sociology"
+      ]
+    },
+    {
+      "prefix": "FIN ART",
+      "name": "History",
+      "course_count": 8,
+      "section_count": 68,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Dance Appreciation",
+        "Film History I",
+        "Film History II",
+        "Hist Of Arch Paint Sculp II",
+        "History of Architecture, Painting & Sculpture I"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 28,
+      "section_count": 67,
+      "colleges": [
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "moraine-valley-community-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Community Oriented Policing",
+        "Community-Based & Crises Inter",
+        "Constitutional Law for Police",
+        "Criminal Law",
+        "Criminalistics I"
+      ]
+    },
+    {
+      "prefix": "MPTV",
+      "name": "MPTV",
+      "course_count": 31,
+      "section_count": 67,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "3-D Animation I",
+        "3-D Animation II",
+        "3D Modeling I",
+        "Adv Film/Video Production",
+        "Advanced Animation"
+      ]
+    },
+    {
+      "prefix": "BAR",
+      "name": "BAR",
+      "course_count": 22,
+      "section_count": 66,
+      "colleges": [
+        "south-suburban-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Adv Barbering Technique II",
+        "Advanced Barbering",
+        "Advanced Barbering Technique I",
+        "Advanced Salon Operations I",
+        "Advanced Salon Operations II"
+      ]
+    },
+    {
+      "prefix": "ANAT",
+      "name": "Human",
+      "course_count": 5,
+      "section_count": 64,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "A & P With Cadaver I",
+        "A & P With Cadaver II",
+        "Human Anatomy & Physiology I",
+        "Human Anatomy & Physiology II",
+        "Survey of Human A & P"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "DMS",
+      "course_count": 32,
+      "section_count": 64,
+      "colleges": [
+        "joliet-junior-college",
+        "lincoln-land-community-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Abdominal & Sm Parts Sonog",
+        "Clinical Applications I",
+        "Clinical Applications II",
+        "Clinical Applications III",
+        "Clinical Education"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "ENT",
+      "course_count": 23,
+      "section_count": 64,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Autodesk Invent Design & Rend",
+        "CNC Plasma Fundamentals",
+        "Descriptive Geometry",
+        "Elec Veh Sply Equip(EVSE)Inst",
+        "Electrical Codes and Standards"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 25,
+      "section_count": 63,
+      "colleges": [
+        "mchenry-county-college",
+        "oakton-college",
+        "parkland-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Change Management",
+        "Corporate Social Responsibility and Decision Making",
+        "CUSTOMER SERVICE MANAGEMENT",
+        "Diversity, Equity and Inclusion in the Workplace",
+        "Effective Management Communications"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 45,
+      "section_count": 63,
+      "colleges": [
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Aging and Impact on Occupation",
+        "Clinical Observation",
+        "Clinical Rotation II",
+        "COND DISRPT PRTCIP",
+        "Conditions Affecting Occupatio"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 31,
+      "section_count": 62,
+      "colleges": [
+        "danville-area-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Alter Curr, Polyphase Cir & Tr",
+        "Conduit Bending & Threading",
+        "Digital Electronics",
+        "Digital Electronics II",
+        "Elec Controls for Machines"
+      ]
+    },
+    {
+      "prefix": "PARALEG",
+      "name": "Paralegal",
+      "course_count": 16,
+      "section_count": 61,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Business Organizations & Agency Law",
+        "Civil Litigation",
+        "Computers in the Law Office",
+        "Contract Law for the Paralegal",
+        "Criminal Law for the Paralegal"
+      ]
+    },
+    {
+      "prefix": "VET",
+      "name": "VET",
+      "course_count": 21,
+      "section_count": 61,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Anesthesia & Surgical Asst. II",
+        "Animal Anatomy",
+        "Animal Care I",
+        "Animal Care III",
+        "Applied Pharmacology I"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "College",
+      "course_count": 5,
+      "section_count": 59,
+      "colleges": [
+        "moraine-valley-community-college",
+        "oakton-college",
+        "prairie-state-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "College:Chngs,Challngs,Choice",
+        "Embrac the College Experience",
+        "Great Beginnings: College Life and Success",
+        "Leadership Studies",
+        "Strategies for Career Exploration"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 59,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Geog World Regions",
+        "Human Geography",
+        "Intro to Physical Geography",
+        "Phys Geog: Landforms"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 16,
+      "section_count": 57,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "parkland-college",
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Basic Chemistry",
+        "Basic Chemistry Lab",
+        "Chem/Health Professions",
+        "Chemistry of Everyday Life",
+        "Contemporary Chemistry"
+      ]
+    },
+    {
+      "prefix": "ASTROMY",
+      "name": "Descriptive",
+      "course_count": 2,
+      "section_count": 56,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Descriptive Astronomy",
+        "The Solar System"
+      ]
+    },
+    {
+      "prefix": "DANCE",
+      "name": "DANCE",
+      "course_count": 21,
+      "section_count": 56,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Ballet II",
+        "Choreography/Comp Dance II",
+        "Choreography/Composition Dance",
+        "Dance Appreciation"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 22,
+      "section_count": 56,
+      "colleges": [
+        "mchenry-county-college",
+        "oakton-college",
+        "parkland-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Brand Marketing",
+        "Consumer Behavior",
+        "e-Business",
+        "Integrated Marketing Communications",
+        "INTRNATL MARKETING"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 11,
+      "section_count": 56,
+      "colleges": [
+        "lincoln-trail-college",
+        "morton-college",
+        "oakton-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "ELEMENTARY SPANISH I",
+        "Elementary Spanish II",
+        "Intermediate Spanish I",
+        "INTERMEDIATE SPANISH I"
+      ]
+    },
+    {
+      "prefix": "POL SCI",
+      "name": "Government",
+      "course_count": 4,
+      "section_count": 55,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "International Relations",
+        "Principles of Political Science",
+        "The National Government",
+        "U.S. State & Local Government"
+      ]
+    },
+    {
+      "prefix": "ANTHRO",
+      "name": "Cultural",
+      "course_count": 3,
+      "section_count": 54,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Cultural Anthropology",
+        "Intro to Biological and Cultural Evolutions of Humans",
+        "Introduction to Archaeology"
+      ]
+    },
+    {
+      "prefix": "HISTO",
+      "name": "History",
+      "course_count": 14,
+      "section_count": 54,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "20th Century World History",
+        "African-American History",
+        "Europe in Modern World",
+        "Foundations of European World",
+        "History & Culture of Japan"
+      ]
+    },
+    {
+      "prefix": "HVA",
+      "name": "HVAC",
+      "course_count": 23,
+      "section_count": 54,
+      "colleges": [
+        "mchenry-county-college",
+        "morton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Basic Heating & A/C",
+        "Basic HVAC/R Controls",
+        "Basic Sheet Metal Fabrication",
+        "Basic Sheet Metal Fabrication and Print Reading",
+        "COMM REFRIG SRVE"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 20,
+      "section_count": 54,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Adv Lab App to Ac Sys",
+        "Advanced Electrical Controls",
+        "Air Handling",
+        "Comm Bldg Air Flow Meas",
+        "Duct Design/Install Appl"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "PS",
+      "course_count": 35,
+      "section_count": 54,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Aarp Smart Driver",
+        "Art",
+        "Automotive & Robotics",
+        "Babysitting",
+        "Christmas in July"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 31,
+      "section_count": 53,
+      "colleges": [
+        "morton-college",
+        "oakton-college",
+        "parkland-college",
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "3D Modeling",
+        "Advanced Building Information Modeling - Revit",
+        "Advanced SolidWorks",
+        "Autocad Fundamentals",
+        "AutoCAD II"
+      ]
+    },
+    {
+      "prefix": "CJA",
+      "name": "CJA",
+      "course_count": 16,
+      "section_count": 53,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Administration of Justice",
+        "Criminal Investigation",
+        "Criminal Justice Capstone",
+        "Criminal Law I",
+        "Criminal Law II"
+      ]
+    },
+    {
+      "prefix": "NAS",
+      "name": "Nurse",
+      "course_count": 3,
+      "section_count": 53,
+      "colleges": [
+        "lincoln-land-community-college",
+        "parkland-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nurs Asst Train Prog",
+        "Basic Nurse Asist. Training Pr",
+        "Basic Nurse Assistant Training"
+      ]
+    },
+    {
+      "prefix": "AIR CON",
+      "name": "AIR CON",
+      "course_count": 17,
+      "section_count": 52,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Advanced Control Systems",
+        "Advanced Laboratory",
+        "Analysis Laboratory",
+        "Commercial Refrigeration",
+        "Commercial Refrigeration Laboratory"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "ARCH",
+      "course_count": 27,
+      "section_count": 52,
+      "colleges": [
+        "college-of-dupage",
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Arch Design Communication",
+        "Arch Presentation & Portfolio",
+        "Arch Tech Drafting I",
+        "Arch Tech Drafting II",
+        "Architectural Design I"
+      ]
+    },
+    {
+      "prefix": "CECK",
+      "name": "CECK",
+      "course_count": 24,
+      "section_count": 52,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Arithme-tricks",
+        "Balloonatics",
+        "Camp Waterschool",
+        "Competitive Strokes",
+        "Creative Gardener Camp"
+      ]
+    },
+    {
+      "prefix": "WEL",
+      "name": "Welding",
+      "course_count": 35,
+      "section_count": 52,
+      "colleges": [
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "morton-college",
+        "olney-central-college",
+        "shawnee-community-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "ADVANCED GAS METAL ARC WELDING",
+        "Advanced SMAW/Cutting I",
+        "Advanced SMAW/Cutting II",
+        "Basic Arc Welding/Cutting I",
+        "Basic Arc Welding/Cutting II"
+      ]
+    },
+    {
+      "prefix": "330CUL",
+      "name": "330CUL",
+      "course_count": 12,
+      "section_count": 51,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Advanced Garde Manger",
+        "Chef's Training I-Section A",
+        "Chef's Training I-Section B",
+        "College Success Hospitality Perspective",
+        "Culinary Math"
+      ]
+    },
+    {
+      "prefix": "CULIN",
+      "name": "CULIN",
+      "course_count": 24,
+      "section_count": 51,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Adv Baking & Pastry Rest Prod",
+        "Advanced Garde Manger",
+        "Asian Cuisine",
+        "Baking Fundamentals",
+        "Baking Science and Techniques"
+      ]
+    },
+    {
+      "prefix": "ELTR",
+      "name": "ELTR",
+      "course_count": 16,
+      "section_count": 51,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Programmable Controllers",
+        "Code & Wiring Method",
+        "Electrical Install Skills I",
+        "Electrical Install Skills II",
+        "Electronics/Electr Internship"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "College",
+      "course_count": 3,
+      "section_count": 51,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "COLLEGE SUCCESS",
+        "First Year Experience",
+        "Strategies for College Success"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "CA",
+      "course_count": 22,
+      "section_count": 50,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "A la Carte Cooking I",
+        "Advanced a la Carte Cooking",
+        "Advanced Culinary Operations",
+        "Applied Food Serv Sanitation",
+        "Cakes I"
+      ]
+    },
+    {
+      "prefix": "HUMNT",
+      "name": "HUMNT",
+      "course_count": 8,
+      "section_count": 50,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Arts & Cultural Diversity",
+        "Humnt Beyond US & Europe",
+        "Intro Humanities: Ideas/Values",
+        "Intro Humanities: The Arts",
+        "Intro to Medical Humanities"
+      ]
+    },
+    {
+      "prefix": "MCC",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 50,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "COLLEGE EXPERIENCE"
+      ]
+    },
+    {
+      "prefix": "VIC",
+      "name": "VIC",
+      "course_count": 23,
+      "section_count": 50,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Adv Digital Studio Photography",
+        "Advanced Digital Photography",
+        "Advanced Illustrator",
+        "Advanced Indesign & Typography",
+        "Advanced Photoshop"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "FIRE",
+      "course_count": 35,
+      "section_count": 48,
+      "colleges": [
+        "college-of-dupage",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Firefighter",
+        "Basic Firefighter: Module A",
+        "Basic Firefighter: Module B",
+        "Basic Ops Firefighter- Mod A",
+        "Basic Ops Firefighter-B"
+      ]
+    },
+    {
+      "prefix": "KIN",
+      "name": "KIN",
+      "course_count": 15,
+      "section_count": 48,
+      "colleges": [
+        "joliet-junior-college",
+        "parkland-college",
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Exercise Fitness",
+        "Exercise Fitness II",
+        "First Aid and CPR",
+        "Health Education",
+        "Human Performance"
+      ]
+    },
+    {
+      "prefix": "LSC",
+      "name": "Biology",
+      "course_count": 10,
+      "section_count": 48,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "ENVIRONMENTAL BIOLOGY",
+        "GENERAL BIOLOGY I",
+        "GENERAL BIOLOGY II",
+        "GENERAL MICROBIOLOGY",
+        "HUMAN ANATOMY &amp; PHYSIOLOGY I"
+      ]
+    },
+    {
+      "prefix": "TRUC",
+      "name": "TRUC",
+      "course_count": 10,
+      "section_count": 48,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Behind The Wheel Road Train",
+        "Behind the Wheel Skill Train",
+        "Class B Driving Orientation",
+        "Class B Maintenance",
+        "Driving Simulation"
+      ]
+    },
+    {
+      "prefix": "EARTH",
+      "name": "EARTH",
+      "course_count": 16,
+      "section_count": 46,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Adv Weather Forecasting I",
+        "Astronomy: Stars & Galaxies",
+        "Astronomy: The Solar System",
+        "Climate & Global Change",
+        "Environmental Geology"
+      ]
+    },
+    {
+      "prefix": "EAS",
+      "name": "EAS",
+      "course_count": 12,
+      "section_count": 46,
+      "colleges": [
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Climate Change and Variability",
+        "Environmental Geology",
+        "Geographic Information Systems I",
+        "Historical Geology",
+        "INTRO ASTRONOMY"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "PSC",
+      "course_count": 16,
+      "section_count": 46,
+      "colleges": [
+        "moraine-valley-community-college",
+        "oakton-college",
+        "olney-central-college",
+        "south-suburban-college",
+        "triton-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "American National Government",
+        "American National Politics",
+        "American State & Local Govts",
+        "Comparative Government",
+        "Global Politics"
+      ]
+    },
+    {
+      "prefix": "STTRDE",
+      "name": "Driving",
+      "course_count": 5,
+      "section_count": 46,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college"
+      ],
+      "sample_titles": [
+        "Commercial Driving Training Practice",
+        "Forklift Operator",
+        "Passenger Driver Practice",
+        "Passenger Driver Theory",
+        "Road Driving"
+      ]
+    },
+    {
+      "prefix": "ARCHITC",
+      "name": "ARCHITC",
+      "course_count": 15,
+      "section_count": 45,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "Advanced Design Studio",
+        "Architectural Design I",
+        "Architectural Design II",
+        "Architectural Sketching",
+        "Basic Design Studio"
+      ]
+    },
+    {
+      "prefix": "DHG",
+      "name": "DHG",
+      "course_count": 13,
+      "section_count": 44,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Applied Head and Neck Anatomy",
+        "Clinic III",
+        "Community Dental Health",
+        "Dental Materials",
+        "Diet Analy & Counseling"
+      ]
+    },
+    {
+      "prefix": "KHS",
+      "name": "KHS",
+      "course_count": 20,
+      "section_count": 44,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "APPL KINESIOLOGY",
+        "BIOMECH EXERCS",
+        "CONTEMP HEALTH ISS",
+        "DRUGS CONT SOCIETY",
+        "EXER PSYCH MOTIV"
+      ]
+    },
+    {
+      "prefix": "PTE",
+      "name": "PTE",
+      "course_count": 14,
+      "section_count": 44,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "BASEBALL I",
+        "BASEBALL III",
+        "BASKETBALL I",
+        "BASKETBALL III",
+        "FISHING I"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 11,
+      "section_count": 43,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college",
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Drafting & Basic Machine Design",
+        "Computer Programming for Engineers",
+        "Descriptive Geometry",
+        "Electrical Circuit Analysis",
+        "Elements of Engineering Drawing"
+      ]
+    },
+    {
+      "prefix": "FIR",
+      "name": "Fire",
+      "course_count": 33,
+      "section_count": 43,
+      "colleges": [
+        "morton-college",
+        "oakton-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Bas ICS & App-Sngl Rsrc/Init",
+        "Build Const for Fire Protect",
+        "Building Construction",
+        "Building Construction-Fir Prot",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "HIA",
+      "name": "HIA",
+      "course_count": 26,
+      "section_count": 43,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Advanced Cake Decoration",
+        "Artisan Breads",
+        "Beverage Management",
+        "Cake & Pastry Decoration",
+        "Catering Management"
+      ]
+    },
+    {
+      "prefix": "INTER",
+      "name": "Design",
+      "course_count": 21,
+      "section_count": 43,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Adv Visualization Techniques",
+        "BIM for Interior Design",
+        "Computer-Aided Int Design I",
+        "Computer-Aided Int Design II",
+        "Contract Design Studio"
+      ]
+    },
+    {
+      "prefix": "PEI",
+      "name": "Weight",
+      "course_count": 2,
+      "section_count": 43,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "WEIGHT TRAINING I",
+        "WEIGHT TRAINING III"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 6,
+      "section_count": 42,
+      "colleges": [
+        "lincoln-land-community-college",
+        "moraine-valley-community-college",
+        "parkland-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Astronomy of the Solar System",
+        "Astronomy of the Stars & Beynd",
+        "Astronomy W/Lab",
+        "Introduction to Astronomy"
+      ]
+    },
+    {
+      "prefix": "CANBS",
+      "name": "Cannabis",
+      "course_count": 10,
+      "section_count": 42,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Cannabis and the Law",
+        "Cannabis Processing",
+        "Cannabis Quality and Compliance",
+        "Cannabis Science",
+        "Dispensary Operations"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Paramedic",
+      "course_count": 12,
+      "section_count": 42,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college",
+        "lewis-and-clark-community-college",
+        "morton-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician -",
+        "Emergency Medical Technician - Basic",
+        "Emergency Medical Technician - First Responder Training",
+        "Emergency Medical Technician-Basic",
+        "Emergency Medical Trainin"
+      ]
+    },
+    {
+      "prefix": "HUMAN",
+      "name": "HUMAN",
+      "course_count": 22,
+      "section_count": 42,
+      "colleges": [
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Addictions Counseling I",
+        "Addictions Counseling II",
+        "Advocacy in Human Services",
+        "Compar Religions",
+        "Contemporary Practice Models"
+      ]
+    },
+    {
+      "prefix": "PHAR TC",
+      "name": "PHAR TC",
+      "course_count": 13,
+      "section_count": 42,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Advanced Practice",
+        "Inpatient Clinical",
+        "Intro To Pharmacy Law",
+        "Non-Sterile Processing",
+        "Pharmacology I"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "Skills",
+      "course_count": 13,
+      "section_count": 41,
+      "colleges": [
+        "college-of-dupage",
+        "morton-college"
+      ],
+      "sample_titles": [
+        "ABE High Intermediate II",
+        "ABE Low Intermediate II",
+        "Basic English Skills I",
+        "Basic English Skills II",
+        "Basic Math Skills I"
+      ]
+    },
+    {
+      "prefix": "ARC",
+      "name": "ARC",
+      "course_count": 21,
+      "section_count": 41,
+      "colleges": [
+        "mchenry-county-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "AEC CONSTRUCTION DOC",
+        "AEC PROD SOFTWARE",
+        "AEC PROJECT DELIVERY",
+        "Architectural Drawing & Models",
+        "AutoCAD & 3D Computer Modelng"
+      ]
+    },
+    {
+      "prefix": "BOFF",
+      "name": "BOFF",
+      "course_count": 20,
+      "section_count": 41,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Systems & Proc",
+        "Adv Spreadsheet Applications",
+        "Adv. Document Processing",
+        "Business Communication Strat",
+        "Business Etiquette and Ethics"
+      ]
+    },
+    {
+      "prefix": "CHEMI",
+      "name": "Chemistry",
+      "course_count": 9,
+      "section_count": 41,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Basic Lab & Computation Chem",
+        "Contemporary Chemistry",
+        "Intro Biochemistry with Lab",
+        "Introduction to Biochemistry",
+        "Organic Chemistry I"
+      ]
+    },
+    {
+      "prefix": "CJS",
+      "name": "CJS",
+      "course_count": 21,
+      "section_count": 41,
+      "colleges": [
+        "mchenry-county-college",
+        "parkland-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "CJS INTERNSHIP",
+        "Constitutional Law",
+        "CRIM JUSTICE MGMT",
+        "Criminal Justice Field Work I",
+        "Criminal Law"
+      ]
+    },
+    {
+      "prefix": "GEG",
+      "name": "Geography",
+      "course_count": 18,
+      "section_count": 41,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "morton-college",
+        "oakton-college",
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "Advanced Geographic Informatio",
+        "Cultural Geography",
+        "ENERGY RESOURCES",
+        "Extreme and Hazardous Weather",
+        "GEOG DEVLOPNG WRLD"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 10,
+      "section_count": 41,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "BEG SPANISH I",
+        "BEG SPANISH II",
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "INTERM SPANISH I"
+      ]
+    },
+    {
+      "prefix": "STHLTH",
+      "name": "Fundamentalsclinical",
+      "course_count": 2,
+      "section_count": 41,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "BNA Fundamentals/Clinical",
+        "Patient Care Technician Training"
+      ]
+    },
+    {
+      "prefix": "HAC",
+      "name": "HAC",
+      "course_count": 16,
+      "section_count": 40,
+      "colleges": [
+        "moraine-valley-community-college",
+        "shawnee-community-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Advanced Control Systems",
+        "Air Conditioning I",
+        "Commercial Refrigeration I",
+        "Cooling I",
+        "Cooling II"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 17,
+      "section_count": 40,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "oakton-college",
+        "parkland-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Acting for the Stage",
+        "ACTING I - PREP",
+        "ACTING II-ACTR WRK",
+        "Film Appreciation",
+        "Film History"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 25,
+      "section_count": 39,
+      "colleges": [
+        "kankakee-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Admin in Child Care Setting",
+        "Admin-Personnel, Fam, Children",
+        "Admin-Practices and Procedures",
+        "ADMINISTRATION-ECE INTERNSHIP",
+        "Art/Music Activities"
+      ]
+    },
+    {
+      "prefix": "GAME",
+      "name": "Game",
+      "course_count": 19,
+      "section_count": 39,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college",
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "3D Modeling",
+        "Advanced 3D Modeling",
+        "Business of Games",
+        "Creating the Art of the Game I",
+        "Creating the Art of the Game II"
+      ]
+    },
+    {
+      "prefix": "MEDIACM",
+      "name": "MEDIACM",
+      "course_count": 18,
+      "section_count": 39,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Advanced Broadcast Writing",
+        "Advanced Editing, Graphics, and Animation",
+        "Advanced Production Workshop",
+        "Announcing",
+        "Audio Engineering I"
+      ]
+    },
+    {
+      "prefix": "ACCOU",
+      "name": "Accounting",
+      "course_count": 16,
+      "section_count": 38,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Accounting Procedures",
+        "Applications Quickbooks Online",
+        "Auditing I",
+        "Auditing II",
+        "Cost Accounting"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 20,
+      "section_count": 38,
+      "colleges": [
+        "kishwaukee-college",
+        "mchenry-county-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chassis Systems",
+        "AUTO BRAKE SYS",
+        "AUTO CLIMATE CNTRL",
+        "AUTO ELCTRNIC FUND",
+        "AUTO ENGINE TECH"
+      ]
+    },
+    {
+      "prefix": "CDEV",
+      "name": "CDEV",
+      "course_count": 14,
+      "section_count": 38,
+      "colleges": [
+        "joliet-junior-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Admin in Early Chldhd Settings",
+        "Career Development",
+        "Child Dvlp Internship & Seminr",
+        "Child Growth & Development",
+        "Child Guidance Practices"
+      ]
+    },
+    {
+      "prefix": "ESSS",
+      "name": "Personal",
+      "course_count": 4,
+      "section_count": 38,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Allied Health Clinical Skills",
+        "Functional Anatomy & Kinesiology",
+        "Personal Trainer Practicum",
+        "Personal Trainer Preparation"
+      ]
+    },
+    {
+      "prefix": "FS MATH",
+      "name": "Math",
+      "course_count": 3,
+      "section_count": 38,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Math",
+        "Math Refresher I",
+        "Math Refresher II"
+      ]
+    },
+    {
+      "prefix": "HRT",
+      "name": "HRT",
+      "course_count": 21,
+      "section_count": 38,
+      "colleges": [
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "parkland-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Entomology:insects/People/Plnt",
+        "Fundamentals of Beekeeping",
+        "HORT INTERNSHIP",
+        "Horticulture Internship",
+        "INTRO PLANT SCI"
+      ]
+    },
+    {
+      "prefix": "LAE",
+      "name": "LAE",
+      "course_count": 19,
+      "section_count": 38,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Advanced Commercial Drone Pilot",
+        "Basic Recreational Drone Pilot",
+        "Community Relations and Procedural Justice",
+        "Criminal Investigations",
+        "Criminal Law"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Care",
+      "course_count": 24,
+      "section_count": 38,
+      "colleges": [
+        "college-of-dupage",
+        "joliet-junior-college",
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Adv Clinc Assess Proto",
+        "Adv Inten Respcareadlt",
+        "Applied Cardiopulmonary A & P",
+        "Basic Respiratory Care",
+        "Cardiopulmonary A & P"
+      ]
+    },
+    {
+      "prefix": "SOC SER",
+      "name": "Social",
+      "course_count": 11,
+      "section_count": 38,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Domestic Violence Practicum",
+        "Introduction To Group Process",
+        "Introduction To Social Work",
+        "Principles of Social Work Practice",
+        "Principles Of Youth & Group Work"
+      ]
+    },
+    {
+      "prefix": "BUSIN",
+      "name": "BUSIN",
+      "course_count": 6,
+      "section_count": 37,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Customer Service",
+        "Entrepreneurship",
+        "International Business",
+        "Introduction to Business",
+        "Principles of Finance"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 31,
+      "section_count": 37,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college",
+        "mchenry-county-college",
+        "oakton-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced PTA Clinical Education",
+        "APPLIED A&amp;P FOR EXERCISE",
+        "Basic Health Skills for the PTA",
+        "Cardiopulmonary & Vascular Practice",
+        "CLINICAL I"
+      ]
+    },
+    {
+      "prefix": "SPANI",
+      "name": "Spanish",
+      "course_count": 13,
+      "section_count": 37,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Civilization & Culture",
+        "Conversation & Composition I",
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Heritage Speakers I"
+      ]
+    },
+    {
+      "prefix": "ECONO",
+      "name": "ECONO",
+      "course_count": 3,
+      "section_count": 36,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Principles of Economics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "FASHI",
+      "name": "Fashion",
+      "course_count": 27,
+      "section_count": 36,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advanced Selected Topics",
+        "Beg Clothing Construction",
+        "Brand Strategy for Fashion",
+        "Business of Fashion",
+        "Clothing Construction I"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "LAW",
+      "course_count": 21,
+      "section_count": 36,
+      "colleges": [
+        "mchenry-county-college",
+        "morton-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Court Procedures and Evidence",
+        "Criminal Law for the Paralegal",
+        "Electroni Discovery",
+        "ESTATE+PROBATE LAW",
+        "Expunge & Entrepreneur Wkshop"
+      ]
+    },
+    {
+      "prefix": "PHYS ED",
+      "name": "PHYS ED",
+      "course_count": 6,
+      "section_count": 36,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Ballet",
+        "Contemporary Dance I",
+        "Contemporary Dance II",
+        "Fitness",
+        "Team Sports"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Communication",
+      "course_count": 5,
+      "section_count": 36,
+      "colleges": [
+        "danville-area-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communication",
+        "Oral Communication",
+        "Public & Private Communication",
+        "Public Speaking"
+      ]
+    },
+    {
+      "prefix": "THR ART",
+      "name": "Theater",
+      "course_count": 10,
+      "section_count": 36,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Acting Workshop",
+        "Intro To Theater",
+        "Stage Make-up"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 25,
+      "section_count": 35,
+      "colleges": [
+        "lincoln-land-community-college",
+        "lincoln-trail-college",
+        "mchenry-county-college",
+        "shawnee-community-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "AG RECORDS AND ANALYSIS",
+        "Agricultural Economics",
+        "AGRICULTURAL FINANCE",
+        "AGRICULTURAL MARKETING",
+        "AGRICULTURAL SALESMANSHIP"
+      ]
+    },
+    {
+      "prefix": "ANTHR",
+      "name": "ANTHR",
+      "course_count": 9,
+      "section_count": 35,
+      "colleges": [
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Business Anthropology",
+        "Cultural Anthropology",
+        "Discovering Archaeology",
+        "Evol of Human Sexual Behavior",
+        "Intr/Cult-Soc Anth"
+      ]
+    },
+    {
+      "prefix": "CHW",
+      "name": "Health",
+      "course_count": 11,
+      "section_count": 35,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Assessing Community Resources",
+        "Case Management",
+        "CHW Fieldwork I",
+        "Community and Public Health",
+        "Community Health Development"
+      ]
+    },
+    {
+      "prefix": "HLTHS",
+      "name": "Noninvasive",
+      "course_count": 6,
+      "section_count": 35,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advanced Non-Invasive EKG",
+        "Basic Non-Invasive EKG",
+        "Basic Phlebotomy Techniques",
+        "Biomedical Terminology",
+        "Non-Invasive EKG Clinical"
+      ]
+    },
+    {
+      "prefix": "MANUF",
+      "name": "MANUF",
+      "course_count": 17,
+      "section_count": 35,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advanced Machine Processes",
+        "Basic Robotics Fabrication",
+        "CNC Operations",
+        "Computer Numerical Control",
+        "Computer-Aided Manufacturing"
+      ]
+    },
+    {
+      "prefix": "MOR SCI",
+      "name": "MOR SCI",
+      "course_count": 16,
+      "section_count": 35,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Advanced Mortuary Practice Capstone",
+        "Anatomy for Embalmers",
+        "Business Communication",
+        "Chemistry For Embalmers",
+        "Embalming Laboratory"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 17,
+      "section_count": 35,
+      "colleges": [
+        "kishwaukee-college",
+        "prairie-state-college",
+        "shawnee-community-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Aerobics I",
+        "Aerobics III",
+        "Basketball",
+        "First Aid & Emergency Response",
+        "Fitness Training I"
+      ]
+    },
+    {
+      "prefix": "ACCY",
+      "name": "Accounting",
+      "course_count": 7,
+      "section_count": 34,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Accounting I",
+        "Accounting II",
+        "Cost Accounting",
+        "Income Tax Accy",
+        "Intermediate Accy I"
+      ]
+    },
+    {
+      "prefix": "RAS",
+      "name": "RAS",
+      "course_count": 19,
+      "section_count": 34,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Applied Radiologic Tech I",
+        "Applied Radiologic Tech II",
+        "Applied Radiologic Tech III",
+        "Applied Radiologic Tech IV",
+        "Applied Radiologic Tech V"
+      ]
+    },
+    {
+      "prefix": "RDG",
+      "name": "Skills",
+      "course_count": 4,
+      "section_count": 34,
+      "colleges": [
+        "moraine-valley-community-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Academic Rdg Skills & Strategy",
+        "Critical Rdg College Content",
+        "Reading & Learning Skills I",
+        "Reading & Learning Skills II"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 21,
+      "section_count": 33,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Precision Agriculture",
+        "Agri Prod/Mgmt Experience",
+        "Agricultural Business Exp",
+        "Agricultural Business Mgmt",
+        "Agricultural Economics"
+      ]
+    },
+    {
+      "prefix": "SOC SCI",
+      "name": "Social",
+      "course_count": 6,
+      "section_count": 33,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "American Social Issues",
+        "Black Economics",
+        "Community Development",
+        "Community Organizing",
+        "General Course I Social Science"
+      ]
+    },
+    {
+      "prefix": "CYBIT",
+      "name": "CYBIT",
+      "course_count": 12,
+      "section_count": 32,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Computer and Network Security",
+        "Computer Forensics",
+        "Cyber Ops",
+        "CyberSecurity Analyst",
+        "Cybersecurity Capstone"
+      ]
+    },
+    {
+      "prefix": "ESC",
+      "name": "ESC",
+      "course_count": 6,
+      "section_count": 32,
+      "colleges": [
+        "parkland-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Climate and Global Change",
+        "Intro Physical Geology",
+        "Introduction to Oceanography",
+        "Severe and Unusual Weather",
+        "Survey of Earth Science"
+      ]
+    },
+    {
+      "prefix": "ESLINTG",
+      "name": "ESLINTG",
+      "course_count": 3,
+      "section_count": 32,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Advanced Intergrated ESL",
+        "High Intermediate ESL",
+        "Intermediate Integrated ESL"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "HOSP",
+      "course_count": 27,
+      "section_count": 32,
+      "colleges": [
+        "college-of-dupage",
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Restaurant Service",
+        "Beverage Mgmt Operation",
+        "Casino Operations",
+        "Cruise Industry Sales",
+        "Explor/Hospitality Industry"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 20,
+      "section_count": 32,
+      "colleges": [
+        "joliet-junior-college",
+        "oakton-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Adv Blpr/Geom Dim Toler",
+        "Advanced CNC Programming",
+        "Advanced Programmable Controllers",
+        "Automation Overview",
+        "CNC Machine Operation - NIMS"
+      ]
+    },
+    {
+      "prefix": "MFX",
+      "name": "Mechanical",
+      "course_count": 17,
+      "section_count": 32,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Basic Hydraulics I",
+        "Basic Hydraulics II",
+        "Basic Pneumatics I",
+        "Basic Pneumatics II",
+        "C-209 Pneumatics Certification"
+      ]
+    },
+    {
+      "prefix": "OCS",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 32,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Foundations of College Success"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Advanced C++",
+        "Advanced Python Programming",
+        "Advanced SQL",
+        "AI Concepts & Ethics",
+        "Code Development in the Cloud"
+      ]
+    },
+    {
+      "prefix": "CTC",
+      "name": "CTC",
+      "course_count": 18,
+      "section_count": 31,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Basic Keyboarding",
+        "Beginning Computers",
+        "Computer Basics",
+        "Database Applications I",
+        "Database Applications II"
+      ]
+    },
+    {
+      "prefix": "EEAS",
+      "name": "EEAS",
+      "course_count": 9,
+      "section_count": 31,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Automated Systems",
+        "Basic Wiring/Circuit Design",
+        "Elec/Eltr Troubleshooting",
+        "Inds Circ Basic Prog LogicCont",
+        "Indust Circuit/Prog Control"
+      ]
+    },
+    {
+      "prefix": "PHOTO",
+      "name": "PHOTO",
+      "course_count": 21,
+      "section_count": 31,
+      "colleges": [
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Basic Lighting Skills",
+        "Digital Photo Print Workshop",
+        "Digital Photography",
+        "Extended Photo Project",
+        "Fine Art Process"
+      ]
+    },
+    {
+      "prefix": "PHT",
+      "name": "PHT",
+      "course_count": 17,
+      "section_count": 31,
+      "colleges": [
+        "morton-college",
+        "oakton-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Cardio Pulmon & Integmnt Mgt",
+        "Clinical Internship",
+        "Clinical Practicum",
+        "Fundamentals of Kinesiology I",
+        "Introduction to Disease"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 20,
+      "section_count": 30,
+      "colleges": [
+        "danville-area-community-college",
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "Art History I",
+        "Art History II",
+        "Basic Design 2-D",
+        "Basic Drawing"
+      ]
+    },
+    {
+      "prefix": "AS",
+      "name": "Auto",
+      "course_count": 13,
+      "section_count": 30,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Auto Engines Rebuild",
+        "Auto Fuel System",
+        "Auto Fund Consumers",
+        "Auto Service I",
+        "Auto Service III"
+      ]
+    },
+    {
+      "prefix": "HLT",
+      "name": "Health",
+      "course_count": 9,
+      "section_count": 30,
+      "colleges": [
+        "frontier-community-college",
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "shawnee-community-college",
+        "south-suburban-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "Drug Use and Abuse",
+        "Health",
+        "HEALTH CAREERS TOPICS",
+        "Health in Today's Society",
+        "Introduction to Nutrition"
+      ]
+    },
+    {
+      "prefix": "IMT",
+      "name": "Systems",
+      "course_count": 15,
+      "section_count": 30,
+      "colleges": [
+        "joliet-junior-college",
+        "mchenry-county-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "C-201 Electrical Systems I",
+        "C-202 Electrical Motor Control Systems 1",
+        "C-203 Variable Frequency Drive",
+        "C-209 Pneumatic Systems I",
+        "C-210 Mechanical Power Systems I"
+      ]
+    },
+    {
+      "prefix": "MENHLTH",
+      "name": "Addictions",
+      "course_count": 6,
+      "section_count": 30,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Addictions & Family Treatment",
+        "Addictions Treatment of Special Populations",
+        "Intro To Addictions Studies",
+        "Practicum In Addictions Treatment",
+        "Principles and Practices of Addiction Studies"
+      ]
+    },
+    {
+      "prefix": "PHLEB",
+      "name": "Phlebotomy",
+      "course_count": 4,
+      "section_count": 30,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy Clinical",
+        "Phlebotomy Practicum",
+        "Phlebotomy Seminar I",
+        "Phlebotomy Seminar II"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 10,
+      "section_count": 30,
+      "colleges": [
+        "college-of-dupage",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "American Politics",
+        "Comparative Politics",
+        "International Relations",
+        "Intro to Political Science"
+      ]
+    },
+    {
+      "prefix": "SURG TC",
+      "name": "Surgical",
+      "course_count": 12,
+      "section_count": 30,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Applied Surgical Procedures",
+        "Applied Surgical Procedures II",
+        "Career Readiness for STs",
+        "Clinical Experience I",
+        "Clinical Experience II"
+      ]
+    },
+    {
+      "prefix": "CPR",
+      "name": "Hcpskills",
+      "course_count": 2,
+      "section_count": 29,
+      "colleges": [
+        "joliet-junior-college",
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "BLS CPR for HCP-Skills Sess",
+        "CPR for Healthcare Providers"
+      ]
+    },
+    {
+      "prefix": "DEHYG",
+      "name": "Dental",
+      "course_count": 11,
+      "section_count": 29,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Appld Nutrition & Biochemistry",
+        "Clinical Dental Hygiene III",
+        "Community Dental Health I",
+        "Dental Hygiene Theory I",
+        "Dental Radiology II"
+      ]
+    },
+    {
+      "prefix": "ELS",
+      "name": "English",
+      "course_count": 12,
+      "section_count": 29,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Academic ESL Grammar II",
+        "Academic Esl Lang/Culture II",
+        "Eng Lang for Arg/Analysis 3",
+        "Eng Lang for Arg/Analysis 4",
+        "Eng Lang for Arg/Analysis 5"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 12,
+      "section_count": 29,
+      "colleges": [
+        "kishwaukee-college",
+        "lincoln-land-community-college",
+        "moraine-valley-community-college",
+        "parkland-college",
+        "south-suburban-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Geo of Undrdevel Areas",
+        "Geography of the Devel. World",
+        "Geography of the Developing World",
+        "Geography of the Emerg World"
+      ]
+    },
+    {
+      "prefix": "HVACR",
+      "name": "HVACR",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Central Heating Plants",
+        "Commercial Air Conditioning",
+        "Electricity & HVACR Controls",
+        "Facility Electrical Systems",
+        "Heating Principles"
+      ]
+    },
+    {
+      "prefix": "OMT",
+      "name": "OMT",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Database Software Fundamentals",
+        "Electronic Recordkeeping",
+        "Introduction to Windows",
+        "Keyboarding & Doc Formatting"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "Physical",
+      "course_count": 8,
+      "section_count": 29,
+      "colleges": [
+        "kishwaukee-college",
+        "morton-college",
+        "south-suburban-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Introduction Physical Science",
+        "Introduction to Astronomy",
+        "Introduction to Earth Science",
+        "Introduction- Physical Geology",
+        "Physical Science"
+      ]
+    },
+    {
+      "prefix": "BSNS",
+      "name": "Business",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Business Law",
+        "Business Statistics",
+        "Human Relations in Business",
+        "Human Resource Management",
+        "Internship Exp"
+      ]
+    },
+    {
+      "prefix": "HTH",
+      "name": "Science",
+      "course_count": 5,
+      "section_count": 28,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Culture Socty Health:Int Aprc",
+        "Drug & Alcohol Education",
+        "First Aid CPR AED",
+        "Nutrition Science",
+        "Science of Personal Health"
+      ]
+    },
+    {
+      "prefix": "RESP TC",
+      "name": "RESP TC",
+      "course_count": 20,
+      "section_count": 28,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiopulmonary Monitoring",
+        "Advanced Pathology & Clinical Application",
+        "Advanced Respiratory Topics & Research",
+        "Advanced Specialty Topics",
+        "Age Specific Care"
+      ]
+    },
+    {
+      "prefix": "AOT",
+      "name": "AOT",
+      "course_count": 11,
+      "section_count": 27,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "AI FOR PROFESSIONALS",
+        "CANVA DESIGN I",
+        "INTGRTD OFFICE APP WINDOWS",
+        "KEYBRD I INTRO",
+        "KEYBRD SPEED ACCUR"
+      ]
+    },
+    {
+      "prefix": "CMN",
+      "name": "Public",
+      "course_count": 2,
+      "section_count": 27,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communication",
+        "Public Speaking Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CRIMJ",
+      "name": "CRIMJ",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Computers & Criminal Justice",
+        "Constitutional Law",
+        "Criminal Law",
+        "Criminology",
+        "Emergency Management"
+      ]
+    },
+    {
+      "prefix": "CRMJ",
+      "name": "CRMJ",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "American Criminal Justice",
+        "Constitutional Law-Justice",
+        "Crim Justice and Mental Health",
+        "Crime and Popular Culture",
+        "Crime Prevent/Patrol Technique"
+      ]
+    },
+    {
+      "prefix": "DMD",
+      "name": "Digital",
+      "course_count": 10,
+      "section_count": 27,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "2D Animation",
+        "3D Modeling",
+        "Advanced Animation",
+        "Advanced Computer Art",
+        "Beg Multimedia Design & Dev"
+      ]
+    },
+    {
+      "prefix": "RSC",
+      "name": "Respiratory",
+      "course_count": 19,
+      "section_count": 27,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Adv Intensive Respiratory Care",
+        "Adv Respiratory Care Technique",
+        "Adv Respiratory Procedure",
+        "Applied Respiratory Care I",
+        "Applied Respiratory Care II"
+      ]
+    },
+    {
+      "prefix": "DMIS",
+      "name": "DMIS",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Case Study Critique II",
+        "Clinical Education IV",
+        "Fundamentals Breast Sonography",
+        "Fundamentals of OB/GYN I",
+        "Hands-On Scan Lab 1"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "ECN",
+      "course_count": 5,
+      "section_count": 26,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Principles of Economics-Macroeconomics",
+        "Principles of Economics-Microeconomics",
+        "PRINCIPLES OF MACROECONOMICS",
+        "PRINCIPLES OF MICROECONOMICS"
+      ]
+    },
+    {
+      "prefix": "EDUCA",
+      "name": "EDUCA",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Diversity in K-12 Schools",
+        "Educa for Exceptional Child",
+        "Instructional Psychology",
+        "Introduction to Education",
+        "School Procedure"
+      ]
+    },
+    {
+      "prefix": "GRDSN",
+      "name": "Design",
+      "course_count": 15,
+      "section_count": 26,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advertising Design",
+        "Cartooning",
+        "Digital Graphic Applications",
+        "Digital Illustration 1",
+        "Digital Illustration 2"
+      ]
+    },
+    {
+      "prefix": "INST",
+      "name": "Career",
+      "course_count": 5,
+      "section_count": 26,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Career Readiness",
+        "Career Readiness Fundamentals",
+        "Global Interaction Skills",
+        "Online Learning Orientation",
+        "Success in College"
+      ]
+    },
+    {
+      "prefix": "JRN",
+      "name": "Mass",
+      "course_count": 7,
+      "section_count": 26,
+      "colleges": [
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "moraine-valley-community-college",
+        "morton-college"
+      ],
+      "sample_titles": [
+        "ADVANCED FILM",
+        "INTRO BROADCASTING",
+        "INTRO FILM",
+        "INTRO MASS COMM",
+        "Intro to Mass Communications"
+      ]
+    },
+    {
+      "prefix": "MCM",
+      "name": "Mass",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Cinema Appreciation",
+        "Cinema History",
+        "Introduction to Mass Communication",
+        "Mass Communication",
+        "Report & Writing for Multimed"
+      ]
+    },
+    {
+      "prefix": "NSO",
+      "name": "Student",
+      "course_count": 1,
+      "section_count": 26,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "New Student Advising"
+      ]
+    },
+    {
+      "prefix": "PHYSI",
+      "name": "Physics",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "college-of-dupage",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "Conceptual Physics",
+        "Energy and Society",
+        "General Physics I",
+        "General Physics II"
+      ]
+    },
+    {
+      "prefix": "PLGL",
+      "name": "PLGL",
+      "course_count": 13,
+      "section_count": 26,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Bankruptcy Law",
+        "Elder Law",
+        "Electronic Discovery",
+        "Family Law",
+        "Immigration Law"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surgical",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "oakton-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum I",
+        "Clinical Practicum III",
+        "Clinical Theory I",
+        "Introduction to Surgical Technology",
+        "Mock Operating Room Lab I"
+      ]
+    },
+    {
+      "prefix": "AHA",
+      "name": "Heartsaver",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "AHA Instructor Certification for BLS CPR and Heartsaver CPR and First Aid",
+        "BLS Provider CPR",
+        "Heartsaver First Aid, CPR/AED for Adults, Children, and Infants"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 16,
+      "section_count": 25,
+      "colleges": [
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "mchenry-county-college",
+        "morton-college",
+        "triton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Analytical Mech-Dynamics",
+        "Analytical Mech-Statics",
+        "Analytical Mechanics-Statics",
+        "Electrical Circuit Analysis",
+        "ENGINEER GRAPH"
+      ]
+    },
+    {
+      "prefix": "HEA",
+      "name": "Health",
+      "course_count": 12,
+      "section_count": 25,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "shawnee-community-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "APPLIED LEGAL CONCEPTS/MEDICAL",
+        "BASIC NURSE ASSIST TRNG PROG",
+        "CASE STUD/PROB IN ALLIED HLTH",
+        "CLINICAL PROCEDURES I",
+        "Heating I"
+      ]
+    },
+    {
+      "prefix": "NA",
+      "name": "Tech",
+      "course_count": 5,
+      "section_count": 25,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Electcardiogr Tech Prac",
+        "Basic Electrocardiograph Tech",
+        "Certified Nurse Asst Training",
+        "Phlebotomy Tech Trng",
+        "Phlebotomy Technic Practicum"
+      ]
+    },
+    {
+      "prefix": "330TRNS",
+      "name": "Diesel",
+      "course_count": 12,
+      "section_count": 24,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college"
+      ],
+      "sample_titles": [
+        "Diesel Brakes",
+        "Diesel Electrical Systems I",
+        "Diesel Electrical Systems II",
+        "Diesel Engine Construction I",
+        "Diesel Engine Construction II"
+      ]
+    },
+    {
+      "prefix": "AVI",
+      "name": "Commercial",
+      "course_count": 14,
+      "section_count": 24,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Aircraft Systems for Pilots",
+        "Aviation Accident Investigatio",
+        "Commercial Drone Ground School",
+        "Commercial Instrument I",
+        "Commercial Instrument II"
+      ]
+    },
+    {
+      "prefix": "CHD",
+      "name": "Child Development",
+      "course_count": 14,
+      "section_count": 24,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Child Family and Community",
+        "Child Growth and Development",
+        "Child Health, Safety and Nutri",
+        "Creative Activit Yng Children",
+        "Early Childhood Curriculum"
+      ]
+    },
+    {
+      "prefix": "COM DSGN",
+      "name": "Design",
+      "course_count": 10,
+      "section_count": 24,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Digital Photography",
+        "Digital Typography",
+        "Graphic Design I",
+        "Graphic Design II",
+        "Introduction to Communication Design"
+      ]
+    },
+    {
+      "prefix": "COSME",
+      "name": "COSME",
+      "course_count": 16,
+      "section_count": 24,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Chemical Services I",
+        "Chemical Services II",
+        "Chemical Services III",
+        "Chemical Services IV",
+        "Esthetics & Nail Technology I"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 19,
+      "section_count": 24,
+      "colleges": [
+        "joliet-junior-college",
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "ADV CPT ICD CODING",
+        "Basic CPT Coding",
+        "BASIC CPT CODING",
+        "Basic ICD Coding",
+        "Clinical Classificaton Sys"
+      ]
+    },
+    {
+      "prefix": "LGLST",
+      "name": "LGLST",
+      "course_count": 13,
+      "section_count": 24,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Adv Leg Res. & Write",
+        "Civil Litigation",
+        "Criminal. Law & Procedure",
+        "Drafting Legal Docs",
+        "Elder Law"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "MA",
+      "course_count": 18,
+      "section_count": 24,
+      "colleges": [
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "prairie-state-college",
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures/Emr",
+        "Administrative Procedures/EMR",
+        "Anatomy and Physiology for MA",
+        "Billing and Coding",
+        "Clinical Asst & Pharmacology"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "MEDA",
+      "course_count": 13,
+      "section_count": 24,
+      "colleges": [
+        "danville-area-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Med Asst Skills I",
+        "Clinical Med Asst Skills II",
+        "Clinical Procedures I",
+        "Clinical Procedures III",
+        "Clinical/Office Internship"
+      ]
+    },
+    {
+      "prefix": "MIS",
+      "name": "MIS",
+      "course_count": 14,
+      "section_count": 24,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Access",
+        "Advanced Operating Systems",
+        "Computer Information Security",
+        "Computer Literacy and Applicat",
+        "Computer Logic"
+      ]
+    },
+    {
+      "prefix": "NCHF",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 24,
+      "colleges": [
+        "frontier-community-college"
+      ],
+      "sample_titles": [
+        "HEALTH AND WELLNESS-SEPTEMBER"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "Nursing",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Nursing I",
+        "Clinical Nursing II",
+        "Fundamentals of Nursing",
+        "Geriatric Nursing",
+        "Growth & Development for PN's"
+      ]
+    },
+    {
+      "prefix": "THEAT",
+      "name": "THEAT",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Audition",
+        "Improvisational Acting",
+        "Performance Practicum",
+        "Rehearsal & Performance"
+      ]
+    },
+    {
+      "prefix": "CAB",
+      "name": "CAB",
+      "course_count": 17,
+      "section_count": 23,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Management and Professional Development",
+        "Adobe Acrobat PDF",
+        "Adobe Illustrator",
+        "Adobe InDesign",
+        "Adobe Photoshop"
+      ]
+    },
+    {
+      "prefix": "COLLG",
+      "name": "COLLG",
+      "course_count": 3,
+      "section_count": 23,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Career Development",
+        "College Success Skills",
+        "Selected Topics I"
+      ]
+    },
+    {
+      "prefix": "COT",
+      "name": "COT",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Carpentry: Finished Carpentry",
+        "Carpentry: Rough Carpentry",
+        "Codes, Spec and Print Reading",
+        "Construc Planning & Scheduling",
+        "Construction Cost Estimating"
+      ]
+    },
+    {
+      "prefix": "ELMEC",
+      "name": "ELMEC",
+      "course_count": 15,
+      "section_count": 23,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Commercial Wiring",
+        "Drive Components",
+        "Hydraulics & Pneumatics",
+        "Indus Control/Data Acquisition",
+        "Industrial Electricity"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 18,
+      "section_count": 23,
+      "colleges": [
+        "moraine-valley-community-college",
+        "oakton-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "A+ Certification Preparation",
+        "Advanced Industrial Controls",
+        "Electricity and Electronics",
+        "Electronic Drafting Using CAD",
+        "Electronic Systems Repair"
+      ]
+    },
+    {
+      "prefix": "MANAG",
+      "name": "MANAG",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Comp, Benefits, Total Rewards",
+        "Human Resources Management",
+        "Leadership",
+        "Organizational Behavior",
+        "Principles of Management"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Advertising",
+        "Intro Marketing",
+        "Marketing",
+        "Principles of Advertising",
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "MRKT",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Branding for Athletes",
+        "Consumer Behavior",
+        "Content Creation",
+        "Digital Marketing",
+        "Intro to Sports Marketing"
+      ]
+    },
+    {
+      "prefix": "PEH",
+      "name": "PEH",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "moraine-valley-community-college",
+        "morton-college"
+      ],
+      "sample_titles": [
+        "A Healthy Lifestyle and You",
+        "First Aid",
+        "Intro. to Body/Mind Fitness",
+        "Lifetime Activities-Condition.",
+        "Lifetime Activities, Net Games"
+      ]
+    },
+    {
+      "prefix": "PHB",
+      "name": "Phlebotomy",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "frontier-community-college",
+        "moraine-valley-community-college",
+        "shawnee-community-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Basic Phlebotomy",
+        "Phlebotomy Clin. Practice Sem.",
+        "Phlebotomy Clinical Practice",
+        "Phlebotomy Internship",
+        "PHLEBOTOMY PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 11,
+      "section_count": 23,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Clinical Education",
+        "Intro to Radiologic Science",
+        "Patient Care in Imaging",
+        "Radiographic Physics",
+        "Radiographic Procedures I"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 7,
+      "section_count": 23,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Basic Spanish",
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Inter Spanish I",
+        "Inter Spanish II"
+      ]
+    },
+    {
+      "prefix": "BARBER",
+      "name": "Barber",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Advanced Barbering",
+        "Barber Salon Technology 1",
+        "Barber Salon Technology II",
+        "Barbering Summative Seminar",
+        "Basic Teaching Skills for Barber Education Instructors"
+      ]
+    },
+    {
+      "prefix": "CAD TEC",
+      "name": "Technology",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "CAD Technology I",
+        "CAD Technology II",
+        "CAD Technology III",
+        "CAD Technology IV"
+      ]
+    },
+    {
+      "prefix": "FRENCH",
+      "name": "French",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-richard-j-daley-college"
+      ],
+      "sample_titles": [
+        "First Course French",
+        "Fourth Course French",
+        "Second Course French",
+        "Third Course French"
+      ]
+    },
+    {
+      "prefix": "GEOLOGY",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 22,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "PEMW",
+      "name": "Weight",
+      "course_count": 10,
+      "section_count": 22,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Weight Training",
+        "Expert Weight Training",
+        "Fitness Center I",
+        "Fitness Center II",
+        "Fitness Center III"
+      ]
+    },
+    {
+      "prefix": "POS",
+      "name": "POS",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "lincoln-land-community-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "American National Government",
+        "International Relations",
+        "Intro Political Science",
+        "Intro to American Politics",
+        "Intro to Political Philosophy"
+      ]
+    },
+    {
+      "prefix": "PSCI",
+      "name": "PSCI",
+      "course_count": 10,
+      "section_count": 22,
+      "colleges": [
+        "joliet-junior-college",
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Amer National Govt",
+        "Amer State/Local Govt",
+        "Applied Technical Science",
+        "Earth Science & Society",
+        "International Relations"
+      ]
+    },
+    {
+      "prefix": "330BKPS",
+      "name": "330BKPS",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking Principles",
+        "Bakery Operations",
+        "Baking Techniques",
+        "Breads and Rolls",
+        "Chocolate and Confections"
+      ]
+    },
+    {
+      "prefix": "AFD",
+      "name": "AFD",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Auto Seminar",
+        "Auto Work Experience I",
+        "Auto Work Experience II",
+        "Automatic Transmissions",
+        "Automotive Chassis Systems"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Clinic Seminar II",
+        "Clinic Seminar III",
+        "Dental Biology",
+        "Dental Hygiene Practice III",
+        "Dental Hygiene Practice IV"
+      ]
+    },
+    {
+      "prefix": "DMIR",
+      "name": "DMIR",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Basic Pathophysiology",
+        "Breast Anatomy & Physiology",
+        "Clinical Appls in Mammography",
+        "Clinical Education II",
+        "Clinical Education V"
+      ]
+    },
+    {
+      "prefix": "FS WRIT",
+      "name": "Foundational",
+      "course_count": 1,
+      "section_count": 21,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Foundational Studies in Literacy"
+      ]
+    },
+    {
+      "prefix": "INFO",
+      "name": "INFO",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "A+ Certification Prep",
+        "Cisco I",
+        "Cisco II",
+        "Cisco III",
+        "Employment Seminar"
+      ]
+    },
+    {
+      "prefix": "LCT",
+      "name": "LCT",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Advanced Excel",
+        "Digital Imaging and Photoshop",
+        "Foundations of Data Analysis",
+        "Graphic Arts Fundamentals",
+        "Intermediate MySQL"
+      ]
+    },
+    {
+      "prefix": "MARKE",
+      "name": "MARKE",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Consumer Behavior",
+        "Digital Marketing",
+        "Intro Dig Marketing Analytics",
+        "Principles of Marketng"
+      ]
+    },
+    {
+      "prefix": "NET",
+      "name": "Cert",
+      "course_count": 14,
+      "section_count": 21,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "A+ CERT PREP",
+        "CCNA CERT PREP",
+        "CLOUD+ CERT PREP",
+        "COMPUTER ETHICS",
+        "CySA+ CERT PREP"
+      ]
+    },
+    {
+      "prefix": "OPH",
+      "name": "Ophthalmic",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Clinical Practicum III",
+        "Contact Lenses",
+        "Ocular Anatomy & Physiology"
+      ]
+    },
+    {
+      "prefix": "PAR",
+      "name": "PAR",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "oakton-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Administrative and Social Security Law",
+        "Civil Litigation",
+        "Contract Law",
+        "Drafting Legal Documents",
+        "Evidence and Investigations"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "Repair",
+      "course_count": 19,
+      "section_count": 20,
+      "colleges": [
+        "parkland-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Collision Repair",
+        "Advanced Refinish Techniques",
+        "Advanced Structural Repair",
+        "Advanced Vehicle Systems",
+        "Automotive Collision and Refinishing Careers"
+      ]
+    },
+    {
+      "prefix": "ATA",
+      "name": "Automotive",
+      "course_count": 14,
+      "section_count": 20,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Engines",
+        "Advanced Engine Performance Analysis",
+        "Advanced Hybrid and Electrical Vehicle Systems",
+        "Automatic Transmissions",
+        "Automotive Electrical Systems I"
+      ]
+    },
+    {
+      "prefix": "BNA",
+      "name": "Nurse",
+      "course_count": 3,
+      "section_count": 20,
+      "colleges": [
+        "moraine-valley-community-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Basic Nurse Assistant",
+        "Basic Nurse Assistant Job Training",
+        "Basic Nurse Assistant Training"
+      ]
+    },
+    {
+      "prefix": "NURSA",
+      "name": "Nurse",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Nurse Assistant Training"
+      ]
+    },
+    {
+      "prefix": "SRT",
+      "name": "Surgical",
+      "course_count": 15,
+      "section_count": 20,
+      "colleges": [
+        "prairie-state-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Advanced Surgical Skills Lab",
+        "Appl Surg Proc. I",
+        "Appl Surg Procedures IV",
+        "Basic Surgical Procedures",
+        "Basic Surgical Skills Lab"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Cost Accounting",
+        "Data Analytics In Accounting",
+        "Financial Accounting",
+        "General Accounting",
+        "Intermediate Acct I"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 7,
+      "section_count": 19,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Anthropology",
+        "Archaeology",
+        "Cultural Anthropology",
+        "Forensic Anthropology",
+        "Intro to Anthropology"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "Child",
+      "course_count": 3,
+      "section_count": 19,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Child Growth & Dev",
+        "Exceptional Child",
+        "Foundations Amer Public Educa"
+      ]
+    },
+    {
+      "prefix": "HMGT",
+      "name": "HMGT",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college"
+      ],
+      "sample_titles": [
+        "Art of the Cocktail",
+        "Bar Administration and Operations",
+        "Bar and Beverage Management",
+        "Bar Concept Management",
+        "Catering and Event Management"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Clinical",
+      "course_count": 17,
+      "section_count": 19,
+      "colleges": [
+        "frontier-community-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "ADV. HEMATOLOGY &amp; HEMOSTASIS",
+        "Basic Skills in Medical Laboratory Technology",
+        "Clinical Chemistry",
+        "CLINICAL CHEMISTRY",
+        "Clinical Practicum I"
+      ]
+    },
+    {
+      "prefix": "ORIN",
+      "name": "Foundation",
+      "course_count": 2,
+      "section_count": 19,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Foundation for Student Success",
+        "Strategies for Academic Succes"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "frontier-community-college",
+        "joliet-junior-college",
+        "kishwaukee-college",
+        "lincoln-trail-college",
+        "moraine-valley-community-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "Criminal Law Paralegal",
+        "GOVERNMENT OF THE U.S.",
+        "Immigration Law",
+        "International Relations",
+        "Intro American Gov/Pol"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "American",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "college-of-dupage",
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language IV",
+        "Basic Communication I",
+        "Basic Communication II"
+      ]
+    },
+    {
+      "prefix": "AGB",
+      "name": "AGB",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Ag-Bus. & Farm Mgt",
+        "Agr Bus Management",
+        "Agri Applic of Computer",
+        "Agri-Business Seminar",
+        "Agri-Business Work Exploration"
+      ]
+    },
+    {
+      "prefix": "AVIATN",
+      "name": "Aviation",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college"
+      ],
+      "sample_titles": [
+        "Aircraft Systems II",
+        "Aviation General Sciences I-Math, Science and General Physics",
+        "Aviation General Sciences II - Tools, Surfaces, and Corrosion Control",
+        "Aviation General Sciences III - Maintenance Operations and Records",
+        "Aviation General Sciences IV - Basic Electricity"
+      ]
+    },
+    {
+      "prefix": "CM",
+      "name": "CM",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Blueprint Rdg for Construction",
+        "Constr Materials and Testing",
+        "Construc Contracts & Specs",
+        "Construc Planning/Scheduling",
+        "Construct Costing & Estimating"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "DH",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Clincal Dental Hygiene IV",
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene III",
+        "Community Dental Health",
+        "Fund Dent Hyg"
+      ]
+    },
+    {
+      "prefix": "HSV",
+      "name": "Substance",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "oakton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Assessment, Treatment Planning, and Addiction Strategies",
+        "Clinical Skills for Substance Use Disorder Counselors",
+        "Counseling/Interviewing",
+        "Counseling/Interviewing II",
+        "Crisis Intervention"
+      ]
+    },
+    {
+      "prefix": "HUS",
+      "name": "HUS",
+      "course_count": 15,
+      "section_count": 18,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Addictions Field Work I",
+        "Advocacy Skills",
+        "Case Management",
+        "Crisis Intervention",
+        "Cultural Awareness"
+      ]
+    },
+    {
+      "prefix": "LITT",
+      "name": "Literature",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "British Literature I",
+        "Children's Literature",
+        "Eastern Mythology",
+        "Film As Literature",
+        "Multicultural American Lit"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "joliet-junior-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Entreprenshp/Sm Bus Mgmt",
+        "Fundamentals Management",
+        "Human Relations",
+        "Human Resource Management",
+        "Human Resource Mgmt"
+      ]
+    },
+    {
+      "prefix": "CNB",
+      "name": "Cannabis",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "oakton-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Botany and Cultivation of Cannabis",
+        "Cannabis Cultivation Operations",
+        "Dispensary Operations",
+        "Introduction to Cannabis",
+        "Pharmacology and Medical Cannabis Use"
+      ]
+    },
+    {
+      "prefix": "CNS",
+      "name": "CNS",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Cisco Enterprise Networking, Security, and Automation",
+        "Cisco Introduction to Networks",
+        "Cisco Switching, Routing, and Wireless Essentials",
+        "Cybersecurity Operations Analysis",
+        "Enterprise Cloud Services 1"
+      ]
+    },
+    {
+      "prefix": "CPS",
+      "name": "CPS",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Business Computer Systems",
+        "C++ Programming",
+        "Informational Technologies",
+        "Intro to Project Management",
+        "Introduction to AI"
+      ]
+    },
+    {
+      "prefix": "ECEC",
+      "name": "ECEC",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Admin ECC-Staff & Families",
+        "Child Guidance Practices",
+        "Child Health/Safety/Nutrition",
+        "Child/Family/Community Relatns",
+        "Curriculum Plan-Young Child"
+      ]
+    },
+    {
+      "prefix": "HEAL",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Introduction to Health Careers",
+        "Prin of Normal Nutrition"
+      ]
+    },
+    {
+      "prefix": "HEAPRO",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Health Career Studies"
+      ]
+    },
+    {
+      "prefix": "MFRG",
+      "name": "MFRG",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "CNC Setup & Operations",
+        "Industrial Safety (OSHA 30)",
+        "Industrial Safety OSHA 10",
+        "Industrial Tech Mgt & Quality",
+        "Intro to CNC Programming"
+      ]
+    },
+    {
+      "prefix": "RELIG",
+      "name": "Bible",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Intro to Bible: New Testament",
+        "Intro to Bible: Old Testament",
+        "Introduction to Religion",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "SURGT",
+      "name": "Surg",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Ethics in Health Care",
+        "Professional Practice",
+        "Surg Health & Tech Sciences",
+        "Surg Pathophy Patient Proc II",
+        "Surg Technology Practicum I"
+      ]
+    },
+    {
+      "prefix": "AFM",
+      "name": "AFM",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Basic Auto Elect/Electrnc",
+        "Climate Control Systems",
+        "Dealership Operations",
+        "Diesel Engine Operations",
+        "Directed Co-Op I (Dealership)"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "CNT",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Enterprise Net/Sec Automation",
+        "Intro to Networks",
+        "Network Architecture",
+        "Securing IT Infrastructure",
+        "Switch/Rout/Wireless Essential"
+      ]
+    },
+    {
+      "prefix": "ECG",
+      "name": "Echo",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Echo Anatomy and Physiology",
+        "Echo Cert. Review",
+        "Echo Clinical I",
+        "Echo Clinical II",
+        "Echo Clinical III"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "Medical",
+      "course_count": 14,
+      "section_count": 16,
+      "colleges": [
+        "moraine-valley-community-college",
+        "parkland-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Admin. Medical Assistant I",
+        "Admin. Medical Assistant II",
+        "Aseptic Techniques",
+        "Basic Swedish Massage",
+        "Clinical Medical Assistant I"
+      ]
+    },
+    {
+      "prefix": "NAE",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "BASIC NURSING ASST"
+      ]
+    },
+    {
+      "prefix": "SCML",
+      "name": "SCML",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college"
+      ],
+      "sample_titles": [
+        "Customer Service Operations",
+        "Demand Planning & Forecasting",
+        "E-Commerce/E-Procurement",
+        "Global Logistics",
+        "Intro To Business Logistics"
+      ]
+    },
+    {
+      "prefix": "SPC",
+      "name": "Speech",
+      "course_count": 3,
+      "section_count": 16,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communication",
+        "Speech",
+        "Theatre Appreciation"
+      ]
+    },
+    {
+      "prefix": "AVIAT",
+      "name": "AVIAT",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Air Traffic Control",
+        "Airline Management",
+        "Aviation Procedures Training",
+        "Aviation Skills Lab",
+        "Commercial Pilot Flight Ins II"
+      ]
+    },
+    {
+      "prefix": "BLAW",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 15,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Business Law I",
+        "Business Law II"
+      ]
+    },
+    {
+      "prefix": "CDS",
+      "name": "Cardiac",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology for the Cardiac Sonographer",
+        "Basic EKG for the Cardiac Sonographer",
+        "Cardiac Sonography Clinical Externship I",
+        "Cardiac Sonography II",
+        "Cardiac Sonography Lab Practicum I"
+      ]
+    },
+    {
+      "prefix": "DPT",
+      "name": "DPT",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesels",
+        "Basic Engine Overhaul",
+        "Basic Hydraulics",
+        "Basic Trans & Final Drives",
+        "Diesel Power Tech Intern"
+      ]
+    },
+    {
+      "prefix": "FIREMGT",
+      "name": "Fire",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "city-colleges-of-chicago-malcolm-x-college"
+      ],
+      "sample_titles": [
+        "Basic Incident Command",
+        "Building Construction for Fire Science",
+        "Fire Apparatus and Equipment Operator",
+        "Fire Behavior and Combustion",
+        "Fire Service Hydraulics"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "HUMS",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Counseling Life Change & Loss",
+        "Fieldwork I",
+        "Intro Human Services",
+        "Intro to Women's & Gender Stud",
+        "Introduction to Humanities"
+      ]
+    },
+    {
+      "prefix": "LAP",
+      "name": "Comptia",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "CompTIA A+ Computer Technician",
+        "CompTIA Cloud+",
+        "CompTIA Cybersecurity Analyst+",
+        "CompTIA Data+",
+        "CompTIA Datasys+"
+      ]
+    },
+    {
+      "prefix": "OFTI",
+      "name": "OFTI",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Advanced Microsoft 365",
+        "Business Correspndence",
+        "E-Mail Electr Communic",
+        "Electr Presentatn-Busin Prof",
+        "Keyboarding/Document Fundamtls"
+      ]
+    },
+    {
+      "prefix": "PHEC",
+      "name": "Personal",
+      "course_count": 2,
+      "section_count": 15,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Low Impact Aerobics",
+        "Personal Fitness"
+      ]
+    },
+    {
+      "prefix": "SOCY",
+      "name": "Sociology",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "danville-area-community-college",
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Social Problems",
+        "DEI & Belonging",
+        "Intro to Sociology",
+        "Racial and Ethnic Relations",
+        "Sociology"
+      ]
+    },
+    {
+      "prefix": "SPM",
+      "name": "Sport",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "ACTIVITY PLANNING",
+        "INTRO TO SPORT MANAGEMENT",
+        "KINESIOLOGY AND SPORT",
+        "PRINCIPLES OF COACHING",
+        "SPORT COMMUNICATION"
+      ]
+    },
+    {
+      "prefix": "VTT",
+      "name": "VTT",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Clinical Pathology I",
+        "Clinical Rotations I",
+        "Intro to Veterinary Technology",
+        "Laboratory Animals",
+        "Large Animal Nursing"
+      ]
+    },
+    {
+      "prefix": "WT",
+      "name": "Welding",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "ASME Pipe Welding I 5G",
+        "Fabrication II",
+        "Fundamental Welding Processes",
+        "Introduction to Fabrication",
+        "Layout II"
+      ]
+    },
+    {
+      "prefix": "AHR",
+      "name": "AHR",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Advanced Automatic Controls",
+        "Air Conditioning II &ndash; Split System",
+        "Commercial Refrigeration Systems",
+        "Energy Audit, Analysis and Management",
+        "EPA Section 608 Certification"
+      ]
+    },
+    {
+      "prefix": "AIRC",
+      "name": "AIRC",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Commercial Refrigeration",
+        "Controls & Circuitry for HVAC",
+        "Fundamentals of Air Condition",
+        "Geothermal Systems",
+        "Heat Pumps"
+      ]
+    },
+    {
+      "prefix": "FRS",
+      "name": "Fire",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "BASC OPER FIREFGHT",
+        "BLDG CNST FIRE SCI",
+        "FIRE BEHAVR COMBST",
+        "FIRE PREV PRINC",
+        "FIRE PROTECT SYS"
+      ]
+    },
+    {
+      "prefix": "GEOGR",
+      "name": "Geography",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Eastern World Geography",
+        "Geodatabase Development",
+        "Geographic Info Systems I",
+        "Western World Geography"
+      ]
+    },
+    {
+      "prefix": "HFA",
+      "name": "Humanities",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "General Humanities I",
+        "General Humanities II",
+        "Humanities of Eastern Asia",
+        "Introduction to Film Appreciat",
+        "Introduction to Film History"
+      ]
+    },
+    {
+      "prefix": "LPN",
+      "name": "Nursing",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Adv Medical Surgical Nursing",
+        "Introduction to Nursing",
+        "Licensure Preparation",
+        "Medical Surgical Nursing",
+        "Nursing Fundamentals"
+      ]
+    },
+    {
+      "prefix": "MICRO",
+      "name": "Microbiology",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Microbiology"
+      ]
+    },
+    {
+      "prefix": "NCPD",
+      "name": "Drivers",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "ART TOPICS-OPEN STUDIO",
+        "DRIVER&#39;S EDUCATION",
+        "DRIVER&#39;S EDUCATION BTW",
+        "NEW STUDENT ORIENTATION",
+        "TRIO PORTAL"
+      ]
+    },
+    {
+      "prefix": "PLT",
+      "name": "Govt",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "COMPARATIVE GOVT",
+        "CONSTITN DELCT BAL",
+        "INTRNATL RELATION",
+        "STATE LOCAL GOVT",
+        "U.S. GOVERNMENT"
+      ]
+    },
+    {
+      "prefix": "RA",
+      "name": "Radiographic",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Practicum I",
+        "Clinical Practicum I",
+        "Clinical Practicum III",
+        "Medical Term for Radiography",
+        "Patient Care Techniques"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Intro Sociology",
+        "Marriage & Family",
+        "Racial & Ethnic Relations",
+        "Social Problems"
+      ]
+    },
+    {
+      "prefix": "SRV",
+      "name": "Surveying",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Basic Surveying",
+        "Boundary Surveying",
+        "Construction Surveying",
+        "Land Development Design",
+        "Surveying Computations I"
+      ]
+    },
+    {
+      "prefix": "XRA",
+      "name": "Clinical",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Adv Radiologic Tech I",
+        "Basic Clinical Skills",
+        "Clinical I",
+        "Clinical III",
+        "Clinical IV"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "Language",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "joliet-junior-college",
+        "moraine-valley-community-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "American Sign Language",
+        "American Sign Language I",
+        "American Sign Language II",
+        "Visual Gestural Language"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "prairie-state-college",
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Behavior",
+        "Criminal Investigations",
+        "Criminal Justice Internship",
+        "Criminal Law I",
+        "Ethics in Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "CMA",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Certified Medical Asst Seminar",
+        "Intro to Medical Assisting",
+        "Med Asst Admin App I",
+        "Med Asst Admin App II",
+        "Med Asst Clinical App II"
+      ]
+    },
+    {
+      "prefix": "CTLE",
+      "name": "CTLE",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "MS Teams Basics",
+        "New Mentor Training",
+        "OneDrive",
+        "Windows 11"
+      ]
+    },
+    {
+      "prefix": "GEL",
+      "name": "Geology",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "frontier-community-college",
+        "mchenry-county-college",
+        "morton-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "GENERAL GEOLOGY",
+        "GEOL OF NATL PARKS",
+        "INTRO PHYS GEOLOGY",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "GEN",
+      "name": "GEN",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "EMPLOYMENT SKILLS",
+        "FBLA COLLEGIATE",
+        "SCHOLARS AND LEADERS",
+        "STUDENT GOVERNMENT"
+      ]
+    },
+    {
+      "prefix": "INS",
+      "name": "Band",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "CONCERT BAND I",
+        "CONCERT BAND III",
+        "INSTRUMENTAL APPLIED MUSIC I",
+        "INSTRUMENTAL APPLIED MUSIC III",
+        "JAZZ BAND I"
+      ]
+    },
+    {
+      "prefix": "SPT",
+      "name": "Sterile",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "oakton-college",
+        "parkland-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Experiential Learning",
+        "Perioperative Services Lab",
+        "Sterile Process Tech Seminar",
+        "Sterile Processing Basics",
+        "Sterile Processing Department Procedures"
+      ]
+    },
+    {
+      "prefix": "TDR",
+      "name": "Truck",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Truck Driving",
+        "Truck Driving Internship"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Cultural Diversity US Theatre",
+        "Foundations of Stage Movement",
+        "Stage Makeup",
+        "Technical Theatre I"
+      ]
+    },
+    {
+      "prefix": "VOC",
+      "name": "Choir",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "CHOIR I",
+        "CHOIR III",
+        "COMMUNITY CHOIR I",
+        "COMMUNITY CHOIR III",
+        "VOCAL APPLIED MUSIC I"
+      ]
+    },
+    {
+      "prefix": "ADD",
+      "name": "ADD",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "AMAZON WEB SERV",
+        "CONTENT MGMT SYS FOR WEB",
+        "DATABSE FNDMNTLS",
+        "FUNDAMNTL WEB DEV",
+        "INTERMEDIATE PYTHON"
+      ]
+    },
+    {
+      "prefix": "CHDV",
+      "name": "Child",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Admin Child Development Prog",
+        "Child Growth & Development",
+        "Children's Laboratory",
+        "Curriculum for Young Children",
+        "Discovering Montessori"
+      ]
+    },
+    {
+      "prefix": "CNC",
+      "name": "CNC",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "MANUAL MCHNG I",
+        "MANUAL MCHNG II",
+        "MASTERCAM I",
+        "MASTERCAM II",
+        "PRCSN MCHNING I"
+      ]
+    },
+    {
+      "prefix": "CSD",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Career Planning",
+        "The College Experience"
+      ]
+    },
+    {
+      "prefix": "DGTL",
+      "name": "Digital",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Concepts of Digital Media",
+        "Dgtl Media Capture Mgt Tools",
+        "Digital Audio Production",
+        "Digital Image Production",
+        "Digital Media Prod Internship"
+      ]
+    },
+    {
+      "prefix": "EDN",
+      "name": "EDN",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Diversity in School and Society",
+        "Educating Exceptional Learners",
+        "Educational Psychology",
+        "Introduction to Education",
+        "Technology in Education"
+      ]
+    },
+    {
+      "prefix": "EESC",
+      "name": "Physical",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Geography",
+        "General Physical Science",
+        "Intro Astronomy",
+        "Intro Geology & Physical Geog",
+        "Physical Geography"
+      ]
+    },
+    {
+      "prefix": "ELECT",
+      "name": "ELECT",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Circuits I",
+        "Digital Fundamentals",
+        "Electricity/Electronic Fundmtl",
+        "Electronic Devices & Applcatns",
+        "Electronic Manufacturing"
+      ]
+    },
+    {
+      "prefix": "ENGIN",
+      "name": "Engineering",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Dynamics",
+        "Engineering Graphics/Design",
+        "Engineering Orientation",
+        "Engineering Thermodynamics",
+        "Intro to Digital Systems"
+      ]
+    },
+    {
+      "prefix": "GWSS",
+      "name": "GWSS",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-richard-j-daley-college"
+      ],
+      "sample_titles": [
+        "Feminist and Queer Artivisms for Social Change",
+        "Introduction to Gender and Sexuality Diversity",
+        "Introduction to Gender, Women's, and Sexuality Studies",
+        "Introduction to Social Justice",
+        "Pleasure Activism, Body Politics, and Translating Sexualities"
+      ]
+    },
+    {
+      "prefix": "LAWF",
+      "name": "LAWF",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Computer Crime Investigation",
+        "Criminal Procedures",
+        "Criminology",
+        "Intro to Criminal Justice",
+        "Introduction to Corrections"
+      ]
+    },
+    {
+      "prefix": "LBS",
+      "name": "LBS",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Business Boot Camp",
+        "Business Compliance &amp; Risk",
+        "Drone Pilot Ground School",
+        "Intro to Payroll Accounting",
+        "Quickbooks Applications"
+      ]
+    },
+    {
+      "prefix": "LIS",
+      "name": "Information",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-malcolm-x-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Information Literacy",
+        "Information Literacy Basics"
+      ]
+    },
+    {
+      "prefix": "MATT",
+      "name": "Mathematics",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Business Mathematics",
+        "Elementary Technical Math",
+        "Technical Mathematics I"
+      ]
+    },
+    {
+      "prefix": "RDTC",
+      "name": "Radiologic",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Atypical Radiologic Procedures",
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Education IV",
+        "Clinical Education V"
+      ]
+    },
+    {
+      "prefix": "URB AG",
+      "name": "Urban",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college"
+      ],
+      "sample_titles": [
+        "Applications in Urban Agriculture Studies",
+        "Greenhouse Management",
+        "Hydroponics and Aquaponics",
+        "Introduction to Urban Agriculture"
+      ]
+    },
+    {
+      "prefix": "WLDG",
+      "name": "Welding",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "GMAW/FCAW",
+        "GTAW Mld Steel, Alum, Stnless",
+        "GTAW Pipe",
+        "Intro to the Welding Processes",
+        "Pipe 6G Certification"
+      ]
+    },
+    {
+      "prefix": "XRY",
+      "name": "Radiography",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Introduction to Radiography and Patient Care",
+        "Radiation Biology and Safety",
+        "Radiographic Image Analysis",
+        "Radiographic Imaging I",
+        "Radiographic Imaging III"
+      ]
+    },
+    {
+      "prefix": "BMGT",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Basics of Business Startup",
+        "Customer Service",
+        "Intro to Sport Management",
+        "Principles of Management",
+        "Supervisory Training"
+      ]
+    },
+    {
+      "prefix": "CADD",
+      "name": "Cadd",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "2D CADD I",
+        "2D CADD II",
+        "3D CADD I",
+        "CADD Internship",
+        "Customizing Auto Cad"
+      ]
+    },
+    {
+      "prefix": "CESW",
+      "name": "Exercise",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Adult Learn to Swim",
+        "Arthritis Exercise",
+        "Master Swimming",
+        "Water Exercise"
+      ]
+    },
+    {
+      "prefix": "CSS",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "lincoln-land-community-college",
+        "morton-college"
+      ],
+      "sample_titles": [
+        "College Success Seminar"
+      ]
+    },
+    {
+      "prefix": "EGT",
+      "name": "Engineering Technology",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "ENGR PRINT READING",
+        "METROLOGY FOR QLTY",
+        "P M SOLIDWORKS I",
+        "TECH DRAW AUTOCAD I"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "joliet-junior-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Corporate Finance",
+        "Personal Finance",
+        "Personal Finance and Investing",
+        "Principles of Finance"
+      ]
+    },
+    {
+      "prefix": "GRA",
+      "name": "Design",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "COMPUTER ART I",
+        "DIGITAL DESIGN TOOLS",
+        "DIGITAL ILLUSTRATION",
+        "GRAPHIC DESIGN I",
+        "GRAPHIC DESIGN II"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "ITEC",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Cisco Networking I",
+        "Computer Network Internship",
+        "Intro To Computer Networking",
+        "Linux and UNIX Operating Sys",
+        "Operating Systems"
+      ]
+    },
+    {
+      "prefix": "MCOMM",
+      "name": "MCOMM",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Intro to Mass Communication",
+        "Reporting/Writing - Multimedia",
+        "Social Media As News",
+        "Special Project"
+      ]
+    },
+    {
+      "prefix": "PHYTA",
+      "name": "PHYTA",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Basic Health Care Skills",
+        "Intro Physical Therapy",
+        "PTA Adv Orthopedic Rehab",
+        "PTA Clinical Practicum I",
+        "PTA Kinesiology"
+      ]
+    },
+    {
+      "prefix": "PMED",
+      "name": "PMED",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Cardiology",
+        "Emergency Medical Tech-Basic",
+        "Emergency Vehicle Driving",
+        "Medical Emergencies",
+        "Paramedic Clinicals II"
+      ]
+    },
+    {
+      "prefix": "POLI",
+      "name": "POLI",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "American Judicial Process",
+        "Comparative Government",
+        "International Relations",
+        "Non-Western Comparative Gov."
+      ]
+    },
+    {
+      "prefix": "RNUR",
+      "name": "Nursingadult",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Concepts of Clinical Pharm",
+        "Introduction to Nursing",
+        "Introduction to Pharmacology",
+        "Nursing Seminar II",
+        "Nursing Seminar IV"
+      ]
+    },
+    {
+      "prefix": "SONO",
+      "name": "SONO",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Adominal Sonography I",
+        "Clinical Internship II",
+        "Clinical Internship III",
+        "Intro to Cardiovascular Sono",
+        "Intro to Sono Phy & Instru"
+      ]
+    },
+    {
+      "prefix": "ATM",
+      "name": "Automotive",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Automotive Air Conditioning",
+        "Automotive Brakes",
+        "Automotive Electrical Systems",
+        "Automotive Engine Repair",
+        "Fuel Sys and Emission Controls"
+      ]
+    },
+    {
+      "prefix": "BRD",
+      "name": "Broadcasting",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "APPLIED BROADCASTING I",
+        "APPLIED BROADCASTING III",
+        "BROADCAST &amp; DIGITAL MEDIA TECH",
+        "BROADCAST ANNOUNCING",
+        "BROADCAST JOURNALISM"
+      ]
+    },
+    {
+      "prefix": "DEQ",
+      "name": "DEQ",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "BRAKES/SUSPENSION SYSTEMS",
+        "DIESEL FUEL SYSTEMS I",
+        "ELECTRICAL SYSTEMS I",
+        "ELECTRONIC CONTROLS/MONITORING",
+        "ENGINE FUNDAMENTALS"
+      ]
+    },
+    {
+      "prefix": "ELX",
+      "name": "Elect",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Blueprints, Circuits, Feeders,",
+        "Conduct, Cables, Wire, & Math",
+        "Elec Safety, Regs, and Tools",
+        "Elect Formula, Measure, &",
+        "Elect Lighting Tech & Practi"
+      ]
+    },
+    {
+      "prefix": "HOR",
+      "name": "HOR",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Beginning Floral Arrangements",
+        "Greenhouse Management",
+        "Horticulture Science",
+        "Landscape Design",
+        "Orna Shrubs Ident & Culture"
+      ]
+    },
+    {
+      "prefix": "INM",
+      "name": "INM",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "BASIC A/C &amp; REFRIGERATION",
+        "BASIC HEATING",
+        "BLUEPRINTS AND SCHEMATICS",
+        "ELECTRO-MECHANICS II",
+        "INTRO TO HVACR"
+      ]
+    },
+    {
+      "prefix": "ITAPP",
+      "name": "Level",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Database Applications--Level 1",
+        "Intro to Computers",
+        "Presentation Applications",
+        "Spreadsheet Apps - Level 1",
+        "Word Processing App - Level 1"
+      ]
+    },
+    {
+      "prefix": "ITSM",
+      "name": "ITSM",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "AI & Big Data: Concepts & Eth",
+        "AI Basics & Prompting",
+        "Database Design & Implementn",
+        "IT Fundamentals",
+        "IT Systems and Hardware"
+      ]
+    },
+    {
+      "prefix": "KPE",
+      "name": "KPE",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Business Management for the Fitness Professional",
+        "Current Issues in Sports",
+        "Introduction to Exercise Science and Sports Professions",
+        "Introduction to Physical Education",
+        "Sport Psychology"
+      ]
+    },
+    {
+      "prefix": "LIBRA",
+      "name": "LIBRA",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Acquisition-Library Materials",
+        "Intro to Cataloging",
+        "Intro to Libraries & Info Age",
+        "Intro to Reference & Info Svcs",
+        "Library Practicum"
+      ]
+    },
+    {
+      "prefix": "MASST",
+      "name": "MASST",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Admin Proc for Health Office",
+        "CMA Prep",
+        "Diagnostic Procedures for MA",
+        "Introduction to Medical Assist",
+        "Legal/Ethical Aspect Hlth Care"
+      ]
+    },
+    {
+      "prefix": "MCHN",
+      "name": "Machine",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Fabrication",
+        "Machine Tool I",
+        "Machine Tool II",
+        "Millwright",
+        "Precision Measurement"
+      ]
+    },
+    {
+      "prefix": "MRT",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Coding Professional Practice",
+        "HIT Professional Practice I",
+        "Intro. to Medical Terminology",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "MT",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Intro to Robotics",
+        "Mach Basics:Measure/Mat/Safet",
+        "Mach Job Plan/Benchwrk/Layout",
+        "Manufacturing Systems",
+        "Metallurgy - Ferrous"
+      ]
+    },
+    {
+      "prefix": "OS",
+      "name": "OS",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Advanced Word Processing/Word",
+        "Beginning Keyboarding",
+        "Employment Strategies",
+        "Presentation Graph/PowerPoint",
+        "Spreadsheets/Excel"
+      ]
+    },
+    {
+      "prefix": "PBT",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy Externship",
+        "Phlebotomy Technician Seminar",
+        "Theoretical and Clinical Aspects of Phlebotomy"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "Fitness",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "kankakee-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Fitness & Conditioning I",
+        "Fitness and Conditioning II",
+        "Fitness and Conditioning III",
+        "Fitness and Conditioning IV",
+        "Health Education"
+      ]
+    },
+    {
+      "prefix": "PRCS",
+      "name": "Process",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Intro Process Technology",
+        "Process Tech Equipment I",
+        "Process Tech Equipment II",
+        "Process Technology Internship",
+        "Process Technology Systems"
+      ]
+    },
+    {
+      "prefix": "RELIGN",
+      "name": "RELIGN",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "city-colleges-of-chicago-kennedy-king-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Introduction To Religion",
+        "Islamic Scriptures: The Qur'an",
+        "The Bible - Hebrew Old Test"
+      ]
+    },
+    {
+      "prefix": "RTT",
+      "name": "Respiratory",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Advanced Ventilation",
+        "Clinical Practicum II",
+        "Clinical Practicum III",
+        "Intro to Respiratory Care",
+        "Respiratory Science"
+      ]
+    },
+    {
+      "prefix": "SLPA",
+      "name": "SLPA",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "college-of-dupage",
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Augment & Alternative Comm",
+        "Clincial Methods & Document",
+        "Clinical Meth and Doc",
+        "Intro Communication Disorders",
+        "Intro to Comm Dis & Sciences"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "SSC",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "oakton-college",
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Contemporary Society",
+        "Introduction to Ethnic Studies",
+        "Introduction to Global Studies"
+      ]
+    },
+    {
+      "prefix": "XRAY",
+      "name": "XRAY",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Radiologic Tech I",
+        "Clinical I",
+        "Clinical III",
+        "Clinical IV",
+        "Introduction to Radiography"
+      ]
+    },
+    {
+      "prefix": "XSCI",
+      "name": "Exercise",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Exercise for Special Pops",
+        "Exercise Physiology",
+        "Exercise Science Internship",
+        "Sport Psychology",
+        "Strength Training & Fitness"
+      ]
+    },
+    {
+      "prefix": "AGC",
+      "name": "Agco",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "AGCO Combine I",
+        "AGCO Dealer Internship I",
+        "AGCO Dealer Internship II",
+        "AGCO Equipment Electrical I",
+        "AGCO Equipment Hydraulics"
+      ]
+    },
+    {
+      "prefix": "ARM",
+      "name": "ARM",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "AUTOMTN RBTICS I",
+        "AUTOMTN RBTICS II",
+        "ELECTRICAL I",
+        "ELECTRICAL II",
+        "HYDRAULCS PNEUMATCS"
+      ]
+    },
+    {
+      "prefix": "AUM",
+      "name": "AUM",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "AUTOMOTIVE ELECTRONICS",
+        "AUTOMOTIVE ENGINES",
+        "AUTOMOTIVE SERVICE INTERNSHIP",
+        "ELECTRICAL FUNDAMENTALS",
+        "ENGINE PERFORMANCE DIAGNOSIS"
+      ]
+    },
+    {
+      "prefix": "BLD",
+      "name": "BLD",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Build Energy Eff Green Home II",
+        "Const Mat & Met II-Msnry",
+        "Construction Mat & Meth IV",
+        "Home Energy Dynamics",
+        "How to General Cont Green Home"
+      ]
+    },
+    {
+      "prefix": "CBUS",
+      "name": "Business",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Business Computer Systems",
+        "Business Law I",
+        "Intro to Business"
+      ]
+    },
+    {
+      "prefix": "CGRD",
+      "name": "CGRD",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "3D Modeling & Animation",
+        "Adobe Illustrator",
+        "Adobe Photoshop",
+        "Adv Adobe InDesign",
+        "Adv Digital Photography"
+      ]
+    },
+    {
+      "prefix": "CSPD",
+      "name": "Central",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Central Sterile Proc & Distrib",
+        "CSPD Practicum"
+      ]
+    },
+    {
+      "prefix": "DMIN",
+      "name": "DMIN",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Clinical Nuclear Medicine I",
+        "CT Clinical Applications I",
+        "CT Clinical Applications II",
+        "CT Principles & Patient Care",
+        "CT Rad Safety and Quality Mgt"
+      ]
+    },
+    {
+      "prefix": "ECD",
+      "name": "Childhood",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "CHILDCARE TOPICS IN BEHAVIOR",
+        "CHILDHOOD TEACHING PRACTICUM",
+        "EARLY CHILDHOOD PRACTICUM",
+        "EARLY CHILDHOOD REFRESHER",
+        "INTRO TO EARLY CHILDHOOD ED"
+      ]
+    },
+    {
+      "prefix": "FRE",
+      "name": "French",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "mchenry-county-college",
+        "oakton-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "BEGINNER FRENCH I",
+        "Beginning French I",
+        "Beginning French II",
+        "INTERM FRENCH I",
+        "INTERM FRENCH II"
+      ]
+    },
+    {
+      "prefix": "FS ESL",
+      "name": "College",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "English Academic Purposes IV",
+        "English Academic Purposes V",
+        "English Academic Purposes VI",
+        "ESL: College Prep I",
+        "ESL: College Prep II"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "joliet-junior-college",
+        "lincoln-land-community-college",
+        "mchenry-county-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "BEG GERMAN I",
+        "Conv German I",
+        "Elementary German I",
+        "INTERM GERMAN I",
+        "INTERM GERMAN II"
+      ]
+    },
+    {
+      "prefix": "HITT",
+      "name": "HITT",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "AI Governance in Healthcare",
+        "Health Informatics",
+        "Healthcare Law and Ethics",
+        "ICD Coding",
+        "Intro Health Info Management"
+      ]
+    },
+    {
+      "prefix": "ICDEM",
+      "name": "Band",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "JJC Chorale",
+        "JJC Community Band",
+        "JJC Jazz Band",
+        "JJC Jazz Combo",
+        "JJC Percussion Ensemble"
+      ]
+    },
+    {
+      "prefix": "PCIT",
+      "name": "PCIT",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Analyzing",
+        "Contrl Loop Tuning/Trblsht",
+        "Eltr Meas/Control",
+        "Indus Data Com:serial Stand",
+        "Intro/Process Technology"
+      ]
+    },
+    {
+      "prefix": "PHTA",
+      "name": "PHTA",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Health Care",
+        "Kinesiology I",
+        "Orthopedics for the PTA",
+        "Pathology I for the PTA",
+        "Prof. Standards of the PTA"
+      ]
+    },
+    {
+      "prefix": "SGT",
+      "name": "SGT",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Central Sterile Service Tech",
+        "Clinical Internship I",
+        "Clinical Internship II",
+        "Introduction to Surgical Techn",
+        "Principles of Asepsis"
+      ]
+    },
+    {
+      "prefix": "SON",
+      "name": "Sonography",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "ABDOMINAL SONOGRAPHY I",
+        "INTRO SONOGRAPHY PATIENT CARE",
+        "OB/GYN SONOGRAPHY I",
+        "SONOGRAPHY SECTIONAL ANATOMY",
+        "ULTRASND PHYS INSTRUM I"
+      ]
+    },
+    {
+      "prefix": "ARABIC",
+      "name": "Arabic",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Arabic for Beginners I",
+        "Arabic for Beginners II",
+        "Intermediate Arabic I",
+        "Intermediate Arabic II"
+      ]
+    },
+    {
+      "prefix": "AVD",
+      "name": "Audio",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "AUDIO VIDEO POST PROD I",
+        "AUDIO VIDEO POST PROD II",
+        "AUDIO VIDEO PRE-PRODUCTION I",
+        "AUDIO VIDEO PRODUCTION I",
+        "AUDIO VIDEO PRODUCTION II"
+      ]
+    },
+    {
+      "prefix": "CECN",
+      "name": "Microeconomic",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Macroeconomic Principles",
+        "Microeconomic Principles"
+      ]
+    },
+    {
+      "prefix": "CNH",
+      "name": "CNH",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "CNH Ag & CE Equipment Functns",
+        "CNH Dealer Work Experience I",
+        "CNH Equpmnt Air Cond II",
+        "CNH Power Generation I",
+        "Intro to CNH Hydraulic System"
+      ]
+    },
+    {
+      "prefix": "COGT",
+      "name": "Digital",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "2D Animation",
+        "AutoCAD I",
+        "Digital Photography",
+        "Digital Sculpting with Mudbox",
+        "Intro to Video Game Design"
+      ]
+    },
+    {
+      "prefix": "DPE",
+      "name": "DPE",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Ag/Heavy Equip Pwr Trains",
+        "Diesel Power Generation I",
+        "Diesel Work Experience I",
+        "Equip Adjustment/Repair",
+        "Intro Mobile Hydraulics"
+      ]
+    },
+    {
+      "prefix": "DRAF",
+      "name": "Graphics",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Applied Autocad",
+        "Engineering Graphics",
+        "Intro to Autocad",
+        "Machining Graphics",
+        "Technology in Adv Mfg"
+      ]
+    },
+    {
+      "prefix": "FRENC",
+      "name": "French",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Conversation & Composition I",
+        "Elementary French I",
+        "Elementary French II",
+        "Intermediate French I",
+        "Intermediate French II"
+      ]
+    },
+    {
+      "prefix": "GOL",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Env Geo: Aspct-Glbl Hzrd&Chg",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "Practicum",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Animation and Multimedia Practicum",
+        "Graphic Design Practicum",
+        "Introduction to Digital Content Creation and Streaming Media",
+        "Introduction to Video Production",
+        "Introduction to Visual Communication"
+      ]
+    },
+    {
+      "prefix": "HCS",
+      "name": "HCS",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Legal Issues in Health Care",
+        "Medical Terminology",
+        "Phlebotomy Skills"
+      ]
+    },
+    {
+      "prefix": "IEL",
+      "name": "Academic",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Academic Communication I",
+        "Academic Communication II",
+        "Academic Reading I",
+        "Academic Reading II",
+        "Academic Writing I"
+      ]
+    },
+    {
+      "prefix": "IMM",
+      "name": "Mechanical",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Fluid Power I: Basic Circuits",
+        "Fluid Power II: Intermediate",
+        "Machinery Moving and Set-Up",
+        "Mechanical Systems I",
+        "Mechanical Systems II"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "Operating",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Ethics in Information Technolo",
+        "Intro to Operating Systems",
+        "IT Orientation",
+        "IT Portfolio Seminar",
+        "Linux Operating System"
+      ]
+    },
+    {
+      "prefix": "ITNET",
+      "name": "ITNET",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Windows Server Admin",
+        "Computer Repair",
+        "Ethical Hacking",
+        "Google It Support",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "LAS",
+      "name": "Diverse",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Diverse Us Cultural Expression",
+        "Intro Lib Arts/Sciences"
+      ]
+    },
+    {
+      "prefix": "MCOM",
+      "name": "MCOM",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Audio Production",
+        "Basic Announcing",
+        "Intermediate Announcing",
+        "Intro Broadcasting",
+        "Intro Video Production"
+      ]
+    },
+    {
+      "prefix": "MRI",
+      "name": "MRI",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "MRI Clinical Education I",
+        "MRI Clinical Education II",
+        "MRI Clinical Education III",
+        "MRI Principles I",
+        "MRI Principles II"
+      ]
+    },
+    {
+      "prefix": "NCBI",
+      "name": "NCBI",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "ADULT MENTAL HEALTH FIRST AID",
+        "LEADERSHIP-ELEVATE &amp; EMPOWER",
+        "WINDOWS SUITE-COPILOT &amp; EXCEL"
+      ]
+    },
+    {
+      "prefix": "OCTA",
+      "name": "Occupation",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of OT Interven",
+        "Health Conditions in OT",
+        "Level II Fieldwork A",
+        "Level II Fieldwork B",
+        "Occupation Across the Lifespan"
+      ]
+    },
+    {
+      "prefix": "RLG",
+      "name": "World",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to World Religions"
+      ]
+    },
+    {
+      "prefix": "RTM",
+      "name": "RTM",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Artisan Breads",
+        "Basic Food Theory",
+        "Beverage Management",
+        "Convention Management & Servic",
+        "Garde Manger"
+      ]
+    },
+    {
+      "prefix": "SCT",
+      "name": "Supported",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Supported College Trans II",
+        "Supported College Trans III",
+        "Supported College Trans IV",
+        "Supported College Transition I"
+      ]
+    },
+    {
+      "prefix": "WLX",
+      "name": "Welding",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Adv Gas Metal Arc Welding I",
+        "Adv Gas Metal Arc Welding II",
+        "Begin Gas Metal Arc Weld I",
+        "Begin Gas Metal Arc Weld II",
+        "Intro to 6011 Arc Welding"
+      ]
+    },
+    {
+      "prefix": "BMK",
+      "name": "BMK",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "ADVERTISING",
+        "INTERNSHIP I",
+        "Internship II",
+        "PRINCIPLES OF MARKETING",
+        "PRINCIPLES OF RETAILING"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Business & Legal Environment",
+        "Business Co-Op I",
+        "Business Software Applications",
+        "Financial Investments",
+        "Intro Modern Business"
+      ]
+    },
+    {
+      "prefix": "CDM",
+      "name": "Cmptr",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "CMPTR LIT -WINDOWS",
+        "TOPICS IN CDM & DGM"
+      ]
+    },
+    {
+      "prefix": "CLM",
+      "name": "Culinary",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "BEV MGMT AND WINE CULT",
+        "CULIN HSPTLTY SUPR",
+        "CULINARY BUS INTRNSHP",
+        "CULINARY SKLS I",
+        "CULINARY SKLS III"
+      ]
+    },
+    {
+      "prefix": "COLL",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "joliet-junior-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "College and Career Success",
+        "New Student Experience"
+      ]
+    },
+    {
+      "prefix": "CONS",
+      "name": "Green",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Green Bldg Skills",
+        "Green Bldg Skills II",
+        "Intro to Green Bldg Skills"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "Drafting",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Adv Computer Aided Drafting",
+        "Advanced Inventor",
+        "Computer Aided Drafting",
+        "Drafting/CAD Internship",
+        "Intro to 3D Parametric Design"
+      ]
+    },
+    {
+      "prefix": "ESS",
+      "name": "Physical",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Physical Education",
+        "Introduction to Coaching",
+        "Physical Conditioning"
+      ]
+    },
+    {
+      "prefix": "EST",
+      "name": "Esthetics",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "kishwaukee-college",
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Career and Technical Ethics",
+        "Esthetics Clinical",
+        "Esthetics Procedures I",
+        "Work Experience and Ethics"
+      ]
+    },
+    {
+      "prefix": "FSC",
+      "name": "Operations",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Technician Firefighter",
+        "Basic Operations Firefighter Module A",
+        "Basic Operations Firefighter Module B",
+        "Basic Operations Firefighter Module C",
+        "Fire Company Principles"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "Fire",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "parkland-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Basic Firefighter Operations",
+        "Basic Firefighter Operations I",
+        "Fire Dept. Incident Safety Off",
+        "Fire Service Instructor II",
+        "Intro to Fire Service"
+      ]
+    },
+    {
+      "prefix": "GERMA",
+      "name": "German",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Conversation & Composition I",
+        "Elementary German I",
+        "Elementary German II",
+        "Intermediate German I",
+        "Intermediate German II"
+      ]
+    },
+    {
+      "prefix": "GOV",
+      "name": "Federal",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Federal Government"
+      ]
+    },
+    {
+      "prefix": "GRY",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Physical Geography"
+      ]
+    },
+    {
+      "prefix": "HPR",
+      "name": "Coaching",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Baseball Coaching",
+        "Fitness Center",
+        "Men's Conditioning I",
+        "Soccer Coaching"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "danville-area-community-college",
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Comparative Religion I",
+        "Fantasy and Mythology",
+        "Intro to Humanities",
+        "Media's Effect on U.S. Culture"
+      ]
+    },
+    {
+      "prefix": "HVC",
+      "name": "Hvac",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Basic Air Conditioning",
+        "Basic Heating",
+        "Ductwork Fabrication",
+        "HVAC Service I",
+        "Hvac Service II"
+      ]
+    },
+    {
+      "prefix": "IMD",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Film & Special Effects Design",
+        "Intro to Integrated Media Desg",
+        "Mobile App Systems and Design",
+        "Motion Graphics Design"
+      ]
+    },
+    {
+      "prefix": "INTP",
+      "name": "Interpreting",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Consec and Sim Interpreting",
+        "Educational Interp & Translit",
+        "Intro to Interpreting & Ethics"
+      ]
+    },
+    {
+      "prefix": "ITALI",
+      "name": "Italian",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Conversation & Composition I",
+        "Elementary Italian I",
+        "Elementary Italian II",
+        "Intermediate Italian I"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "oakton-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese II",
+        "Conversational Japanese",
+        "Elementary Japanese I",
+        "Intermediate Japanese I",
+        "Japanese Conversation And Composition"
+      ]
+    },
+    {
+      "prefix": "LAN",
+      "name": "LAN",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "IT Essentials - A+",
+        "Managing IT - A+",
+        "Microsoft Azure Fundamentals",
+        "Network Essentials",
+        "Network Services"
+      ]
+    },
+    {
+      "prefix": "LENF",
+      "name": "LENF",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigation",
+        "Criminal Law",
+        "Drugs, Addiction and Crime",
+        "Evidence/Criminal Procedure",
+        "Intro to Law Enforcement"
+      ]
+    },
+    {
+      "prefix": "LING",
+      "name": "Language",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college",
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Introduction To Linguistics",
+        "Language And Culture"
+      ]
+    },
+    {
+      "prefix": "LTA",
+      "name": "LTA",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Information Tools",
+        "Cataloging/Classification",
+        "Info and Internet Literacy",
+        "Information and User Services",
+        "Intro to Library/Inf Studies"
+      ]
+    },
+    {
+      "prefix": "MAFT",
+      "name": "Mnfg",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Mnfg. and Safety",
+        "Intro to Mnfg. Maintenance",
+        "Lean and Quality Overview",
+        "Manufacturing Processes",
+        "Quality and Measurement"
+      ]
+    },
+    {
+      "prefix": "MLA",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Basic Administrative Procedures for the Medical Assistant",
+        "Medical Assistant Clinical I",
+        "Medical Assistant Externship",
+        "Medical Law and Ethics"
+      ]
+    },
+    {
+      "prefix": "MM",
+      "name": "Marketing",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Intern Marketing Or Management",
+        "Introduction to Management",
+        "Introduction to Marketing",
+        "Principles of Sales",
+        "Supervision"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "MTT",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "CNC Mill Operations and Programming",
+        "Introduction to Computer Numerical Control",
+        "Machining Fundamentals",
+        "Manual Machine Shop Operations",
+        "Metrology/Mechanical Inspection"
+      ]
+    },
+    {
+      "prefix": "NUAD",
+      "name": "Nurse",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nurse Assistant Training"
+      ]
+    },
+    {
+      "prefix": "PLG",
+      "name": "PLG",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Civil Litigation I",
+        "Estate Law",
+        "Family Law",
+        "Immigration Law",
+        "Introduction to the Paralegal Profession"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "Nursing",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant",
+        "Practical Nursing I",
+        "Practical Nursing III",
+        "Practical Nursing Pharm I",
+        "Practical Nursing Seminar"
+      ]
+    },
+    {
+      "prefix": "PTT",
+      "name": "Process",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "lincoln-trail-college"
+      ],
+      "sample_titles": [
+        "INTRO TO PROCESS TECHNOLOGY",
+        "PROCESS TECH INSTRUMENTATION",
+        "PROCESS TECHNOLOGY INTERNSHIP",
+        "PROCESS TROUBLESHOOTING",
+        "PTECH QUALITY CONTROL"
+      ]
+    },
+    {
+      "prefix": "RCP",
+      "name": "RCP",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Adv Cardiopul Diag & Monitor",
+        "Adv RC Practices & Proc II",
+        "Basic Therapeutic Practices",
+        "Clinical Practice III",
+        "Clinical Practice IV"
+      ]
+    },
+    {
+      "prefix": "REAL",
+      "name": "Real",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Real Estate Brokerage",
+        "Real Estate Transactions",
+        "Transaction Applications"
+      ]
+    },
+    {
+      "prefix": "SCM",
+      "name": "Supply",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "joliet-junior-college",
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Global Logistics",
+        "International Logistics",
+        "Prin /Operations Mgmt",
+        "Principles of Supply Chain Mgm",
+        "Purchasing and Supply Mgmt"
+      ]
+    },
+    {
+      "prefix": "ABM",
+      "name": "ABM",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Agri-Business Internship",
+        "Crop Production",
+        "Crop Scouting",
+        "Farm Management",
+        "Livestock Select & Evaluation"
+      ]
+    },
+    {
+      "prefix": "ADCG",
+      "name": "ADCG",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Arch Building Systems",
+        "Architectural Design II",
+        "Architectural Graphics",
+        "Comp Graphics for Architects",
+        "Intro Architecture"
+      ]
+    },
+    {
+      "prefix": "ALW",
+      "name": "Writing",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Writing Effective Essays"
+      ]
+    },
+    {
+      "prefix": "ARB",
+      "name": "Arabic",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "moraine-valley-community-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Arabic III",
+        "Arabic IV",
+        "Beginning Arabic I",
+        "Beginning Arabic II"
+      ]
+    },
+    {
+      "prefix": "BLW",
+      "name": "Business",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Cyberlaw, Legal Issues in Cybe",
+        "Intermediate Business Law",
+        "Intr to Business Law"
+      ]
+    },
+    {
+      "prefix": "BOTANY",
+      "name": "Botany",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college",
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "General Botany I"
+      ]
+    },
+    {
+      "prefix": "BUSLW",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Business Law I",
+        "Legal Environment of Business"
+      ]
+    },
+    {
+      "prefix": "CACC",
+      "name": "Accounting",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Financial Accounting",
+        "Intermediate Accounting I",
+        "Managerial Accounting"
+      ]
+    },
+    {
+      "prefix": "CADMD",
+      "name": "Autocad",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Computer Aided Design",
+        "Intermed Auto-Cad",
+        "Intro to Inventor",
+        "Introduction to Auto-Cad",
+        "Tech Drafting I"
+      ]
+    },
+    {
+      "prefix": "CCS",
+      "name": "Critical",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Critical Comp Skills I",
+        "Critical Comp Skills II"
+      ]
+    },
+    {
+      "prefix": "CDLB",
+      "name": "Class",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Class B Truck Driver Training"
+      ]
+    },
+    {
+      "prefix": "CMS",
+      "name": "Communication",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Chorl Ensmbl/Chambr Sngrs",
+        "Guitar Ensemble",
+        "Instrmntl Ensmbl/Concrt Bnd",
+        "Instrmntl Ensmbl/Orchestra",
+        "Instrumental Ensemble-Wind Ens"
+      ]
+    },
+    {
+      "prefix": "CMT",
+      "name": "Const",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "mchenry-county-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "CONST ESTIMATNG",
+        "Construction Materials and Methods I",
+        "INTRO TO RESIDENTIAL CONST I",
+        "The Construction Industry"
+      ]
+    },
+    {
+      "prefix": "CVS",
+      "name": "Cardiovascular",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Cardiovasc Clinical Prac I",
+        "Cardiovasc Clinical Prac II",
+        "Cardiovascular Scanning Lab I",
+        "Comprehensive Echocardiography",
+        "Normal Cardiovascular Sono"
+      ]
+    },
+    {
+      "prefix": "CWE",
+      "name": "Coop",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Coop Education Work Experience"
+      ]
+    },
+    {
+      "prefix": "DAP",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "frontier-community-college",
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "BUSINESS COMPUTER SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "Diesel",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Diesel Brakes",
+        "Diesel Electrical",
+        "Diesel Engines and Repairs",
+        "Diesel Fundamentals",
+        "Diesel Steering and Suspension"
+      ]
+    },
+    {
+      "prefix": "DRM",
+      "name": "DRM",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Introduction to Voiceovers",
+        "Theatre Appreciation"
+      ]
+    },
+    {
+      "prefix": "EDS",
+      "name": "EDS",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "frontier-community-college"
+      ],
+      "sample_titles": [
+        "CLIMBING SKILLS",
+        "ELECTRICAL DISTRIBUTION SYS",
+        "EQUIPMENT OPERATION",
+        "POLE FRAMING AND CONST. SPECS.",
+        "SAFETY AND ACCIDENT PREVENTION"
+      ]
+    },
+    {
+      "prefix": "EPM",
+      "name": "Paramedic",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "frontier-community-college"
+      ],
+      "sample_titles": [
+        "CPR FUNDAMENTALS",
+        "EMT FUNDAMENTALS",
+        "PARAMEDIC CLINICALS II",
+        "PARAMEDIC III"
+      ]
+    },
+    {
+      "prefix": "ESI",
+      "name": "Employability",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Employability Skills"
+      ]
+    },
+    {
+      "prefix": "FSCI",
+      "name": "Emergency",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Haz Mat-First Responder/Opertn",
+        "Introduction to Emergency Mgmt",
+        "Introduction to Fire Science",
+        "Princ of Emergency Services",
+        "Terrorism and Counterterrorism"
+      ]
+    },
+    {
+      "prefix": "HBH",
+      "name": "Human",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-trail-college",
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "HUMAN BEHAVIORAL INTERVENTION",
+        "INTRO TO HUMAN BEHAVIOR HEALTH",
+        "SPEC TOPICS IN PUB/SOC SVCS"
+      ]
+    },
+    {
+      "prefix": "HDFS",
+      "name": "Human",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Basic Applications in Human Services",
+        "Family Development/Cross Cultural Perspective",
+        "Intimate Relationships",
+        "Practicum for Human Services",
+        "Principles of Human Services"
+      ]
+    },
+    {
+      "prefix": "HED",
+      "name": "Personal",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Personal Wellness"
+      ]
+    },
+    {
+      "prefix": "ITPRG",
+      "name": "Programming",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "C++ Programming I",
+        "Game Design I",
+        "Internship",
+        "Intro to Programming Logic",
+        "Java Programmming II"
+      ]
+    },
+    {
+      "prefix": "JUS",
+      "name": "Criminal",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "CRIMINAL INVESTIGATION I",
+        "CRIMINAL JUSTICE INTERNSHIP",
+        "CRIMINAL LAW I",
+        "INTRO TO CRIMINAL JUSTICE",
+        "TRAFFIC ADMINISTRATION"
+      ]
+    },
+    {
+      "prefix": "KOREA",
+      "name": "Korean",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Elementary Korean I",
+        "Elementary Korean II",
+        "Intermediate Korean I"
+      ]
+    },
+    {
+      "prefix": "LEM",
+      "name": "Foundations",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "AI: Strategies For Marketing",
+        "Career Exploration: AI/Cloud",
+        "Exploring Emerging Technology",
+        "Foundations of AI",
+        "Foundations of Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "LFT",
+      "name": "Fire",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Company Fire Officer",
+        "Fire Dept Incidnt Sfty Officer",
+        "Fire Service Instructor I",
+        "Fire Service Instructor II",
+        "Self Defense/Safety Awareness"
+      ]
+    },
+    {
+      "prefix": "LITR",
+      "name": "LITR",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Chief English Writers I",
+        "Intro to Fiction",
+        "Intro to Film"
+      ]
+    },
+    {
+      "prefix": "LIX",
+      "name": "Python",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Forecasting with Python",
+        "Intermed Python Programming",
+        "Intro to Python Programming",
+        "Python for Data Analysis"
+      ]
+    },
+    {
+      "prefix": "MFT",
+      "name": "Machine",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Adv Mach Proc/Inspectn Pract",
+        "Basic Machine Processes",
+        "Intermediate Machine Processes",
+        "Intro Manufact/Industr Safety",
+        "Manufacturing Work Exp I"
+      ]
+    },
+    {
+      "prefix": "OCEAN",
+      "name": "Oceanography",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Intro To Oceanography",
+        "Marine Sciences"
+      ]
+    },
+    {
+      "prefix": "OPT",
+      "name": "OPT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Lower Extremity Orthotics III",
+        "OPT Clinical Experience I",
+        "Orthotic Prosthetic Skill Dev.",
+        "Pedorthics",
+        "Transfemoral Prosthetics"
+      ]
+    },
+    {
+      "prefix": "PCN",
+      "name": "Practical",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Practical Nursing I",
+        "Practical Nursing III"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "morton-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Polish I",
+        "Intermediate Polish II",
+        "U.S. Natl. Government"
+      ]
+    },
+    {
+      "prefix": "POLSC",
+      "name": "POLSC",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Comparative Govt",
+        "Intro to U.S. Gove",
+        "Model United Nations"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "mchenry-county-college",
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "ANTI OPPRS PRACTICE",
+        "FOUNDATIONAL SKLS",
+        "Intro to Social Work",
+        "INTRO TO SOCIAL WORK"
+      ]
+    },
+    {
+      "prefix": "TEM",
+      "name": "Vocationaltechnical",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Vocational-Technical Math"
+      ]
+    },
+    {
+      "prefix": "THM",
+      "name": "Massage",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "ETHICS FOR MASSAGE THERAPY",
+        "MASSAGE THERAPY ANATOMY/PHYSIO",
+        "MASSAGE THERAPY CLINICAL II",
+        "MASSAGE THERAPY I",
+        "MASSAGE THERAPY III"
+      ]
+    },
+    {
+      "prefix": "TPM",
+      "name": "Massage",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Anatomy/Physiology Comp Health",
+        "Massage Clinical",
+        "Massage Techniques I",
+        "Massage Techniques III",
+        "Ther Massage Licensure Seminar"
+      ]
+    },
+    {
+      "prefix": "TQM",
+      "name": "Developing",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Developing Job Skills"
+      ]
+    },
+    {
+      "prefix": "VTA",
+      "name": "VTA",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Animal Care & Management",
+        "Practicum",
+        "Veterinary Nurs & Surg Assist"
+      ]
+    },
+    {
+      "prefix": "ALM",
+      "name": "Algebra",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Topics Intermediate Algebra"
+      ]
+    },
+    {
+      "prefix": "ASTRO",
+      "name": "Guide",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Guide to the Universe",
+        "The Solar System and Beyond"
+      ]
+    },
+    {
+      "prefix": "CEAE",
+      "name": "CEAE",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Bridge to Paraprofessional",
+        "Clean Energy Basics",
+        "HVAC/Energy Audit"
+      ]
+    },
+    {
+      "prefix": "CLA",
+      "name": "CLA",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Pastry and Baking",
+        "Culinary Internship",
+        "Food Production I",
+        "Garde Manger"
+      ]
+    },
+    {
+      "prefix": "EDTR",
+      "name": "Orientation",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Orientation for Adjunct Instr",
+        "Using Blackboard Ultra"
+      ]
+    },
+    {
+      "prefix": "EPP",
+      "name": "Concealed",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "CONCEALED CARRY HANDGUN"
+      ]
+    },
+    {
+      "prefix": "FIS",
+      "name": "Fire",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Fire Investigation Module C",
+        "Fire Service Academy V",
+        "Fire Service Internship",
+        "Fire Service Seminar",
+        "Hazardous Materials Operations"
+      ]
+    },
+    {
+      "prefix": "FLM",
+      "name": "Film",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "lincoln-land-community-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Film and Literature",
+        "Film as Art: A Survey of Film",
+        "History of Film",
+        "Introduction to Film Art"
+      ]
+    },
+    {
+      "prefix": "JAPAN",
+      "name": "Japanese",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I",
+        "Elementary Japanese II",
+        "Intermediate Japanese I"
+      ]
+    },
+    {
+      "prefix": "JAPANES",
+      "name": "Japanese",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "First Course Japanese",
+        "Second Course Japanese"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "Clinical",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Internship I",
+        "Clinical Internship III",
+        "EEG Electronics & Instrumenta",
+        "NDT Capstone",
+        "NDT Fundamentals"
+      ]
+    },
+    {
+      "prefix": "NSCI",
+      "name": "Interdisciplinary",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Interdisciplinary Research",
+        "Undergraduate Research"
+      ]
+    },
+    {
+      "prefix": "RES",
+      "name": "RES",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "moraine-valley-community-college",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Mng.The Critically Ill Patient",
+        "Real Estate Principles",
+        "Resp. Clinical Practice II"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Science",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Human Sexuality",
+        "The Science of Happiness"
+      ]
+    },
+    {
+      "prefix": "STSK",
+      "name": "Integrated",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Integrated Study Skills"
+      ]
+    },
+    {
+      "prefix": "TEL",
+      "name": "TEL",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "lincoln-trail-college"
+      ],
+      "sample_titles": [
+        "COMBINATION TECHNICIAN I",
+        "INTERNSHIP IN TELECOMM",
+        "IT FUNDAMENTALS",
+        "NETWORKING FUNDAMENTALS I",
+        "OUTSIDE PLANT I"
+      ]
+    },
+    {
+      "prefix": "ADC",
+      "name": "ADC",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Diversity-Addiction Counseling",
+        "Field Practicum",
+        "Seminar",
+        "Women: Addiction and Recovery"
+      ]
+    },
+    {
+      "prefix": "AGP",
+      "name": "Farm",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "FARM FUTURE MARKETS",
+        "FARM MANAGEMENT",
+        "SUPERVISED OCC. EXP. II",
+        "SUPERVISED OCC. EXP. III"
+      ]
+    },
+    {
+      "prefix": "AGT",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Intro Crop Science",
+        "Intro Soils & Fertilizers",
+        "Intro to Animal Science",
+        "Orientation Agr Careers"
+      ]
+    },
+    {
+      "prefix": "ARABI",
+      "name": "Arabic",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Arabic Civilization & Culture",
+        "Elementary Arabic I",
+        "Elementary Arabic II",
+        "Intermediate Arabic I"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Descriptive Astronomy"
+      ]
+    },
+    {
+      "prefix": "ATR",
+      "name": "Automotive",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Descriptive Astronomy"
+      ]
+    },
+    {
+      "prefix": "BACC",
+      "name": "Accounting",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Individual Income Tax Account",
+        "Intro to Accounting"
+      ]
+    },
+    {
+      "prefix": "BIOTECH",
+      "name": "Biotechnology",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Basic Laboratory Skills and Safety",
+        "Laboratory Math for Biotechnology",
+        "Survey of Biotechnology"
+      ]
+    },
+    {
+      "prefix": "BOC",
+      "name": "Office",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "lincoln-trail-college",
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "MEDICAL FRONT OFFICE",
+        "OFFICE INTERNSHIP I",
+        "OFFICE SEMINAR I"
+      ]
+    },
+    {
+      "prefix": "CDLA",
+      "name": "Tractortrailer",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Tractor/Trailer Driver Train"
+      ]
+    },
+    {
+      "prefix": "CEPD",
+      "name": "Food",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Food Manager Online & Proctor"
+      ]
+    },
+    {
+      "prefix": "CEPE",
+      "name": "Beginners",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Foxtrot for Beginners",
+        "Rumba for Beginners",
+        "Swing for Beginners",
+        "Waltz for Beginners"
+      ]
+    },
+    {
+      "prefix": "CHINE",
+      "name": "Chinese",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Elementary Chinese I",
+        "Elementary Chinese II",
+        "Intermediate Chinese I"
+      ]
+    },
+    {
+      "prefix": "COSC",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Intro Information Processing"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "Patrol",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Justice Internship",
+        "Patrol Techniques"
+      ]
+    },
+    {
+      "prefix": "CRM",
+      "name": "Coding",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "ABSTRACTING METHODS",
+        "CNCR DISEASE, CODING & STAG",
+        "CRM DATA QUAL & UTIL",
+        "ONCOLOGY TREAT & CODING"
+      ]
+    },
+    {
+      "prefix": "CRMC",
+      "name": "Cancer",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Cancer Dis, Coding & Staging",
+        "Cancer Registry Operations",
+        "Cancer Rgsty Struct & Mgmt",
+        "Virtual Practicum"
+      ]
+    },
+    {
+      "prefix": "CSA",
+      "name": "Cpraed",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "CPR/AED Instructor (AHA)",
+        "Unarmed Security Training"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Culinary Essentials",
+        "Food Sanitation and Safety",
+        "Meats, Poultry, Fish, and Eggs"
+      ]
+    },
+    {
+      "prefix": "DGM",
+      "name": "Game",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "3D GAME DEVEL 1",
+        "3D GAME DEVEL 2",
+        "GAME DESIGN 1",
+        "GAME DESIGN 2"
+      ]
+    },
+    {
+      "prefix": "ECHO",
+      "name": "ECHO",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Education II",
+        "CV Hemodynamics and EKG",
+        "Echocardiography Procedures",
+        "Special Topics in Echocardiogr"
+      ]
+    },
+    {
+      "prefix": "FDS",
+      "name": "Food",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Food Service Sanitation"
+      ]
+    },
+    {
+      "prefix": "GC",
+      "name": "GC",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Illustration",
+        "Intro to Comp. Art",
+        "Intro to Web Site Development",
+        "Typography"
+      ]
+    },
+    {
+      "prefix": "GED",
+      "name": "Review",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "GED Bridge to CIT",
+        "General Education Review",
+        "Spanish GED Review"
+      ]
+    },
+    {
+      "prefix": "GLG",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "south-suburban-college",
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Physical Geology",
+        "Introduction to Physical Geology Laboratory"
+      ]
+    },
+    {
+      "prefix": "HAZM",
+      "name": "Hazmat",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Hazmat"
+      ]
+    },
+    {
+      "prefix": "HIDP",
+      "name": "HIDP",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Clinical Practicum",
+        "Intro to Audiology",
+        "Professional Issues",
+        "The Auditory Mechanism"
+      ]
+    },
+    {
+      "prefix": "HORTIC",
+      "name": "Plant",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "city-colleges-of-chicago-olive-harvey-college",
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "Plant Propagation"
+      ]
+    },
+    {
+      "prefix": "HSP",
+      "name": "Hospitality",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Hospitality Internship",
+        "Hospitality Leadership",
+        "Restaurant Management"
+      ]
+    },
+    {
+      "prefix": "INT",
+      "name": "Interpreting",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Certification Test Preparation",
+        "Intro to ASL Interpreting",
+        "Special Topics in Interpreting"
+      ]
+    },
+    {
+      "prefix": "JRNM",
+      "name": "JRNM",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Audio Technology",
+        "Intro to Mass Media",
+        "Intro to Television Productio"
+      ]
+    },
+    {
+      "prefix": "KOR",
+      "name": "Korean",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "joliet-junior-college",
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Korean I",
+        "Conversational Korean I",
+        "Intermediate Korean I"
+      ]
+    },
+    {
+      "prefix": "LRE",
+      "name": "Broker",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Applied Real Estate Principles",
+        "Broker Pre-Licensing/60 Hours"
+      ]
+    },
+    {
+      "prefix": "MED",
+      "name": "Coding",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CODING",
+        "CERTIFICATION PREP",
+        "CODING PRACTICUM",
+        "INTRO TO HEALTH INFORMATION"
+      ]
+    },
+    {
+      "prefix": "MEDT",
+      "name": "Clinical",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Chemistry",
+        "Clinical Microbiology",
+        "Medical Laboratory Skills",
+        "Urinalysis and Immunology"
+      ]
+    },
+    {
+      "prefix": "MILL",
+      "name": "Industrial",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Industrial Maintenance Tech I",
+        "Industrial Maintenance Tech II"
+      ]
+    },
+    {
+      "prefix": "MRIT",
+      "name": "MRIT",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Physical Principles & Instru",
+        "Principles & Procedures I",
+        "Sectional Anatomy"
+      ]
+    },
+    {
+      "prefix": "NLT",
+      "name": "Nail",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Nail Technology Lab I",
+        "Nail Technology Lab II",
+        "Nail Technology Theory I",
+        "Nail Technology Theory II"
+      ]
+    },
+    {
+      "prefix": "OET",
+      "name": "Industrial",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Industrial Plant Operations",
+        "OET Internship"
+      ]
+    },
+    {
+      "prefix": "PHEW",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Physical Activities-Women"
+      ]
+    },
+    {
+      "prefix": "PLSC",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "American Government"
+      ]
+    },
+    {
+      "prefix": "POLISH",
+      "name": "Polish",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "city-colleges-of-chicago-wilbur-wright-college"
+      ],
+      "sample_titles": [
+        "First Course Polish",
+        "Second Course Polish"
+      ]
+    },
+    {
+      "prefix": "RATH",
+      "name": "Practice",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Cross-Sectional Anatomy",
+        "Principles & Practice I",
+        "Radiation Therapy Physics"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "College Reading",
+        "Reading"
+      ]
+    },
+    {
+      "prefix": "REN",
+      "name": "Energy",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Elec Const Safe Renew Energy",
+        "Intro to Renewable Energy",
+        "Photovoltaic Design Fund"
+      ]
+    },
+    {
+      "prefix": "RSP",
+      "name": "Resp",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "INTRO TO RESP THERAPY",
+        "RESP THERAPY PROCEDURES",
+        "RSP CLINICAL PRACTICE I"
+      ]
+    },
+    {
+      "prefix": "TMAT",
+      "name": "Technical",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "joliet-junior-college",
+        "kishwaukee-college"
+      ],
+      "sample_titles": [
+        "Technical Math I",
+        "Technical Mathematics",
+        "Technical Mathematics II"
+      ]
+    },
+    {
+      "prefix": "WEB",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "HTML & CSS",
+        "Intro to UX Design",
+        "Web Designer Cooperative",
+        "Web Page Design Essentials"
+      ]
+    },
+    {
+      "prefix": "AGHT",
+      "name": "AGHT",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Internship",
+        "Intro to Farmsteading",
+        "Special Topics"
+      ]
+    },
+    {
+      "prefix": "ANI",
+      "name": "Animation",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "2D ANIMATION",
+        "ANIMATION TECH 1",
+        "ANIMATION TECH 2"
+      ]
+    },
+    {
+      "prefix": "ARAB",
+      "name": "Conv",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Conv Arabic I"
+      ]
+    },
+    {
+      "prefix": "ASE",
+      "name": "Citizenshp",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Citizenshp Preparation"
+      ]
+    },
+    {
+      "prefix": "AVIO",
+      "name": "Aircraft",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Comm & Cont Systems",
+        "Basic Aircraft Wiring & Tools",
+        "Intro To Aircraft Systems"
+      ]
+    },
+    {
+      "prefix": "BEL",
+      "name": "BEL",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity I",
+        "Conduit Bending & Fabrication",
+        "Electrical Safety"
+      ]
+    },
+    {
+      "prefix": "CGI",
+      "name": "CGI",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "3D Computer Animation I",
+        "Advanced Photoshop",
+        "Game Engine"
+      ]
+    },
+    {
+      "prefix": "CHINESE",
+      "name": "Chinese",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "Chinese II",
+        "Introduction to Chinese"
+      ]
+    },
+    {
+      "prefix": "CNA",
+      "name": "Nurse",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nurse Asst Training Prog"
+      ]
+    },
+    {
+      "prefix": "CSG",
+      "name": "Careerlife",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Career/Life Planning"
+      ]
+    },
+    {
+      "prefix": "DA",
+      "name": "Dental",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Chairside Dental Assisting",
+        "Clinical Applications I",
+        "Introduction Dental Assisting"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "Electronics",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Industrial Electronics",
+        "Microcomputer Electronics",
+        "Power Supplies"
+      ]
+    },
+    {
+      "prefix": "ENS",
+      "name": "Engineeringcad",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Engr Mech I (statics)",
+        "Intro to Engineering/CAD"
+      ]
+    },
+    {
+      "prefix": "ENVR TC",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Environmental Geology"
+      ]
+    },
+    {
+      "prefix": "FAD",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Emergency Care and Safety"
+      ]
+    },
+    {
+      "prefix": "FRCH",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Elem French I",
+        "Inter French I"
+      ]
+    },
+    {
+      "prefix": "FS READ",
+      "name": "Reading",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "Reading, Writing, Critical Thinking I",
+        "Reading, Writing, Critical Thinking II",
+        "Reading, Writing, Critical Thinking III"
+      ]
+    },
+    {
+      "prefix": "GBS",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Introduction to Global Business"
+      ]
+    },
+    {
+      "prefix": "HCE",
+      "name": "Evidence",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "EVIDENCE BASD PRAC"
+      ]
+    },
+    {
+      "prefix": "HEED",
+      "name": "First",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "First Aid",
+        "Personal & Community Health"
+      ]
+    },
+    {
+      "prefix": "HIMC",
+      "name": "Health",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Health Info/Coding Externship",
+        "Intro to Health Information",
+        "Medical Billing and Coding"
+      ]
+    },
+    {
+      "prefix": "ITALIAN",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "First Course Italian"
+      ]
+    },
+    {
+      "prefix": "ITCYB",
+      "name": "Cybersecurity",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Digital Forensics",
+        "Introduction to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "ITWEB",
+      "name": "Page",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Web Page Fundamentals",
+        "Web Site Design - Level 2"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Conv",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Conv Japanese I",
+        "Conv Japanese II",
+        "Conv Japanese III"
+      ]
+    },
+    {
+      "prefix": "LTC",
+      "name": "LTC",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Intro Long-Term Care Services",
+        "Intro to Nursing Home Admin.",
+        "Social Gerontology and LTC"
+      ]
+    },
+    {
+      "prefix": "LVV",
+      "name": "Autocad",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Autocad Essentials",
+        "Autocad Intermediate",
+        "Autocad:Creat/Present 3D Model"
+      ]
+    },
+    {
+      "prefix": "LWN",
+      "name": "Expungeseal",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "DUI & the Law",
+        "Expunge/Seal a Criminal Record"
+      ]
+    },
+    {
+      "prefix": "MAP",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Basic Healthcare Skills for the Medical Assistant",
+        "Clinical Skills for the Medical Assistant",
+        "Medical Assistant Practicum"
+      ]
+    },
+    {
+      "prefix": "NTR",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Basic Nutrition"
+      ]
+    },
+    {
+      "prefix": "OFT",
+      "name": "Microsoft",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Keyboarding Speed and Accuracy",
+        "Microsoft Excel",
+        "Microsoft Outlook"
+      ]
+    },
+    {
+      "prefix": "PAS",
+      "name": "Pastry",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "ADV PASTRY SKILLS",
+        "BAKERY OPERATIONS",
+        "PASTRY SKILLS I"
+      ]
+    },
+    {
+      "prefix": "PHEM",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Physical Activities-Men"
+      ]
+    },
+    {
+      "prefix": "PHYSC",
+      "name": "Earth",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Earth Science"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Essentials",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Essentials of Forensic Science",
+        "Frnsc Sci II/Death Anlys"
+      ]
+    },
+    {
+      "prefix": "SLP",
+      "name": "Security",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Issues: Security",
+        "Special Topics in Security",
+        "Unarmed Security Guard Trng."
+      ]
+    },
+    {
+      "prefix": "SMGT",
+      "name": "Sport",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Intro To Sport Management",
+        "Sport Law",
+        "Sport Marketing"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Data",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Data Visualization",
+        "Introduction to Data Science"
+      ]
+    },
+    {
+      "prefix": "STEM",
+      "name": "Printing",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "3D Printing & 3D Technologies",
+        "STEM Guitar"
+      ]
+    },
+    {
+      "prefix": "SUST",
+      "name": "Sustainability",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "danville-area-community-college",
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Green Facilities Management",
+        "Introduction to Sustainability",
+        "Principles of Sustainability"
+      ]
+    },
+    {
+      "prefix": "TRN",
+      "name": "Transition",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Transition to Develpmntl Math"
+      ]
+    },
+    {
+      "prefix": "TWDL",
+      "name": "TWDL",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Import/Export",
+        "Transport & Cargo Security",
+        "Transportation & Physical Dist"
+      ]
+    },
+    {
+      "prefix": "VCTR",
+      "name": "Paraprofessional",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Paraprofessional Exam Prep",
+        "Sheet Metal Fabrication"
+      ]
+    },
+    {
+      "prefix": "VSLR",
+      "name": "Solar",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Solar Applications I",
+        "Solar Applications II",
+        "Solar Applications III"
+      ]
+    },
+    {
+      "prefix": "WTE",
+      "name": "Operations",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Special Topics/Water and Wastewater",
+        "Wastewater Operations I",
+        "Water Operations I"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "Barber",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Barber Styling II",
+        "License Review"
+      ]
+    },
+    {
+      "prefix": "BDM",
+      "name": "Construction",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Construction Plumbing Systems",
+        "Construction Tech Applications"
+      ]
+    },
+    {
+      "prefix": "BMG",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "olney-central-college",
+        "wabash-valley-college"
+      ],
+      "sample_titles": [
+        "HUMAN RESOURCE MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "BRE",
+      "name": "English",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "English bridge"
+      ]
+    },
+    {
+      "prefix": "BRM",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Math Bridge"
+      ]
+    },
+    {
+      "prefix": "CHI",
+      "name": "Chinese",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Chinese I",
+        "Intermediate Chinese I"
+      ]
+    },
+    {
+      "prefix": "CHL",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "INTRO TO HEALTH ADMINISTRATION",
+        "SURVEY OF COMMUNITY HEALTH"
+      ]
+    },
+    {
+      "prefix": "CMMEDIA",
+      "name": "Film",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Film Rhetoric"
+      ]
+    },
+    {
+      "prefix": "CSF",
+      "name": "Cprbls",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Cpr:bls for Prof Rescuers Inst"
+      ]
+    },
+    {
+      "prefix": "CSFA",
+      "name": "Surg",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Surg First Asst Principles I",
+        "Surgical Laboratory Practicum"
+      ]
+    },
+    {
+      "prefix": "DISN",
+      "name": "Disney",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Disney Program I",
+        "Disney Program II"
+      ]
+    },
+    {
+      "prefix": "EKG",
+      "name": "Electrocardiography",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Electrocardiography"
+      ]
+    },
+    {
+      "prefix": "ELC",
+      "name": "Electrical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Digital Electronics",
+        "Electrical Circuits I"
+      ]
+    },
+    {
+      "prefix": "EMR",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "First Responder-EMR"
+      ]
+    },
+    {
+      "prefix": "ENVR ST",
+      "name": "Environment",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Man & Environment I"
+      ]
+    },
+    {
+      "prefix": "ESLREAD",
+      "name": "Reading",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "ESL High-Intermediate Reading",
+        "ESL Intermediate Reading"
+      ]
+    },
+    {
+      "prefix": "ESLSPCH",
+      "name": "Oral",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "city-colleges-of-chicago-harold-washington-college"
+      ],
+      "sample_titles": [
+        "ESL High-Intermediate Oral Communication",
+        "ESL Intermediate Oral Communication"
+      ]
+    },
+    {
+      "prefix": "FME",
+      "name": "Management",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Energy Management and DDC Controls",
+        "Introduction to Facilities Management and Engineering"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Prin",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Prin of Physical Geology"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Geographic Information Systems I"
+      ]
+    },
+    {
+      "prefix": "HBW",
+      "name": "Hebrew",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Hebrew I",
+        "Intermediate Hebrew I"
+      ]
+    },
+    {
+      "prefix": "HC",
+      "name": "Train",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Train the Trainer CNA Instruc"
+      ]
+    },
+    {
+      "prefix": "HDV",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Career Planning"
+      ]
+    },
+    {
+      "prefix": "HIN",
+      "name": "Hindi",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Hindi I",
+        "Intermediate Hindi I"
+      ]
+    },
+    {
+      "prefix": "HNRS",
+      "name": "HNRS",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Honors Seminar 101",
+        "Honors Seminar 201"
+      ]
+    },
+    {
+      "prefix": "HSA",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Intro. to Addiction Counseling",
+        "Introduction to Human Services"
+      ]
+    },
+    {
+      "prefix": "HYDR",
+      "name": "Fund",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Fund of Hydraulics",
+        "Hydraulic Controls"
+      ]
+    },
+    {
+      "prefix": "IND",
+      "name": "IND",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "IND RESEARCH"
+      ]
+    },
+    {
+      "prefix": "ITL",
+      "name": "Italian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Italian I",
+        "Intermediate Italian I"
+      ]
+    },
+    {
+      "prefix": "JOBS",
+      "name": "Seeking",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Job Seeking Skills",
+        "Targeting the Job Market"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Intro/Mass Media",
+        "News Report/Writing"
+      ]
+    },
+    {
+      "prefix": "KEY",
+      "name": "Keyboard",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lincoln-trail-college"
+      ],
+      "sample_titles": [
+        "KEYBOARD APPLIED MUSIC I",
+        "KEYBOARD APPLIED MUSIC III"
+      ]
+    },
+    {
+      "prefix": "LAH",
+      "name": "Training",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Dental Assistant Training",
+        "Pharmacy Technician Training"
+      ]
+    },
+    {
+      "prefix": "LCE",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Career Explor/Right for You",
+        "Foundations of Manufacturing"
+      ]
+    },
+    {
+      "prefix": "LCI",
+      "name": "Cisco",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Cisco CCNA Ntwk Specialist"
+      ]
+    },
+    {
+      "prefix": "LEA",
+      "name": "Leadership",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Leadership I",
+        "Leadership III"
+      ]
+    },
+    {
+      "prefix": "LPM",
+      "name": "Agile",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "PMI Agile Cert Practitioner",
+        "Pmp Certification Prep Review"
+      ]
+    },
+    {
+      "prefix": "MOA",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Medical Assistant Externship",
+        "Medical Assistant Seminar"
+      ]
+    },
+    {
+      "prefix": "MUL",
+      "name": "Radiography",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "TOPICS: RADIOGRAPHY CLUB I"
+      ]
+    },
+    {
+      "prefix": "NAT",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science I"
+      ]
+    },
+    {
+      "prefix": "NCBD",
+      "name": "Faculty",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "frontier-community-college"
+      ],
+      "sample_titles": [
+        "FACULTY ORIENTATION-ONBOARDING"
+      ]
+    },
+    {
+      "prefix": "OPS",
+      "name": "Osha",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "OSHA 10Hr Construction Safety"
+      ]
+    },
+    {
+      "prefix": "OSH",
+      "name": "Osha",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "OSHA 10 General Industry"
+      ]
+    },
+    {
+      "prefix": "PCT",
+      "name": "Patient",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-dupage",
+        "south-suburban-college"
+      ],
+      "sample_titles": [
+        "Patient Care Technician",
+        "PCT Certificate Review"
+      ]
+    },
+    {
+      "prefix": "PEC",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Physical Fitness"
+      ]
+    },
+    {
+      "prefix": "PEG",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "FIRST AID &amp; SAFETY EDUCATION"
+      ]
+    },
+    {
+      "prefix": "PHMB",
+      "name": "Icdcm",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "ICD-10-CM Diagnosis Coding",
+        "Med Billing & Reimb Methods"
+      ]
+    },
+    {
+      "prefix": "PIHBR",
+      "name": "Communitypsc",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Community-Psc Fitnesscenter-Su",
+        "Employee-Pscfitnesscenter-Summ"
+      ]
+    },
+    {
+      "prefix": "PSG",
+      "name": "Sleep",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Sleep Education",
+        "Sleep Disorders"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Real Estate Broker Pre-License Topics (60-hour)"
+      ]
+    },
+    {
+      "prefix": "RUS",
+      "name": "Russian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Russian I",
+        "Intermediate Russian I"
+      ]
+    },
+    {
+      "prefix": "RUSSI",
+      "name": "Russian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Elementary Russian I",
+        "Intermediate Russian I"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "Community Health Systems",
+        "Intro to Social Work"
+      ]
+    },
+    {
+      "prefix": "TES",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Technical Shop Physics"
+      ]
+    },
+    {
+      "prefix": "THR",
+      "name": "Theatre",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Acting",
+        "Introduction to Theatre"
+      ]
+    },
+    {
+      "prefix": "URD",
+      "name": "Urdu",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Beginning Urdu I",
+        "Intermediate Urdu I"
+      ]
+    },
+    {
+      "prefix": "WIND",
+      "name": "Wind",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Wind Solar Energy",
+        "Wind Power Delivery Systems"
+      ]
+    },
+    {
+      "prefix": "WIT",
+      "name": "Mechatronics",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Mechatronics Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "XCT",
+      "name": "Computed",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Computed Tomography Imaging",
+        "CT Clinical"
+      ]
+    },
+    {
+      "prefix": "XMR",
+      "name": "Clinical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Magnetic Resonance Imaging",
+        "MRI Clinical"
+      ]
+    },
+    {
+      "prefix": "ZOOLOGY",
+      "name": "Zoology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "General Zoology"
+      ]
+    },
+    {
+      "prefix": "AGRC",
+      "name": "Soil",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Soil Science"
+      ]
+    },
+    {
+      "prefix": "AMATH",
+      "name": "Mathskilled",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Applied Math/Skilled Trades"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "Cell",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "triton-college"
+      ],
+      "sample_titles": [
+        "Cell and Tissue Culture"
+      ]
+    },
+    {
+      "prefix": "BOTAN",
+      "name": "Prairie",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Prairie Ecology"
+      ]
+    },
+    {
+      "prefix": "CESC",
+      "name": "Dance",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Dance Well(ness)"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Conv",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Conv Mand/Chinese I"
+      ]
+    },
+    {
+      "prefix": "COOP",
+      "name": "Coop",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Coop Ed Exp II"
+      ]
+    },
+    {
+      "prefix": "DASC",
+      "name": "Data",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Data Science"
+      ]
+    },
+    {
+      "prefix": "DET",
+      "name": "Diesel",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Diesel Engine Theory & Repair"
+      ]
+    },
+    {
+      "prefix": "DIS",
+      "name": "Disability",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Disability in Society"
+      ]
+    },
+    {
+      "prefix": "DRA",
+      "name": "Theatre",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "olney-central-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO THEATRE"
+      ]
+    },
+    {
+      "prefix": "DRAFT",
+      "name": "Blprnt",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Blprnt Rdg/Mech Tr"
+      ]
+    },
+    {
+      "prefix": "DRT",
+      "name": "Blueprint",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "parkland-college"
+      ],
+      "sample_titles": [
+        "Blueprint Rdg/Tech Draw"
+      ]
+    },
+    {
+      "prefix": "DTEC",
+      "name": "Mhdt",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "MHDT Electricity & Electronic"
+      ]
+    },
+    {
+      "prefix": "ECOL",
+      "name": "Introductory",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lewis-and-clark-community-college"
+      ],
+      "sample_titles": [
+        "Introductory Soils"
+      ]
+    },
+    {
+      "prefix": "EGN",
+      "name": "Design",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "moraine-valley-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Design"
+      ]
+    },
+    {
+      "prefix": "ENTRE",
+      "name": "Entrepreneurship",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "city-colleges-of-chicago-harry-s-truman-college"
+      ],
+      "sample_titles": [
+        "Introduction to Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "EYE",
+      "name": "Care",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Eye Care Assistant I"
+      ]
+    },
+    {
+      "prefix": "FRESP",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "First Responder"
+      ]
+    },
+    {
+      "prefix": "GSCI",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Human Body-Structure & Functi"
+      ]
+    },
+    {
+      "prefix": "GSP",
+      "name": "Game",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "morton-college"
+      ],
+      "sample_titles": [
+        "Game Development Essentials"
+      ]
+    },
+    {
+      "prefix": "HON",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lincoln-land-community-college"
+      ],
+      "sample_titles": [
+        "Honors Leadership and Modules"
+      ]
+    },
+    {
+      "prefix": "HTC",
+      "name": "Horticultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Horticultural Therapy Application and Practicum"
+      ]
+    },
+    {
+      "prefix": "INRM",
+      "name": "Risk",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "danville-area-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Ins and Risk Mgmt"
+      ]
+    },
+    {
+      "prefix": "ITAL",
+      "name": "Conv",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Conv Italian I"
+      ]
+    },
+    {
+      "prefix": "ITS",
+      "name": "ITS",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "waubonsee-community-college"
+      ],
+      "sample_titles": [
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "JRNLM",
+      "name": "Introjournalism",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Intro/Journalism"
+      ]
+    },
+    {
+      "prefix": "LCB",
+      "name": "Pharmacology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Pharmacology of Cannabis"
+      ]
+    },
+    {
+      "prefix": "LCW",
+      "name": "Cert",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "AWS Cert Solutions Architect"
+      ]
+    },
+    {
+      "prefix": "LIB",
+      "name": "Rsrch",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "RSRCH DIGIT AGE"
+      ]
+    },
+    {
+      "prefix": "LNT",
+      "name": "Microsoft",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "william-rainey-harper-college"
+      ],
+      "sample_titles": [
+        "Microsoft Azure Fundamentals"
+      ]
+    },
+    {
+      "prefix": "LRC",
+      "name": "Library",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "shawnee-community-college"
+      ],
+      "sample_titles": [
+        "The Library as an Information"
+      ]
+    },
+    {
+      "prefix": "MAC",
+      "name": "Manufacturing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lincoln-trail-college"
+      ],
+      "sample_titles": [
+        "MANUFACTURING PROCESSES"
+      ]
+    },
+    {
+      "prefix": "MEC",
+      "name": "Processes",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oakton-college"
+      ],
+      "sample_titles": [
+        "Processes and Materials"
+      ]
+    },
+    {
+      "prefix": "OPTH",
+      "name": "Ophthalmic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Ophthalmic Technician I"
+      ]
+    },
+    {
+      "prefix": "PDV",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mchenry-county-college"
+      ],
+      "sample_titles": [
+        "CAREER DEVELOPMENT"
+      ]
+    },
+    {
+      "prefix": "PHSCI",
+      "name": "Life",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Life in the Universe"
+      ]
+    },
+    {
+      "prefix": "RST",
+      "name": "Sanitation",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "frontier-community-college"
+      ],
+      "sample_titles": [
+        "SANITATION &amp; SAFETY"
+      ]
+    },
+    {
+      "prefix": "RUSS",
+      "name": "Conv",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "joliet-junior-college"
+      ],
+      "sample_titles": [
+        "Conv Russian I"
+      ]
+    },
+    {
+      "prefix": "SOCW",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kankakee-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Technical Math I"
+      ]
+    },
+    {
+      "prefix": "THTRE",
+      "name": "Understanding",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "prairie-state-college"
+      ],
+      "sample_titles": [
+        "Understanding Theatre"
+      ]
+    },
+    {
+      "prefix": "ZOOLO",
+      "name": "Animal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-dupage"
+      ],
+      "sample_titles": [
+        "Intro to Animal Care Captivity"
+      ]
+    }
+  ],
+  "program_titles": [
+    "3D CAD Certificate (CDC)",
+    "3D Computer Animation Software Certificate",
+    "AA 100 - Associate in Arts",
+    "Accelerated Personal Fitness Training Certificate",
+    "Accountancy, A.A.S. — Associate in Applied Science",
+    "Accounting",
+    "Accounting & Business Management, A.A.S",
+    "Accounting • Associate in Arts",
+    "Accounting Certificate",
+    "Accounting I, Certificate",
+    "Accounting II, Certificate",
+    "Accounting or Business or Business Marketing or Finance or Operation Management Information Systems - Transfer, A. S.",
+    "Accounting or Business or Operations Management Information Systems - Transfer, A.A.",
+    "Accounting Specialist • Associate in Applied Science",
+    "Accounting Specialist, Certificate — Associate in Applied Science",
+    "Accounting Technologies, A.A.S.",
+    "Accounting Transfer Pathway, A.A. — Associate in Applied Science",
+    "Accounting, A.A.S.",
+    "Accounting, AAS",
+    "Accounting, Certificate of Achievement",
+    "Addictions Counseling, A.A.S.",
+    "Addictions Counseling, A.A.S. — Associate in Applied Science",
+    "Addictions Counseling, Certificate — Associate in Applied Science",
+    "Additional Flight Training",
+    "Administrative Office Skills Certificate",
+    "Administrative Office Technologies Certificate",
+    "Administrative Office Technologies, AAS",
+    "Administrative Professional, A.A.S.",
+    "Administrative Professional, Certificate of Achievement",
+    "Administrative Professional, Certificate of Completion",
+    "Administrative Support and Meeting/Event Planning, A.A.S. — Associate in Applied Science",
+    "Administrative Support and Meeting/Event Planning, Certificate — Associate in Applied Science",
+    "Administrative Support Essentials, Certificate — Associate in Applied Science",
+    "Administrative Support Specialist, A.A.S. — Associate in Applied Science",
+    "Administrative Support Specialist, Certificate — Associate in Applied Science",
+    "Adult Basic Education",
+    "Adult Secondary Education",
+    "Adv. Cyber Security & Net-Dev, Certificate of Completion",
+    "Advanced Accounting, Certificate — Associate in Applied Science",
+    "Advanced Automotive Technician Certificate",
+    "Advanced Bedside Care Provider Certificate",
+    "Advanced Construction, Certificate of Completion",
+    "Advanced Drivetrains-Powertrains, Certificate",
+    "Advanced Electronics Technology, Certificate — Associate in Applied Science",
+    "Advanced Emergency Medical Technician • Certificate of Completion",
+    "Advanced EMT Certificate",
+    "Advanced Engineering Technician Certificate",
+    "Advanced Horticultural Therapy, Certificate — Associate in Applied Science",
+    "Advanced Mechatronics, Certificate — Associate in Applied Science",
+    "Advanced Technician Firefighter • Certificate of Completion",
+    "Advanced Technician Firefighter Certificate",
+    "Advanced Unmanned Aircraft Systems Certificate",
+    "Advanced Welder, Certificate of Achievement",
+    "Advanced Welding Technician Certificate",
+    "Advanced-Level Welding • Certificate of Achievement",
+    "AES 140 - Associate in Engineering Science",
+    "AFA 130 - Associate in Fine Arts, Art Option",
+    "AGCO Service Technician, A.A.S.",
+    "AGR 342 - Agribusiness, A.A.S.",
+    "AGR 425 - Foundations of Agribusiness Certificate",
+    "AGR 447 - Precision Agriculture Certificate",
+    "Agri-Business Certificate",
+    "Agri-Hort Technology, AAS",
+    "Agribusiness • Associate in Applied Science",
+    "AgriBusiness, AAS",
+    "Agricultural Business Management, A.A.S.",
+    "Agricultural Production, Certificate of Completion",
+    "Agricultural Sciences, Certificate of Completion",
+    "Agriculture • Associate in Arts",
+    "Agriculture Business, A.A.S.",
+    "Agriculture Business, Certificate of Completion",
+    "Agriculture or Horticulture, A.S.",
+    "Agriculture Production & Mgmt, A.A.S.",
+    "Agriculture Retail Operations Certificate",
+    "Agriculture, A.S.",
+    "Agriculture, Advanced Certificate",
+    "Agriculture, AS",
+    "Agriculture, Certificate",
+    "AI & Cloud Based Networks and IT Infrastructure, A.A.S.",
+    "Air Conditioning and Refrigeration, AAS",
+    "Air Conditioning and Refrigeration, Certificate",
+    "Airframe and Powerplant Aviation Mechanics • Associate in Applied Science",
+    "American Sign Language Interpreter, A.A.S. — Associate in Applied Science",
+    "American Sign Language Interpreting, Certificate — Associate in Applied Science",
+    "American Sign Language, Certificate — Associate in Applied Science",
+    "AMT 230 - Automotive Technology, A.A.S.",
+    "AMT 416 - Basic Automotive Technology Certificate",
+    "AMT 417 - Advanced Automotive Technology Certificate",
+    "Android with Integrated AI Certificate",
+    "Animation Certificate",
+    "Animation, A.A.S. — Associate in Applied Science",
+    "Animation, Certificate — Associate in Applied Science",
+    "Anthropology - Transfer, A.A.",
+    "Anthropology - Transfer, A.S.",
+    "Anthropology Sample Transfer Pathway",
+    "Anthropology Transfer Pathway, A.A. — Associate in Applied Science",
+    "Anthropology Transfer Pathway, A.S. — Associate in Applied Science",
+    "Application and Technical Support Specialist, A.A.S. — Associate in Applied Science",
+    "Application Specialist Certificate",
+    "Applied Electrocardiography Certificate",
+    "Applied Gerontology, Certificate — Associate in Applied Science",
+    "Applied Technology, Certificate — Associate in Applied Science",
+    "Architectural and Engineering Design Technology Certificate",
+    "Architectural Design Certificate",
+    "Architectural Rendering, Certificate — Associate in Applied Science",
+    "Architectural Studies, A.A.S.",
+    "Architectural Tech Advanced, Certificate of Achievement",
+    "Architectural Tech Basic, Certificate of Completion",
+    "Architectural Technology",
+    "Architectural Technology Certificate",
+    "Architectural Technology-CADD , A.A.S. — Associate in Applied Science",
+    "Architectural Technology, AAS",
+    "Architectural Technology, Certificate — Associate in Applied Science",
+    "Art - Transfer, A.A.",
+    "Art and Design, A.F.A.",
+    "Art Education, A.A.",
+    "Art Education, A.F.A.",
+    "Art Electives",
+    "Art History Sample Transfer Pathway",
+    "Art Sample Transfer Pathway",
+    "Art, AFA",
+    "Art/Art History, A.A.",
+    "Artificial Intelligence and Cloud Integration",
+    "Artificial Intelligence, A.A.S. — Associate in Applied Science",
+    "AS 120 - Associate in Science",
+    "Assistant Restaurant Manager Certificate",
+    "Associate Degree in Nursing",
+    "Associate in Applied Science",
+    "Associate in Applied Science (A.A.S.) Degree Requirements",
+    "Associate in Applied Science (AAS) Degree",
+    "Associate in Arts",
+    "Associate in Arts - ARTS.AA",
+    "Associate in Arts (A.A.) Degree",
+    "Associate in Arts (AA) Degree",
+    "Associate in Arts Degree, A.A.",
+    "Associate in Arts Online Degree (AA 100)",
+    "Associate in Arts, 8-Week Degree (AA 100)",
+    "Associate in Engineering Science - ENGR/SCI.AES",
+    "Associate in Engineering Science (A.E.S)",
+    "Associate in Engineering Science (AES) Degree",
+    "Associate in Fine Arts (AFA) Degree-Art Option",
+    "Associate in Fine Arts (AFA) Degree-Music Option",
+    "Associate in Fine Arts (Art Emphasis) - ART.AFA",
+    "Associate in Fine Arts (Music Performance) - MUSC/PERF.AFA",
+    "Associate in Fine Arts in Music Education",
+    "Associate in General Studies",
+    "Associate in General Studies - AGS.AGS",
+    "Associate in General Studies (A.G.S.)",
+    "Associate in General Studies (AGS) Degree",
+    "Associate in General Studies Degree, A.G.S.",
+    "Associate in Liberal Studies (A.L.S.)",
+    "Associate in Science",
+    "Associate in Science - SCI.AS",
+    "Associate in Science (A.S.) Degree",
+    "Associate in Science (AS) Degree",
+    "Associate in Science Degree, A.S.",
+    "Astronomy Sample Transfer Pathway",
+    "Astronomy Transfer Pathway, A.S. — Associate in Applied Science",
+    "Astronomy, A.S.",
+    "Audio Production, Certificate — Associate in Applied Science",
+    "Audio Video Technician Certificate",
+    "Auto - Automotive Alignment Specialist Certificate",
+    "Auto - Automotive Brake Specialist Certificate",
+    "Auto - Automotive Drivability Specialist Certificate",
+    "Auto - Automotive Engines Specialist Certificate",
+    "Auto - Automotive Heating/Air Conditioning Specialist Certificate",
+    "Auto - Automotive Parts Specialist Certificate",
+    "Auto - Automotive Service Management Specialist Certificate",
+    "Auto - Automotive Services Technology Certificate",
+    "Auto - Automotive Transmission Specialist Certificate",
+    "Auto - Hybrid and Electric Vehicle Certificate",
+    "Auto Heating and Air Conditioning • Certificate of Completion",
+    "Auto/Diesel Mechanic, Certificate",
+    "Automated Controls & Robotics, Certificate of Completion",
+    "Automated Manufacturing Systems, A.A.S. — Associate in Applied Science",
+    "Automated Manufacturing Systems, Certificate — Associate in Applied Science",
+    "Automation Technician Certificate",
+    "Automation, Robotics, and Mechatronics AAS",
+    "Automotive Chassis Certificate",
+    "Automotive Collision Engineering, A.A.S.",
+    "Automotive Collision Repair Certificate",
+    "Automotive Driveline Specialist, Certificate of Completion",
+    "Automotive Electrical Certificate",
+    "Automotive Engine Performance Specialist, Certificate of Completion",
+    "Automotive Ford Motor ASSET Program, A.A.S.",
+    "Automotive Heating and Air Conditioning, Certificate",
+    "Automotive Maintenance and Light Repair Certificate",
+    "Automotive Maintenance Technician Certificate",
+    "Automotive Service Management, Certificate — Associate in Applied Science",
+    "Automotive Service Technology (Advanced), Certificate of Achievement",
+    "Automotive Service Technology, A.A.S.",
+    "Automotive Service Technology, Certificate of Achievement",
+    "Automotive Technician • Certificate of Achievement",
+    "Automotive Technician Certificate",
+    "Automotive Technology",
+    "Automotive Technology • Associate in Applied Science",
+    "Automotive Technology Advanced Certificate",
+    "Automotive Technology, A.A.S.",
+    "Automotive Technology, A.A.S. - Automotive Management Concentration",
+    "Automotive Technology, A.A.S. - Automotive Motorsport Concentration",
+    "Automotive Technology, A.A.S. - Automotive Technician Concentration",
+    "Automotive Technology, AAS",
+    "Automotive Technology, AAS (Management Option)",
+    "Automotive Technology, AAS Sample Semester Pathway",
+    "Automotive Technology, Certificate",
+    "Aviation Airframe Technician • Certificate of Achievement",
+    "Aviation Management • Associate in Applied Science",
+    "Aviation Management, A.A.S. — Associate in Applied Science",
+    "Aviation Powerplant Technician • Certificate of Achievement",
+    "Aviation, A.S.",
+    "AWS Sense 1, Certificate — Associate in Applied Science",
+    "Back End Development Certificate",
+    "Baking and Pastry Arts, A.A.S. — Associate in Applied Science",
+    "Baking and Pastry Arts, Certificate — Associate in Applied Science",
+    "Baking and Pastry Assistant I Certificate",
+    "Baking and Pastry Assistant II Certificate",
+    "Baking and Pastry Certificate • Certificate of Achievement",
+    "Baking and Pastry Management, AAS",
+    "Baking and Pastry, Certificate of Completion",
+    "Basic Construction Skills Certificate",
+    "Basic Construction, Certificate of Completion",
+    "Basic Electronics, Occupational Certificate",
+    "Basic Firefighter Operations Certificate",
+    "Basic Law Enforcement Principles, Certificate",
+    "Basic Manufacturing Industrial Maintenance, Certificate",
+    "Basic Manufacturing Machine Tool, Certificate",
+    "Basic Manufacturing TWDL, Certificate",
+    "Basic Manufacturing Welding, Certificate",
+    "Basic Multipractice Welding • Certificate of Completion",
+    "Basic Nurse Assistant • Certificate of Completion",
+    "Basic Nursing Assistant Certificate",
+    "Basic Operations Fire Fighter • Certificate of Completion",
+    "Basic Operations Firefighter I Certificate",
+    "Basic Welding Technician Certificate",
+    "Basic Welding, Certificate of Completion",
+    "Beverage Management Certificate",
+    "Biochemistry Transfer Pathway, A.S. — Associate in Applied Science",
+    "Bioengineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Biological Sciences, A.A.",
+    "Biological Sciences, A.S.",
+    "Biological Sciences, AS",
+    "Biology - Transfer, A.S.",
+    "Biology Sample Transfer Pathway",
+    "Biology Transfer Pathway, A.S. — Associate in Applied Science",
+    "Biomedical Engineering Technology, A.A.S. — Associate in Applied Science",
+    "Blueprint Reading, Certificate of Completion",
+    "Bookkeeping Certificate",
+    "Bookkeeping Office Assistant Certificate",
+    "Bookkeeping, Certificate — Associate in Applied Science",
+    "Brake and Chassis Specialist, Certificate of Completion",
+    "Brakes • Certificate of Completion",
+    "Brakes and Alignment, Certificate",
+    "Building Automation Systems (BAS), Certificate — Associate in Applied Science",
+    "Business • Associate in Applied Science",
+    "Business Administration • Associate in Arts",
+    "Business Administration, A.A.S.",
+    "Business Administration, A.S.",
+    "Business Administrative Technology, A.A.S. - Administrative Assistant Track",
+    "Business Administrative Technology, A.A.S. - Bookkeeping Track",
+    "Business Administrative Technology, A.A.S. - Business Track",
+    "Business Administrative Technology, A.A.S. - Customer Service Track",
+    "Business Administrative Technology, A.A.S. - PC Support Track",
+    "Business Anthropology, Certificate — Associate in Applied Science",
+    "Business Core, Certificate of Completion",
+    "Business Elective Courses",
+    "Business Environment and Concepts, Certificate — Associate in Applied Science",
+    "Business Essentials Certificate",
+    "Business Intelligence Analysis, Certificate — Associate in Applied Science",
+    "Business Management Principles Certificate",
+    "Business Management, A.A.S.",
+    "Business Management, AAS",
+    "Business Management, Certificate",
+    "Business Marketing, A.A.S.",
+    "Business Marketing, Certificate",
+    "Business Operations Facilitator • Certificate of Completion",
+    "Business Productivity Software, Certificate — Associate in Applied Science",
+    "Business Transfer Pathway, A.A. — Associate in Applied Science",
+    "Business, A.A.",
+    "Business, AAS",
+    "Business, Advanced Certificate",
+    "Business, AS",
+    "Business, Certificate",
+    "C++ Language Proficiency, Certificate — Associate in Applied Science",
+    "CAD Degree (MDT)",
+    "CAD Drafter Certificate",
+    "CAD Technician Certificate",
+    "CAD/Mechanical Design Technology Certificate",
+    "CAD/Mechanical Design Technology, A.A.S.",
+    "CADD Management, Certificate of Achievement",
+    "CADD Mechanical Design Tech, Certificate of Achievement",
+    "CADD Mechanical Design Technology, Certificate of Completion",
+    "Cancer Registry Management Certificate",
+    "Cancer Registry Management, Certificate",
+    "Cannabis and Industrial Hemp Cultivation and Operations, Certificate — Associate in Applied Science",
+    "Canva Design for Business Certificate",
+    "Career and Technical General Education",
+    "Carpenters Concentration Certificate",
+    "Case New Holland Service Technician, A.A.S.",
+    "Central Sterile Processing Distribution Technician, Certificate — Associate in Applied Science",
+    "Certificates of Completion",
+    "Certificates of Proficiency",
+    "Certified Nurse Assistant, Certificate",
+    "Certified Nursing Assistant (CNA), Certificate — Associate in Applied Science",
+    "Certified Nursing Assistant, Certificate",
+    "Certified Production Technician Certificate",
+    "Chef’s Assistant I Certificate",
+    "Chef’s Assistant II Certificate",
+    "Chemical Engineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Chemistry - Transfer, A.S.",
+    "Chemistry Sample Transfer Pathway",
+    "Chemistry Transfer Pathway, A.S. — Associate in Applied Science",
+    "Chemistry, A.S.",
+    "Chemistry, AS",
+    "Child Development",
+    "Child Development Director Certificate",
+    "Child Development Preschool Teacher Certificate",
+    "Child Development Professional, Certificate of Completion",
+    "Child Development, A.A.S.",
+    "Child Development, Certificate of Achievement",
+    "Chinese Transfer Pathway, A.A. — Associate in Applied Science",
+    "CIS 411 - Google IT Support Certificate",
+    "CIS 412 - Networking Fundamentals - Certificate",
+    "CIS 437 - Computer Information Systems, A.A.S.",
+    "CIS 437 Electives",
+    "CIS 451 - Computer Programming Certificate",
+    "CIS 454 - Web Development Certificate",
+    "CIS 460 - Networking and Systems Administration, A.A.S.",
+    "CIS 460 Electives",
+    "CIS 467 - Network Administration Certificate",
+    "CIS 480 - Network Security Specialist Certificate",
+    "CIS 484 - Cybersecurity Specialist Certificate",
+    "Cisco Network Associate (CCNA), Certificate of Completion",
+    "CISCO Networking Certificate",
+    "CIT CCNA, Certificate — Associate in Applied Science",
+    "CIT Network Associate Security, Certificate — Associate in Applied Science",
+    "CIT Networking Professional, Certificate — Associate in Applied Science",
+    "Civil Engineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Clinical Medical Assisting Certificate",
+    "CMA Professional Certification",
+    "CNC Job Readiness, Certificate — Associate in Applied Science",
+    "CNC Machine Tool Operator, Certificate",
+    "CNC Operations, Certificate — Associate in Applied Science",
+    "CNC Operator Level I Certificate",
+    "CNC Operator Level II Certificate",
+    "CNC Programmer Certificate",
+    "Co-occurring Disorders, Certificate — Associate in Applied Science",
+    "Commercial Air Conditioning I Certificate",
+    "Commercial Air Conditioning II Certificate",
+    "Commercial Electrical Maintenance • Associate in Applied Science",
+    "Commercial Electrical Maintenance • Certificate of Completion",
+    "Commercial Heating and Air Conditioning I Certificate",
+    "Commercial Heating II Certificate",
+    "Commercial Pilot Certificate",
+    "Commercial Refrigeration Certificate",
+    "Communication - Transfer, A.A.",
+    "Communication • Associate in Arts",
+    "Communication Sample Transfer Pathway",
+    "Communication, A.A. - Media Communication Concentration",
+    "Communication, A.A. - Public and Professional Communication Concentration",
+    "Communications - 9 Credit Hours",
+    "CompTIA A+ and Network+ PC Technician, Certificate — Associate in Applied Science",
+    "Computed Tomography (CT), Certificate — Associate in Applied Science",
+    "Computer Aided Design and Drafting, A.A.S.",
+    "Computer Aided Design Technology Program (CAD)",
+    "Computer and Information Technology, A.A.S. — Associate in Applied Science",
+    "Computer and Internetworking Technologies, Certificate — Associate in Applied Science",
+    "Computer Electronics Technology, A.A.S.",
+    "Computer Engineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Computer Forensics Certificate",
+    "Computer Foundations Certificate",
+    "Computer Graphic Technology, AAS",
+    "Computer Graphic Technology, Advanced Certificate",
+    "Computer Graphic Technology, Certificate I",
+    "Computer Graphic Technology, Certificate II",
+    "Computer Information Systems, A.S.",
+    "Computer Network Support Specialist Certificate",
+    "Computer Network Support Specialist, Certificate of Achievement",
+    "Computer Numerical Control, Certificate of Completion",
+    "Computer Programming, A.A.S.",
+    "Computer Programming, Certificate",
+    "Computer Science • Associate in Arts",
+    "Computer Science • Certificate of Achievement",
+    "Computer Science Pathway",
+    "Computer Science-Technical Emphasis, A.A.",
+    "Computer Science, A.S.",
+    "Computer Service Technician Certificate (CRT)",
+    "Computer Systems • Associate in Applied Science",
+    "Computer-Aided Design, Certificate — Associate in Applied Science",
+    "Computer-Aided Drafting Certificate",
+    "Computers in Business Certificate",
+    "Construction Design and Management Certificate",
+    "Construction Management • Associate in Applied Science",
+    "Construction Management Certificate",
+    "Construction Management, A.A.S.",
+    "Construction Management, A.A.S. — Associate in Applied Science",
+    "Construction Management, AAS",
+    "Construction Management, Certificate — Associate in Applied Science",
+    "Construction Project Management, Certificate of Completion",
+    "Construction Technologies • Certificate of Achievement",
+    "Construction Trade Technology, A.A.S.",
+    "Consumer Marketing, Certificate — Associate in Applied Science",
+    "Corrections Counseling, Certificate — Associate in Applied Science",
+    "Cosmetology, A.A.S. — Associate in Applied Science",
+    "Cosmetology, Certificate — Associate in Applied Science",
+    "Courses Approved for Transfer",
+    "CPA Professional Certification",
+    "Creative Writing, Certificate — Associate in Applied Science",
+    "Credit for Prior Learning | Early Childhood Education",
+    "Crime, Criminals, and Corrections, Certificate",
+    "Criminal Justice",
+    "Criminal Justice - Law Enforcement, AAS",
+    "Criminal Justice • Associate in Applied Science",
+    "Criminal Justice • Associate in Arts",
+    "Criminal Justice Certificate",
+    "Criminal Justice Education, A.A.",
+    "Criminal Justice Sample Transfer Pathway",
+    "Criminal Justice Services, A.A.S.",
+    "Criminal Justice Transfer Pathway, A.A. — Associate in Applied Science",
+    "Criminal Justice, A.A.",
+    "Criminal Justice, A.A.S. — Associate in Applied Science",
+    "Criminal Justice, AA",
+    "Criminal Justice, AAS",
+    "CRJ 208 - Traffic Investigations Certificate",
+    "CRJ 214 - Criminal Investigations Certificate",
+    "CRJ 217 - Law for Policing Certificate",
+    "CRJ 218 - Crime Scene Processing Certificate",
+    "CRJ 223 - Criminal Justice Management Certificate",
+    "CRJ 224 - Social Role of Law Enforcement Certificate",
+    "CRJ 228 - Criminal Justice - General, A.A.S.",
+    "CRJ 350 Criminal Justice - Forensic Tech, A.A.S.",
+    "Culinary Arts • Associate in Applied Science",
+    "Culinary Arts Management, A.A.S.",
+    "Culinary Arts, A.A.S. — Associate in Applied Science",
+    "Culinary Arts, Certificate",
+    "Culinary Arts, Certificate — Associate in Applied Science",
+    "Culinary Management, AAS",
+    "Culinary Manager • Certificate of Achievement",
+    "Culinology and Food Science, A.A.S. — Associate in Applied Science",
+    "Cultivation • Certificate of Completion",
+    "Customer Service Certificate",
+    "Customer Service, Certificate of Completion",
+    "Cybersecurity • Certificate of Achievement",
+    "Cybersecurity and Defense, A.A.S. — Associate in Applied Science",
+    "Cybersecurity Specialist, Certificate — Associate in Applied Science",
+    "Cybersecurity Specialist, Certificate of Achievement",
+    "Cybersecurity, A.A.S.",
+    "Dance Transfer Pathway, A.A. — Associate in Applied Science",
+    "Data Analytics, Certificate — Associate in Applied Science",
+    "Data Systems and Development, A.A.S.",
+    "Database Foundation Certificate",
+    "Database, Certificate — Associate in Applied Science",
+    "Dental Assisting",
+    "Dental Hygiene",
+    "Dental Hygiene, A.A.S.",
+    "Dental Hygiene, A.A.S. — Associate in Applied Science",
+    "Developmental Disabilities, Certificate — Associate in Applied Science",
+    "Diagnostic Medical Imaging Radiography, A.A.S. — Associate in Applied Science",
+    "Diagnostic Medical Imaging Sonography (Ultrasound), Certificate — Associate in Applied Science",
+    "Diagnostic Medical Imaging Sonography, A.A.S. — Associate in Applied Science",
+    "Diagnostic Medical Sonography, A.A.S.",
+    "Diagnostic Medical Sonography, AAS",
+    "Diagnostic Medical Vascular Sonography, Certificate — Associate in Applied Science",
+    "Diesel Maintenance Specialist, Certificate of Completion",
+    "Diesel Mechanic, Certificate",
+    "Diesel Power Equipment Technology, A.A.S.",
+    "Digital and Social Media Marketing, Certificate — Associate in Applied Science",
+    "Digital Broadcast Journalism, A.A.S. — Associate in Applied Science",
+    "Digital Marketing, Certificate",
+    "Digital Media and Animation Certificate",
+    "Digital Media and Animation, AAS",
+    "Digital Media Production, A.A.S.",
+    "Digital Media Production, Certificate of Achievement",
+    "Digital Media, A.A.S.",
+    "Digital Photography, Certificate — Associate in Applied Science",
+    "Digital Streaming & Broadcast Media",
+    "Dimensional Metrology, Certificate of Completion",
+    "DPT426 - Diesel Power Technology, A.A.S.",
+    "DPT429 - Diesel Power/Equipment Repair Certificate",
+    "Drafting and Design",
+    "Drafting/Design, Certificate — Associate in Applied Science",
+    "Drivelines, Certificate",
+    "Early Childhood Administration, A.A.S. — Associate in Applied Science",
+    "Early Childhood Care and Education • Associate in Applied Science",
+    "Early Childhood Education - Paraprofessional, AAS",
+    "Early Childhood Education - Teaching Assistant, AAS",
+    "Early Childhood Education - Teaching Assistant, Certificate",
+    "Early Childhood Education - Transfer, A. A.",
+    "Early Childhood Education – Director/Administrator Option, AAS",
+    "Early Childhood Education • Associate in Arts",
+    "Early Childhood Education and Care Administrator, Certificate — Associate in Applied Science",
+    "Early Childhood Education and Care Advanced, Certificate — Associate in Applied Science",
+    "Early Childhood Education and Care, A.A.S. — Associate in Applied Science",
+    "Early Childhood Education and Care, Certificate — Associate in Applied Science",
+    "Early Childhood Education Certificate",
+    "Early Childhood Education Credential Level II • Certificate of Completion",
+    "Early Childhood Education Credential Level III • Certificate of Completion",
+    "Early Childhood Education Degree (ECE)",
+    "Early Childhood Education Infant - Toddler Level, Certificate",
+    "Early Childhood Education Level Four Credential, Certificate",
+    "Early Childhood Education Level Four Transfer Pathway",
+    "Early Childhood Education Level Three Credential, Certificate",
+    "Early Childhood Education Level Three Transfer Pathway",
+    "Early Childhood Education Level Two Credential, Certificate",
+    "Early Childhood Education Level Two Transfer Pathway",
+    "Early Childhood Education Pathway Electives",
+    "Early Childhood Education-Level ll Certificate",
+    "Early Childhood Education-Level lll Certificate",
+    "Early Childhood Education, A.A.S.",
+    "Early Childhood Education, AAS",
+    "Early Childhood Education, Advanced Certificate",
+    "Early Elementary Education, A.A.",
+    "Early Elementary Education, A.S.",
+    "ECE 259 - Early Childhood Education A.A.S.",
+    "ECE 475 - Gateways ECE Level 2 Certificate",
+    "ECE 477 - Gateways ECE Level 3 Certificate",
+    "Echocardiography, AAS",
+    "Ecological Restoration, Certificate — Associate in Applied Science",
+    "Economics Sample Transfer Pathway",
+    "Economics Transfer Pathway, A.A. — Associate in Applied Science",
+    "Economics Transfer Pathway, A.S. — Associate in Applied Science",
+    "Education",
+    "Education - Early Childhood Education, A.A.",
+    "Education - Elementary Education, A.A.",
+    "Education - Secondary Education, A.A.",
+    "Education Transfer Pathway, A.A. — Associate in Applied Science",
+    "Electric Vehicle Technology, Certificate",
+    "Electric Vehicle Technology, Certificate — Associate in Applied Science",
+    "Electrical Distribution Lineman • Associate in Applied Science",
+    "Electrical Distribution Lineman Maintenance • Certificate of Achievement",
+    "Electrical Engineering Technology, AAS",
+    "Electrical Engineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Electrical Inside Wireman Concentration Certificate",
+    "Electrical Troubleshooting Certificate",
+    "Electrical/Electronic Automated Systems Technology, A.A.S.",
+    "Electrical/Electronics, Certificate of Completion",
+    "Electrician Apprenticeship, A.A.S. — Associate in Applied Science",
+    "Electrician Foundations Certificate",
+    "Electrician’s Preparation, Certificate — Associate in Applied Science",
+    "Electro-Mechanical Technology, A.A.S. — Associate in Applied Science",
+    "Electronic Control Systems Technology, A.A.S.",
+    "Electronic Power Certificate",
+    "Electronic Records Management Certificate (ERM)",
+    "Electronic Technician, Certificate",
+    "Electronics Engineering Technology, A.A.S.",
+    "Electronics Engineering Technology, A.A.S. — Associate in Applied Science",
+    "Electronics Engineering Technology, Certificate of Achievement",
+    "Electronics Technology, Certificate — Associate in Applied Science",
+    "Elementary Education - Transfer, A.A.",
+    "Elementary Education • Associate in Arts",
+    "Elementary Education Sample Transfer Pathway",
+    "Elementary Education, A.A.",
+    "Elementary Education, A.S.",
+    "Elementary Education, AA",
+    "Emergency Dispatcher Certificate",
+    "Emergency Medical Responder • Certificate of Completion",
+    "Emergency Medical Services • Associate in Applied Science",
+    "Emergency Medical Services, A.A.S.",
+    "Emergency Medical Services, A.A.S. — Associate in Applied Science",
+    "Emergency Medical Technician – Basic (EMT-B), Certificate",
+    "Emergency Medical Technician – Paramedic (EMT-P), Advanced Certificate",
+    "Emergency Medical Technician (EMT) Certificate",
+    "Emergency Medical Technician • Certificate of Completion",
+    "Emergency Medical Technician Certificate",
+    "Emergency Medical Technician, Certificate — Associate in Applied Science",
+    "EMS 456 - EMS Paramedic, A.A.S.",
+    "EMS 457 - Paramedic Certificate",
+    "EMS 458 - EMT Certificate",
+    "EMS Paramedic, A.A.S.",
+    "EMS Paramedic/Basic Operations Firefighter, A.A.S.",
+    "EMT Basic, Certificate of Completion",
+    "Energy Audit and Analysis, Certificate — Associate in Applied Science",
+    "Energy Audit Certificate",
+    "Energy Audit Flow, Certificate",
+    "Energy Audit, Advanced Certificate",
+    "Energy Audit, Certificate",
+    "Engineering - Transfer, A.S.",
+    "Engineering Sample Transfer Pathway",
+    "Engineering Science, A.E.S.",
+    "Engineering Technology, AAS",
+    "Engineering, A.S.",
+    "Engineering, AES",
+    "English - Transfer, A.A.",
+    "English (Literature), A.A.",
+    "English as a Second Language",
+    "English Elective",
+    "English Sample Transfer Pathway",
+    "English Transfer Pathway, A.A. — Associate in Applied Science",
+    "English, AA",
+    "English/Literature, A.A.",
+    "Enterprise System Administrator, Certificate — Associate in Applied Science",
+    "Entertainment Technology Certificate",
+    "Entertainment Technology, A.A.S.",
+    "Entrepreneur Basics Certificate",
+    "Entrepreneurship • Certificate of Achievement",
+    "Entrepreneurship Certificate",
+    "Entrepreneurship, Certificate",
+    "Entrepreneurship, Certificate — Associate in Applied Science",
+    "Entrepreneurship, Certificate of Completion",
+    "Entry Level Automotive Service Technology, Certificate — Associate in Applied Science",
+    "Entry Level HVACR, Certificate — Associate in Applied Science",
+    "Entry Level Welder, Certificate of Completion",
+    "Environmental Horticulture, A.A.S.",
+    "Environmental Science",
+    "EST 450 - Esthetics Certificate",
+    "Executive Assistant, A.A.S. — Associate in Applied Science",
+    "Exercise Science",
+    "Exercise Science, AA",
+    "Exercise Specialist Certificate",
+    "Exploring Earth Science Transfer Pathway, A.S. — Associate in Applied Science",
+    "Eye Care Assistant, Certificate — Associate in Applied Science",
+    "Facility Maintenance Mechanic, A.A.S. — Associate in Applied Science",
+    "Family Child Care Provider, Certificate — Associate in Applied Science",
+    "Fashion Design, A.A.S. — Associate in Applied Science",
+    "Fashion Design, Certificate — Associate in Applied Science",
+    "Fashion Entrepreneurship, Certificate — Associate in Applied Science",
+    "Fashion Merchandising, A.A.S. — Associate in Applied Science",
+    "Fashion Merchandising, Certificate — Associate in Applied Science",
+    "FCAW - Flux Core Arc Welding, Occupational Certificate",
+    "Film/Video Production, A.A.S. — Associate in Applied Science",
+    "Fire and Emergency Services Professional, A.A.S",
+    "Fire Apparatus Engineer • Certificate of Completion",
+    "Fire EMT, Certificate of Completion",
+    "Fire Fighter, Certificate — Associate in Applied Science",
+    "Fire Prevention Principles • Certificate of Completion",
+    "Fire Science",
+    "Fire Science and EMS, A.A.S.",
+    "Fire Science Technology • Associate in Applied Science",
+    "Fire Science Technology Degree (FST)",
+    "Fire Science Technology, A.A.S.",
+    "Fire Science Technology, A.A.S. — Associate in Applied Science",
+    "Fire Science, AAS",
+    "Fire Service Instructor I • Certificate of Completion",
+    "Fire Service Instructor II • Certificate of Completion",
+    "Fire Service Technology, A.A.S.",
+    "Fire Service Vehicle Operator • Certificate of Completion",
+    "Firefighter Basic Certificate",
+    "First Cook • Certificate of Completion",
+    "Flight Technology, A.A.S. - Drone Pilot Track",
+    "Flight Technology, A.A.S. - Professional Pilot Track",
+    "Floral Design, Certificate of Completion",
+    "Floral Shop Management, Certificate — Associate in Applied Science",
+    "Food Preparation, Certificate of Completion",
+    "French Sample Transfer Pathway",
+    "French Transfer Pathway, A.A. — Associate in Applied Science",
+    "Front End Development Certificate",
+    "Full Stack Developer, Certificate of Completion",
+    "Game 3D Modeling, Certificate — Associate in Applied Science",
+    "Game Animation, Certificate — Associate in Applied Science",
+    "Game Audio Engineer, Certificate — Associate in Applied Science",
+    "Game Design and Development, A.A.S.",
+    "Game Design and Development, Certificate of Achievement",
+    "Game Design, Certificate — Associate in Applied Science",
+    "Game Development, A.A.S. — Associate in Applied Science",
+    "Game Narrative Design, Certificate — Associate in Applied Science",
+    "Game Programming, Certificate — Associate in Applied Science",
+    "Gastronomy and Marketing in Hospitality, Certificate — Associate in Applied Science",
+    "GECC 110 - General Education Core Curriculum Credential",
+    "GECC Credential",
+    "GECC, Certificate",
+    "General Education Core Curriculum",
+    "General Education Core Curriculum (GECC), Certificate",
+    "General Education Core Curriculum Certificate",
+    "General Education Courses - Occupational Degrees",
+    "General Math/Science, A.S.",
+    "General Programming Certificate",
+    "General Studies, AGS",
+    "General Technician, Certificate",
+    "General Transfer, AA",
+    "General Transfer, AS",
+    "Geographic Information Systems (GIS) • Certificate of Completion",
+    "Geographic Information Systems, Certificate — Associate in Applied Science",
+    "Geography • Associate in Arts",
+    "Geography Sample Transfer Pathway",
+    "Geography Transfer Pathway, A.A. — Associate in Applied Science",
+    "Geology Sample Transfer Pathway",
+    "Geology Transfer Pathway, A.S. — Associate in Applied Science",
+    "Geology, A.S.",
+    "German Sample Transfer Pathway",
+    "German Transfer Pathway, A.A. — Associate in Applied Science",
+    "Global Supply Chain, Certificate",
+    "GMAW - Gas Metal Arc Welding, Occupational Certificate",
+    "Google IT Support Professional Certificate",
+    "Graphic Design",
+    "Graphic Design Certificate",
+    "Graphic Design Foundation, Certificate — Associate in Applied Science",
+    "Graphic Design, A.A.S.",
+    "Graphic Design, A.A.S. — Associate in Applied Science",
+    "Graphic Design, AAS",
+    "Graphic Design, Certificate of Achievement",
+    "Greenhouse Management, Certificate — Associate in Applied Science",
+    "Greenhouse Operations, Certificate of Completion",
+    "GS 350 - Associate in General Studies",
+    "GTAW - Gas Tungsten Arc Welding, Occupational Certificate",
+    "Hazardous Materials for the First Responder • Certificate of Completion",
+    "Health Care Office Assistant, Certificate — Associate in Applied Science",
+    "Health Information & Medical Coding",
+    "Health Information Management Technology, A.A.S.",
+    "Health Information Management, AAS",
+    "Health Information Technology, AAS",
+    "Healthcare Assistant, Certificate",
+    "Hearing Instrument Dispensary Program, Certificate — Associate in Applied Science",
+    "Heating Systems, Certificate",
+    "Heating, Air Conditioning and Refrigeration Service Technician, A.A.S. — Associate in Applied Science",
+    "Heating, Ventilation and Air Conditioning, A.A.S.",
+    "Heating, Ventilation and Air Conditioning, Certificate of Achievement",
+    "Heating, Ventilation, and Air Conditioning AAS",
+    "Help Desk • Certificate of Completion",
+    "Help Desk Specialist Certificate",
+    "Help Desk Technician, AAS",
+    "High School or Middle School Education, A.A.",
+    "High School or Middle School Education, A.S.",
+    "History - Transfer, A.A.",
+    "History Sample Transfer Pathway",
+    "History Transfer Pathway, A.A. — Associate in Applied Science",
+    "History, A.A.",
+    "History, AA",
+    "HIT 274 - Medical Billing and Coding Certificate",
+    "HOR 227 - Floral Horticulture Certificate",
+    "HOR 238 - Landscape Design/Construction Certificate",
+    "HOR 241 - Greenhouse/Garden Center Certificate",
+    "HOR 290 - Foundations in Horticulture Certificate",
+    "HOR 401 - Horticulture, A.A.S.",
+    "HOR 420 - Cannabis & Hemp Cultivation Certificate",
+    "HOR 430 - Turf & Grounds Management Certificate",
+    "Horticultural Therapy, Certificate — Associate in Applied Science",
+    "Horticulture and Cultivation • Associate in Applied Science",
+    "Horticulture Basics Certificate",
+    "Horticulture Certificate",
+    "Horticulture Landscape Contracting Option, A.A.S.",
+    "Horticulture Landscaping, Certificate of Completion",
+    "Horticulture Production, Certificate of Achievement",
+    "Horticulture, A.A.S. — Associate in Applied Science",
+    "Horticulture, AAS",
+    "Horticulture, Advanced Certificate",
+    "Horticulture, Certificate",
+    "Horticulture, Certificate — Associate in Applied Science",
+    "HOS 325 - Hospitality Management, A.A.S.",
+    "HOS 420 - Foundations of Culinary Arts Certificate",
+    "Hospitality - Transfer, A.A.",
+    "Hospitality Foundations, Certificate — Associate in Applied Science",
+    "Hospitality Management • Associate in Applied Science",
+    "Hospitality Management Operations, Certificate — Associate in Applied Science",
+    "Hospitality Management, A.A.S.",
+    "Hospitality Management, A.A.S. — Associate in Applied Science",
+    "Hospitality Management, Certificate of Completion",
+    "Hospitality Operations, Certificate",
+    "Hospitality Professional • Certificate of Completion",
+    "Hospitality Sales and Marketing, Certificate — Associate in Applied Science",
+    "Hospitality Supervisor• Certificate of Achievement",
+    "Hotel Management, Certificate of Completion",
+    "Human Resource Management (HRM), Certificate — Associate in Applied Science",
+    "Human Resource Management, Certificate",
+    "Human Resources Management Certificate",
+    "Human Resources Management, Certificate of Achievement",
+    "Human Resources Management, Certificate of Completion",
+    "Human Services",
+    "Human Services Domestic/Family Violence, Certificate — Associate in Applied Science",
+    "Human Services Generalist, A.A.S.",
+    "Human Services Generalist, Certificate — Associate in Applied Science",
+    "Human Services Professional, Certificate of Completion",
+    "Human Services Specialist, Certificate of Achievement",
+    "Human Services, A.A.S. — Associate in Applied Science",
+    "Humanities and Fine Arts - 6 Credit Hours (A.S.)",
+    "Humanities and Fine Arts - 9 Credit Hours (A.A.)",
+    "HVAC Technician Certificate",
+    "HVAC/R Service, Advanced Certificate",
+    "HVACR Contractor, A.A.S. — Associate in Applied Science",
+    "Hybrid & Electric Vehicle Specialist, Certificate of Completion",
+    "IAI Elective",
+    "IAI Fine Arts",
+    "IAI Fine Arts or Humanities",
+    "IAI General Education Core Requirements",
+    "IAI Humanities",
+    "IAI Life Sciences",
+    "IAI Mathematics",
+    "IAI Physical and Life Sciences Electives",
+    "IAI Physical Sciences",
+    "IAI Social and Behavioral Sciences",
+    "Income Tax Preparer, Certificate — Associate in Applied Science",
+    "Industrial Controls and Automation, Certificate — Associate in Applied Science",
+    "Industrial Electrical Engineering Technology, Advanced Certificate",
+    "Industrial Electrical/Electronics, Certificate of Achievement",
+    "Industrial Electrician, Industrial Electrician Option, A.A.S.",
+    "Industrial Electrician, Solar Photovoltaic Technician Option, A.A.S.",
+    "Industrial Electrician, Wind Turbine Technician Option, A.A.S.",
+    "Industrial Electricity",
+    "Industrial Engineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Industrial Machining Certificate",
+    "Industrial Maintenance Technician Certificate",
+    "Industrial Maintenance Technology Certificate",
+    "Industrial Maintenance Technology, A.A.S.",
+    "Industrial Maintenance Technology, Certificate of Achievement",
+    "Industrial Maintenance Technology, Certificate of Completion",
+    "Industrial Maintenance, Certificate — Associate in Applied Science",
+    "Industrial Management and Technology, AAS",
+    "Industrial Mechanic, A.A.S.",
+    "Industrial Mechanics Certificate",
+    "Industrial Motor Control, Certificate",
+    "Industrial Supervision Certificate",
+    "Industrial Technology: Machine Tools, A.A.S.",
+    "Industrial Technology: Maintenance and Automation, A.A.S.",
+    "Industrial Technology: Welding, A.A.S.",
+    "Industrial Welding Certificate",
+    "Infant Toddler and Two’s Educator, Certificate of Achievement",
+    "Infant, Toddler and Two-Year Old Child Care, Certificate — Associate in Applied Science",
+    "Information Security Analyst Certificate",
+    "Information Technology",
+    "Information Technology Cyber Defense Option, A.A.S.",
+    "Information Technology Cyber Systems Option, A.A.S.",
+    "Information Technology Networking Option, A.A.S.",
+    "Information Technology Professional, Certificate",
+    "Information Technology Programming Option, A.A.S.",
+    "Information Technology Specialist, Advanced Certificate",
+    "Information Technology Support Specialist, A.A.S.",
+    "Information Technology Web Option, A.A.S.",
+    "Information Technology, AAS",
+    "Injection Molding Process Technician Certificate",
+    "Instrument Rating Certificate",
+    "Instrumentation and Process Control, Advanced Certificate",
+    "Integrated Maintenance, Certificate of Completion",
+    "Integrated Mechatronics and Manufacturing Technology, A.A.S. — Associate in Applied Science",
+    "Interactive Media, A.A.S. — Associate in Applied Science",
+    "Interactive Web Developer, Certificate",
+    "Interdisciplinary Studies Transfer Pathway, A.A. — Associate in Applied Science",
+    "Interior Design Computer Applications, Certificate — Associate in Applied Science",
+    "Interior Design Lighting, Certificate — Associate in Applied Science",
+    "Interior Design, A.A.S. — Associate in Applied Science",
+    "Intermediate Manufacturing Industrial Maintenance, Advanced Certificate",
+    "Intermediate Manufacturing Machine Tool, Advanced Certificate",
+    "Intermediate Manufacturing TWDL, Advanced Certificate",
+    "Intermediate Manufacturing Welding, Advanced Certificate",
+    "Intermediate-Level Welding • Certificate of Completion",
+    "International Content Course List",
+    "International Studies Milestone",
+    "Internet of Things (IoT) Proficiency, Certificate — Associate in Applied Science",
+    "Introduction to Graphic Design Certificate",
+    "Investigation and Organization, Certificate",
+    "iOS Developer Proficiency, Certificate — Associate in Applied Science",
+    "iOS Development with Integrated AI Certificate",
+    "Ironworkers Concentration Certificate",
+    "IT Automation and Security, Certificate of Completion",
+    "IT Computer Support Certificate of Completion",
+    "IT Support Specialist Certificate",
+    "Italian Transfer Pathway, A.A. — Associate in Applied Science",
+    "Japanese Transfer Pathway, A.A. — Associate in Applied Science",
+    "JAVA Language Proficiency, Certificate — Associate in Applied Science",
+    "Java Software Developer, Certificate",
+    "Kinesiology and Fitness Transfer Pathway, A.A. — Associate in Applied Science",
+    "Kinesiology and Fitness Transfer Pathway, A.S. — Associate in Applied Science",
+    "Kinesiology and Health Studies, AAS",
+    "Kinesiology, A.S. - Athletic Training/Therapeutic Pathway Concentration",
+    "Kinesiology, A.S. - Exercise Physiology Concentration",
+    "Kinesiology, A.S. - Sports Management Concentration",
+    "Kinesiology, A.S. - Teaching/Coaching Concentration",
+    "Kitchen and Bath Design, Certificate — Associate in Applied Science",
+    "Korean Transfer Pathway, A.A. — Associate in Applied Science",
+    "Laborers Concentration Certificate",
+    "Land Surveying Certificate",
+    "Land Surveying Technician Certificate",
+    "Land Surveying, A.A.S.",
+    "Landscape and Turf Maintenance, Certificate — Associate in Applied Science",
+    "Landscape and Urban Horticulture Certificate",
+    "Landscape and Urban Horticulture, A.A.S.",
+    "Landscape Contracting and Management, A.A.S. — Associate in Applied Science",
+    "Landscape Design and Construction, Certificate — Associate in Applied Science",
+    "Landscaping, Certificate of Achievement",
+    "Law Enforcement, A.A.S.",
+    "Law Enforcement, AAS",
+    "Law Enforcement, Advanced Certificate",
+    "Laws and Evidentiary Procedures, Certificate",
+    "Legal Administrative Assistant, Certificate — Associate in Applied Science",
+    "Legal Studies, A.A.S. — Associate in Applied Science",
+    "Legal Studies, AAS",
+    "Level 1 Nursing, Certificate",
+    "Liberal Arts and Sciences, A.A.",
+    "Liberal Arts, A.A.",
+    "Library and Information Technology, A.A.S. — Associate of Applied Science",
+    "Library and Information Technology, Certificate — Associate in Applied Science",
+    "Library Technical Assistant, Certificate of Completion",
+    "Licensed Practical Nurse Certificate (NPN)",
+    "Linux Administration Certificate",
+    "LINUX, Certificate — Associate in Applied Science",
+    "Local Foods, Certificate",
+    "Long-Term Care Administration, Certificate — Associate in Applied Science",
+    "LPN to ADN Transition",
+    "LPN to RN Bridge Program, Sample Transfer Pathway",
+    "MA 408 - Medical Assistant Certificate",
+    "Machine Learning, Certificate — Associate in Applied Science",
+    "Machine Tool Operations, Certificate",
+    "Machine Tool Technology, Advanced Certificate",
+    "Machinery Maintenance Certificate",
+    "Magnetic Resonance Imaging Advanced Certificate — Associate in Applied Science",
+    "Maintenance Mechanic, Advanced Certificate",
+    "Maintenance Mechanic, Certificate",
+    "Maintenance Welding, Certificate",
+    "Major Elective (COM, HUM, THE)",
+    "Major Elective for A.A. in ANT, PLS, PSY, or SOC",
+    "Major Elective for AS in ANT, GEO, PSY, or SOC",
+    "Mammography, Certificate — Associate in Applied Science",
+    "Management",
+    "Management • Certificate of Completion",
+    "Management and Supervision, A.A.S.",
+    "Management and Supervision, Certificate of Achievement",
+    "Management Information Systems A.A.S.",
+    "Management Information Systems, Certificate of Achievement",
+    "Management Skills Certificate",
+    "Management, A.A.S.",
+    "Management, A.A.S. — Associate in Applied Science",
+    "Management, Certificate",
+    "Management, Certificate — Associate in Applied Science",
+    "Manual Machining Certificate",
+    "Manufacturing Engineering Technology CAD, AAS",
+    "Manufacturing Engineering Technology, A.A.S. — Associate in Applied Science",
+    "Manufacturing Essentials Certificate",
+    "Manufacturing Industrial Maintenance I, Certificate",
+    "Manufacturing Industrial Maintenance II, Advanced Certificate",
+    "Manufacturing Logistics, Certificate",
+    "Manufacturing Machine Tool II, Advanced Certificate",
+    "Manufacturing Production, Certificate",
+    "Manufacturing Skills Standards, Certificate — Associate in Applied Science",
+    "Manufacturing Technology Drafting/Design, A.A.S. — Associate in Applied Science",
+    "Manufacturing Technology, A.A.S.",
+    "Manufacturing Technology, A.A.S. — Associate in Applied Science",
+    "Manufacturing Technology, AAS",
+    "Manufacturing Technology, Certificate — Associate in Applied Science",
+    "Manufacturing Technology: Machine Tool I, Certificate",
+    "Manufacturing Technology: Welding II, Advanced Certificate",
+    "Manufacturing Transportation, Warehousing, Distribution and Logistics I, Certificate",
+    "Manufacturing Transportation, Warehousing, Distribution and Logistics II, Advanced Certificate",
+    "Manufacturing Welding I, Certificate",
+    "Marketing Certificate",
+    "Marketing Management Certificate",
+    "Marketing, A.A.S.",
+    "Marketing, A.A.S. — Associate in Applied Science",
+    "Marketing, AAS",
+    "Marketing, Certificate — Associate in Applied Science",
+    "Mass Communication, AA",
+    "Master Automotive Service Technology Advanced Certificate — Associate in Applied Science",
+    "Master Automotive Service Technology, A.A.S. — Associate in Applied Science",
+    "Mathematics - 3 Credit Hours (A.A.)",
+    "Mathematics - 6-9 Credit Hours (A.S.)",
+    "Mathematics - Transfer, A.S.",
+    "Mathematics Sample Transfer Pathway",
+    "Mathematics Transfer Pathway, A.A. and A.S. — Associate in Applied Science",
+    "Mathematics, A.A.",
+    "Mathematics, A.S.",
+    "Mathematics, AS",
+    "Mechanical Design Certificate",
+    "Mechanical Engineering Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Mechanical Maintenance, Certificate — Associate in Applied Science",
+    "Mechanical Production Technology Machine Tool Metalworking, A.A.S.",
+    "Mechanical Production Technology Machine Tool Metalworking, Certificate of Completion",
+    "Mechanical Production Technology, Certificate of Achievement",
+    "Mechatronics Technology (MET), Certificate — Associate in Applied Science",
+    "Media and Communication Arts: Advertising/Public Relations, A.A.",
+    "Media and Communication Arts: Communication Studies, A.A.",
+    "Media and Communication Arts: Multimedia, A.A.",
+    "Media and Communication Arts: Radio/TV/Film, A.A.",
+    "Media Arts and Production, A.A.S.",
+    "Media Journalism Sample Transfer Pathway",
+    "Media Literacy, Journalism, and Production, Certificate — Associate in Applied Science",
+    "Media Production Certificate",
+    "Medical Administration Certificate",
+    "Medical Assistant, A.A.S. — Associate in Applied Science",
+    "Medical Assistant, Certificate — Associate in Applied Science",
+    "Medical Assisting",
+    "Medical Assisting Certificate",
+    "Medical Assisting, Certificate of Achievement",
+    "Medical Billing and Coding Certificate",
+    "Medical Billing, Certificate — Associate in Applied Science",
+    "Medical Coding Specialist, Certificate of Achievement",
+    "Medical Coding, Certificate",
+    "Medical Laboratory Assistant, Certificate",
+    "Medical Laboratory Technology Advanced Placement Sequence (Option 1)",
+    "Medical Laboratory Technology, AAS",
+    "Medical Office Support Certificate (MOS)",
+    "Medical Office, Certificate — Associate in Applied Science",
+    "Meeting and Event Planning, A.A.S. — Associate in Applied Science",
+    "Meeting and Event Planning, Certificate — Associate in Applied Science",
+    "Meeting and Special Event Planning, A.A.S.",
+    "Meeting and Special Event Planning, Certificate of Achievement",
+    "Mental Health Certificate",
+    "Mental Health Technician, Certificate",
+    "Meteorology Sample Transfer Pathway",
+    "Meteorology Transfer Pathway, A.S. — Associate in Applied Science",
+    "Microsoft Administration Certificate",
+    "Microsoft Office Certificate (DMO)",
+    "Microsoft Office Specialist, Certificate of Completion",
+    "Microsoft Skills Certificate",
+    "Microsoft Specialist Cert, Occupational Certificate",
+    "Millwright, Advanced Certificate",
+    "MM 218 - Marketing and Management, A.A.S.",
+    "MM 218 Electives",
+    "MM 405 - Bookkeeping Certificate",
+    "MM 409 - Supervision Basics Certificate",
+    "MM 411 - Organizational Leadership Certificate",
+    "MM or OS Electives",
+    "Modern Language",
+    "Mold Making, Certificate — Associate in Applied Science",
+    "Motion Picture/Television, Certificate — Associate in Applied Science",
+    "Multimedia Arts, A.A.S.",
+    "Music • Associate in Arts",
+    "Music Business, A.A.S. — Associate in Applied Science",
+    "Music Education, A.A.",
+    "Music Foundations, A.A. - Music Studies Concentration",
+    "Music Foundations, A.A. - Music Technology Concentration",
+    "Music Performance • Associate in Fine Arts",
+    "Music Performance, A.A.",
+    "Music Production",
+    "Music Production, A.A.S.",
+    "Music Technology, Certificate of Completion",
+    "Music, A.F.A. Music — Associate in Applied Science",
+    "Nail Technology, Certificate — Associate in Applied Science",
+    "Network Administration • Certificate of Completion",
+    "Network Administration and Support, A.A.S.",
+    "Network Security Foundation, Certificate of Completion",
+    "Network Security Specialist, Certificate of Achievement",
+    "Network Security, AAS",
+    "Networking and Cybersecurity, Certificate",
+    "Non-Invasive Electrocardiography Technician, Certificate — Associate in Applied Science",
+    "Nuclear Medicine Technology, Certificate — Associate in Applied Science",
+    "NUR 310 - Basic Nurse Assisting Certificate",
+    "Nurse Assistant Certificate",
+    "Nurse Assistant, Occupational Certificate",
+    "Nursery and Garden Center Management, Certificate — Associate in Applied Science",
+    "Nursery Operations, Certificate of Completion",
+    "Nursing (RN), A.A.S.",
+    "Nursing • Associate in Applied Science",
+    "Nursing Assistant Certificate (NUA)",
+    "Nursing Degree (NUR)",
+    "Nursing LPN-RN, AAS",
+    "Nursing Sample Transfer Pathway",
+    "Nursing, A.A.S.",
+    "Nursing, A.A.S. — Associate of Applied Science",
+    "Nursing: Associate Degree Nursing",
+    "Nursing: LPN Advanced Placement (LPN to ADN Bridge), A.A.S.",
+    "Nursing: Nurse Assistant",
+    "Nursing: Paramedic Advanced Placement (Paramedic to ADN Bridge), A.A.S.",
+    "Nursing: Practical Nursing",
+    "Occupational Therapy Assistant",
+    "Occupational Therapy Assistant, A.A.S.",
+    "Occupational Therapy Assistant, AAS",
+    "Office Assistant Certificate",
+    "Office Specialist Certificate",
+    "Office Technology Specialist, Certificate — Associate in Applied Science",
+    "Operations Engineering A.A.S.",
+    "Operations Engineering, Certificate of Achievement",
+    "Operations Technician, AAS",
+    "Operations Technician, Certificate of Achievement",
+    "Ophthalmic Technician, A.A.S. — Associate in Applied Science",
+    "Organizational Leadership Certificate",
+    "Organizational Leadership, Certificate — Associate in Applied Science",
+    "Orthotics and Prosthetics Technology, A.A.S.",
+    "Orthotics Technology, Certificate of Achievement",
+    "Paralegal",
+    "Paralegal Studies Certificate",
+    "Paralegal Studies, A.A.S.",
+    "Paralegal Studies, Certificate of Completion",
+    "Paralegal, Certificate — Associate in Applied Science",
+    "Paramedic • Certificate of Achievement",
+    "Paramedic Certificate",
+    "Paramedic, AAS",
+    "Paramedic, Certificate — Associate in Applied Science",
+    "Paramedicine",
+    "Paramedicine, A.A.S.",
+    "Paraprofessional Accountant, Certificate — Associate in Applied Science",
+    "Paraprofessional Educator/Teacher’s Aide, AAS",
+    "Paraprofessional Educator/Teacher's Aide, Advanced Certificate",
+    "Paraprofessional in Education, Certificate — Associate in Applied Science",
+    "Patient Care Technician, CCO",
+    "Patient Care Technician, Certificate — Associate in Applied Science",
+    "PC Support Technician, Certificate",
+    "PCIT, Certificate of Completion",
+    "Personal Fitness Training Certificate",
+    "Personal Trainer, Certificate — Associate in Applied Science",
+    "Personal Trainer, Certificate of Achievement",
+    "Pharmacy Technician",
+    "Pharmacy Technician, Certificate — Associate in Applied Science",
+    "Philosophy Sample Transfer Pathway",
+    "Philosophy Transfer Pathway, A.A. — Associate in Applied Science",
+    "Phlebotomy, Certificate",
+    "Phlebotomy, Certificate — Associate in Applied Science",
+    "Photographic Studies, A.A.S.",
+    "Photography Technology, A.A.S. — Associate in Applied Science",
+    "Photography Technology, Certificate — Associate in Applied Science",
+    "Photography, A.A.S.",
+    "Physical Education Teaching and Coaching Transfer Pathway, A.A. — Associate in Applied Science",
+    "Physical Education, A.A.",
+    "Physical Science, A.S. - Astronomy/Physics Concentration",
+    "Physical Science, A.S. - Chemistry Concentration",
+    "Physical Science, A.S. - Geology Concentration",
+    "Physical Science, A.S. - Meteorology Concentration",
+    "Physical Therapist Assistant, A.A.S. — Associate in Applied Science",
+    "Physical Therapist Assistant, AAS",
+    "Physician Coding, Certificate — Associate in Applied Science",
+    "Physics Sample Transfer Pathway",
+    "Physics Transfer Pathway, A.E.S. — Associate in Applied Science",
+    "Physics, A.S.",
+    "Physics, AS",
+    "Pipe Welding, Certificate",
+    "Pipe Welding, Occupational Certificate",
+    "Plumbers and Pipefitters Concentration Certificate",
+    "Pneumatic and Hydraulic Power, Certificate",
+    "Policing Certificate",
+    "Political Science Sample Transfer Pathway",
+    "Political Science Transfer Pathway, A.A. — Associate in Applied Science",
+    "Political Science, A.A.",
+    "Political Science, AA",
+    "Power Equipment and Technology, Certificate — Associate in Applied Science",
+    "Practical Nurse • Certificate of Achievement",
+    "Practical Nursing - Advanced Placement",
+    "Practical Nursing (PN), Certificate — Associate in Applied Science",
+    "Practical Nursing (PN), Certificate of Achievement",
+    "Practical Nursing Certificate",
+    "Practical Nursing, Advanced Certificate",
+    "Pre-Apprenticeship Welding Technician Certificate",
+    "Pre-Architecture Technology, A.A.S. — Associate in Applied Science",
+    "Pre-Architecture, Certificate — Associate in Applied Science",
+    "Pre-Clinical Laboratory Science, A.A.",
+    "Pre-Dentistry, A.A.",
+    "Pre-Health Professions, A.A.",
+    "Pre-Law, A.A.",
+    "Pre-Medicine, A.A.",
+    "Pre-Nursing Emphasis • Associate in Arts",
+    "Pre-Nursing Emphasis • Associate in Science",
+    "Pre-Nursing, A.A.",
+    "Pre-Occupational Therapy, A.A.",
+    "Pre-Pharmacy Transfer Pathway, A.S. — Associate in Applied Science",
+    "Pre-Pharmacy, A.S.",
+    "Pre-Physical Therapy, A.A.",
+    "Precision Ag Fundamentals Certificate",
+    "Precision Ag Technology Certificate",
+    "Precision Ag Technology, A.A.S.",
+    "Precision Agriculture, Certificate of Completion",
+    "Precision Agronomy and Custom Application • Associate in Applied Science",
+    "Precision Agronomy Operator • Certificate of Completion",
+    "Precision Machining, AAS",
+    "Prehospital Emergency Care, AAS",
+    "Private Pilot Certificate",
+    "Private Security, Certificate",
+    "Process Control Instrumentation, Certificate — Associate in Applied Science",
+    "Process Instrumentation Technology, A.A.S.",
+    "Process Operations Technology",
+    "Process Technology Solutions, Certificate",
+    "Production Technician Certificate",
+    "Production Welding Technician Certificate",
+    "Professional Selling Certificate",
+    "Professional Writing, Certificate — Associate in Applied Science",
+    "Programmable Logic Controllers in Automation, Certificate — Associate in Applied Science",
+    "Programmable Logic Controllers, Certificate",
+    "Prosthetics Technology, Certificate of Completion",
+    "Psychology Sample Transfer Pathway",
+    "Psychology Transfer Pathway, A.A. — Associate in Applied Science",
+    "Psychology, A.A.",
+    "Psychology, AA",
+    "Public Safety Telecommunicator, Certificate — Associate in Applied Science",
+    "Python Certificate",
+    "Python Language Proficiency, Certificate — Associate in Applied Science",
+    "Quality Engineering Technician Certificate",
+    "Quality Inspector, Certificate",
+    "Radiation Therapy, Certificate — Associate in Applied Science",
+    "Radiography, AAS",
+    "Radiologic Technology, A.A.S.",
+    "Radiologic Technology, AAS",
+    "Radiologic Technology: Computed Tomography Certificate",
+    "Radiologic Technology: Magnetic Resonance Imaging Certificate",
+    "Recovery Support Specialist, Certificate — Associate in Applied Science",
+    "Registered Nursing – Advanced Placement",
+    "Registered Nursing, AAS",
+    "Relationships and Juveniles, Certificate",
+    "Religious Studies Transfer Pathway, A.A. — Associate in Applied Science",
+    "Renewable Energy Technology, Certificate — Associate in Applied Science",
+    "Residential Air Conditioning Certificate",
+    "Residential and Industrial Wiring, Certificate",
+    "Residential Child Care, Certificate — Associate in Applied Science",
+    "Residential Heating and Air Conditioning Installation Certificate",
+    "Residential Heating Certificate",
+    "Resort Management, Certificate — Associate in Applied Science",
+    "Respiratory Care, A.A.S.",
+    "Respiratory Care, A.A.S. — Associate in Applied Science",
+    "Respiratory Therapist, AAS",
+    "Respiratory Therapist, Advanced Placement Sequence",
+    "Respiratory Therapy, AAS",
+    "Restaurant Management, A.A.S. — Associate in Applied Science",
+    "Restaurant Management, Certificate — Associate in Applied Science",
+    "Restaurant/Foodservice Management, Certificate of Completion",
+    "Restoration Ecology",
+    "Retail Associate, Certificate of Completion",
+    "Retail Business Management, Certificate of Achievement",
+    "Retail Marketing Specialist Certificate",
+    "Russian Transfer Pathway, A.A. — Associate in Applied Science",
+    "School-Age Child Care, Certificate — Associate in Applied Science",
+    "Secondary Education • Associate in Arts",
+    "Secondary Education, AA",
+    "Service Technician, Certificate — Associate in Applied Science",
+    "Sheet Metal Certificate",
+    "Shielded Metal Arc Welding • Certificate of Completion",
+    "Shielded Metal-Arc All Positions, Certificate",
+    "Small Business Marketing Certificate",
+    "Small-Wind Technology, Certificate",
+    "SMAW- Shielded Metal Arc Welding, Occupational Certificate",
+    "Social Media Marketing Certificate",
+    "Social Media Marketing, Certificate",
+    "Social Media Marketing, Certificate of Completion",
+    "Social Media Specialist, Certificate of Completion",
+    "Social Work Certificate",
+    "Social Work, A.A.",
+    "Sociology Sample Transfer Pathway",
+    "Sociology Transfer Pathway, A.A. — Associate in Applied Science",
+    "Sociology, A.A.",
+    "Sociology, AA",
+    "Software Application Design and Development, AAS",
+    "Software Development, A.A.S. — Associate in Applied Science",
+    "Solar-Photovoltaic Technology, Certificate",
+    "Solar-Thermal Technology, Certificate",
+    "Spanish Sample Transfer Pathway",
+    "Spanish Transfer Pathway, A.A. — Associate in Applied Science",
+    "Special Education, A.A.",
+    "Special Education, A.S.",
+    "Specialty Crop Fundamentals Certificate",
+    "Specialty Crop Management Certificate",
+    "Speech Communication Transfer Pathway, A.A. — Associate in Applied Science",
+    "Speech Communication, A.A.",
+    "Speech-Language Pathology Assistant, A.A.S. — Associate in Applied Science",
+    "Sports Management Transfer Pathway, A.A. — Associate in Applied Science",
+    "Sports Marketing, Certificate",
+    "Spreadsheet Certificate",
+    "Stationary Operator, Certificate — Associate in Applied Science",
+    "Steering and Alignment • Certificate of Completion",
+    "Sterile Processing Technician Certificate",
+    "Still Deciding/Undecided Transfer Pathway, A.A. — Associate in Applied Science",
+    "Structural and Civil Certificate",
+    "Studio Art • Associate in Fine Arts",
+    "Supervision, Certificate — Associate in Applied Science",
+    "Supply Chain Management Certificate",
+    "Supply Chain Management, Certificate",
+    "Supply Chain Management, Certificate of Achievement",
+    "Supply Chain Management, Certificate of Completion",
+    "Surgical First Assistant, Certificate — Associate in Applied Science",
+    "Surgical Technology, A.A.S.",
+    "Surgical Technology, A.A.S. — Associate in Applied Science",
+    "Sustainable Landscapes, Certificate — Associate in Applied Science",
+    "Sustainable Urban Agriculture, A.A.S. — Associate in Applied Science",
+    "Sustainable Urban Agriculture, Certificate — Associate in Applied Science",
+    "Swine Management, A.A.S.",
+    "Swine Management, Certificate of Completion",
+    "System Support Specialist, Certificate — Associate in Applied Science",
+    "Tax Practitioner Certificate",
+    "Teacher Assistant, A.A.S.",
+    "Teacher Assistant, Certificate of Achievement",
+    "Teaching Online Utilizing Technology (TOUT), Certificate — Associate in Applied Science",
+    "Technical Rescue Awareness • Certificate of Completion",
+    "Technical Theater Transfer Pathway, A.A. — Associate in Applied Science",
+    "Television Production, A.A.S. — Associate in Applied Science",
+    "The General Education Core",
+    "Theater Transfer Pathway, A.A. — Associate in Applied Science",
+    "Theatre Arts, A.A. - Design or Technology Concentration",
+    "Theatre Arts, A.A. - Performance Concentration",
+    "Theatre Sample Transfer Pathway",
+    "Tool and Die Making, A.A.S.",
+    "Tool and Die Making, Certificate — Associate in Applied Science",
+    "Tractor-Trailer Driver Training, 11 Hour Certificate",
+    "Tractor-Trailer Driver Training, 16 Hour Certificate",
+    "Transfer Degree General Education Requirements",
+    "Transfer Electives for A.A. and A.S. Degrees",
+    "Travel and Tourism Foundations, Certificate — Associate in Applied Science",
+    "Travel and Tourism Professional, Certificate — Associate in Applied Science",
+    "Travel and Tourism, A.A.S. — Associate in Applied Science",
+    "Tungsten Inert Gas and Metallic Inert Gas, Certificate",
+    "Turf Grass Operations, Certificate of Completion",
+    "UNIX Proficiency, Certificate — Associate in Applied Science",
+    "Unmanned Aircraft Systems Certificate",
+    "Urban Farming, Certificate — Associate in Applied Science",
+    "Vehicle/Machinery Operations • Certificate of Completion",
+    "Veteran Counseling, Certificate — Associate in Applied Science",
+    "Veterinary Assistant, Certificate of Completion",
+    "Veterinary Medical Technology, A.A.S.",
+    "Veterinary Technology, A.A.S.",
+    "Video Production and Editing Certificate",
+    "Video Production and Editing, AAS",
+    "Virtual Office Assistant Certificate",
+    "Visual Arts, AA",
+    "Visual BASIC Language Proficiency, Certificate — Associate in Applied Science",
+    "Voice Over IP Telephony, Certificate — Associate in Applied Science",
+    "Warehousing and Distribution Certificate of Completion",
+    "Weather Hazards and Preparedness, Certificate — Associate in Applied Science",
+    "Web Accessibility Specialist, Certificate of Completion",
+    "Web Client Developer, Certificate — Associate in Applied Science",
+    "Web Design & Development",
+    "Web Design, Certificate — Associate in Applied Science",
+    "Web Design, Certificate of Completion",
+    "Web Design/Development, Social Media, A.A.S.",
+    "Web Developer and UX Designer, Certificate of Achievement",
+    "Web Development Certificate",
+    "Web Development, A.A.S. — Associate in Applied Science",
+    "Web Programmer, Certificate — Associate in Applied Science",
+    "Wedding Planning Management, Certificate — Associate in Applied Science",
+    "Welding and Fabrication, AAS",
+    "Welding Technology",
+    "Welding Technology, A.A.S.",
+    "Welding Technology, A.A.S. — Associate in Applied Science",
+    "Welding Technology, AAS",
+    "Welding Technology, Advanced Certificate",
+    "Welding, Advanced Certificate",
+    "Welding, Certificate",
+    "Welding, Certificate — Associate in Applied Science",
+    "Windows Network Administration, Certificate — Associate in Applied Science",
+    "Wine Appreciation and Knowledge, Certificate — Associate in Applied Science",
+    "Word Processing Certificate",
+    "Word Specialist, Certificate — Associate in Applied Science",
+    "Workplace Dynamics • Certificate of Completion"
+  ]
+}

--- a/data/in/subject-vocab.json
+++ b/data/in/subject-vocab.json
@@ -1,0 +1,1774 @@
+{
+  "state": "in",
+  "generated_at": "2026-06-06T15:41:40.228Z",
+  "subjects": [
+    {
+      "prefix": "NSGA",
+      "name": "NSGA",
+      "course_count": 20,
+      "section_count": 1054,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Adv Hlth Conc Clin",
+        "Adv Hlth Concepts",
+        "Bridge to ADN Conc/Clin Judge",
+        "Bridge to ADN Lab/Clinical",
+        "Fam/Comm Hlth Conc"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 21,
+      "section_count": 783,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Applied Technical Mathematics",
+        "Brief Calculus I",
+        "Brief Calculus II",
+        "Calculus for Technology I",
+        "Calculus for Technology II"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 19,
+      "section_count": 639,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Creative Writing",
+        "American Literature After 1865",
+        "American Literature to 1865",
+        "British Literature to 1800",
+        "Childrens Literature"
+      ]
+    },
+    {
+      "prefix": "APHY",
+      "name": "Physiology",
+      "course_count": 3,
+      "section_count": 448,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Human Physiology",
+        "Anatomy and Physiology I",
+        "Anatomy and Physiology II"
+      ]
+    },
+    {
+      "prefix": "IVYT",
+      "name": "Student",
+      "course_count": 10,
+      "section_count": 372,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Critical Thinking",
+        "Health and Wellness",
+        "Leadership",
+        "Managing Personal Finances"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 7,
+      "section_count": 367,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Culture and Communication",
+        "Fundamentals of Public Speaking",
+        "Introduction to Interpersonal Communication",
+        "Introduction to Mass Communication",
+        "Introduction to Public Relations"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 9,
+      "section_count": 363,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Drugs and Human Behavior",
+        "Health Psychology",
+        "Human Sexuality",
+        "Introduction to Psychology"
+      ]
+    },
+    {
+      "prefix": "HLHS",
+      "name": "HLHS",
+      "course_count": 21,
+      "section_count": 361,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Behavioral Health",
+        "CNA Preparation",
+        "CPR/Basic Life Support",
+        "Customer Relations-Healthcare",
+        "Dementia Care"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "HUMS",
+      "course_count": 32,
+      "section_count": 324,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Activity Director Basic",
+        "Child and Youth Development",
+        "Community Health Worker",
+        "Content and Curriculum in Youth Work",
+        "Counseling Issues in Substance Abuse"
+      ]
+    },
+    {
+      "prefix": "NSGP",
+      "name": "Essen",
+      "course_count": 11,
+      "section_count": 308,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Essen Nrsg Conc/Clin Judge",
+        "Essen Nrsg Prac Fam/Comm",
+        "Essen Nrsg Prac Fam/Comm Clin",
+        "Essen Nrsg Prac I Lab/Clin",
+        "Essen Nrsg Prac II Clin"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 33,
+      "section_count": 301,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Business, Financial, and Legal",
+        "CDA Process",
+        "Child Growth and Development",
+        "Cognitive Curriculum",
+        "Curriculum in the Early Childhood Classroom"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 20,
+      "section_count": 298,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Benefits Administration",
+        "Business Ethics and Social Responsibility",
+        "Business Law",
+        "Business Statistics",
+        "Co-Op/Internship"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "INDT",
+      "course_count": 19,
+      "section_count": 286,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Industrial Mechanics I",
+        "Electrical Circuits",
+        "INDT 104 Fluid Power I",
+        "INDT 113 Industrial Elec. I",
+        "Industrial Technology Capstone"
+      ]
+    },
+    {
+      "prefix": "MEAS",
+      "name": "MEAS",
+      "course_count": 17,
+      "section_count": 251,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Procedures",
+        "Advanced Insur Claims Processi",
+        "Advanced Insurance Coding",
+        "Advanced Medical Terminology",
+        "CCMA Workforce Develop Prep"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 14,
+      "section_count": 231,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Gas Metal Arc Welding II",
+        "Advanced Gas Tungsten Arc Welding II",
+        "Advanced Shielded Metal Arc Welding II",
+        "Blueprint Reading for Welders",
+        "Gas Metal Arc (MIG) Welding"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 13,
+      "section_count": 210,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Biology I - Molecular and Cellular Processes",
+        "Biology II-Diversity of Life",
+        "Ecology",
+        "Environmental Science",
+        "General Biology I"
+      ]
+    },
+    {
+      "prefix": "SDEV",
+      "name": "Development",
+      "course_count": 23,
+      "section_count": 203,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Simulation and Game Design",
+        "Algorithms and Design Patterns",
+        "Client-Side Scripting Language and Tools",
+        "Computing Logic",
+        "Content Management Systems"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "CRIM",
+      "course_count": 28,
+      "section_count": 196,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Communication and Conflict Management for Criminal Justice",
+        "Criminal Evidence",
+        "Criminal Investigation",
+        "Criminal Law",
+        "Cultural Awareness"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 14,
+      "section_count": 191,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Systems Applications",
+        "Advanced Income Tax",
+        "Auditing",
+        "Co-op/Internship",
+        "Cost Accounting I"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "HOSP",
+      "course_count": 42,
+      "section_count": 190,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Decorating and Candies",
+        "Bakery Merchandising",
+        "Baking Science",
+        "Basic Food Theory and Skills",
+        "Beverage Service"
+      ]
+    },
+    {
+      "prefix": "AUTI",
+      "name": "AUTI",
+      "course_count": 29,
+      "section_count": 187,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chassis Systems",
+        "Advanced Hybrid Vehicle and Electric Technologies",
+        "Automatic Transmissions I",
+        "Automatic Transmissions II",
+        "Automotive Capstone"
+      ]
+    },
+    {
+      "prefix": "OTEC",
+      "name": "Microsoft",
+      "course_count": 14,
+      "section_count": 150,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Microsoft Excel",
+        "Advanced Microsoft Word",
+        "Business Communications",
+        "Co-Op/Internship/Externship",
+        "Google Technologies"
+      ]
+    },
+    {
+      "prefix": "ADMF",
+      "name": "ADMF",
+      "course_count": 13,
+      "section_count": 141,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Digital Fundamentals and Siemens Automation Controllers",
+        "Fluid Power II",
+        "Industrial Electrical II",
+        "Industrial Robotics I",
+        "Industrial Robotics II"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 13,
+      "section_count": 141,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Child and Adolescent Development",
+        "Educational Psychology",
+        "Educational Psychology for Teachers",
+        "Intro to Literacy - SoR II",
+        "Intro to Literacy-SoR I"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 20,
+      "section_count": 132,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cooling Service",
+        "Advanced Heat Pump Systems",
+        "Basic Carpentry and Building Maintenance",
+        "Bldg/Property Maint II",
+        "Co-Op/Internship"
+      ]
+    },
+    {
+      "prefix": "PARM",
+      "name": "PARM",
+      "course_count": 15,
+      "section_count": 129,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Airway Patient Assessment",
+        "Ambulance Internship",
+        "Clinical Application I",
+        "Clinical Application II",
+        "Clinical Application III"
+      ]
+    },
+    {
+      "prefix": "MTTC",
+      "name": "MTTC",
+      "course_count": 18,
+      "section_count": 128,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Abrasive Processes I",
+        "Advanced Turning Processes II",
+        "CAD/CAM I",
+        "CAD/CAM II",
+        "CNC Lathe Programming"
+      ]
+    },
+    {
+      "prefix": "ITSP",
+      "name": "Support",
+      "course_count": 7,
+      "section_count": 115,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Internet of Things Fundamentals",
+        "IT Customer Support and Helpdesk Software",
+        "IT Support Essentials I",
+        "IT Support Essentials II",
+        "Mobile/Wireless Computing Support"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 4,
+      "section_count": 112,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Ethics",
+        "Introduction to Philosophy",
+        "Logic",
+        "Philosophy of Religion"
+      ]
+    },
+    {
+      "prefix": "VISC",
+      "name": "VISC",
+      "course_count": 26,
+      "section_count": 110,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "3D Rendering and Animation I",
+        "Art in the Community",
+        "Business Practices for Visual Artists",
+        "Co-op/Internship",
+        "Design Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CSIA",
+      "name": "CSIA",
+      "course_count": 8,
+      "section_count": 107,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Forensics",
+        "Business Continuity in an Information World",
+        "Cyber Ops",
+        "Ethical Hacking",
+        "Introduction to Cyber Security/Information Assurance"
+      ]
+    },
+    {
+      "prefix": "LEGS",
+      "name": "LEGS",
+      "course_count": 20,
+      "section_count": 107,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Business Associations",
+        "Civil Procedure",
+        "Constitutional Law",
+        "Contracts and Commercial Law",
+        "Criminal Law and Procedure"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 40,
+      "section_count": 105,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Animal Science",
+        "Advanced Plant and Soil Science",
+        "Agricultural Business and Farm Management",
+        "Agricultural Data Management",
+        "Agricultural Education"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "Sociology",
+      "course_count": 5,
+      "section_count": 105,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Diversity in the United States",
+        "Introduction to Sociology",
+        "Multicultural Studies",
+        "Social Problems",
+        "Sociology of Relationships and the Family"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 8,
+      "section_count": 96,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Chemistry I",
+        "General Chemistry I",
+        "General Chemistry II",
+        "General, Organic, and Biological Chemistry",
+        "Introductory Chemistry I"
+      ]
+    },
+    {
+      "prefix": "DESN",
+      "name": "Design",
+      "course_count": 27,
+      "section_count": 96,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "2D Computer-Aided Design",
+        "3D Computer-Aided Design",
+        "Advanced Solid Modeling",
+        "Architectural Design I",
+        "Architectural Design II"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surgical",
+      "course_count": 7,
+      "section_count": 96,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Application of Surgical Fundamentals",
+        "Clinical Applications I",
+        "Clinical Applications III",
+        "Fundamentals of Surgical Technology",
+        "Surgical Pharmacology"
+      ]
+    },
+    {
+      "prefix": "SVAD",
+      "name": "Workforce",
+      "course_count": 13,
+      "section_count": 89,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Azure Services and Technology",
+        "Cloud Foundations",
+        "Enterprise Computing",
+        "Linux Administration I",
+        "Linux and Virtualization Technologies Fundamentals"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "RESP",
+      "course_count": 15,
+      "section_count": 88,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Adv Assessmnt/Care Cardiopu",
+        "Adv Clinical App CC/Spe",
+        "Advanced Concepts in Cardio Di",
+        "Advanced Emergency Mgmt",
+        "Assessmnt/Crng for Resp P"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 6,
+      "section_count": 87,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "African American History",
+        "History of American Technology",
+        "Survey of American History I",
+        "Survey of American History II",
+        "World Civilization I"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 4,
+      "section_count": 86,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Spanish Level I",
+        "Spanish Level II",
+        "Spanish Level III",
+        "Spanish Level IV"
+      ]
+    },
+    {
+      "prefix": "NETI",
+      "name": "Networking",
+      "course_count": 9,
+      "section_count": 84,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Special Topics in Network Infrastructure",
+        "Infrastructure Design - Logical and Physical",
+        "Introductions to Networking",
+        "Network Security",
+        "Networking I"
+      ]
+    },
+    {
+      "prefix": "DMSI",
+      "name": "Sonography",
+      "course_count": 47,
+      "section_count": 82,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonog I/Clinic Lab I",
+        "Abdominal Sonog II/Clin Lab II",
+        "Abdominal Sonography III and C",
+        "Abdominal Sonography IV and Cl",
+        "Basic Radiation Physics/Prin"
+      ]
+    },
+    {
+      "prefix": "INFM",
+      "name": "Informatics",
+      "course_count": 3,
+      "section_count": 75,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Business Intelligence and Reporting",
+        "Informatics and Human - Computer Interaction",
+        "Informatics Fundamentals"
+      ]
+    },
+    {
+      "prefix": "LOGM",
+      "name": "LOGM",
+      "course_count": 16,
+      "section_count": 71,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Quality Management",
+        "Appropriations Law and the Planning, Programming, Budgeting & Execution (PPB&E) Process",
+        "Commercial Driver’s License Application",
+        "Commercial Drivers Vehicles Operations I",
+        "Commercial Drivers Vehicles Operations II"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 6,
+      "section_count": 66,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Consumer Behavior",
+        "Digital Marketing Management",
+        "Intro to Digital Marketing",
+        "Introduction to Market Research",
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "DBMS",
+      "name": "Data",
+      "course_count": 7,
+      "section_count": 65,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Data Analytics",
+        "Data Management using Structured Query Language",
+        "Data Visualization and Analysis",
+        "Database Design and Development",
+        "Introduction to Data Analytics"
+      ]
+    },
+    {
+      "prefix": "BCTI",
+      "name": "Part",
+      "course_count": 18,
+      "section_count": 60,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry Forms, Part 1",
+        "Carpentry Forms, Part 2",
+        "Carpentry Framing and Finishing, Part 2",
+        "Carpentry Framing and Finishing, Part I",
+        "Electrical, Part 2"
+      ]
+    },
+    {
+      "prefix": "SCIN",
+      "name": "Science",
+      "course_count": 3,
+      "section_count": 60,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "Physical Science",
+        "Science of Energy Generation and Utilization"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 14,
+      "section_count": 59,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Externship I and II",
+        "Clinical Externship II",
+        "Dental Anatomy",
+        "Dental Emergencies/Pharmacology",
+        "Dental Materials and Lab I"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Entrepreneurial",
+      "course_count": 9,
+      "section_count": 59,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurial Marketing and Market Research",
+        "Entrepreneurial Mindset",
+        "Entrepreneurial Mindset & Awareness",
+        "Entrepreneurial Pursuits",
+        "Entrepreneurship Capstone"
+      ]
+    },
+    {
+      "prefix": "EECT",
+      "name": "EECT",
+      "course_count": 14,
+      "section_count": 57,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "AC Circuit Analysis",
+        "Digital Applications",
+        "Digital Fundamentals",
+        "Electrical Machines",
+        "Electronics Circuit Analysis"
+      ]
+    },
+    {
+      "prefix": "HSPS",
+      "name": "HSPS",
+      "course_count": 28,
+      "section_count": 56,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Computer Applications in Homeland Security/Public Safety",
+        "Contingency Planning",
+        "Disaster and Terrorism Awareness",
+        "DOT Regulations",
+        "Emergency Medical Responder"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 3,
+      "section_count": 54,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Economics Fundamentals",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "BCOM",
+      "name": "Construction",
+      "course_count": 15,
+      "section_count": 52,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Estimating",
+        "Codes and Specifications",
+        "Commercial and Industrial Construction",
+        "Concrete and Soils",
+        "Construction Business Management"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "Radiographic",
+      "course_count": 21,
+      "section_count": 52,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "General Exam Review",
+        "Image Production and Evaluation I",
+        "Image Production and Evaluation II",
+        "Introduction to Cross Sectional Anatomy",
+        "Orientation and Patient Care"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 8,
+      "section_count": 49,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Capstone Course",
+        "Computer Organization and Architecture",
+        "Computer Science Bridging Course",
+        "Computer Science I",
+        "Computer Science II"
+      ]
+    },
+    {
+      "prefix": "BIOT",
+      "name": "Biotechnology",
+      "course_count": 18,
+      "section_count": 48,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Analytic Methods in Biotechnology I",
+        "Analytic Methods in Biotechnology II",
+        "Automation for Biotechnology",
+        "Capstone in Biotechnology",
+        "Cell Culture and Cellular Processes"
+      ]
+    },
+    {
+      "prefix": "TRCK",
+      "name": "Truck",
+      "course_count": 14,
+      "section_count": 48,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Emissions Controls",
+        "Co-op or Internship",
+        "Diesel Capstone",
+        "Diesel Engine Performance I",
+        "Diesel Engine Performance II"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 4,
+      "section_count": 47,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "History of Design",
+        "Surv of Art and Cult I",
+        "Surv of Art and Cult II"
+      ]
+    },
+    {
+      "prefix": "TMAS",
+      "name": "Massage",
+      "course_count": 14,
+      "section_count": 45,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Acupressure Theory and Methods",
+        "Advanced Techniques",
+        "Biomechanics",
+        "Business Development",
+        "Deep Tissue Techniques"
+      ]
+    },
+    {
+      "prefix": "PHLB",
+      "name": "Phlebotomy",
+      "course_count": 2,
+      "section_count": 43,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy",
+        "Phlebotomy Externship"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 14,
+      "section_count": 42,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Community & Public Health Dent",
+        "Dental Anatomy",
+        "Dental Hygiene Clinic II",
+        "Dental Hygiene Clinical Procedures",
+        "Dental Materials"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 5,
+      "section_count": 42,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Heat, Electricity and Optics",
+        "Introductory Physics",
+        "Mechanics",
+        "Physics 1",
+        "Physics II"
+      ]
+    },
+    {
+      "prefix": "METC",
+      "name": "METC",
+      "course_count": 7,
+      "section_count": 40,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "CAD for Mechanical Design",
+        "Fluid Power",
+        "Introduction to Engineering Technology",
+        "Materials and Processes",
+        "Mechanical Design & Documentation"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "English",
+      "course_count": 10,
+      "section_count": 38,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Academic English for Speakers of Other Languages",
+        "English for Speakers of Other Languages - Reading III",
+        "English for Speakers of Other Languages - Writing II",
+        "English for Speakers of Other Languages-Grammar/Structure II",
+        "English for Speakers of Other Languages-Grammar/Structure III"
+      ]
+    },
+    {
+      "prefix": "AVIT",
+      "name": "AVIT",
+      "course_count": 22,
+      "section_count": 35,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Air Traffic Control",
+        "Aircraft Hydraulic and Landing Gear Systems",
+        "Aircraft Sheetmetal",
+        "Aviation Management Career Seminar",
+        "Aviation Safety Management Systems"
+      ]
+    },
+    {
+      "prefix": "CPIN",
+      "name": "Information",
+      "course_count": 5,
+      "section_count": 35,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Computing and Informatics Co-op/Internship/Externship",
+        "Information Technology Capstone",
+        "Information Technology Project Management",
+        "Systems Analysis and Design",
+        "Workforce Preparation: CompTIA Project+ Certification"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 4,
+      "section_count": 34,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to American Government and Politics",
+        "Introduction to Political Science",
+        "Introduction to World Politics",
+        "State and Local Government"
+      ]
+    },
+    {
+      "prefix": "PTAS",
+      "name": "PTAS",
+      "course_count": 12,
+      "section_count": 31,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Aspects of the Physical Therapist Assistant",
+        "Clinical I",
+        "Clinical III",
+        "Current Issues and Review",
+        "Diseases, Trauma and Terminology"
+      ]
+    },
+    {
+      "prefix": "SMDI",
+      "name": "Manufacturing",
+      "course_count": 4,
+      "section_count": 30,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Systems for Smart Manufacturing",
+        "Introduction to Industrial Internet of Things",
+        "Mechanical Sytems in Manufacturing",
+        "Technology in Smart Manufacturing and Digital Integration"
+      ]
+    },
+    {
+      "prefix": "MEDL",
+      "name": "MEDL",
+      "course_count": 17,
+      "section_count": 29,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Chemistry",
+        "Clinical Hematology",
+        "Clinical Immunology",
+        "Clinical Microbiology Applications",
+        "Clinical Pathology"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "Photography",
+      "course_count": 7,
+      "section_count": 29,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Field Photography",
+        "Fine Art Photography",
+        "Independent Study",
+        "Journalistic and Editorial Photography",
+        "Photography I"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 7,
+      "section_count": 28,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Capstone Course",
+        "Electrical Circuits I",
+        "Engineering Software Tools I",
+        "Engineering Software Tools II",
+        "Geometric Modeling for Visualization"
+      ]
+    },
+    {
+      "prefix": "HIMT",
+      "name": "Health",
+      "course_count": 10,
+      "section_count": 26,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced ICD Coding",
+        "Basic ICD Coding",
+        "CPT Coding",
+        "Health Data Content and Structure",
+        "Health Info Tech Extnshp I"
+      ]
+    },
+    {
+      "prefix": "GENS",
+      "name": "Capstone",
+      "course_count": 1,
+      "section_count": 25,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "General Studies Capstone Course"
+      ]
+    },
+    {
+      "prefix": "MPRO",
+      "name": "MPRO",
+      "course_count": 17,
+      "section_count": 25,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Lean Manufacturing",
+        "CNC Operations",
+        "Geometric Dimensioning and Tolerancing",
+        "Introduction to Plant Floor and CNC Prinicples",
+        "Introduction to Print Reading"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Solar System Astronomy",
+        "Stellar and Galactic Astronomy"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "French Level I",
+        "French Level II",
+        "French Level III",
+        "French Level IV"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "Appreciation",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Humanities: Prehistory Through the Renaissance",
+        "Introduction to Music Theory",
+        "Music Appreciation",
+        "Theatre Appreciation",
+        "Travel Study"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "4D Art and Design",
+        "Ceramics I",
+        "Color and Design Theory I",
+        "Exploration of Art",
+        "Fine Arts Portfolio"
+      ]
+    },
+    {
+      "prefix": "AOLS",
+      "name": "Leadership",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Applied Theories of Management & Leadership",
+        "Followership",
+        "Leadership and Personal Development",
+        "Multicultural Leadership",
+        "Organizational Culture & Change Leadership"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "School",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "School of Business Evaluation and Professional Development"
+      ]
+    },
+    {
+      "prefix": "AUBR",
+      "name": "Automotive",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Refinish Techniques and Technology",
+        "Automotive Body Repair II",
+        "Automotive Body Welding",
+        "Automotive Detailing",
+        "Automotive Paint Fundamentals"
+      ]
+    },
+    {
+      "prefix": "MORT",
+      "name": "Funeral",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Cremation Processes and Management",
+        "Embalming Chemistry",
+        "Embalming Theory I",
+        "Embalming Theory II",
+        "Funeral Directing I"
+      ]
+    },
+    {
+      "prefix": "CARD",
+      "name": "CARD",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrocardiograph Technique",
+        "ECG Experiential Seminar",
+        "Introduction to Electrocardiography"
+      ]
+    },
+    {
+      "prefix": "PHAR",
+      "name": "Pharmacy",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Pharm Tech Exper Seminar",
+        "Pharmacy Technician Concepts"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Anthropology",
+        "Human Origins /Prehist.",
+        "Introduction to Archaeology"
+      ]
+    },
+    {
+      "prefix": "EDSN",
+      "name": "Design",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "3-D Architectural Design and Rendering",
+        "Advanced Environmental Design",
+        "Design/Constr Graphics",
+        "History of Environmental Design",
+        "Introduction to Environmental Design"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "Engineering",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Concepts in Technology",
+        "Portfolio Preparation"
+      ]
+    },
+    {
+      "prefix": "AAIT",
+      "name": "Essentials",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "AI Essentials",
+        "Machine Learning"
+      ]
+    },
+    {
+      "prefix": "CSTC",
+      "name": "Central",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Application of Central Service Technician Skills",
+        "Clinical Experiential Seminar",
+        "Fundamentals of Central Service Technician Skills",
+        "Surgical Instrumentation"
+      ]
+    },
+    {
+      "prefix": "PAET",
+      "name": "Precision",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Application Control",
+        "Co-Op Internship",
+        "Introduction to Precision Agriculture",
+        "Planting/Harvest Sys",
+        "Precision Agriculture GPS/GIS"
+      ]
+    },
+    {
+      "prefix": "ENRG",
+      "name": "Line",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Climbing",
+        "Electrical Essentials for Power Line Workers",
+        "Energy Industry Fundamentals",
+        "Rigging for Line Workers",
+        "Transmission and Distribution of Electric Power"
+      ]
+    },
+    {
+      "prefix": "VETN",
+      "name": "VETN",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Animal Diseases I",
+        "Animal Diseases II",
+        "Clin Lab Procedures I",
+        "Comp Animal Nursing",
+        "Intro to Vet Profession"
+      ]
+    },
+    {
+      "prefix": "RDTH",
+      "name": "Therapy",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Externship III",
+        "Introduction to Radiation Therapy",
+        "Pathology and Treatment Principles II",
+        "Patient Care in Radiation Oncology",
+        "Rad Therapy Clinical Seminar"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "SPED",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Collaborative Relationships in Special Education",
+        "Informal and Formal Assessments for Mild Disabilities",
+        "Introduction to Inclusive Teaching"
+      ]
+    },
+    {
+      "prefix": "GRDN",
+      "name": "Gardening",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Gardening",
+        "Garden Design",
+        "Sustainable Gardening and Permaculture"
+      ]
+    },
+    {
+      "prefix": "LIBA",
+      "name": "Liberal",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Liberal Arts Capstone Course"
+      ]
+    },
+    {
+      "prefix": "QUAL",
+      "name": "Control",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Statistical Process Control",
+        "ISO/QS Int. Standards",
+        "Quality Control Concepts and Techniques I",
+        "Statistical Process Control",
+        "Total Quality Management"
+      ]
+    },
+    {
+      "prefix": "TTEN",
+      "name": "Toyota",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Toyota T-TTEN",
+        "Toyota T-Ten Advanced Chassis",
+        "Toyota T-Ten Driveline Service",
+        "Toyota T-Ten Electrical I",
+        "Toyota T-Ten Maintenance Level"
+      ]
+    },
+    {
+      "prefix": "AMSL",
+      "name": "Amer",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Amer Sign Lang I",
+        "Amer Sign Lang II"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "World Geography"
+      ]
+    },
+    {
+      "prefix": "PROC",
+      "name": "Safety",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Process Technology",
+        "Safety, Health and Environment I"
+      ]
+    },
+    {
+      "prefix": "EETC",
+      "name": "Capstone",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "EE Capstone Course"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "German Level I",
+        "German Level II"
+      ]
+    },
+    {
+      "prefix": "NRSG",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Care of Childbearing and Childrearing Families",
+        "Nursing Care of Childbearing and Childrearing Families Clinical",
+        "Practice Issues for Associate Degree Nursing"
+      ]
+    },
+    {
+      "prefix": "OTAS",
+      "name": "OTAS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Applied Kinesiology in OT",
+        "Conditions in OT",
+        "Foundations and Theory in OT"
+      ]
+    },
+    {
+      "prefix": "PRCM",
+      "name": "Professional",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Professional Communication Capstone Course"
+      ]
+    },
+    {
+      "prefix": "ASEP",
+      "name": "Asep",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "GM ASEP Electrical Systems 1",
+        "Introduction to GM ASEP"
+      ]
+    },
+    {
+      "prefix": "EPCS",
+      "name": "Epics",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "EPICS Multidiscipl Team Servic",
+        "EPICS; Multidisciplinary Team Service Learning Projects I"
+      ]
+    },
+    {
+      "prefix": "AIVY",
+      "name": "Managing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Managing Personal Finances"
+      ]
+    },
+    {
+      "prefix": "AUTC",
+      "name": "Chassis",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chassis Systems"
+      ]
+    },
+    {
+      "prefix": "MAMO",
+      "name": "Mammography",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Mammography Pat Care,Im Prod"
+      ]
+    },
+    {
+      "prefix": "NGAS",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Natural Gas"
+      ]
+    },
+    {
+      "prefix": "SUST",
+      "name": "Wind",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Wind Power"
+      ]
+    },
+    {
+      "prefix": "VIDT",
+      "name": "Production",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ivy-tech-community-college"
+      ],
+      "sample_titles": [
+        "Production Editing I"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/ks/subject-vocab.json
+++ b/data/ks/subject-vocab.json
@@ -1,0 +1,5430 @@
+{
+  "state": "ks",
+  "generated_at": "2026-06-06T15:41:40.263Z",
+  "subjects": [
+    {
+      "prefix": "MA",
+      "name": "MA",
+      "course_count": 48,
+      "section_count": 470,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Analytic Geometry & Calculus I",
+        "Analytic Geometry & Calculus III",
+        "Analytical Geometry and Calculus I",
+        "Analytical Geometry and Calculus II",
+        "Analytical Geometry and Calculus III"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 76,
+      "section_count": 295,
+      "colleges": [
+        "colby-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Adv Basketball Cond",
+        "Adv Bsktbl Cond-Wm",
+        "Aerobic Fitness I",
+        "Aerobic Fitness II",
+        "Aerobic Fitness III"
+      ]
+    },
+    {
+      "prefix": "MU",
+      "name": "MU",
+      "course_count": 118,
+      "section_count": 286,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "A Cappella Ensemble 1",
+        "A Cappella Ensemble 2",
+        "A Cappella Ensemble 3",
+        "A Cappella Ensemble 4",
+        "Adult Beginning Piano II"
+      ]
+    },
+    {
+      "prefix": "BI",
+      "name": "BI",
+      "course_count": 24,
+      "section_count": 245,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology (w/Lab)",
+        "Anatomy & Physiology I (w/Lab)",
+        "Anatomy & Physiology II (w/Lab)",
+        "Anatomy and Physiology",
+        "Anatomy and Physiology 1"
+      ]
+    },
+    {
+      "prefix": "EN",
+      "name": "EN",
+      "course_count": 26,
+      "section_count": 227,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "American Literature I",
+        "American Literature II",
+        "Arch Des Bldg Info Model",
+        "British Literature II",
+        "Building Design 1 w/CAD"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 28,
+      "section_count": 215,
+      "colleges": [
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "independence-community-college",
+        "northwest-kansas-technical-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Am Lit Col-Civ War",
+        "Am Lit II:Recon-Pres",
+        "AMERICAN LIT I",
+        "BRIT LIT I",
+        "Children's Literature"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 38,
+      "section_count": 215,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Ana Geo&Calc I",
+        "Ana Geom&CalcII",
+        "Analytic Geometry and Calculus I",
+        "Analytic Geometry and Calculus II",
+        "Applications of Technical Analysis"
+      ]
+    },
+    {
+      "prefix": "BU",
+      "name": "BU",
+      "course_count": 43,
+      "section_count": 214,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Accounting I",
+        "Accounting II",
+        "Advertising",
+        "Business Communications",
+        "Business Document Preparation"
+      ]
+    },
+    {
+      "prefix": "HR",
+      "name": "HR",
+      "course_count": 28,
+      "section_count": 208,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Abstracting Methods",
+        "Cancer Disease, Coding, and Staging",
+        "Cancer Registry Clinical Practicum",
+        "Cancer Registry Operations",
+        "Cancer Registry Structure and Management"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 34,
+      "section_count": 190,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "A & P I",
+        "Anatomy &amp; Phy I Lab",
+        "Anatomy &amp; Phys I",
+        "Anatomy Physiology I",
+        "Anatomy Physiology II"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "WELD",
+      "course_count": 35,
+      "section_count": 173,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced GMAW",
+        "Advanced SMAW",
+        "Ag Weld GMAW",
+        "Ag Weld SMAW",
+        "Auto Cut Processes"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "Psychology",
+      "course_count": 11,
+      "section_count": 160,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "highland-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "College Chemistry I",
+        "College Physical Sci",
+        "General Psychology",
+        "Human Growth and Development"
+      ]
+    },
+    {
+      "prefix": "SP",
+      "name": "Interpersonal",
+      "course_count": 7,
+      "section_count": 156,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish II",
+        "Fundamentals of Oral Communicati",
+        "Interpersonal Comm.",
+        "Interpersonal Communication (Independent Study)",
+        "Public Speaking"
+      ]
+    },
+    {
+      "prefix": "SO",
+      "name": "SO",
+      "course_count": 18,
+      "section_count": 151,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Assertiveness Training",
+        "Contemporary Social Problems",
+        "Cultural Anthropology",
+        "Cultural Diversity",
+        "Fall Sociology of Sports"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 50,
+      "section_count": 140,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "independence-community-college",
+        "manhattan-area-technical-college",
+        "northwest-kansas-technical-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Accounting I",
+        "Business Capstone",
+        "BUSINESS COMMUNICAT",
+        "Business Communicati",
+        "Business Communication"
+      ]
+    },
+    {
+      "prefix": "EG",
+      "name": "English",
+      "course_count": 8,
+      "section_count": 139,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Creative Writing",
+        "English Comp 1",
+        "English Comp 2",
+        "ESL Fundamentals of English",
+        "ESL Pronunciation of Eng Appld"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 29,
+      "section_count": 133,
+      "colleges": [
+        "allen-county-community-college",
+        "highland-community-college",
+        "independence-community-college",
+        "manhattan-area-technical-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Statistics",
+        "Basic Stats Review",
+        "CALCULUS",
+        "Calculus w/Analytic Geom I",
+        "Calculus w/Analytic Geom II"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 15,
+      "section_count": 130,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Childrens Literature",
+        "Comp Studio",
+        "Comp Studio ESL",
+        "Composition I",
+        "Composition II"
+      ]
+    },
+    {
+      "prefix": "FS",
+      "name": "FS",
+      "course_count": 37,
+      "section_count": 128,
+      "colleges": [
+        "butler-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Adv Emerg Med Tech (AEMT)",
+        "Advanced Fire Administration",
+        "Construction Methods and Materials",
+        "Emerg Med Responder (EMR)",
+        "Emerg Medical Tech (EMT)"
+      ]
+    },
+    {
+      "prefix": "VN",
+      "name": "Veterinary",
+      "course_count": 56,
+      "section_count": 126,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Large Animal Nursing",
+        "Anatomy and Physiology for Vet Nur",
+        "Ani Facility Mgmt/Sanitation Mentors",
+        "Animal Facility Management II",
+        "Animal Facility Mgmt and Sanitation"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 15,
+      "section_count": 125,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "manhattan-area-technical-college",
+        "northwest-kansas-technical-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Academic Success",
+        "Cognitive Psychology",
+        "Developmental Psychology",
+        "Developmental Psychology (Hybrid)"
+      ]
+    },
+    {
+      "prefix": "SH",
+      "name": "SH",
+      "course_count": 3,
+      "section_count": 113,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communication",
+        "Public Speaking",
+        "Voice and Diction"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "AG",
+      "course_count": 67,
+      "section_count": 112,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "dodge-city-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Agri-Business Management",
+        "Agricultural Chemicals",
+        "Agricultural Finance",
+        "Agriculture Economics",
+        "Agriculture Equipment Safety"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "IS",
+      "course_count": 42,
+      "section_count": 110,
+      "colleges": [
+        "butler-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Adv Security Practitioner",
+        "Advanced Microcomputer Applications",
+        "Cisco CCNA I/Networking I",
+        "Cisco CCNA II",
+        "Cloud Computing"
+      ]
+    },
+    {
+      "prefix": "BA",
+      "name": "BA",
+      "course_count": 17,
+      "section_count": 97,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Business Ethics",
+        "Business Law 1",
+        "Comp Concepts and Appl",
+        "Entrepreneurship",
+        "Financial Accounting"
+      ]
+    },
+    {
+      "prefix": "AR",
+      "name": "AR",
+      "course_count": 28,
+      "section_count": 94,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "3-D Design",
+        "Art Appreciation",
+        "Art Capstone",
+        "Art History I",
+        "Art History: Paleolithic to Medieval"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 47,
+      "section_count": 93,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "independence-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "2D Design",
+        "2D DESIGN",
+        "3-D Design",
+        "Advanced Painting",
+        "Analog Photography"
+      ]
+    },
+    {
+      "prefix": "TEC",
+      "name": "Osha",
+      "course_count": 9,
+      "section_count": 91,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "First Aid/CPR/AED",
+        "Forklift Op Training",
+        "Machinery Operations",
+        "OSHA 10 Construction",
+        "OSHA 10 Gen Industry"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 14,
+      "section_count": 90,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Child Development",
+        "Child Devopment",
+        "Death and Dying",
+        "Develop Psych"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "ED",
+      "course_count": 21,
+      "section_count": 87,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "A Culture of Caring: Stu Mental Heal",
+        "Career Decision Making",
+        "College Orientation and Career Exploration",
+        "Educating Exceptional Students",
+        "Education as a Career"
+      ]
+    },
+    {
+      "prefix": "CO",
+      "name": "CO",
+      "course_count": 25,
+      "section_count": 86,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cosmetology Services",
+        "Advanced Electronic Spreadsheets",
+        "Advanced Nails",
+        "Chemistry & Chemical Texturizing",
+        "Client Services"
+      ]
+    },
+    {
+      "prefix": "PY",
+      "name": "PY",
+      "course_count": 13,
+      "section_count": 85,
+      "colleges": [
+        "butler-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Child Psychology",
+        "Developmental Psychology",
+        "Engineering Mechanics-Statics",
+        "Engineering Physics I"
+      ]
+    },
+    {
+      "prefix": "WE",
+      "name": "Welding",
+      "course_count": 23,
+      "section_count": 84,
+      "colleges": [
+        "butler-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Basic Welding",
+        "Blueprint Reading",
+        "Cutting Processes",
+        "Cutting Processes for Welding",
+        "Flux Cored Arc Welding"
+      ]
+    },
+    {
+      "prefix": "AL",
+      "name": "AL",
+      "course_count": 11,
+      "section_count": 83,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "CNA",
+        "Geriatric Aide--CNA",
+        "Medical Terminology",
+        "Medication (CMA) Update",
+        "Medication Aide--CMA"
+      ]
+    },
+    {
+      "prefix": "PL",
+      "name": "Ethics",
+      "course_count": 7,
+      "section_count": 81,
+      "colleges": [
+        "butler-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Death and Dying",
+        "Engineering Ethics",
+        "Ethics",
+        "Introduction to Philosophy",
+        "Logic and Critical Thinking"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 25,
+      "section_count": 80,
+      "colleges": [
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "BUS PRACTICES I",
+        "Business Practices 2",
+        "Business Practices/Student's Needs (HSJ Track: HS Afternoon Sem 3)",
+        "CHEM SERVICES I",
+        "CHEM SERVICES II"
+      ]
+    },
+    {
+      "prefix": "BT",
+      "name": "BT",
+      "course_count": 15,
+      "section_count": 77,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Cabinet Construction and Installation",
+        "Carpentry I",
+        "Carpentry II-A",
+        "Carpentry II-B",
+        "Concrete Flatwork and Finishing"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 49,
+      "section_count": 74,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Applied Bass",
+        "Applied Bassoon",
+        "Applied Cello",
+        "Applied Clarinet",
+        "Applied Composition"
+      ]
+    },
+    {
+      "prefix": "AE",
+      "name": "AE",
+      "course_count": 28,
+      "section_count": 73,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits",
+        "Actuator/Sensor Systems",
+        "Adult Ed Bridge to Success",
+        "Adult Ed ESL Bridge to Success",
+        "AG/Rural Wind Applications"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 38,
+      "section_count": 73,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "AI Prompt Writing",
+        "AI Security Operations (SECOPS)",
+        "AI-Driven Log Analysis & Trblshoot",
+        "AI-Native Networking (AIOPS)",
+        "Artificial Intelligence Programming"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 25,
+      "section_count": 71,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Accounting I",
+        "Accounting II",
+        "Business Communications",
+        "Business Law I",
+        "Business Law II"
+      ]
+    },
+    {
+      "prefix": "HI",
+      "name": "History",
+      "course_count": 10,
+      "section_count": 68,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "American History 1492-1865",
+        "American History 1865 to Present",
+        "American History 1865-Present",
+        "Fall American History to 1865",
+        "History of the Holocaust"
+      ]
+    },
+    {
+      "prefix": "MC",
+      "name": "MC",
+      "course_count": 44,
+      "section_count": 68,
+      "colleges": [
+        "butler-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Applied Radio/Television 1",
+        "Applied Radio/Television 2",
+        "Applied Radio/Television 3",
+        "Applied Radio/Television 4",
+        "Applied Radio/Television 5"
+      ]
+    },
+    {
+      "prefix": "EM",
+      "name": "Paramedic",
+      "course_count": 8,
+      "section_count": 67,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT I",
+        "Advanced EMT II",
+        "Cardiac Care (CPR)",
+        "Emergency Medical Technician",
+        "Paramedic I"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 25,
+      "section_count": 64,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "independence-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "ANATOMY AND PHYS",
+        "Animal and Plant Biology & Lab",
+        "Basic Nutrition",
+        "BIOLOGY I",
+        "Biology Review"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 17,
+      "section_count": 63,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "American History I (Hybrid)",
+        "American History II (Service Learning)",
+        "Black History",
+        "Modern Latin America",
+        "The Bible As History"
+      ]
+    },
+    {
+      "prefix": "NR",
+      "name": "Nursing",
+      "course_count": 24,
+      "section_count": 63,
+      "colleges": [
+        "butler-community-college",
+        "dodge-city-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Applied Pathophysiology",
+        "Complex Care of the Adult",
+        "Concept Synthesis",
+        "Health Assess&#39;t for Pract Nurs",
+        "Health Assessment"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 23,
+      "section_count": 63,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "independence-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Contemporary Social Problems",
+        "CRIMINAL JUSTICE",
+        "CRIMINAL LAW",
+        "Cultural Diversity & Ethnicity",
+        "Cultural Diversity and Ethnicity"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 16,
+      "section_count": 62,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "independence-community-college",
+        "manhattan-area-technical-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Composition Workshop",
+        "English Composition I--KRSN ENG1010",
+        "English Composition II",
+        "INTERPERSONAL COM",
+        "Interpersonal Comm--KRSN COM1020"
+      ]
+    },
+    {
+      "prefix": "DSL",
+      "name": "DSL",
+      "course_count": 22,
+      "section_count": 62,
+      "colleges": [
+        "highland-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "AC Diag/Repair",
+        "Adv Diesel Engines",
+        "Adv Elec/Elec Syst",
+        "Adv Engine Ovrhaul",
+        "Air Conditioning"
+      ]
+    },
+    {
+      "prefix": "HHP",
+      "name": "Vars",
+      "course_count": 32,
+      "section_count": 62,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Care &amp; Prevn of Exer",
+        "Intro to Health &amp; Hm",
+        "Personal Wellness",
+        "Prin of Nutrition",
+        "Shotgun Sft &amp; Maint"
+      ]
+    },
+    {
+      "prefix": "AM",
+      "name": "AM",
+      "course_count": 12,
+      "section_count": 58,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Brakes I",
+        "Brakes II",
+        "Drive Train",
+        "Electrical I",
+        "Electrical II"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 26,
+      "section_count": 58,
+      "colleges": [
+        "dodge-city-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Auto Trans Rep",
+        "Auto Trans Serv II",
+        "Auto Trans/Transaxle",
+        "AutoHVACSyst I",
+        "Automotive Climate Control"
+      ]
+    },
+    {
+      "prefix": "BS",
+      "name": "BS",
+      "course_count": 9,
+      "section_count": 57,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "College Biology",
+        "CPR-Basic",
+        "Human Anatomy",
+        "Human Physiology",
+        "Intro Environ. Scien"
+      ]
+    },
+    {
+      "prefix": "ELET",
+      "name": "ELET",
+      "course_count": 16,
+      "section_count": 57,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits I",
+        "Analog Circuits",
+        "Circuits, Instruments, Measure",
+        "Commerical Wiring I",
+        "Communication Fundamentals"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 14,
+      "section_count": 57,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "highland-community-college",
+        "independence-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "American History From 1865",
+        "American History to 1865",
+        "U S History I - 1877",
+        "U.S. HISTORY I",
+        "U.S. HISTORY II"
+      ]
+    },
+    {
+      "prefix": "ALHT",
+      "name": "ALHT",
+      "course_count": 19,
+      "section_count": 56,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "AdvCoding&Revie",
+        "CurrProcTermCo",
+        "ElectHlthRecrds",
+        "Experiential Learning in HP",
+        "HealthcareDelSy"
+      ]
+    },
+    {
+      "prefix": "COMS",
+      "name": "Debate",
+      "course_count": 9,
+      "section_count": 55,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Adv Discus Debate",
+        "Advance Debate",
+        "Debate",
+        "Discussion Debate",
+        "Interpersonal Commun"
+      ]
+    },
+    {
+      "prefix": "CSMT",
+      "name": "CSMT",
+      "course_count": 20,
+      "section_count": 55,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Training",
+        "Business Skills I",
+        "Business Skills II",
+        "Business Skills III",
+        "Chem Services II"
+      ]
+    },
+    {
+      "prefix": "CH",
+      "name": "Chemistry",
+      "course_count": 13,
+      "section_count": 53,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Chemistry I",
+        "Chemistry I (w/Lab)",
+        "College Chemistry 1",
+        "College Chemistry 2",
+        "Fundamentals of Chemistry w/Lab"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "AH",
+      "course_count": 8,
+      "section_count": 52,
+      "colleges": [
+        "butler-community-college",
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Health Pro Medical Term 1",
+        "Health Pro Medical Term 2",
+        "Introduction to Aging Studies",
+        "Medical Terminology",
+        "Medication Aide (Hybrid)"
+      ]
+    },
+    {
+      "prefix": "CIST",
+      "name": "CIST",
+      "course_count": 18,
+      "section_count": 52,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Security Practitioner",
+        "Computer Concpt & App",
+        "Computer Repair and Maintenanc",
+        "Data Structures C++",
+        "Digital Forensics"
+      ]
+    },
+    {
+      "prefix": "EC",
+      "name": "EC",
+      "course_count": 7,
+      "section_count": 52,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Economics",
+        "Macroeconomics",
+        "Microeconomics",
+        "Prin of MacroEcon",
+        "Prin of MicroEcon"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "Weld",
+      "course_count": 5,
+      "section_count": 51,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "AdvGas Metl Arc",
+        "AdvShieldArcWd",
+        "MetalArcWeldng",
+        "Weld Bluepri Rd",
+        "Weld Cuttng Pro"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "SOSC",
+      "course_count": 16,
+      "section_count": 51,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Am Gov't",
+        "Criminology",
+        "CulturalAnthro",
+        "Diversity Studies",
+        "Field Prj Soc Work"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "Composition",
+      "course_count": 6,
+      "section_count": 49,
+      "colleges": [
+        "allen-county-community-college",
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Children's Literature",
+        "Coll Success",
+        "Composition I with Review",
+        "English Composition I",
+        "English Composition II"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "ACR",
+      "course_count": 31,
+      "section_count": 48,
+      "colleges": [
+        "highland-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Air,Fiber,Pin A",
+        "Air,Fiber,Pin B",
+        "Fleet/Com Vehicles",
+        "Intro to Estimating",
+        "Non Struct A & D I A"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "CDL",
+      "course_count": 9,
+      "section_count": 48,
+      "colleges": [
+        "dodge-city-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "BTW Road &amp; Range",
+        "CDL Drvng Skill Test",
+        "CDL Endors (N) &amp; (T)",
+        "CDL Endorse (S) &amp; (P",
+        "CDL Inspections"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 33,
+      "section_count": 48,
+      "colleges": [
+        "allen-county-community-college",
+        "dodge-city-community-college",
+        "independence-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Child Care Administration",
+        "CHILD HEALTH SAFETY",
+        "Child Health, Safety, and Nutrition",
+        "Child Nutrition Practicum (Hybrid)",
+        "Child Nutrition, Health, and Safety"
+      ]
+    },
+    {
+      "prefix": "FIP",
+      "name": "Pilot",
+      "course_count": 25,
+      "section_count": 48,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Air Transportation Management",
+        "Cert FIight Instr Flt: Fixed-Wing",
+        "Cert Flight Instr Flt: Helicopter",
+        "Cert Flight Instr Gnd: Fixed-Wing (Hybrid)",
+        "Cert Flight Instr Gnd: Helicopter (Hybrid)"
+      ]
+    },
+    {
+      "prefix": "CULN",
+      "name": "CULN",
+      "course_count": 14,
+      "section_count": 47,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking",
+        "Beginning Baking",
+        "Cooking Methods",
+        "Culinary Arts Internship",
+        "Culinary Capstone"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 12,
+      "section_count": 47,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Calculus for Business & Economics",
+        "Calculus I",
+        "Calculus II",
+        "Calculus III",
+        "College Algebra"
+      ]
+    },
+    {
+      "prefix": "CHLD",
+      "name": "Care",
+      "course_count": 13,
+      "section_count": 45,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Child Care Lab I: In",
+        "Child Care Lab II:",
+        "Child Care Obs",
+        "Childcare Reg &amp; Ops",
+        "Chld Care Lab I: Hom"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "Academic",
+      "course_count": 19,
+      "section_count": 45,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Imp Pro Non Eng Spk",
+        "L1 Listen-Speak for Engl Learn",
+        "L1 Read for English Learn",
+        "L1 Vocab for English Learn",
+        "L1 Writing/Grammar for English"
+      ]
+    },
+    {
+      "prefix": "MED",
+      "name": "MED",
+      "course_count": 16,
+      "section_count": 45,
+      "colleges": [
+        "allen-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Certified Nurse Aide",
+        "Dietary Need &amp; Nutrn",
+        "Emergency Preprdnss",
+        "Hmn Body Health &amp;",
+        "Ins Billing &amp; Coding"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 32,
+      "section_count": 45,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Instrumental Music I (Concert)",
+        "Advanced Instrumental Music-Jazz I",
+        "Applied Instrum. Lesson III",
+        "Applied Instrum. Lessons I (Piano)",
+        "Applied Music I"
+      ]
+    },
+    {
+      "prefix": "WEL",
+      "name": "Welding",
+      "course_count": 14,
+      "section_count": 45,
+      "colleges": [
+        "cowley-county-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Welding Processes I",
+        "Basic Welding Processes III",
+        "Core Wire Welding",
+        "Cutting Processes",
+        "Gas Metal Arc Welding"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 11,
+      "section_count": 44,
+      "colleges": [
+        "butler-community-college",
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "CPT Coding II",
+        "HC Apps/Elec Encoder",
+        "Healthcare Code Prac",
+        "Hist World Civilization 1",
+        "ICD Coding I"
+      ]
+    },
+    {
+      "prefix": "DR",
+      "name": "Drafting",
+      "course_count": 16,
+      "section_count": 43,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Architectural Drafting I",
+        "Architectural Drafting II",
+        "Civil Drafting",
+        "Commercial Architectural Drafting",
+        "Computer Aided Drafting I"
+      ]
+    },
+    {
+      "prefix": "AB",
+      "name": "AB",
+      "course_count": 20,
+      "section_count": 42,
+      "colleges": [
+        "highland-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Estimating and Blueprinting",
+        "Agriculture Economic",
+        "Intro to Estimating & Diagnostic Scanning",
+        "Mechanical and Electrical Components",
+        "Non-Structural Analysis and Damage Repair I"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 27,
+      "section_count": 41,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Ag Chemicals & Fertilizer",
+        "Ag Construction & Welding",
+        "Agricultural Chemicals",
+        "Agricultural Entomology",
+        "Agriculture Business Managment"
+      ]
+    },
+    {
+      "prefix": "BR",
+      "name": "BR",
+      "course_count": 22,
+      "section_count": 41,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Client Services",
+        "Advanced Hair Techniques",
+        "Barbering Clinical Experience",
+        "Barbering I",
+        "Barbering II"
+      ]
+    },
+    {
+      "prefix": "HPR",
+      "name": "HPR",
+      "course_count": 17,
+      "section_count": 40,
+      "colleges": [
+        "cowley-county-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "BASKETBALL",
+        "CHEER",
+        "FOOTBALL",
+        "FOOTBALL THEORY",
+        "FUND OF CHEER"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 15,
+      "section_count": 39,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Col Chem I",
+        "Col Chem I Lab",
+        "College Chem I + Lab",
+        "College Chem II + Lab",
+        "College Chemistry I"
+      ]
+    },
+    {
+      "prefix": "CURR",
+      "name": "CURR",
+      "course_count": 4,
+      "section_count": 38,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "First Year Semi",
+        "Goalsetting",
+        "SLL:KnittingArt",
+        "Study/Test Skls"
+      ]
+    },
+    {
+      "prefix": "CONS",
+      "name": "CONS",
+      "course_count": 8,
+      "section_count": 37,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Cabinet Fabrication",
+        "Concrete",
+        "Construction Basics",
+        "Electrical",
+        "Introductory to Craft Skills"
+      ]
+    },
+    {
+      "prefix": "ALHE",
+      "name": "Aide",
+      "course_count": 7,
+      "section_count": 36,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Community CPR",
+        "Em Med Tech",
+        "Intro Pharmacol",
+        "Med Aide Update",
+        "Medical Term"
+      ]
+    },
+    {
+      "prefix": "HVAR",
+      "name": "HVAR",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Ductless Systems",
+        "Elec Theory/Circuit Design",
+        "Electric Heating Systems",
+        "Electrical Fundamentals",
+        "EPA 608"
+      ]
+    },
+    {
+      "prefix": "ID",
+      "name": "ID",
+      "course_count": 27,
+      "section_count": 36,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "3D Virtual Environments",
+        "Advanced HTML and CSS",
+        "Animate Fundamentals",
+        "C++ w/Game Programming",
+        "CMS for Web Development"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 31,
+      "section_count": 35,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Clinical: Common Hlth Prob",
+        "Clinical: Complex Hlth Prob",
+        "Clinical: Management Concepts",
+        "Clinical: Multi Syst Hlth Prob",
+        "Foundation Clinical"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 20,
+      "section_count": 34,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "Art Hist I: Prehist-Med",
+        "Ceramics I",
+        "Ceramics II",
+        "Ceramics III"
+      ]
+    },
+    {
+      "prefix": "CMCT",
+      "name": "CMCT",
+      "course_count": 7,
+      "section_count": 34,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "BasicHomeRepair",
+        "Carpentry I",
+        "ElecHVACDrWstVt",
+        "IntroConcrete",
+        "IntroCraftSkill"
+      ]
+    },
+    {
+      "prefix": "INR",
+      "name": "INR",
+      "course_count": 5,
+      "section_count": 34,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Applied Economics",
+        "Industrial Materials",
+        "OSHA 10",
+        "Print Reading",
+        "Technical Mathematics"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 22,
+      "section_count": 34,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Applied Music Brass I",
+        "Applied Music Brass II",
+        "Applied Music Keyboard I",
+        "Applied Music Keyboard II",
+        "Applied Music Percussion I"
+      ]
+    },
+    {
+      "prefix": "AUTT",
+      "name": "AUTT",
+      "course_count": 18,
+      "section_count": 33,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Adv Electronics Chassis HVAC",
+        "Auto Shop Oper and Safety",
+        "Automotive Chassis Systems",
+        "Brakes I",
+        "Electrical & Electronics 3"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 17,
+      "section_count": 33,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Agency Administration",
+        "Criminal Investigation",
+        "Criminal Law",
+        "Criminal Procedures",
+        "Criminal Profiling"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "CNST",
+      "course_count": 13,
+      "section_count": 33,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "ADV Furniture/Cabine",
+        "App Carp II",
+        "App Carptentry I",
+        "Carpentry I",
+        "Carpentry II"
+      ]
+    },
+    {
+      "prefix": "TR",
+      "name": "TR",
+      "course_count": 3,
+      "section_count": 33,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "General Industrial Safety/OSHA10",
+        "Technical Math",
+        "Work Ethics"
+      ]
+    },
+    {
+      "prefix": "AP",
+      "name": "AP",
+      "course_count": 12,
+      "section_count": 32,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Ag Air Conditioning",
+        "Ag Equipment Electricity",
+        "Ag Equipment Hydraulics",
+        "Ag Equipment Powertrains",
+        "Agriculture Equipment Technology & Optimization"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 8,
+      "section_count": 32,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "highland-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "AM GOVERNMENT",
+        "American Government",
+        "American National Government",
+        "Constitutional Law",
+        "Intro to Political Science"
+      ]
+    },
+    {
+      "prefix": "ALH",
+      "name": "ALH",
+      "course_count": 22,
+      "section_count": 31,
+      "colleges": [
+        "cowley-county-community-college",
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "Allied Healthcare A & P",
+        "Athletic Training Practicum I",
+        "Athletic Training Practicum III",
+        "Basic First Aid",
+        "Bioethics"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 22,
+      "section_count": 31,
+      "colleges": [
+        "highland-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Elec/Electronic",
+        "Auto Tech Lab I",
+        "Auto Tech Lab I A",
+        "Auto Tech Lab I B",
+        "Auto Trans/Axles I"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 7,
+      "section_count": 31,
+      "colleges": [
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Fund of Acting",
+        "Fund of Oral Comm",
+        "Fund Of Speech",
+        "Interpersonal Comm",
+        "Interprsnl Comm"
+      ]
+    },
+    {
+      "prefix": "NC",
+      "name": "Silversmithing",
+      "course_count": 3,
+      "section_count": 31,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Motorcycle Safety--Beginning",
+        "Silversmithing I",
+        "Silversmithing II"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 21,
+      "section_count": 30,
+      "colleges": [
+        "highland-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Cert Nurse Aide",
+        "Complex Care of Mental Health and Maternal Child Populations",
+        "Health Assessment and Advanced Nursing Skills",
+        "Hgh Risk Mat-Cld Nu",
+        "KSPN Care of Adults II"
+      ]
+    },
+    {
+      "prefix": "PD",
+      "name": "Chall",
+      "course_count": 7,
+      "section_count": 30,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Early College Academy 1",
+        "Early College Academy 3",
+        "Nav Chall Business/Industry",
+        "Nav Chall Health Sciences",
+        "Nav Chall in Liberal Arts"
+      ]
+    },
+    {
+      "prefix": "CGT",
+      "name": "Design",
+      "course_count": 14,
+      "section_count": 29,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Design in Comp",
+        "Computer Design I",
+        "Computer Design II",
+        "Computer Design III",
+        "Design for Print"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "Hair",
+      "course_count": 13,
+      "section_count": 29,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Business Practices I",
+        "Business Practices II",
+        "Chemical Services I",
+        "Chemical Services II",
+        "Chemical Services III"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "ENGT",
+      "course_count": 7,
+      "section_count": 29,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "App of CAD/CAM in",
+        "App of En Tech",
+        "CAD Fundamentals",
+        "Civ Drftng Fund",
+        "Computer Aided Draft"
+      ]
+    },
+    {
+      "prefix": "FW",
+      "name": "Varsity",
+      "course_count": 20,
+      "section_count": 29,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Muscle Pump 1",
+        "Spirit Squad 1",
+        "Spirit Squad 3",
+        "Varsity Baseball 1",
+        "Varsity Baseball 3"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 10,
+      "section_count": 29,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Care&Prev Ath",
+        "CondWgts:Baseba",
+        "Int Athl Trn",
+        "Intro Coaching",
+        "Lifetime Fit"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "Welding",
+      "course_count": 15,
+      "section_count": 29,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "CAD Systems and Processes",
+        "CNC Plasma Cutting",
+        "Core Wire Welding",
+        "Cutting Processes",
+        "Gas Metal Arc Welding (GMAW)"
+      ]
+    },
+    {
+      "prefix": "BE",
+      "name": "BE",
+      "course_count": 20,
+      "section_count": 28,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Beginning Document Processing",
+        "Beginning Medical Coding",
+        "Business Comm",
+        "Business English"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "dodge-city-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "AI and Introduction to Machine Learning",
+        "Computer Concepts and Applications",
+        "Computer Engineering",
+        "Computers in Healthcare",
+        "Data Structures and Algorithms"
+      ]
+    },
+    {
+      "prefix": "DN",
+      "name": "Dance",
+      "course_count": 20,
+      "section_count": 28,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Ballet 1",
+        "Ballet 2",
+        "Ballet 3",
+        "Ballet 4",
+        "Beginning Jazz Dance"
+      ]
+    },
+    {
+      "prefix": "PO",
+      "name": "Week",
+      "course_count": 5,
+      "section_count": 28,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "American Fed Govt",
+        "International Rel",
+        "Week 1 American Government",
+        "Week 2 Introduction to Political Science",
+        "Week 2 State & Local Government"
+      ]
+    },
+    {
+      "prefix": "BLUE",
+      "name": "Freshman",
+      "course_count": 1,
+      "section_count": 27,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Freshman Seminar"
+      ]
+    },
+    {
+      "prefix": "HVS",
+      "name": "Varsity",
+      "course_count": 23,
+      "section_count": 27,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Cheerleading I",
+        "Cheerleading III",
+        "ESports III",
+        "Rhythm I",
+        "Rhythm III"
+      ]
+    },
+    {
+      "prefix": "ME",
+      "name": "ME",
+      "course_count": 12,
+      "section_count": 27,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Commercial Heating and Air Conditioning",
+        "Commercial Refrigeration",
+        "EPA 608",
+        "Fundamentals of Motor Controls",
+        "Heating System Fundamentals"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "Testing",
+      "course_count": 15,
+      "section_count": 27,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Adv Nondestructive Testing Methods",
+        "Codes & Practices",
+        "Eddy Current Testing I",
+        "Eddy Current Testing II",
+        "Intro to Nondestructive Testing"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "Kspn",
+      "course_count": 12,
+      "section_count": 27,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "KSPN Community Health Across the Lifespan",
+        "KSPN Foundations of Nursing",
+        "KSPN Foundations of Nursing Clinical",
+        "KSPN Leadership, Roles, and Issues",
+        "KSPN Maternal Child Nursing"
+      ]
+    },
+    {
+      "prefix": "ACRT",
+      "name": "ACRT",
+      "course_count": 11,
+      "section_count": 26,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Adv Estimating/Blueprinting",
+        "Intro Estimating/Diag Scan",
+        "Mech/Elect Components",
+        "Non-Structural A&D Repair 1",
+        "Non-Structural A&D Repair 2"
+      ]
+    },
+    {
+      "prefix": "INRW",
+      "name": "Integrated",
+      "course_count": 2,
+      "section_count": 26,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Integrated Reading & Writing"
+      ]
+    },
+    {
+      "prefix": "MP",
+      "name": "Production",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Production Techniques",
+        "Applied Production Logistics",
+        "Audio Production I",
+        "Audio Production II",
+        "Audio/Video Scriptwriting"
+      ]
+    },
+    {
+      "prefix": "TH",
+      "name": "Theatre",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Costume Design and Construction",
+        "Stage Makeup",
+        "Stage/Television Lighting"
+      ]
+    },
+    {
+      "prefix": "ELCT",
+      "name": "ELCT",
+      "course_count": 11,
+      "section_count": 25,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Basics of Electricit",
+        "Blueprints &amp; Schemat",
+        "Elect Practicum I",
+        "Instrmnts &amp; Measure",
+        "Motor Controls I"
+      ]
+    },
+    {
+      "prefix": "M",
+      "name": "M",
+      "course_count": 20,
+      "section_count": 25,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "App Music III-voc",
+        "App. Music II (Voc)",
+        "Appl. Music IV-Voc",
+        "Applied Keyboard I",
+        "Applied Keyboard II"
+      ]
+    },
+    {
+      "prefix": "AMFT",
+      "name": "AMFT",
+      "course_count": 10,
+      "section_count": 24,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits",
+        "Advanced Prog Logic Controller",
+        "AutoCAD Concepts",
+        "Electrical Motor Controls",
+        "GMAW"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 7,
+      "section_count": 24,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Labor Studies",
+        "Microeconomics",
+        "Prin Macroeconomics",
+        "Prin Microeconomics",
+        "Prin of Microecon"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "EXSC",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Begin Swimming",
+        "Care Prev Ath Injury",
+        "Exercise Physiology",
+        "First Aid",
+        "Fndtions in Coaching"
+      ]
+    },
+    {
+      "prefix": "IND",
+      "name": "IND",
+      "course_count": 17,
+      "section_count": 24,
+      "colleges": [
+        "allen-county-community-college",
+        "dodge-city-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits",
+        "Bench Work",
+        "CDL Entry-Level Driver Operations",
+        "CDL Road and Range Driving",
+        "Electrical Control Systems I"
+      ]
+    },
+    {
+      "prefix": "PH",
+      "name": "Physics",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Basic Physics 1",
+        "Descriptive Astronomy",
+        "General Physics 1",
+        "General Physics 2",
+        "Introduction to Meteorology"
+      ]
+    },
+    {
+      "prefix": "AUDI",
+      "name": "AUDI",
+      "course_count": 19,
+      "section_count": 23,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Aud Eng Keyboard Skills",
+        "Aud Eng Mus Skills",
+        "Aud Eng Portfolio 1",
+        "Aud Eng Portfolio 2",
+        "Aud Recordng 2"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 21,
+      "section_count": 23,
+      "colleges": [
+        "cowley-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Agency Administration",
+        "Controlled Force I",
+        "Controlled Force II",
+        "Criminal Investigation",
+        "Criminal Investigation II"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "AC Circuits",
+        "AC/DC Circuits I",
+        "CommerWiring I",
+        "Digital Electronics I",
+        "Electronic Communication Syst"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "PHS",
+      "course_count": 12,
+      "section_count": 22,
+      "colleges": [
+        "cowley-county-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "ASTRONOMY",
+        "CHEM I MAJORS",
+        "CHEM NONMAJORS",
+        "ENGINEER PHYSICS II",
+        "Engineering Economy"
+      ]
+    },
+    {
+      "prefix": "THR",
+      "name": "THR",
+      "course_count": 17,
+      "section_count": 22,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "ACTING I",
+        "DRAFTING FOR THR II",
+        "Fund of Theatrical Design",
+        "Intro to Costume Tech",
+        "INTRO TO PLAYWRITING"
+      ]
+    },
+    {
+      "prefix": "FL",
+      "name": "Spanish",
+      "course_count": 8,
+      "section_count": 21,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Beg Spanish 1",
+        "Beg Spanish 2",
+        "Beginning French 1",
+        "Beginning Russian 1",
+        "Elementary Spanish I"
+      ]
+    },
+    {
+      "prefix": "LE",
+      "name": "Criminal",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigation",
+        "Criminal Justice Interview and Report Writing",
+        "Criminal Justice Interviewing",
+        "Criminal Law",
+        "Criminal Procedures"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "MEDA",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Patient Care",
+        "Billing and Coding",
+        "Emergency Preparedness",
+        "Externship",
+        "Human Body"
+      ]
+    },
+    {
+      "prefix": "MENT",
+      "name": "MENT",
+      "course_count": 6,
+      "section_count": 21,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Add Mfg Desn &amp; Ops",
+        "Adv Mech Drafting",
+        "App of Mec Design Pr",
+        "Intro 3D Print Ops",
+        "Intro to CNC Mch Ops"
+      ]
+    },
+    {
+      "prefix": "RA",
+      "name": "RA",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Training I",
+        "Clinical Training II",
+        "Clinical Training III",
+        "Cranial Imaging and Computed Tomography",
+        "Imaging Modalities"
+      ]
+    },
+    {
+      "prefix": "HP",
+      "name": "HP",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nutrition",
+        "First Aid/CPR/AED",
+        "Healthy Living",
+        "Intro to Exercise Science",
+        "Intro to Sport Management"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Commercial HVAC",
+        "Htg Sys Fundmnt",
+        "Htg Sys-Lab",
+        "Pipefitting"
+      ]
+    },
+    {
+      "prefix": "IWT",
+      "name": "Weld",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Read II",
+        "Blueprint Reading",
+        "Cutting Processes",
+        "Gas Mtl Arc Weld",
+        "Gas Mtl Arc Weld II"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 12,
+      "section_count": 20,
+      "colleges": [
+        "dodge-city-community-college",
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Astronomy Laboratory",
+        "Fund Astronomy",
+        "FundAstronLab",
+        "General Physics I & Lab",
+        "Int Coll Phys I"
+      ]
+    },
+    {
+      "prefix": "PT",
+      "name": "PT",
+      "course_count": 18,
+      "section_count": 20,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Basic Principles and Practices of Physical Therapy",
+        "Clinical Kinesiology and Applied Anatomy",
+        "Clinical Practice I",
+        "Clinical Practice II",
+        "Clinical Practice III"
+      ]
+    },
+    {
+      "prefix": "ALMA",
+      "name": "ALMA",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "A&PAlliedHealth",
+        "ClinAspPatCare",
+        "Emerg Prepare",
+        "LabFundamentals",
+        "Med Admin Aspec"
+      ]
+    },
+    {
+      "prefix": "ECH",
+      "name": "ECH",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Child Abuse, Neg, HT",
+        "Creat Exp Yng Child",
+        "ECH Cred Port II",
+        "ECH Cred Portfolio I",
+        "ECH Fundamentals"
+      ]
+    },
+    {
+      "prefix": "JL",
+      "name": "JL",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Magazine Production",
+        "Introduction to Mass Communications",
+        "Journalism & Graphic Arts Technology Internship I",
+        "Magazine Production and Planning",
+        "Multimedia Writing"
+      ]
+    },
+    {
+      "prefix": "A",
+      "name": "A",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "2-D Design",
+        "Advanced Studio I",
+        "Art Appreciation",
+        "Ceramics I",
+        "Ceramics II"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "Children & Adolescent Literature",
+        "Children with Special Needs",
+        "Educational Technology",
+        "Educational Technology in Teaching",
+        "Elementary School PE & Health"
+      ]
+    },
+    {
+      "prefix": "FM",
+      "name": "Crop",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural Mathematics",
+        "Agriculture Marketing",
+        "Crop and Weed Identification I",
+        "Crop and Weed Identification II",
+        "Crop and Weed Identification III"
+      ]
+    },
+    {
+      "prefix": "GO",
+      "name": "GO",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Comparative Politics",
+        "International Relations",
+        "Introduction to Political Science"
+      ]
+    },
+    {
+      "prefix": "HE",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 18,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "PLM",
+      "name": "PLM",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Craft Skills for Pl",
+        "DWV &amp; Water Dist",
+        "Interm Plumbing",
+        "Pipes and Fittings",
+        "Plumbing Tools and"
+      ]
+    },
+    {
+      "prefix": "TA",
+      "name": "Thtre",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Acting 1",
+        "Audition Techniques",
+        "Stagecraft",
+        "Theatre Appreciation",
+        "Thtre Practicum 1"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "cowley-county-community-college",
+        "highland-community-college",
+        "manhattan-area-technical-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Chemistry I",
+        "Gen Chem I w/lab",
+        "General Chemistry",
+        "General Organic & Bio Chemistry",
+        "Into to Chem w/Lab"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry I",
+        "Carpentry/Construction Internship I",
+        "Carpentry/Construction Skills App 1",
+        "Concrete",
+        "Construction Basics"
+      ]
+    },
+    {
+      "prefix": "DIGI",
+      "name": "DIGI",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Illustrator",
+        "Advanced Photoshop",
+        "Begining Illustrator",
+        "Beginning Photoshop",
+        "Graphic Design Multimed+web II"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Prin of Prsn Finance"
+      ]
+    },
+    {
+      "prefix": "INF",
+      "name": "Intr",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Intr to Comp Inf Sys"
+      ]
+    },
+    {
+      "prefix": "NASC",
+      "name": "Physics",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Engnr Physics I",
+        "Gen Physical Science",
+        "General Physics I",
+        "Intro Astronomy",
+        "Intro Astronomy Lab"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "cowley-county-community-college",
+        "independence-community-college",
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "Accounting with QuickBooks",
+        "Business Accounting",
+        "COMP ACC",
+        "Financial Accounting",
+        "FINANCIAL ACCOUNTING"
+      ]
+    },
+    {
+      "prefix": "AN",
+      "name": "Animation",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "butler-community-college",
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Animation Portfolio Capstone",
+        "Character Animation",
+        "Cultural Anthropology",
+        "Digital Animation I",
+        "Digital Animation II"
+      ]
+    },
+    {
+      "prefix": "CECT",
+      "name": "CECT",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Fundamentals",
+        "Electrical Fundamentals II",
+        "Energy Loads and Calculations",
+        "EPA 608",
+        "Heating System Fundamentals II"
+      ]
+    },
+    {
+      "prefix": "CRTE",
+      "name": "CRTE",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Adv Op Sys",
+        "Applied Networking 2",
+        "Comp Net Security",
+        "Comp TIA A +Core 2",
+        "COMP TIA A+Core 1"
+      ]
+    },
+    {
+      "prefix": "HVA",
+      "name": "HVAC",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "highland-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Blueprint Rd/Sketch",
+        "Comm Refrigeration",
+        "Compressors and Refrigeration Controls",
+        "Controls and Motors",
+        "Electrical Fundamentals"
+      ]
+    },
+    {
+      "prefix": "LA",
+      "name": "LA",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Law",
+        "Bankruptcy Law",
+        "Elder Law",
+        "Family Law",
+        "Introduction to Legal Research and Writing"
+      ]
+    },
+    {
+      "prefix": "RD",
+      "name": "College",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "College Reading 1",
+        "College Reading 2",
+        "ELL College Reading 1",
+        "ELL College Reading 2"
+      ]
+    },
+    {
+      "prefix": "CD",
+      "name": "Child Development",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Bldg Relationships w/Families",
+        "Child Care Administration",
+        "Child Care Practicum 1",
+        "Child Care Practicum 2",
+        "Creative Exper Young Children"
+      ]
+    },
+    {
+      "prefix": "CRJS",
+      "name": "CRJS",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Invest II",
+        "Criminal Justice Capstone",
+        "Criminal Law",
+        "Intro Crimnl Justice",
+        "Juv Delinquency & Just"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "dodge-city-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support",
+        "First Aid (Hybrid)",
+        "HC Clinical Sklls I",
+        "Hlth Info Tech",
+        "IV Therapy"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "HPE",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Athletic Training Practicum I",
+        "Athletic Training Practicum II",
+        "Care & Prevention of Athletic Injuries",
+        "Elementary School PE & Health",
+        "Ind/Dual Lifetime Act (Fitness)"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Intro to Philosophy",
+        "Introduction to Ethics",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "RSCR",
+      "name": "RSCR",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Cardio Car & Diag II",
+        "Cardio Care & Diag I",
+        "Clinic Practice III",
+        "Clinic Practice IV",
+        "Crdio Car + Diag III"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Acting",
+        "Improvisation",
+        "Introduction to Film",
+        "Introduction to Makeup for Theat re and Film",
+        "Stagecraft"
+      ]
+    },
+    {
+      "prefix": "CSIS",
+      "name": "CSIS",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "CompConceptsApp",
+        "Computr Litercy",
+        "IntroWebDesign",
+        "JavaProgramming"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Creative Activities for Child",
+        "Dev Lang & Literacy",
+        "Early Childhood Curriculum",
+        "Infant, Toddler I",
+        "Intro to Early Childhood Educ"
+      ]
+    },
+    {
+      "prefix": "EE",
+      "name": "Conduit",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Conduit Fabrication",
+        "NEC Codeology"
+      ]
+    },
+    {
+      "prefix": "MOA",
+      "name": "MOA",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Body Struc/Functions",
+        "Emerg Preparedness",
+        "Ins. Billing/Coding",
+        "Med Admin Asp I",
+        "Med Prof Issues"
+      ]
+    },
+    {
+      "prefix": "MTSC",
+      "name": "MTSC",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Embalming Theory",
+        "Funeral Ser Counslng",
+        "Funeral Serv Merch",
+        "Mort Sci Practicm I",
+        "Mort Sci Practicm II"
+      ]
+    },
+    {
+      "prefix": "JD",
+      "name": "John",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "John Deere Advanced Ag Equipment Hydraulics",
+        "John Deere Advanced Ag Equipment Systems",
+        "John Deere Ag Air Conditioning",
+        "John Deere Ag Diesel Diagnostics",
+        "John Deere Ag Equipment Electricity"
+      ]
+    },
+    {
+      "prefix": "LANG",
+      "name": "Spanish",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "French I",
+        "Spanish I",
+        "Spanish II"
+      ]
+    },
+    {
+      "prefix": "PLGL",
+      "name": "PLGL",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Interv&Investig",
+        "PA AdvLegResWri",
+        "PA in Legal Sys",
+        "PA Real Prop La",
+        "PA: CriminalLaw"
+      ]
+    },
+    {
+      "prefix": "RT",
+      "name": "RT",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary Anatomy and Physiology I",
+        "Cardiopulmonary Anatomy and Physiology II",
+        "Cardiopulmonary Assessment",
+        "Cardiopulmonary Pathology",
+        "Clinical Training I"
+      ]
+    },
+    {
+      "prefix": "APP",
+      "name": "APP",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Front-end Web Dev",
+        "Obj Ornt Program",
+        "Progamming in Swift",
+        "Software Planning"
+      ]
+    },
+    {
+      "prefix": "BEH",
+      "name": "Psych",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "DEVELOPMENTAL PSYCH",
+        "GEN PSYCH"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "Culinary",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Cuisines of America",
+        "Culinary Nutrition",
+        "Food Truck Administration",
+        "Garde Manger",
+        "Kitchen Essen/Culinary Math"
+      ]
+    },
+    {
+      "prefix": "CENT",
+      "name": "Civil",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "App of Civil Design",
+        "Civil Plans &amp; Regs",
+        "Geo Info Syst (GIS)",
+        "Global Pos. Sys GPS"
+      ]
+    },
+    {
+      "prefix": "CHC",
+      "name": "Child",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Child Care Development Portfolio",
+        "Child Care Practicum I",
+        "Collabor with Child Family & Commun",
+        "Development of the Young Child",
+        "Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "CN",
+      "name": "CN",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Architectural Blueprint Read&#39;g",
+        "Cabinet Making and Install",
+        "Ceilings/Walls/Build&#39;g Systems",
+        "Craft Fundamentals",
+        "Introduction to Craft Skills"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "Dental",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Dental Health Safety",
+        "Dental Hygiene Biochemistry",
+        "Dental Hygiene Orientation",
+        "Dental Hygiene Process I",
+        "Dental Hygiene Process III"
+      ]
+    },
+    {
+      "prefix": "EBE",
+      "name": "English",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "ELL: English Comp Supplemental Sem.",
+        "English Comp. Supplemental Seminar",
+        "English for Academic Purposes I"
+      ]
+    },
+    {
+      "prefix": "GE",
+      "name": "World",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "colby-community-college",
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Week World Regional Geography",
+        "World Geography"
+      ]
+    },
+    {
+      "prefix": "KSPN",
+      "name": "Kspn",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "KSPN Care of Aging Adults",
+        "KSPN Found of Nurs Clini",
+        "KSPN Foundations of Nursing",
+        "KSPN Fund Pharmacology",
+        "KSPN Maternal Child Nursing"
+      ]
+    },
+    {
+      "prefix": "NAIL",
+      "name": "NAIL",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Artificial Nails",
+        "Business Practices",
+        "KS State Law Nail Technology",
+        "Manicuring Skills",
+        "Obtaining Employmt"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "highland-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "ETHICS",
+        "INTRO TO PHILOSOPHY",
+        "Introduction to Ethics",
+        "Introduction to Phil",
+        "Logic/Critical Think"
+      ]
+    },
+    {
+      "prefix": "PHTR",
+      "name": "Clinical",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Skills",
+        "Clinical Skills III",
+        "Clinical Skills IV",
+        "Clinical Skills V",
+        "Clinical Sklls II"
+      ]
+    },
+    {
+      "prefix": "BCT",
+      "name": "BCT",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry Basics",
+        "Commercial Framing & Construction I",
+        "Construction Technology II",
+        "Floors Walls Ceiling Framing",
+        "Intro Construction Industry Safety"
+      ]
+    },
+    {
+      "prefix": "BEMT",
+      "name": "BEMT",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry Basics",
+        "EPA 608",
+        "Landscaping",
+        "Masonry & Concrete",
+        "OSHA 30"
+      ]
+    },
+    {
+      "prefix": "BTT",
+      "name": "BTT",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry I",
+        "Carpentry II",
+        "Construction Basics",
+        "Intro Craft Skills",
+        "Res. Concrete Const."
+      ]
+    },
+    {
+      "prefix": "MCM",
+      "name": "Mass",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Audio and Video Production",
+        "Digital Photography",
+        "Mass Communication Internship I",
+        "Mass Communication Internship II",
+        "Mass Communication Internship III"
+      ]
+    },
+    {
+      "prefix": "NS",
+      "name": "Nursing",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "KSPN Foundations of Nursing",
+        "KSPN Fund of Pharm and Safe Med",
+        "KSPN Maternal Child Nursing I",
+        "KSPN Mental Health Nursing I",
+        "Leadership Roles and Issues II"
+      ]
+    },
+    {
+      "prefix": "OR",
+      "name": "Orientation",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Orientation"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Ag Tech Conslt &amp; Imp",
+        "App Geo &amp; Nav Tec",
+        "Crop Pro &amp; Fert Tec",
+        "Geo Info Syst",
+        "Info Tech in Ag"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "DMS",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "AbdomSono",
+        "DiagMeSo Lab IV",
+        "DiaMedSonLab I",
+        "DiaMeSo Lab III",
+        "IntroDiagMedSon"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Macroeconomics",
+        "Microeconomics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "HEA",
+      "name": "Health",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "independence-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "ADVANCED EMT",
+        "CNA",
+        "EMT",
+        "Medical Terminology",
+        "MEDICAL TERMINOLOGY"
+      ]
+    },
+    {
+      "prefix": "MMVP",
+      "name": "Animation",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Animation",
+        "Intro to Digital Imaging",
+        "Intro to Video Production",
+        "Intro to Web Animation",
+        "Introduction to Multimedia"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "Machining",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "CNC Machining",
+        "Machine Tool Processes",
+        "Machining I",
+        "Machining II",
+        "Workplace Ethics"
+      ]
+    },
+    {
+      "prefix": "PRLG",
+      "name": "PRLG",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Crimnl Law Paralegal",
+        "Family Law",
+        "Intro to Law",
+        "Legal Ethics, Interview/Invest",
+        "Legal Research"
+      ]
+    },
+    {
+      "prefix": "ADCN",
+      "name": "ADCN",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Adn Cncl Fld Pract I",
+        "Adn Cncl Fld Prct II",
+        "Group Dynam Addict I",
+        "Indiv Counseling and Assess",
+        "Intro to Addictions"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Transmissions & Transaxles 1",
+        "Auto Transmissions & Transaxles 2",
+        "Electrical 1",
+        "Electrical 2",
+        "Engine Performance 1"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "dodge-city-community-college",
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Anthropology",
+        "Gen Anthropology",
+        "Int Cultural Anthrop",
+        "Native Amer Indians"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "College Chemistry I",
+        "College Chemistry II",
+        "Introduction to Chemistry",
+        "Organic Chemistry I"
+      ]
+    },
+    {
+      "prefix": "FY",
+      "name": "Week",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Week 1 First Year Experience"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "allen-county-community-college",
+        "dodge-city-community-college",
+        "highland-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "GEOGRAPHY",
+        "Geography (Hybrid)",
+        "Principles of Geography",
+        "World Regional Geogr"
+      ]
+    },
+    {
+      "prefix": "MUE",
+      "name": "MUE",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "ATHLETIC BAND",
+        "CHORALE I",
+        "CHORALE III",
+        "CONCERT BAND",
+        "MUSIC APPRECIATION"
+      ]
+    },
+    {
+      "prefix": "OSHA",
+      "name": "Osha",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "OSHA 10 (for Ind Maint afternoon)",
+        "OSHA 30 (for ELEC afternoon)"
+      ]
+    },
+    {
+      "prefix": "PHO",
+      "name": "PHO",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "cowley-county-community-college",
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Intro Digital Photo",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "POSC",
+      "name": "Political",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Intro Political Sci"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "Physics",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "College Physics II",
+        "Engineering Physics I",
+        "Physical Geology",
+        "Physical Science"
+      ]
+    },
+    {
+      "prefix": "AMS",
+      "name": "Electrical",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions",
+        "Electrical I",
+        "Electrical II",
+        "Manual Transmissions"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "highland-community-college",
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Basics of AutoCAD",
+        "Computer Graphics I",
+        "Intermediate Mechanical Drafting",
+        "Introduction to Mechanical Drafting",
+        "SolidWorks Assembly Modeling"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "Microsoft",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Computer Applications",
+        "Microsoft Excel",
+        "Microsoft Word"
+      ]
+    },
+    {
+      "prefix": "DEN",
+      "name": "Dental",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Chairside Assisting 1",
+        "Dental Anatomy",
+        "Dental Materials",
+        "Dental Radiology 1",
+        "Dental Science"
+      ]
+    },
+    {
+      "prefix": "DIE",
+      "name": "DIE",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Engines",
+        "Brakes",
+        "Drive Trains",
+        "Hydraulics",
+        "Shop Operations Customer Relations"
+      ]
+    },
+    {
+      "prefix": "DST",
+      "name": "DST",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Diesel Engines 1",
+        "Electrical/Electronic Systems",
+        "Fuel Lab",
+        "Hydraulics",
+        "Hydrostatic Drive"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "kansas-city-kansas-community-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Childrens Lit",
+        "Ed Multicultural Soc",
+        "EducatExcepStud",
+        "Intro Teach Car Awar",
+        "Stdy Child + Adolesc"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT 1",
+        "Emergency Medical Technician",
+        "Paramedic 1",
+        "Paramedic 2",
+        "Paramedic 4"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "ETEC",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "CompTIAA+Core 1",
+        "IndustInternshp",
+        "Intro Netwrking",
+        "Spec Skills Wel",
+        "TopicsTech/Ind"
+      ]
+    },
+    {
+      "prefix": "IP",
+      "name": "IP",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Career Readiness",
+        "Internship 1.2",
+        "Internship 2.2"
+      ]
+    },
+    {
+      "prefix": "LDR",
+      "name": "Leadership",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Civic Leadership",
+        "Ethics & Diversity in Leadership",
+        "Internship in Leadership I",
+        "Organizational Leadership",
+        "Principles of Leadership"
+      ]
+    },
+    {
+      "prefix": "LG",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Spanish I",
+        "Spanish II"
+      ]
+    },
+    {
+      "prefix": "LT",
+      "name": "LT",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "American Lit 2",
+        "Childrens Literature",
+        "Intro to Lit 1",
+        "Intro to Poetry"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "AdltNeurAppsOTA",
+        "AdultPhysAppOTA",
+        "CoreSkls&ModOTA",
+        "DocumentaForOTA",
+        "Menlth&PscPrOTA"
+      ]
+    },
+    {
+      "prefix": "SD",
+      "name": "SD",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Artificial Intelligence Prog",
+        "C#",
+        "Data Science",
+        "Dbase Design and Management",
+        "Introduction to SQL Language"
+      ]
+    },
+    {
+      "prefix": "ST",
+      "name": "Surgical",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Clinical I",
+        "Clinical II",
+        "Clinical III",
+        "Introduction to Surgical Technology",
+        "Principles and Practices of Surgical Technology"
+      ]
+    },
+    {
+      "prefix": "TCH",
+      "name": "Osha",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "OSHA 10"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Acting II:(play Prod)",
+        "Acting Practicum",
+        "Introductn to Acting",
+        "Stagecraft",
+        "Stagecraft II"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "neosho-county-community-college",
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "College Acct",
+        "Financial Acct",
+        "Managerial Acct",
+        "Prin of Acct I"
+      ]
+    },
+    {
+      "prefix": "ADM",
+      "name": "ADM",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Administ. Procedures",
+        "Business Finance",
+        "Micro Apps I",
+        "Office Sim II",
+        "Office Simulations I"
+      ]
+    },
+    {
+      "prefix": "APFE",
+      "name": "Frontend",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Front-end Dev",
+        "Inter Front-end Web",
+        "Live Wrk I Front-end",
+        "Live Wrk II Frnt-end",
+        "Native Android Dev"
+      ]
+    },
+    {
+      "prefix": "CC",
+      "name": "CC",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Building Family and Community Relations",
+        "Infant and Toddler Development",
+        "Introduction to Early Childhood Education",
+        "Nutrition, Health, and Safety",
+        "Observation & Assessment of Young Children"
+      ]
+    },
+    {
+      "prefix": "CJS",
+      "name": "Criminal",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Agency Administration",
+        "Criminal Investigation",
+        "Intro to Criminal Justice",
+        "Introduction to Corrections",
+        "Professional Responsibility in Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "CTD",
+      "name": "Commercial",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "CDL/Entry-Level Commercial Motor Vehicle Driver Training",
+        "Class B Commercial Truck Driving",
+        "Commercial Motor Vehicle Theory"
+      ]
+    },
+    {
+      "prefix": "ELE",
+      "name": "ELE",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits I",
+        "Blueprint/Schematics",
+        "Elec Motor Op/Contrl",
+        "Generators & Trans",
+        "Ind Con Wire/Desgn"
+      ]
+    },
+    {
+      "prefix": "EMTC",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Responder",
+        "EMT"
+      ]
+    },
+    {
+      "prefix": "FRSC",
+      "name": "Firefighter",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Fire Behavior and Combustion",
+        "Fire Prevention",
+        "Firefighter I",
+        "Firefighter II",
+        "Principles of Emergency Servic"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "Adobe",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Adobe InDesign",
+        "Adobe Photoshop",
+        "Graphic Design I",
+        "Social Media Design",
+        "Web and Motion Graphics: Adobe Animate"
+      ]
+    },
+    {
+      "prefix": "HYG",
+      "name": "Dental",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene I - Pre-Clinical",
+        "Clinical Dental Hygiene III",
+        "Dental Public Health",
+        "Dental Radiography",
+        "Embryology, Histology, and Oral Anatomy"
+      ]
+    },
+    {
+      "prefix": "PI",
+      "name": "Philosophy",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Ethics",
+        "Introduction to Philosophy",
+        "Week Philosophy of Thought & Logic"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Civic Engagement I",
+        "Civic Engagement II",
+        "Civic Engagement III",
+        "Civic Engagement IV"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Resp",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary A&amp;P",
+        "Clinical Practice II",
+        "Patient Assmt &amp; Plan",
+        "Resp Care Sciences",
+        "Resp Therapy I"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "College",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "allen-county-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "COLLEGE SUCCESS",
+        "INFO LITERACY",
+        "Mastering College Study Skills"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Aero",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Aero Adhes Bond",
+        "Aero Assembly",
+        "Aero Blueprt Rd",
+        "Bas Drlg&Rivet",
+        "Intro to Sealng"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "AT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Brakes 1",
+        "Brakes 2",
+        "Electrical 1",
+        "Electrical 2",
+        "Engine Performance 1"
+      ]
+    },
+    {
+      "prefix": "GOV",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "American National Government"
+      ]
+    },
+    {
+      "prefix": "HONR",
+      "name": "HONR",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Honors Tutorl I{H}",
+        "Honrs Tutrl III{H}",
+        "PTK Leadershp Dev St"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Intro to Logic",
+        "Intro to Philos"
+      ]
+    },
+    {
+      "prefix": "HVPA",
+      "name": "HVPA",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Pole Climbing",
+        "Rigging Principles",
+        "Safety & Workplace Fundmentals"
+      ]
+    },
+    {
+      "prefix": "IMT",
+      "name": "IMT",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "manhattan-area-technical-college",
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "ElecContSys I",
+        "IndProcessContr",
+        "IndProgLogicCon",
+        "Mech Systems",
+        "Occupational Work Experiance"
+      ]
+    },
+    {
+      "prefix": "JP",
+      "name": "Digital",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Imagery--Photoshop",
+        "Basic Photography",
+        "Introduction to Digital Imagery--Photoshop"
+      ]
+    },
+    {
+      "prefix": "MEC",
+      "name": "MEC",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Maintenance",
+        "Mechanical Systems",
+        "Principles of Electricity"
+      ]
+    },
+    {
+      "prefix": "RE",
+      "name": "Testament",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to World Religions",
+        "New Testament Literature",
+        "Old Testament Literature"
+      ]
+    },
+    {
+      "prefix": "SC",
+      "name": "Princ",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Princ of Geography"
+      ]
+    },
+    {
+      "prefix": "ZOO",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Human Anatomy & Phys I & Lab (Hybrid)",
+        "Human Anatomy & Physiology II & Lab"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Cultural",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "allen-county-community-college",
+        "cowley-county-community-college",
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Anthropolog",
+        "Cultural Anthropology"
+      ]
+    },
+    {
+      "prefix": "APPD",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Adv UI/UX User Inter",
+        "Lv Wrk I Prod Design",
+        "Responsive Design",
+        "UI/UX User Intface/U"
+      ]
+    },
+    {
+      "prefix": "ATH",
+      "name": "Train",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "FIRST AID/RESP EMER",
+        "INTRO TO ATH TRAIN",
+        "PRACT ATH TRAIN I",
+        "PRACT ATH TRAIN II"
+      ]
+    },
+    {
+      "prefix": "BAT",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Law",
+        "Financial Accounting I",
+        "Leadership",
+        "Management"
+      ]
+    },
+    {
+      "prefix": "DT",
+      "name": "Diesel",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Brakes 1",
+        "Diesel Drive Trains",
+        "Diesel Engines",
+        "Electrical/Electronic Systems",
+        "Truck and Heavy Equip Repair"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Safety Orientation (OSHA 10)"
+      ]
+    },
+    {
+      "prefix": "HM",
+      "name": "Management",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Food and Beverage Management",
+        "Intro Hosp&amp;Tourism",
+        "Sanitation Management"
+      ]
+    },
+    {
+      "prefix": "LC",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "College Learning Methods"
+      ]
+    },
+    {
+      "prefix": "MCH",
+      "name": "MCH",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Bench Work",
+        "Machine Tool Processes",
+        "Machining Math",
+        "Metallurgy",
+        "Quality Control and Inspection"
+      ]
+    },
+    {
+      "prefix": "NCO",
+      "name": "Tiger",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "New Tiger Orientation"
+      ]
+    },
+    {
+      "prefix": "NHA",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Long Term Care Medical Records",
+        "Medical Administrative Aspects",
+        "Mental Health First Aid",
+        "Pharmacology for Health Professi on als",
+        "Professionalism in Health Care"
+      ]
+    },
+    {
+      "prefix": "RG",
+      "name": "Testament",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Comparative Religions",
+        "New Testament",
+        "Old Testament"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "Elementary Spanish II"
+      ]
+    },
+    {
+      "prefix": "SURV",
+      "name": "Surveying",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Boundary Control",
+        "Geographic Info Syst (GIS)",
+        "Global Nav Sat Syst (GNSS)",
+        "Surveying I",
+        "Surveying II"
+      ]
+    },
+    {
+      "prefix": "AC",
+      "name": "Accounting",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Fundamentals",
+        "Accounting I",
+        "Financial Accounting",
+        "Managerial Accounting"
+      ]
+    },
+    {
+      "prefix": "APBE",
+      "name": "APBE",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "API Development",
+        "Data Mangement",
+        "Live Work I Back-end",
+        "Microservices &amp; Ser"
+      ]
+    },
+    {
+      "prefix": "APDO",
+      "name": "APDO",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Apps Security",
+        "CI/CD Cont Intg/Cont",
+        "Cloud Systems",
+        "Lv Wrk I Dev Ops"
+      ]
+    },
+    {
+      "prefix": "BSC",
+      "name": "BSC",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology",
+        "Biology--KRSN BIO1010",
+        "Microbiology"
+      ]
+    },
+    {
+      "prefix": "CGA",
+      "name": "Design",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Design Portfolio",
+        "Design Software",
+        "Graphic Design I"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "A+PC REPAIR & MAINTE",
+        "ADV SERVER ADMIN",
+        "COMP CONCEPTS&APPS"
+      ]
+    },
+    {
+      "prefix": "DA",
+      "name": "Data",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Data Mining",
+        "Data Visualization",
+        "Intro to Data Analytics",
+        "Tableau"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis I",
+        "Electric Circut Fund"
+      ]
+    },
+    {
+      "prefix": "FOL",
+      "name": "Spanish",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Spanish I",
+        "Spanish II",
+        "Spanish III"
+      ]
+    },
+    {
+      "prefix": "MGMK",
+      "name": "MGMK",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Intro Business",
+        "Marketing",
+        "Sm Bus Manage"
+      ]
+    },
+    {
+      "prefix": "MLL",
+      "name": "Wheat",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Industrial Electric Power",
+        "Intro to Milling & Wheat",
+        "Mechatronic Systems",
+        "Wheat Cleaning & Tempering"
+      ]
+    },
+    {
+      "prefix": "PA",
+      "name": "Professional",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Bread Basics",
+        "Professional Pastry Arts 1"
+      ]
+    },
+    {
+      "prefix": "PHA",
+      "name": "Pharmacy",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Healthcare and Pharmacy Law",
+        "Orientation to Pharmacy Technician",
+        "Pharmacology",
+        "Pharmacy Customer Service"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "PHL",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Logic and Critical Thinking",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "PLMB",
+      "name": "Casircarstpifi",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "CasIr&CarStPiFi",
+        "Fix&DrainWaVeSy"
+      ]
+    },
+    {
+      "prefix": "PMED",
+      "name": "Paramedic",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Paramedic Concepts I",
+        "Paramedic Concepts III",
+        "Paramedic Concepts Med Emer",
+        "Paramedic Hospital Clinical"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "cowley-county-community-college",
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "Comparative Religions",
+        "Survey of the New Testament",
+        "WORLD RELIGIONS"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "SURG",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "IntroSurgTech",
+        "PrinSurgTechLab",
+        "Surg Tech Clin",
+        "SurgProceduresI"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "butler-community-college",
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Social Work",
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "APBC",
+      "name": "Inter",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Inter Dist App Dev",
+        "Inter Smart Contract",
+        "Lv Wk I Blockchain"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "Business",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Business Comm",
+        "Business Math",
+        "Pers/Fam Financ"
+      ]
+    },
+    {
+      "prefix": "CHML",
+      "name": "Chemistry",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "College Chemistry I Lab",
+        "College Chemistry II Lab",
+        "General Chemistry Lab"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "CRIM",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Invest",
+        "Criminology",
+        "Intr Crim Just"
+      ]
+    },
+    {
+      "prefix": "CSA",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Computer Applications & Concepts"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "ESL I",
+        "ESL III"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Int Cultur Geography"
+      ]
+    },
+    {
+      "prefix": "HER",
+      "name": "Nutrition",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Nutrition",
+        "Therapeutic Nutrition"
+      ]
+    },
+    {
+      "prefix": "MDM",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO LEADERSHIP"
+      ]
+    },
+    {
+      "prefix": "PRM",
+      "name": "Pharmacy",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "allen-county-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Pharmacy Technic ia n",
+        "Pharmacy Calculations",
+        "Pharmacy Operations"
+      ]
+    },
+    {
+      "prefix": "AGL",
+      "name": "Crop",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Ag Chemicals Lab",
+        "Crop Science Lab"
+      ]
+    },
+    {
+      "prefix": "BCOM",
+      "name": "Corp",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Corp Comm"
+      ]
+    },
+    {
+      "prefix": "BMFR",
+      "name": "Survey",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Survey of Biomanufacturing"
+      ]
+    },
+    {
+      "prefix": "CPT",
+      "name": "CPT",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "neosho-county-community-college"
+      ],
+      "sample_titles": [
+        "9781640163225"
+      ]
+    },
+    {
+      "prefix": "EGT",
+      "name": "Engineering Technology",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Comp CAD/CAM",
+        "Machining Process"
+      ]
+    },
+    {
+      "prefix": "GEG",
+      "name": "Geography",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Geography"
+      ]
+    },
+    {
+      "prefix": "HZMT",
+      "name": "Mats",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Haz Mats Awareness & Ops"
+      ]
+    },
+    {
+      "prefix": "LAN",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Spanish 1",
+        "Spanish II"
+      ]
+    },
+    {
+      "prefix": "LDRS",
+      "name": "Discovering",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Discovering Leadrshp"
+      ]
+    },
+    {
+      "prefix": "LED",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Leadership"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Introductory",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Introductory Meteorology & Lab"
+      ]
+    },
+    {
+      "prefix": "MFT",
+      "name": "Bluprnt",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "highland-community-college"
+      ],
+      "sample_titles": [
+        "Bluprnt Read/Geo Dim",
+        "Precision Measure"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Business"
+      ]
+    },
+    {
+      "prefix": "NUPN",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "App of Health Assessment",
+        "Clinical Judgment for PN"
+      ]
+    },
+    {
+      "prefix": "PHYY",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Physical Science Lab"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Criminal Procedures",
+        "Professional Responsibility in Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "VM",
+      "name": "Obedience",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "colby-community-college"
+      ],
+      "sample_titles": [
+        "Obedience Training"
+      ]
+    },
+    {
+      "prefix": "CECS",
+      "name": "Adult",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Adult Education"
+      ]
+    },
+    {
+      "prefix": "CSE",
+      "name": "Computer Science",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "NETWORK/DATA COMM"
+      ]
+    },
+    {
+      "prefix": "DAN",
+      "name": "Dance",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Jazz Dance I"
+      ]
+    },
+    {
+      "prefix": "EPD",
+      "name": "Utility",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "Utility Internship"
+      ]
+    },
+    {
+      "prefix": "ESP",
+      "name": "Esports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "Esports Business"
+      ]
+    },
+    {
+      "prefix": "EV",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "butler-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Issues"
+      ]
+    },
+    {
+      "prefix": "FIR",
+      "name": "Firefighter",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Firefighter II"
+      ]
+    },
+    {
+      "prefix": "FR",
+      "name": "French",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Elementary French I"
+      ]
+    },
+    {
+      "prefix": "FRL",
+      "name": "Spanish",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "independence-community-college"
+      ],
+      "sample_titles": [
+        "SPANISH I"
+      ]
+    },
+    {
+      "prefix": "GEL",
+      "name": "Geology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Geology & Lab"
+      ]
+    },
+    {
+      "prefix": "HUDV",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Human Sexuality"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "Womens",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "kansas-city-kansas-community-college"
+      ],
+      "sample_titles": [
+        "Intro Womens Studies"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Theory",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Theory of Leadership (Hybrid, Service Learning)"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cowley-county-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Literature"
+      ]
+    },
+    {
+      "prefix": "MLNG",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-kansas-technical-college"
+      ],
+      "sample_titles": [
+        "Beginning Spanish I"
+      ]
+    },
+    {
+      "prefix": "NTR",
+      "name": "Nutritionkrsn",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "manhattan-area-technical-college"
+      ],
+      "sample_titles": [
+        "Nutrition--KRSN HSC1010"
+      ]
+    },
+    {
+      "prefix": "PSS",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salina-area-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Emergency Communications"
+      ]
+    },
+    {
+      "prefix": "SM",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hutchinson-community-college"
+      ],
+      "sample_titles": [
+        "Basic Sports Medicine"
+      ]
+    },
+    {
+      "prefix": "SPAD",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Sports Administration"
+      ]
+    },
+    {
+      "prefix": "ZOOL",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dodge-city-community-college"
+      ],
+      "sample_titles": [
+        "Human Anatomy & Physiology I Lab"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/la/subject-vocab.json
+++ b/data/la/subject-vocab.json
@@ -1,0 +1,5055 @@
+{
+  "state": "la",
+  "generated_at": "2026-06-06T15:41:40.323Z",
+  "subjects": [
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 96,
+      "section_count": 1452,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(12 wks) Gen Biology Lab II",
+        "(12wks) Anatomy &amp; Phys II Lab",
+        "(12wks)General Microbiology",
+        "(1st7wks) Biofor Science Maj I",
+        "(2nd7wks) Anat &amp; Physio I Lab"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 66,
+      "section_count": 1432,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "12 wk English Composition II",
+        "1st 4-wk English Composition I",
+        "2nd 7-wk Co-req w/21496",
+        "African-American Literature",
+        "African-American Writers"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 86,
+      "section_count": 1290,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(12 wks) Elementary Statistics",
+        "(12wks) 21361 Co-Req MATH 1213",
+        "(12wks) Coreq Math 1003(20725)",
+        "(12wks) Nature Math (20726)",
+        "(12wks) Plane Trigonometry"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "WELD",
+      "course_count": 115,
+      "section_count": 1099,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Flx Cor &amp; Gas Met Arc Wel",
+        "Adv Pipe Weld &amp; Fitting",
+        "Adv Shield Metal Arc Welding",
+        "Advanced Gas Tungsten Arc Weld",
+        "Advanced SMAW V-Groove"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 68,
+      "section_count": 567,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health II",
+        "Adult Health Nursing I",
+        "Adult Nursing I",
+        "Adult Nursing II",
+        "Adult Nursing III"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 41,
+      "section_count": 504,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(1st 7wks) Intro to Psychology",
+        "(1st4wks) Psyc of Development",
+        "Abnormal Psychology",
+        "Adolescent Psychology",
+        "Child Psychology"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 39,
+      "section_count": 458,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "2nd 4-wk Wrld Civ 1500 to Pres",
+        "African American History",
+        "African-American History",
+        "American Hist 1865 to Present",
+        "American Hist Colonial to 1865"
+      ]
+    },
+    {
+      "prefix": "PTEC",
+      "name": "Process",
+      "course_count": 42,
+      "section_count": 416,
+      "colleges": [
+        "baton-rouge-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Campus Internship",
+        "External Capstone",
+        "Fluid Mechanics",
+        "Independent Internship",
+        "Intro to Process Technology"
+      ]
+    },
+    {
+      "prefix": "EMSE",
+      "name": "EMSE",
+      "course_count": 45,
+      "section_count": 347,
+      "colleges": [
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "A &amp; P for Paramedics",
+        "Adv Emerg Med Tech Capstone",
+        "Airway and Ventilation",
+        "Capstone",
+        "Clin Reason &amp; Decision Making"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 78,
+      "section_count": 316,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Elec. Troubleshooting",
+        "Advanced Motor Controls",
+        "Basic Electrical Skills I",
+        "Basic Electrical Skills II",
+        "Basic Electricity"
+      ]
+    },
+    {
+      "prefix": "LPNU",
+      "name": "Nursing",
+      "course_count": 29,
+      "section_count": 298,
+      "colleges": [
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Fundamentals in PN",
+        "Adv Pharmacology &amp; IV Therapy",
+        "Advanced Fundamentals in Practical Nursing",
+        "Advanced Pharmacology and IV Therapy",
+        "Anatomy and Physiology for Practical Nurses"
+      ]
+    },
+    {
+      "prefix": "BLGY",
+      "name": "BLGY",
+      "course_count": 17,
+      "section_count": 297,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology II",
+        "Anatomy and Physiology II Lab",
+        "Basic Nutrition",
+        "Biology I (Science Majors)",
+        "Biology I Lab (Science Majors)"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 50,
+      "section_count": 270,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(12Wks) Financial Acct III",
+        "(12Wks)Financial Accounting I",
+        "Accounting Information Systems",
+        "Advanced Accounting Projects",
+        "Bookkeeping Applications"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 43,
+      "section_count": 254,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "2nd 7wk Organic Chem II Lab",
+        "2nd7wks Chemistry I Sci Majors",
+        "Analytical Chemistry (Quantitative Analysis)",
+        "Analytical Chemistry Lab",
+        "Chemistry for PTEC Students"
+      ]
+    },
+    {
+      "prefix": "CTEC",
+      "name": "CTEC",
+      "course_count": 61,
+      "section_count": 245,
+      "colleges": [
+        "bossier-parish-community-college",
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cloud Computing",
+        "Advanced JAVA Programming",
+        "Advanced MS Excel",
+        "Advanced Network Topics",
+        "CCNA I"
+      ]
+    },
+    {
+      "prefix": "BUSG",
+      "name": "Business",
+      "course_count": 13,
+      "section_count": 241,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Computer Applications",
+        "Business Ethics",
+        "Business Math with Excel",
+        "Consumer Lending"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 40,
+      "section_count": 194,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Acadian Music and Culture",
+        "Applied Voice",
+        "Chorus I",
+        "Chorus III",
+        "Class Piano II"
+      ]
+    },
+    {
+      "prefix": "HACR",
+      "name": "HACR",
+      "course_count": 74,
+      "section_count": 191,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning I",
+        "Air Conditioning II",
+        "App Elctrcty &amp; Troubleshooting",
+        "Applied Elec &amp; Troubleshooting",
+        "Applied Electricity"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 24,
+      "section_count": 189,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "12-wk Digital Art",
+        "2nd 7wks Intro to Visual Arts",
+        "Art Appreciation",
+        "Art History I (2 JFCA)",
+        "Art History II"
+      ]
+    },
+    {
+      "prefix": "CDYC",
+      "name": "CDYC",
+      "course_count": 57,
+      "section_count": 188,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "12 wk Preschool Methods",
+        "2nd 7-wk Infant &amp; Toddler Curr",
+        "2nd 7-wk Wrk w Young Children",
+        "Adm Early Childhood Programs",
+        "Admin of Childcare Programs"
+      ]
+    },
+    {
+      "prefix": "BADM",
+      "name": "Business",
+      "course_count": 19,
+      "section_count": 183,
+      "colleges": [
+        "bossier-parish-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Business Analytics",
+        "Business Communications",
+        "Business Internship",
+        "Business Law",
+        "Business Math"
+      ]
+    },
+    {
+      "prefix": "INST",
+      "name": "INST",
+      "course_count": 42,
+      "section_count": 183,
+      "colleges": [
+        "baton-rouge-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "AC Electrical Principles&amp;Appl",
+        "Advanced PLC",
+        "Analy Measurements &amp; Control",
+        "AutoControl,Controllers&amp;Tuning",
+        "Comm &amp; Distributed Control"
+      ]
+    },
+    {
+      "prefix": "HESC",
+      "name": "HESC",
+      "course_count": 24,
+      "section_count": 165,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Terminology",
+        "Cultural Diver Awarness: HC Pr",
+        "Dialysis Clinical Practicum",
+        "Dialysis Procedures",
+        "Dosage Calcu.: Allied Health"
+      ]
+    },
+    {
+      "prefix": "CJUS",
+      "name": "CJUS",
+      "course_count": 48,
+      "section_count": 154,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "louisiana-delta-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "(12wk)Intr to Criminal Justice",
+        "(2nd7wk)Juv Delinquency",
+        "Accident Investigation",
+        "Careers in Criminal Justice",
+        "Correctional Law"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 11,
+      "section_count": 141,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(12Wks) Economic Principles",
+        "Economics of Money &amp; Banking",
+        "Macroeconomics",
+        "Microeconomics",
+        "Principles of Macro Economics"
+      ]
+    },
+    {
+      "prefix": "HNUR",
+      "name": "HNUR",
+      "course_count": 48,
+      "section_count": 141,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Adv Fund in Practical Nursing",
+        "Adv Pharmacology &amp; IV Therapy",
+        "Advanced Pharmacology",
+        "Anat &amp; Phys for Prac Nursing",
+        "Anatomy and Physiology for Hea"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 48,
+      "section_count": 140,
+      "colleges": [
+        "baton-rouge-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "(12Wks) Intro to Business",
+        "Business Communication",
+        "Business Internship",
+        "Business Law",
+        "Business Law I"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Physical",
+      "course_count": 13,
+      "section_count": 124,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(2nd7wks) Physical Science II",
+        "12 wks Physical Science I",
+        "Elemental Physics",
+        "Environmental Science",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Speaking",
+      "course_count": 10,
+      "section_count": 123,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "2nd 7wks Fund of Communication",
+        "2nd 7wks Public Speaking",
+        "Fund of Effective Speaking",
+        "Fundamentals of Speech Comm",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "CRJU",
+      "name": "CRJU",
+      "course_count": 37,
+      "section_count": 120,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Adjudication Process",
+        "Comp Criminal Justice Systems",
+        "Contemporary Law Enforcement",
+        "Course Introduction to Corrections - 22673 - CRJU 103 - 101",
+        "Criminal Investigation"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 35,
+      "section_count": 113,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Physics II",
+        "Engineering Physics III",
+        "Foundations of Astronomy",
+        "Gen Physics I (Alg/Trig Based)",
+        "General Physics I"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "Radiographic",
+      "course_count": 28,
+      "section_count": 112,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Radiographic Positioning",
+        "Adv Radiographic Practicum I",
+        "Adv Radiographic Practicum II",
+        "Adv Radiographic Practicum III",
+        "Adv Radiographic Technique"
+      ]
+    },
+    {
+      "prefix": "MAST",
+      "name": "MAST",
+      "course_count": 24,
+      "section_count": 111,
+      "colleges": [
+        "baton-rouge-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Administrative Procedures I",
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Electrocardiography (EKG)"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 46,
+      "section_count": 109,
+      "colleges": [
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking",
+        "American Regional Cuisine",
+        "Baking",
+        "Basic Culinary Skills",
+        "Basic Food Preparation"
+      ]
+    },
+    {
+      "prefix": "YCNA",
+      "name": "Aide",
+      "course_count": 2,
+      "section_count": 109,
+      "colleges": [
+        "bossier-parish-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Nurse Aide Written Exam",
+        "SKILLS NURSING AIDE EXAM"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 55,
+      "section_count": 107,
+      "colleges": [
+        "baton-rouge-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Drivability",
+        "Auto Climate Control Systems",
+        "Auto Electrical Systems",
+        "Auto Field Experience I",
+        "Auto Field Experience II"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 18,
+      "section_count": 107,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "nunez-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Social Problems",
+        "Criminology",
+        "Drug Abuse",
+        "Intro to Sociology",
+        "Introduction to Social Welfare"
+      ]
+    },
+    {
+      "prefix": "MANG",
+      "name": "Management",
+      "course_count": 20,
+      "section_count": 106,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Foundations: Strategic Mgmt",
+        "Human Relations in Business",
+        "Human Resource Management",
+        "Intro to Entrepreneurship",
+        "Intro to Operations Mgmt"
+      ]
+    },
+    {
+      "prefix": "ALHT",
+      "name": "ALHT",
+      "course_count": 14,
+      "section_count": 98,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Language",
+        "Basic ECG",
+        "Health Care Systems &amp; Safety",
+        "Intro to Phlebotomy Lab",
+        "Introduction to Phlebotomy"
+      ]
+    },
+    {
+      "prefix": "MOVH",
+      "name": "MOVH",
+      "course_count": 29,
+      "section_count": 98,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Asst. Brakes/Steering &amp; Suspen",
+        "Auto Gas Metal Arc Welding",
+        "Auto Painting Techniques",
+        "Auto Service Bus Professionalm",
+        "Automatic Transmissions"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 12,
+      "section_count": 98,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "12 wk Biomedical Ethics",
+        "2nd 4-wk Intro to Philosophy",
+        "2nd 7-wk Intro to Ethics",
+        "2nd 7-wk Intro to Logic",
+        "Environmental Ethics"
+      ]
+    },
+    {
+      "prefix": "WETH",
+      "name": "Work",
+      "course_count": 4,
+      "section_count": 98,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Work Ethic 1",
+        "Work Ethic 2",
+        "Work Ethic 3",
+        "Work Ethic 4"
+      ]
+    },
+    {
+      "prefix": "HCOR",
+      "name": "HCOR",
+      "course_count": 18,
+      "section_count": 95,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures for",
+        "Basic Body Structure&amp;Function",
+        "Communication Techniques in Healthcare",
+        "Electrocardiograph Prep Lab",
+        "Electrocardiograph Procedures"
+      ]
+    },
+    {
+      "prefix": "CULN",
+      "name": "CULN",
+      "course_count": 35,
+      "section_count": 92,
+      "colleges": [
+        "baton-rouge-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "&Agrave; La Carte",
+        "A la Carte",
+        "Artisn Thery &amp; Bred Techniques",
+        "Baking &amp; Pastries Internship",
+        "Baking &amp; Pastries of the South"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "COSM",
+      "course_count": 39,
+      "section_count": 91,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Artistry of Artificial Hair",
+        "Cells, Anatomy, &amp; Physiology",
+        "Chemical Hair Relaxing",
+        "Chemical Services",
+        "Clinic Floor Experience I"
+      ]
+    },
+    {
+      "prefix": "WLDG",
+      "name": "Welding",
+      "course_count": 17,
+      "section_count": 90,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Basic FCAW and GMAW",
+        "Basic SMAW",
+        "FCAW &amp; GMAW Groove Welds",
+        "FCAW &amp; GMAW Pipe 2G",
+        "FCAW &amp; GMAW Pipe 5G"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "DRFT",
+      "course_count": 48,
+      "section_count": 89,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Discip - Architectural Drf",
+        "Adv Discip - Industrial Drft",
+        "Adv Discipline I - Architectur",
+        "Adv Discipline I - Civil",
+        "Adv Discipline-Civil/Stru Drft"
+      ]
+    },
+    {
+      "prefix": "CITS",
+      "name": "CITS",
+      "course_count": 24,
+      "section_count": 85,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "3D Modeling &amp; Animation ......",
+        "Back-End Web Development I",
+        "Cloud Computing Foundations",
+        "Computer and Internet Literacy",
+        "Database Management System"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "ITEC",
+      "course_count": 29,
+      "section_count": 83,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Android App Development",
+        "Apple App Development",
+        "Application Basics",
+        "Cloud Computing",
+        "Cloud Computing Internship"
+      ]
+    },
+    {
+      "prefix": "TEED",
+      "name": "TEED",
+      "course_count": 25,
+      "section_count": 82,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Solid Works 3D",
+        "Basic Process Control",
+        "Building Info Modeling I",
+        "Electric Motor Controls",
+        "Electrical Raceways"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 38,
+      "section_count": 81,
+      "colleges": [
+        "baton-rouge-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "(12 wks) Microcomp Appl in Bus",
+        "(12wks) Info Assurance and Sec",
+        "(1st 7wks) Society &amp; Ethics",
+        "(1st7wks) Intro to Data Design",
+        "(2nd 7wks) Emerging Technology"
+      ]
+    },
+    {
+      "prefix": "MLTS",
+      "name": "MLTS",
+      "course_count": 58,
+      "section_count": 81,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Lab Methods",
+        "Advanced Practicum",
+        "Blood Bank Practicum",
+        "Body Fluid Analysis",
+        "Chemistry Practicum"
+      ]
+    },
+    {
+      "prefix": "CADD",
+      "name": "Cadd",
+      "course_count": 24,
+      "section_count": 69,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "3D CAD",
+        "Adv Comp Aided Drft &amp; Design",
+        "Adv. Cptr. Aid Draft &amp; Design",
+        "Advanced CAD",
+        "Architectural Apps in CADD"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "Business",
+      "course_count": 10,
+      "section_count": 68,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "northwest-louisiana-technical-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Ethics",
+        "Internship",
+        "Intro to Human Resource Mngmnt",
+        "Introduction to Business"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 41,
+      "section_count": 68,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "3D Animation",
+        "3D Modeling",
+        "Acting for Media",
+        "Adobe Illustrator",
+        "Adobe Photoshop"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 9,
+      "section_count": 68,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "12-wk Elem Spanish I (8Wood)",
+        "Civil &amp; Cultures of Hispanoame",
+        "Elem Span II (EBRV/GEO/Istr)",
+        "Elementary Spanish I",
+        "Elementary Spanish II"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 65,
+      "colleges": [
+        "baton-rouge-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Health Professions",
+        "Medical Terminology",
+        "Sterile Processing Basic"
+      ]
+    },
+    {
+      "prefix": "HEIT",
+      "name": "HEIT",
+      "course_count": 33,
+      "section_count": 63,
+      "colleges": [
+        "delgado-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Advanced CPT Coding",
+        "Advanced Medical Coding",
+        "Basic CPT Coding",
+        "Basic Medical Coding I"
+      ]
+    },
+    {
+      "prefix": "CPTR",
+      "name": "Computer",
+      "course_count": 9,
+      "section_count": 62,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Spreadsheets",
+        "Business Computer Applications",
+        "Computer Literacy and Applications",
+        "Database Management",
+        "Intro to Computer Applications"
+      ]
+    },
+    {
+      "prefix": "BUSL",
+      "name": "Legal",
+      "course_count": 11,
+      "section_count": 60,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Business Law",
+        "Cyberlaw",
+        "Employment Law",
+        "Intro to Paralegal Studies",
+        "Legal Environment of Business"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 9,
+      "section_count": 60,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Age of Dinosaurs",
+        "Earth History",
+        "Historical Geology",
+        "Intro to Geology Lab",
+        "Introduction to Earth Science"
+      ]
+    },
+    {
+      "prefix": "EMTP",
+      "name": "EMTP",
+      "course_count": 19,
+      "section_count": 59,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "A&amp;P Patho for Paramedics",
+        "Advanced EMT",
+        "Advanced EMT Applications",
+        "Airway Management &amp; Ventilatio",
+        "Applied Practice"
+      ]
+    },
+    {
+      "prefix": "FNAR",
+      "name": "FNAR",
+      "course_count": 13,
+      "section_count": 59,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Art History I",
+        "Art History II",
+        "Beginning Drawing",
+        "Contemporary Art",
+        "Drawing II"
+      ]
+    },
+    {
+      "prefix": "SOCL",
+      "name": "SOCL",
+      "course_count": 9,
+      "section_count": 59,
+      "colleges": [
+        "baton-rouge-community-college",
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(1st 7wks) Intro to Sociology",
+        "(1st 7wks) Race Relations",
+        "Contemporary Social Problems",
+        "Criminology",
+        "Introduction to Sociology"
+      ]
+    },
+    {
+      "prefix": "CMCN",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 58,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Human Comm",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "ESLN",
+      "name": "ESLN",
+      "course_count": 16,
+      "section_count": 58,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Basic Composition I",
+        "Basic Composition II",
+        "Basic Grammar I",
+        "Basic Grammar II",
+        "Basic Reading I"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "SURG",
+      "course_count": 23,
+      "section_count": 57,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Clinical Practicum III",
+        "Clinical Specialties",
+        "Clinical Specialties II"
+      ]
+    },
+    {
+      "prefix": "YTRA",
+      "name": "YTRA",
+      "course_count": 21,
+      "section_count": 57,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Lift Safety",
+        "Comm Driver&#39;s License Class A",
+        "Commercial Driver&#39;s License",
+        "Commercial Vehicle Inspector",
+        "Commercial Vehicle Operator"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 11,
+      "section_count": 53,
+      "colleges": [
+        "baton-rouge-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "2nd 7wks Cultural Geography",
+        "2nd 7wks Intro to Geography",
+        "Cultural Geography",
+        "Geography of Food and Cuisines",
+        "Geography of the US and Canada"
+      ]
+    },
+    {
+      "prefix": "CRMJ",
+      "name": "CRMJ",
+      "course_count": 20,
+      "section_count": 52,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigation",
+        "Criminal Justice Ethics",
+        "Criminal Justice Externship",
+        "Criminology",
+        "Crisis &amp; Trauma"
+      ]
+    },
+    {
+      "prefix": "EMHS",
+      "name": "EMHS",
+      "course_count": 2,
+      "section_count": 52,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "NC EMT I",
+        "NC EMT II"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 21,
+      "section_count": 52,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "12-wk Acting I",
+        "12-wk Introduction to Theatre",
+        "Acting I",
+        "Acting II",
+        "Costume Constr Techniques"
+      ]
+    },
+    {
+      "prefix": "YPRO",
+      "name": "YPRO",
+      "course_count": 15,
+      "section_count": 52,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "CDL Testing",
+        "Ceramics Hand Building Tech.",
+        "Certified Kitchen Cook",
+        "Drones",
+        "Elementary Spanish I"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 18,
+      "section_count": 50,
+      "colleges": [
+        "delgado-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Acting I",
+        "Acting II",
+        "Classical Theater",
+        "Classical Theatre"
+      ]
+    },
+    {
+      "prefix": "CMST",
+      "name": "Communication",
+      "course_count": 3,
+      "section_count": 49,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Communication",
+        "Interpersonal Communication",
+        "Public Speaking"
+      ]
+    },
+    {
+      "prefix": "IMFG",
+      "name": "IMFG",
+      "course_count": 34,
+      "section_count": 49,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Program Control Mechatroni",
+        "Automation",
+        "Basic DC/AC Electronics",
+        "Basic Lathe I",
+        "Basic Lathe II"
+      ]
+    },
+    {
+      "prefix": "SONO",
+      "name": "SONO",
+      "course_count": 32,
+      "section_count": 49,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography",
+        "Abdominal Sonography II",
+        "Abdominal Sonography III",
+        "Abdominal Ultrasoud II",
+        "Abdominal Ultrasound I"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 10,
+      "section_count": 48,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "2-D Design",
+        "Art History I",
+        "Art History II",
+        "Ceramics I",
+        "Ceramics II"
+      ]
+    },
+    {
+      "prefix": "POLI",
+      "name": "Government",
+      "course_count": 11,
+      "section_count": 48,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "(12wks)American Government",
+        "American Government",
+        "Constitutional Law",
+        "Intro to American Government",
+        "Intro to Comparative Politics"
+      ]
+    },
+    {
+      "prefix": "CORE",
+      "name": "Craft",
+      "course_count": 2,
+      "section_count": 47,
+      "colleges": [
+        "baton-rouge-community-college",
+        "louisiana-delta-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Craft Skills",
+        "NCCER Core Intro. Craft Skills"
+      ]
+    },
+    {
+      "prefix": "HOST",
+      "name": "HOST",
+      "course_count": 8,
+      "section_count": 47,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Convention Management &amp; Svc",
+        "Geographic Destinations",
+        "Hospitality Practicum",
+        "Hotel Sys &amp; Operations Mgmt",
+        "Intro to Hospitality Industry"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "Humanities",
+      "course_count": 5,
+      "section_count": 47,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Humanities I",
+        "Humanities II",
+        "Humanities Through the Arts",
+        "Modernism in the Arts -- Honors",
+        "Structure of Western Thought: Ancient Greece -- Honors"
+      ]
+    },
+    {
+      "prefix": "INTE",
+      "name": "INTE",
+      "course_count": 20,
+      "section_count": 47,
+      "colleges": [
+        "baton-rouge-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "1st 7wk Inst &amp; Troubleshoot I",
+        "2nd 7wk Inst &amp; Troubleshoot II",
+        "Cloud Technologies",
+        "Configuring Adv Server Service",
+        "Desktop Support"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "TECH",
+      "course_count": 5,
+      "section_count": 47,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Computer Fundamentals for Tech",
+        "Engineering Economics",
+        "Industrial Safety",
+        "NCCER Technical Core",
+        "Orientation to Technology"
+      ]
+    },
+    {
+      "prefix": "YHET",
+      "name": "YHET",
+      "course_count": 20,
+      "section_count": 47,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced EKG",
+        "Advanced EMT",
+        "Cert. Clinical Med. Assistant",
+        "Certified Medical Assistant",
+        "Certified Nurse Aide"
+      ]
+    },
+    {
+      "prefix": "MARK",
+      "name": "MARK",
+      "course_count": 5,
+      "section_count": 46,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "How to Promote a New Business",
+        "Personal Selling",
+        "Principles of Marketing",
+        "Retailing and E-Commerce",
+        "Sports &amp; Entertainment Mark"
+      ]
+    },
+    {
+      "prefix": "OCTA",
+      "name": "OCTA",
+      "course_count": 20,
+      "section_count": 46,
+      "colleges": [
+        "bossier-parish-community-college",
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Applications I",
+        "Clinical Applications Ii",
+        "Clinical Documentation II",
+        "Community Occupations",
+        "Conditions &amp; Applications I"
+      ]
+    },
+    {
+      "prefix": "PRNU",
+      "name": "Nursing",
+      "course_count": 10,
+      "section_count": 46,
+      "colleges": [
+        "bossier-parish-community-college",
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Career Preparation for PN",
+        "Essential Nursing Skills",
+        "Intro to Practical Nursing",
+        "Medical-Surgical Nursing I",
+        "Medical-Surgical Nursing II"
+      ]
+    },
+    {
+      "prefix": "GBUS",
+      "name": "GBUS",
+      "course_count": 7,
+      "section_count": 43,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Human Resource Management",
+        "Intro to Risk Management/Ins",
+        "Introduction to Business",
+        "Legal Environment Business",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "BARB",
+      "course_count": 27,
+      "section_count": 42,
+      "colleges": [
+        "delgado-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology",
+        "Barber Shop Management",
+        "Barber Styling II",
+        "Barber-Styling 2",
+        "Barber-Styling I"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "CARP",
+      "course_count": 28,
+      "section_count": 42,
+      "colleges": [
+        "baton-rouge-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Applied Math for Carpentry",
+        "Blueprint Basics",
+        "Blueprint Reading",
+        "Building Calculations",
+        "Building Materials"
+      ]
+    },
+    {
+      "prefix": "COLS",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 42,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "College Success Skills"
+      ]
+    },
+    {
+      "prefix": "CCSS",
+      "name": "Success",
+      "course_count": 3,
+      "section_count": 41,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Careeer Success Skills",
+        "College Success Skills",
+        "Success in College"
+      ]
+    },
+    {
+      "prefix": "DPET",
+      "name": "Diesel",
+      "course_count": 28,
+      "section_count": 41,
+      "colleges": [
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Electrical Sys",
+        "Advanced Diesel Eng &amp; Fuel Sys",
+        "Air Conditioning",
+        "Basic Diesel Electrical System",
+        "Basic Hydraulics"
+      ]
+    },
+    {
+      "prefix": "YCOS",
+      "name": "YCOS",
+      "course_count": 29,
+      "section_count": 40,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Basic Construction Crafts",
+        "Basic Plumbing",
+        "Broadband - Telecommunications",
+        "Broadband-Fiber Optics",
+        "Broadband-Fusion Splicing"
+      ]
+    },
+    {
+      "prefix": "GART",
+      "name": "GART",
+      "course_count": 26,
+      "section_count": 39,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Video Production",
+        "Advertising Theory",
+        "Agency",
+        "Animation",
+        "Audio Arts I"
+      ]
+    },
+    {
+      "prefix": "YINF",
+      "name": "Google",
+      "course_count": 12,
+      "section_count": 39,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "AI For Educators",
+        "AI for Students",
+        "Digital Literacy",
+        "Fiber Optics Boot Camp",
+        "Fiber Optics I"
+      ]
+    },
+    {
+      "prefix": "CINS",
+      "name": "CINS",
+      "course_count": 13,
+      "section_count": 38,
+      "colleges": [
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Database Applications",
+        "Desktop Publishing",
+        "Information Security Fund",
+        "Introduction to Computers",
+        "Project Apps in the Office"
+      ]
+    },
+    {
+      "prefix": "PTAP",
+      "name": "PTAP",
+      "course_count": 19,
+      "section_count": 38,
+      "colleges": [
+        "bossier-parish-community-college",
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Clinical Practice II",
+        "Clinical Practice III",
+        "Comprehensive Interv for PTA",
+        "Devlopment Considerations"
+      ]
+    },
+    {
+      "prefix": "SLGY",
+      "name": "SLGY",
+      "course_count": 5,
+      "section_count": 37,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Criminology",
+        "Introduction to Sociology",
+        "Marriage &amp; Family Living",
+        "Race, Class &amp; Ethnicity",
+        "Social Problems"
+      ]
+    },
+    {
+      "prefix": "EMTE",
+      "name": "EMTE",
+      "course_count": 19,
+      "section_count": 36,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Emerg. Med. Tech, Lab",
+        "Adv. Emerg. Tech. Clinical Pra",
+        "Advanced Emergency Med. Tech.",
+        "Airway Cardiac Care",
+        "Airway Cardiac Care Lab"
+      ]
+    },
+    {
+      "prefix": "CNCY",
+      "name": "CNCY",
+      "course_count": 13,
+      "section_count": 35,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Cloud Architecture",
+        "Cyber Security I",
+        "Cyber Security II",
+        "Digital Forensic Analy &amp; Cyber",
+        "Ethical Hacking &amp; Network Def."
+      ]
+    },
+    {
+      "prefix": "ENSC",
+      "name": "Science",
+      "course_count": 7,
+      "section_count": 35,
+      "colleges": [
+        "baton-rouge-community-college",
+        "fletcher-technical-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Environmental Sustainability",
+        "Introduction to Marine Science",
+        "Oceanography",
+        "Plant Science"
+      ]
+    },
+    {
+      "prefix": "CMGT",
+      "name": "CMGT",
+      "course_count": 11,
+      "section_count": 34,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "(12Wks)Contracts and Const Law",
+        "Comrcial &amp; Indstrial Estimatng",
+        "Const Materials &amp; Methods",
+        "Const. Plan Reading &amp; Graphics",
+        "Construction Estimating"
+      ]
+    },
+    {
+      "prefix": "RSPT",
+      "name": "Respiratory",
+      "course_count": 22,
+      "section_count": 34,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiopulmonary Disease",
+        "Body Structure and Function for Respiratory Care",
+        "Clinical Seminar",
+        "Clinical Simulations",
+        "Critical Care Concepts I"
+      ]
+    },
+    {
+      "prefix": "ASLS",
+      "name": "American",
+      "course_count": 17,
+      "section_count": 33,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "12-wk Deaf Culture",
+        "Advanced Interpreting",
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III"
+      ]
+    },
+    {
+      "prefix": "FSED",
+      "name": "Funeral",
+      "course_count": 18,
+      "section_count": 33,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Dynamics of Grief",
+        "Embalming Laboratory I",
+        "Embalming Laboratory II",
+        "Embalming Techniques I",
+        "Embalming Techniques II"
+      ]
+    },
+    {
+      "prefix": "VISC",
+      "name": "Design",
+      "course_count": 18,
+      "section_count": 32,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Advertising Design",
+        "Cartooning and Comic Book Art",
+        "Color Design",
+        "Digital Photography I",
+        "Digital Photography II"
+      ]
+    },
+    {
+      "prefix": "VMRE",
+      "name": "VMRE",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Auto &amp; Manual Trans",
+        "Adv Electrical &amp; Electronics",
+        "Adv Susp, Steer, &amp; Brakes",
+        "Automatic Transmission&amp; Transa",
+        "Brake Systems"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 11,
+      "section_count": 30,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Biological Anthropology",
+        "Cultural Anthropology",
+        "Intro Cultural/Soc Anthropolog",
+        "Intro Phys Anthropology &amp; Preh",
+        "Intro to Anthropology"
+      ]
+    },
+    {
+      "prefix": "IMMT",
+      "name": "IMMT",
+      "course_count": 14,
+      "section_count": 30,
+      "colleges": [
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Basic Electricity Lab",
+        "Blueprint Reading",
+        "Hydraulics",
+        "Hydraulics Troubleshooting"
+      ]
+    },
+    {
+      "prefix": "PHAR",
+      "name": "Pharmacy",
+      "course_count": 16,
+      "section_count": 30,
+      "colleges": [
+        "bossier-parish-community-college",
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Community Pharm Practice Lab",
+        "Community Pharmacy Practice",
+        "Institutional Pharm Pract Lab",
+        "Institutional Pharm Practice",
+        "Intro to Pharmacy Technology"
+      ]
+    },
+    {
+      "prefix": "SCIE",
+      "name": "Science",
+      "course_count": 10,
+      "section_count": 30,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science I",
+        "Internship",
+        "Intro Astronomy:Stars/Galaxies",
+        "Intro: Astronomy/Solar System",
+        "Intro: Science Laboratory Tech"
+      ]
+    },
+    {
+      "prefix": "HCM",
+      "name": "Healthcare",
+      "course_count": 8,
+      "section_count": 29,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Healthcare Informatics",
+        "Healthcare Law",
+        "Internship in Healthcare Mgmt",
+        "Intro to Healthcare Management",
+        "Perspectives on Aging"
+      ]
+    },
+    {
+      "prefix": "PALG",
+      "name": "PALG",
+      "course_count": 22,
+      "section_count": 29,
+      "colleges": [
+        "baton-rouge-community-college",
+        "fletcher-technical-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Civil Litigation",
+        "Computers in the Law Office",
+        "Criminal Law",
+        "Ethics and Paralegals",
+        "Intro to Legal Research"
+      ]
+    },
+    {
+      "prefix": "RLST",
+      "name": "Real",
+      "course_count": 6,
+      "section_count": 29,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "LA Real Estate Law",
+        "Princ/Resid Real Estate Apprs",
+        "Principles of Real Estate",
+        "Property Management",
+        "Real Estate Financing"
+      ]
+    },
+    {
+      "prefix": "AMTP",
+      "name": "Engine",
+      "course_count": 16,
+      "section_count": 28,
+      "colleges": [
+        "baton-rouge-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft &amp; Engine Fire Protect",
+        "Engine Electrical Systems",
+        "Engine Inspection",
+        "Engine Instruments",
+        "Exhaust (Reverser) &amp; Cool Sys"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 27,
+      "section_count": 28,
+      "colleges": [
+        "fletcher-technical-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Applied Elec &amp; Troubleshooting",
+        "Capstone: HVAC System Design",
+        "Domestic Refrigeration",
+        "Electric Motors &amp; Components",
+        "Electrical Components"
+      ]
+    },
+    {
+      "prefix": "IIET",
+      "name": "IIET",
+      "course_count": 14,
+      "section_count": 28,
+      "colleges": [
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Control Systems Theory &amp; Pract",
+        "Elec Power Theory &amp; Prac II",
+        "Elec Power Theory &amp; Practice I",
+        "Electrical Circuits I",
+        "Electrical Circuits II"
+      ]
+    },
+    {
+      "prefix": "MCIS",
+      "name": "Applications",
+      "course_count": 4,
+      "section_count": 28,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Microcomputer Applications",
+        "Presentation Applications",
+        "Spreadsheet I",
+        "Word Processing"
+      ]
+    },
+    {
+      "prefix": "DGMD",
+      "name": "DGMD",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Color &amp; Design",
+        "Digital Editing and Effects",
+        "Digital Production Studio",
+        "Foundations for 3D Art",
+        "Intermediate Level 3D Art"
+      ]
+    },
+    {
+      "prefix": "DMSU",
+      "name": "Ultrasound",
+      "course_count": 20,
+      "section_count": 27,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Ultrasound I",
+        "Abdominal Ultrasound II",
+        "Abdominal Ultrasound III",
+        "Comprehensive Seminar",
+        "Directed Reading"
+      ]
+    },
+    {
+      "prefix": "ETRN",
+      "name": "ETRN",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Basic Electronics",
+        "Basic Networking",
+        "Communication Princ &amp; System",
+        "Digital Circuits"
+      ]
+    },
+    {
+      "prefix": "GAEC",
+      "name": "Trade",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Apprent Trade Related Science",
+        "Apprent Trade Tech Part III",
+        "Apprent Trade Tech Part IV",
+        "Apprent Trade Tech Part IX",
+        "Apprent Trade Tech Part V"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "FILM",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "2nd 4wk Cinema Hist thro1945",
+        "Film &amp; New Media Production I",
+        "Film &amp; New Media Production II",
+        "Intro Entertainment Industries",
+        "Introduction to Cinema Studies"
+      ]
+    },
+    {
+      "prefix": "VETT",
+      "name": "Animal",
+      "course_count": 22,
+      "section_count": 26,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Anesthesia for Vet Technicians",
+        "Animal Anatomy &amp; Physiology",
+        "Animal Anatomy &amp; Physiology Lb",
+        "Animal Health Careers",
+        "Animal Nursing Skills I"
+      ]
+    },
+    {
+      "prefix": "AMTA",
+      "name": "AMTA",
+      "course_count": 18,
+      "section_count": 25,
+      "colleges": [
+        "baton-rouge-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Electrical",
+        "Aircraft Electrical and Airframe Fire Protection Systems",
+        "Aircraft Finishes",
+        "Aircraft Fuel Systems",
+        "Aircraft Instruments"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Nurse Asst Skills Application",
+        "Nursing as a Career",
+        "Nursing Assistant Fundamentals"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 25,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Foundations in Science",
+        "Foundations in Science II"
+      ]
+    },
+    {
+      "prefix": "VTEC",
+      "name": "Animal",
+      "course_count": 23,
+      "section_count": 25,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Anesthesia for Veterinary Tech",
+        "Animal Anatomy &amp; Phys Lab",
+        "Animal Anatomy &amp; Physiology",
+        "Animal Breeds and Behavior",
+        "Animal Health Careers"
+      ]
+    },
+    {
+      "prefix": "HPHL",
+      "name": "Phlebotomy",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Body Structure and Function",
+        "Intro to Health Care",
+        "Phleb Techn Lab &amp; Clinical Exp",
+        "Phlebotomy",
+        "Phlebotomy Capstone"
+      ]
+    },
+    {
+      "prefix": "INCO",
+      "name": "Process",
+      "course_count": 10,
+      "section_count": 24,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Fluid Mechanics",
+        "Intro: Process Technology",
+        "Process Instrumentation I",
+        "Process Instrumentation II",
+        "Process Tech: Unit Operations"
+      ]
+    },
+    {
+      "prefix": "NDTT",
+      "name": "Testing",
+      "course_count": 12,
+      "section_count": 24,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Liquid Penetrant",
+        "Magnetic Particle Testing",
+        "Manufacturing Processes",
+        "NDT Blueprint Read &amp; Sketching",
+        "NDT Technical Report Writing"
+      ]
+    },
+    {
+      "prefix": "OGPT",
+      "name": "OGPT",
+      "course_count": 23,
+      "section_count": 24,
+      "colleges": [
+        "bossier-parish-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Basic Production Operation",
+        "Drilling Fluids",
+        "Drilling Processes",
+        "Drilling Technology",
+        "Hydraulic/Pneumatic App OGPT"
+      ]
+    },
+    {
+      "prefix": "WFMA",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 24,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Math for Workforce Occupations"
+      ]
+    },
+    {
+      "prefix": "YMAU",
+      "name": "YMAU",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "AWS Advanced Welding 2",
+        "CNC Basic Mill Operator",
+        "EMPWR LA Training Program",
+        "EMPWR Oil and Gas",
+        "Machinist"
+      ]
+    },
+    {
+      "prefix": "FRSC",
+      "name": "Fire",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Bldg Const for Fire Protection",
+        "Fire &amp; Emerg. Serv. Admin.",
+        "Fire Behavior and Combustion",
+        "Fire Investigation I",
+        "Fire Investigation II"
+      ]
+    },
+    {
+      "prefix": "CSSK",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 21,
+      "colleges": [
+        "baton-rouge-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "12-wks College Success Skills",
+        "College Success"
+      ]
+    },
+    {
+      "prefix": "MTTC",
+      "name": "MTTC",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "delgado-community-college",
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advance Manual Machining",
+        "Advanced Lathe",
+        "Advanced Mill",
+        "Basic Lathe",
+        "Basic Mill"
+      ]
+    },
+    {
+      "prefix": "OADM",
+      "name": "OADM",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Spreadsheet Apps",
+        "Customer Service",
+        "Introduction to Software Apps",
+        "Introduction to Spreadsheets",
+        "Keyboarding"
+      ]
+    },
+    {
+      "prefix": "PHYE",
+      "name": "PHYE",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Baseball I",
+        "Baseball II",
+        "Baseball III",
+        "Baseball IV",
+        "Basketball I"
+      ]
+    },
+    {
+      "prefix": "RSTH",
+      "name": "RSTH",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "bossier-parish-community-college",
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Practitioners Review",
+        "Card Case Stud Ethical Issues",
+        "Cardiopulmonary Diagnostics",
+        "Cardiopulmonary Pharmacology",
+        "Cardiopulmonary Physiology I"
+      ]
+    },
+    {
+      "prefix": "SPTD",
+      "name": "Released",
+      "course_count": 1,
+      "section_count": 21,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Released Time (TECH)"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 7,
+      "section_count": 20,
+      "colleges": [
+        "bossier-parish-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Education Technology",
+        "Introduction to Education",
+        "Investigating School Contexts",
+        "Teach &amp; Learn Diverse Setting",
+        "Teach&amp;Learn Diverse SettingII"
+      ]
+    },
+    {
+      "prefix": "INTC",
+      "name": "INTC",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Construction Mat Equip &amp; Proc",
+        "Electronics I",
+        "General Saf &amp; Accd Prev",
+        "Hydraulics",
+        "Intro to Comp-Aid Des and Draf"
+      ]
+    },
+    {
+      "prefix": "STEC",
+      "name": "Surgical",
+      "course_count": 16,
+      "section_count": 20,
+      "colleges": [
+        "bossier-parish-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Specialties",
+        "Foundations of Surg. Tech",
+        "Intro to Surgical Tech Lab",
+        "Introduction to Surgical Tech",
+        "Surgical Case Review"
+      ]
+    },
+    {
+      "prefix": "WELL",
+      "name": "Fitness",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Fitness I",
+        "Fitness II",
+        "Fitness III",
+        "Personal Nutrition: Wellness",
+        "Personal Wellness"
+      ]
+    },
+    {
+      "prefix": "CIVL",
+      "name": "Surveying",
+      "course_count": 19,
+      "section_count": 19,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Survey Practice",
+        "App Math &amp; Trig for CSM",
+        "Civl Survey &amp; Mapping CST Revi",
+        "Computer Aided Drafting",
+        "Hydrographic Surveying"
+      ]
+    },
+    {
+      "prefix": "CIVT",
+      "name": "CIVT",
+      "course_count": 14,
+      "section_count": 19,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Surveying",
+        "Civil Drafting",
+        "Construction Contrac &amp; Laws",
+        "Construction Management",
+        "Design &amp; Control of Concr Mixt"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 6,
+      "section_count": 19,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "12-wks Elementary French I",
+        "Elem French II (w/20935)",
+        "Elementary French I",
+        "Elementary French II",
+        "Fren Culture Around the World"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "Architectural",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Arch Restoration &amp; Renovation",
+        "Architectural Design I",
+        "Architectural Design II",
+        "Architectural Design III",
+        "Architectural Design IV"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "Horticulture",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "baton-rouge-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Botany",
+        "General Horticulture",
+        "Horticulture Lab I",
+        "Horticulture Laws &amp; Regultions",
+        "Plant Identification Theory I"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 18,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Medical Assist.&amp; Patient Prepa",
+        "Medical Assistant Clinical",
+        "Pharmacology for Medical Assis"
+      ]
+    },
+    {
+      "prefix": "CRPT",
+      "name": "CRPT",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Buildg Materials &amp; Estimating",
+        "Carpentry Calculations",
+        "Design, Blueprint Readg, Codes",
+        "Exterior Finishes",
+        "Form Carpentry"
+      ]
+    },
+    {
+      "prefix": "CSIT",
+      "name": "CSIT",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "CSIT Capstone",
+        "Intro to Cloud Computing",
+        "Introduction to Programming",
+        "Introduction to Scripting",
+        "Introduction to Virtualization"
+      ]
+    },
+    {
+      "prefix": "ELET",
+      "name": "ELET",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis",
+        "Digital Circuits",
+        "Electrical Circuits I",
+        "Electrical Circuits II",
+        "Electrical Machinery/Controls"
+      ]
+    },
+    {
+      "prefix": "EPTN",
+      "name": "EPTN",
+      "course_count": 15,
+      "section_count": 17,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Applied Elec &amp; Indus Instru I",
+        "Applied Elec &amp; Indus Instru II",
+        "Energy Prod Tech Equipment I",
+        "Energy Prod Tech Equipment II",
+        "Fluid Mechanics"
+      ]
+    },
+    {
+      "prefix": "MCSI",
+      "name": "Medical",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "General Body Structure",
+        "Med Insurance Billing Part 1",
+        "Med Insurance Billing Part II",
+        "Medical Coding CPT/HCPCS",
+        "Medical Coding ICD-10 CM"
+      ]
+    },
+    {
+      "prefix": "MSTH",
+      "name": "Massage",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "A&amp;P for Massage Therapy",
+        "Busi/Ethics/Law in MSTH Pract.",
+        "Deep Tissue Therapy",
+        "Foundation: Swedish Techniques",
+        "Fund:Traditional Chinese Med"
+      ]
+    },
+    {
+      "prefix": "AVMT",
+      "name": "Maintenance",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Airframe Maint Tech I",
+        "Airframe Maintenance Tech II",
+        "Airframe Maintenance Tech III",
+        "Aviation Maintenance Fund I",
+        "Aviation Maintenance Fund II"
+      ]
+    },
+    {
+      "prefix": "DIVE",
+      "name": "DIVE",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Air Decompression",
+        "Chamber Operations",
+        "Dive Medicine",
+        "Diving Equipment",
+        "Diving Physics"
+      ]
+    },
+    {
+      "prefix": "DSEL",
+      "name": "Diesel",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Electrical Sys",
+        "Air Conditioning",
+        "Basic Hydraulics",
+        "Diesel Engine Fuel &amp; Control",
+        "Diesel Engines"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "(12 wks) Statics",
+        "Circuits",
+        "Comp. Electrical Engineering",
+        "Engineering Fundamentals",
+        "Engineering Fundamentals II"
+      ]
+    },
+    {
+      "prefix": "FPTC",
+      "name": "Fire",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Basic Response to Terrorism",
+        "Building Materials",
+        "Codes &amp; Prevention Principles",
+        "Exec Mgmnt in Fire Science",
+        "Fire Administration"
+      ]
+    },
+    {
+      "prefix": "JOBS",
+      "name": "Seeking",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Job Seeking Skills"
+      ]
+    },
+    {
+      "prefix": "PAST",
+      "name": "Baking",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chocolate Techniques",
+        "Artisan Breads",
+        "Baking &amp; Pastry Cafe",
+        "Baking &amp; Pastry Skills Lab II",
+        "Baking/Pastry Skills Lab I"
+      ]
+    },
+    {
+      "prefix": "SPCM",
+      "name": "Speech",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Speech",
+        "Intro to Public Speaking"
+      ]
+    },
+    {
+      "prefix": "YFIR",
+      "name": "Cert",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Cert Fiber Optics Spec Splc.",
+        "Cert. Fiber Optic Spec. CFOS/T",
+        "Cert. Fiber Optic Technician",
+        "HVAC",
+        "Pipefitting"
+      ]
+    },
+    {
+      "prefix": "YPSE",
+      "name": "YPSE",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "baton-rouge-community-college",
+        "bossier-parish-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advertising &amp; Marketing I",
+        "Basic Computer Skills",
+        "Culinary Fundamentals",
+        "Customer Service",
+        "Employment Readiness"
+      ]
+    },
+    {
+      "prefix": "HASC",
+      "name": "Phlebotomy",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "EKG II",
+        "Intro to EKG",
+        "Phlebotomy",
+        "Phlebotomy Clin Externship",
+        "Phlebotomy Lab"
+      ]
+    },
+    {
+      "prefix": "MVSB",
+      "name": "MVSB",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Essentials-AUTO",
+        "Fundamentals and Safety-Diesel",
+        "Heating and Air Conditioning",
+        "Motor Vehicle Service Basics-A"
+      ]
+    },
+    {
+      "prefix": "SURT",
+      "name": "Surgical",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "(1st 4wk)Surgical Procedures I",
+        "Practicum I Surgical Procedure",
+        "Practicum II Surgical Procedur",
+        "Skills Lab I Surgical Tech",
+        "Skills Lab II Surgical Tech 7w"
+      ]
+    },
+    {
+      "prefix": "AMTG",
+      "name": "AMTG",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "baton-rouge-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Drawings",
+        "Aircraft Math and Physics",
+        "Basic Electricity",
+        "Cleaning and Corrosion Control",
+        "Documents and Regulations"
+      ]
+    },
+    {
+      "prefix": "FDFS",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Foundations for Success"
+      ]
+    },
+    {
+      "prefix": "MOS",
+      "name": "Medical",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Coding Practice",
+        "Medical Coding I",
+        "Medical Coding II",
+        "Medical Office Administration",
+        "Reimbursement Methodology"
+      ]
+    },
+    {
+      "prefix": "NUMT",
+      "name": "Nuclear",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Clinical Procedures III",
+        "Comprehensive Seminar",
+        "Instrumentation"
+      ]
+    },
+    {
+      "prefix": "OPHT",
+      "name": "Ophthalmic",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "A&amp;P for Ophthalmic Personnel",
+        "Basic Ophthalmic Pharmacology",
+        "Intro Ophthalmic Medical Assis",
+        "Intro to Diseases of the Eye",
+        "Maintenance of Ophthalmic Inst"
+      ]
+    },
+    {
+      "prefix": "WKSF",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Industrial Workplace Safety"
+      ]
+    },
+    {
+      "prefix": "ASDV",
+      "name": "Programming",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Adv Programming Language I",
+        "Advanced SQL Programming",
+        "C# Programming",
+        "C++ Programming",
+        "Data Structures and Algorithms"
+      ]
+    },
+    {
+      "prefix": "MCS",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Advanced Medical Coding Lab",
+        "Basic Medical Coding",
+        "Basic Medical Coding Lab",
+        "Healthcare Delivery Systems"
+      ]
+    },
+    {
+      "prefix": "MTEC",
+      "name": "MTEC",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Machinist",
+        "Advanced Millwright",
+        "Cmptr Numerical Cntrl II (CNC)",
+        "Cmptr Numerical Ctrl III (CNC)",
+        "Computer Numerical Cntrl (CNC)"
+      ]
+    },
+    {
+      "prefix": "ELST",
+      "name": "Electronics",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electronics",
+        "Basic Electronics Laboratory",
+        "Biomed Instrumentation Lab",
+        "Biomed Instrumentation Systems",
+        "Biomedical Equipment Practicum"
+      ]
+    },
+    {
+      "prefix": "HCVO",
+      "name": "HCVO",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Construction Tech &amp; Equipment",
+        "Introduction to Earth Moving",
+        "Orientation to Constr. Trade",
+        "Soils and Machinery"
+      ]
+    },
+    {
+      "prefix": "HSOM",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Basic CPT Coding",
+        "Basic ICD-10CM Coding",
+        "Human Disease for Allied Hlth",
+        "Legal Aspects of Medical Ofc",
+        "Medical Office Management"
+      ]
+    },
+    {
+      "prefix": "IMEL",
+      "name": "IMEL",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Adv Remote Operated Vehicle",
+        "Alternating Current Circuits",
+        "Digital Circuits",
+        "Direct Current Circuit",
+        "Industrial Marine Hydraulics"
+      ]
+    },
+    {
+      "prefix": "KYBD",
+      "name": "Keyboarding",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Formatting",
+        "Introduction to Keyboarding",
+        "Keyboarding I"
+      ]
+    },
+    {
+      "prefix": "SCSP",
+      "name": "Central",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Central Process Practicum II",
+        "Central Processing I",
+        "Central Processing II",
+        "Central Processing III",
+        "Central Processing Practicum I"
+      ]
+    },
+    {
+      "prefix": "ANUR",
+      "name": "Medsurg",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Pharmacology",
+        "Maternal/Neonate Nursing",
+        "Med/Surg Nrsng Clincl Apps II",
+        "Med/Surg Nrsng Cncpts II",
+        "Med/Surg Nursing Concepts III"
+      ]
+    },
+    {
+      "prefix": "CORR",
+      "name": "CORR",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Correctional Counseling",
+        "Corrections Process",
+        "Probation, Parole, &amp; Treatment"
+      ]
+    },
+    {
+      "prefix": "FYSE",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "First Year Student Experience"
+      ]
+    },
+    {
+      "prefix": "HSCI",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Medical Ethics &amp; Law",
+        "Medical Terminology",
+        "Pharmacology for Hlth Careers"
+      ]
+    },
+    {
+      "prefix": "STPR",
+      "name": "Sterile",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "fletcher-technical-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Intr Sterile Prcessing Concpts",
+        "Sterile Process Concepts II Ap",
+        "Sterile Processing Capstone",
+        "Sterile Processing Concepts Ap",
+        "Sterile Processing Concepts I"
+      ]
+    },
+    {
+      "prefix": "BOTH",
+      "name": "Medical",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures for Medical Offices",
+        "CPT &amp; HCPCS Coding",
+        "General Body Structure",
+        "ICD Coding",
+        "Insurance Billing"
+      ]
+    },
+    {
+      "prefix": "CLCR",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Career Preparation",
+        "On-the-Job Learning"
+      ]
+    },
+    {
+      "prefix": "CLTE",
+      "name": "Analysis",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Chemical Indstrial Analysis II",
+        "Chemical Industrial Analysis I",
+        "Chemical Lab Analysis I Lab",
+        "Chemicl Indstrl Anaysis II Lab",
+        "Introduction to Lab Analysis"
+      ]
+    },
+    {
+      "prefix": "CNET",
+      "name": "CNET",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "baton-rouge-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "(12-wks) Desktop/Server Netwrk",
+        "Computer User Support I",
+        "Computer User Support II",
+        "Firewalls &amp; Network Security",
+        "Information Technology Fundame"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "Construction",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Carpentry 1",
+        "Construct. Materials &amp; Methods",
+        "Construction Safety",
+        "Intro to Construction Mgmt",
+        "Introduction to Construction"
+      ]
+    },
+    {
+      "prefix": "DHTT",
+      "name": "Truck",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Hydraulic Systems",
+        "Preventative Maint Inspection",
+        "Truck Advanced Electrical",
+        "Truck Brake Systems",
+        "Truck Drivetrain"
+      ]
+    },
+    {
+      "prefix": "HEKG",
+      "name": "HEKG",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "EKG",
+        "EKG Clinical",
+        "EKG Procedures"
+      ]
+    },
+    {
+      "prefix": "IAMT",
+      "name": "IAMT",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Basic Hydraulics",
+        "Basic Industrial Eng Elec",
+        "Engine Fuel Systems",
+        "Engine Parts Ident &amp; Oper Prin",
+        "General Engine Diagnostics"
+      ]
+    },
+    {
+      "prefix": "ORNT",
+      "name": "Freshman",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "south-louisiana-community-college",
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Freshman Seminar",
+        "FRESHMAN SEMINAR"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Heritagevalues",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Heritage/Values USAF I Lab",
+        "Heritage/Values USAF II",
+        "Heritage/Values USAF II Lab",
+        "Heritige/Values US Air Force I",
+        "Team/Leadership Fund I"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "A/C Principle and Lab",
+        "Advanced Field Study Intern.",
+        "Advanced GIS &amp; Mapping Systems",
+        "Agri Small Engine Service &amp; Re",
+        "Intro Agricultural Power Units"
+      ]
+    },
+    {
+      "prefix": "FIAR",
+      "name": "Ceramics",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Independent Study In Ceramics",
+        "Intermediate Ceramics",
+        "Introduction to Ceramics",
+        "Introduction to Drawing",
+        "Introduction to Fine Art"
+      ]
+    },
+    {
+      "prefix": "FRTY",
+      "name": "Forest",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Biology of Forest Plants",
+        "Forest Insects And Diseases",
+        "Forest Mensuration I",
+        "Intr Forest Surv/Geog Info Sys",
+        "Intr to Forest Technology"
+      ]
+    },
+    {
+      "prefix": "PSOM",
+      "name": "PSOM",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "A&amp;P of Sleep and Breathing",
+        "Fundamentals: Polysomnography",
+        "Instrumentation: Polysomnograp",
+        "Introduction to Sleep and Wake",
+        "Monit/Intro: Therap Intervent"
+      ]
+    },
+    {
+      "prefix": "RLGN",
+      "name": "Testament",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "New Testament Survey I",
+        "New Testament Survey II",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "TEAC",
+      "name": "Diverse",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "baton-rouge-community-college",
+        "delgado-community-college",
+        "louisiana-delta-community-college",
+        "nunez-community-college",
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Teac. &amp; Learn. in Diver. Set.1",
+        "Teach &amp; Learn Diverse Setting",
+        "Teach &amp; Learning in Diverse II",
+        "Teach&amp;Learn Diverse SettingII",
+        "Teaching &amp; Learning in Div S I"
+      ]
+    },
+    {
+      "prefix": "CLRP",
+      "name": "CLRP",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Auto Body Internship I",
+        "Auto Body Internship II",
+        "Auto Body Welding",
+        "Collison Repair Appraisal",
+        "Non-Structural Damage"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "COMP",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Cloud Foundations",
+        "Computer Maintenance I",
+        "Computer Maintenance II",
+        "Cooperative Education",
+        "Database Management Systems"
+      ]
+    },
+    {
+      "prefix": "CSON",
+      "name": "CSON",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Cardiac Anatomy &amp; Pathophysiol",
+        "Echocardiogrphy Cln/Prac I",
+        "Echocardiogrphy Skills App Lab",
+        "Sonographic Principles &amp; Instr",
+        "Vasc ECG Clin Practicum III"
+      ]
+    },
+    {
+      "prefix": "CSRV",
+      "name": "Customer",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Customer Service"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "INDT",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Fluid Mechanics",
+        "Industrial &amp; Plant Safety",
+        "Job Readiness Skills",
+        "Quality Control"
+      ]
+    },
+    {
+      "prefix": "RATH",
+      "name": "RATH",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Student Seminar",
+        "Clinical Practice I",
+        "Clinical Practice IV",
+        "CT Simulation w/ Sect. Anatomy",
+        "Oncologic Pathology"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "Diesel",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Basic Hydraulics",
+        "Diesel Eng ID &amp; Op Priniples",
+        "Diesel Engine Systems",
+        "Diesel Equipment Powertrains",
+        "Diesel-Pwd Equip &amp; Ap Ind Skl"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Africa and the Middle East",
+        "The Heroic Journey:Class/Cont",
+        "World Mythology"
+      ]
+    },
+    {
+      "prefix": "ISYS",
+      "name": "Word",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Word Processing",
+        "Desktop Publishing",
+        "Word Processing"
+      ]
+    },
+    {
+      "prefix": "MWRT",
+      "name": "Millwright",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Millwright I",
+        "Advanced Millwright II",
+        "Intermediate Millwright I",
+        "Intermediate Millwright II",
+        "Introduction to Millwright"
+      ]
+    },
+    {
+      "prefix": "SECA",
+      "name": "SECA",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Rescue Ops &amp; First Aid",
+        "Advanced Rescue Operations",
+        "Basics of Electric Motors",
+        "Basics of Hydraulic Systems",
+        "Intro to Mechanical Systems"
+      ]
+    },
+    {
+      "prefix": "VETA",
+      "name": "Techniques",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Vet Assist Clinical Pathology",
+        "Vet Assist Externship",
+        "Vet Assist Surgical Techniques",
+        "Vet Assistant Husbandry",
+        "Vet Assistant Nursing Skills"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Astronomy"
+      ]
+    },
+    {
+      "prefix": "BUSE",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Business English"
+      ]
+    },
+    {
+      "prefix": "CSTL",
+      "name": "CSTL",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Coastal Science",
+        "Computer Graphs &amp; Maps",
+        "Drone Surveying Lab",
+        "Fundamentals of Mapping &amp; GIS",
+        "Introduction to sUAS"
+      ]
+    },
+    {
+      "prefix": "CTDP",
+      "name": "Theory",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "CDL Theory &amp; Operations"
+      ]
+    },
+    {
+      "prefix": "ESTH",
+      "name": "Esthetics",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Esth. Treatments &amp; Techniques",
+        "Introduction to Esthetics",
+        "Makeup Application",
+        "Science of Esthetics",
+        "Spa &amp; Alternative Treatments"
+      ]
+    },
+    {
+      "prefix": "HMAN",
+      "name": "Culture",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Film and Culture",
+        "Prehistoric - Medieval Culture",
+        "Renaissance &ndash; Modern Culture"
+      ]
+    },
+    {
+      "prefix": "HMDT",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "HPHM",
+      "name": "Pharm",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Math Dosage Calc for Pharm Tec",
+        "Pharm Tech Fund, Law &amp; Ethics",
+        "Pharmacology for Pharm Techs"
+      ]
+    },
+    {
+      "prefix": "INCT",
+      "name": "Systems",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Basic Routers",
+        "Linux Systems Administration",
+        "Managing Network Security",
+        "Operating Systems",
+        "Server Technology"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Work Readiness"
+      ]
+    },
+    {
+      "prefix": "MCOM",
+      "name": "Media",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "river-parishes-community-college",
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Media Writing",
+        "Introduction to Mass Media"
+      ]
+    },
+    {
+      "prefix": "MEDL",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Intro Healthcare for Surg Tech",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "OSYS",
+      "name": "Office",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "fletcher-technical-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Office Procedures",
+        "Records Management"
+      ]
+    },
+    {
+      "prefix": "PARL",
+      "name": "PARL",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Case Analysis and Writing",
+        "Domestic Law and Litigation",
+        "Intro to Law and the Para Prof",
+        "Legal Ethics",
+        "Paralegal Practicum"
+      ]
+    },
+    {
+      "prefix": "POSC",
+      "name": "National",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "National Gov in US",
+        "State and Local Gov."
+      ]
+    },
+    {
+      "prefix": "ADMN",
+      "name": "Business",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Business Correspondence",
+        "Business Math",
+        "Keyboarding"
+      ]
+    },
+    {
+      "prefix": "AMFG",
+      "name": "AMFG",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Lean Manu &amp; Six Sigma",
+        "MFG Materials and Methods",
+        "Mfg Process, Prod &amp; Maint Awar",
+        "Mfg Safety, Qual &amp; Measurement"
+      ]
+    },
+    {
+      "prefix": "ARST",
+      "name": "Assembly",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Intro Mech Assembly",
+        "Intro to Elec.&amp; Elec. Assembly",
+        "Introduction to Aerospace",
+        "Print Reading",
+        "Welding Aero Manuf"
+      ]
+    },
+    {
+      "prefix": "BUSM",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college",
+        "northwest-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Business Math"
+      ]
+    },
+    {
+      "prefix": "CHTC",
+      "name": "Analysis",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Applied Instrum. Analysis II",
+        "Applied Instrument. Analysis I",
+        "Applied Organic Chemistry Lab",
+        "Instrument Analysis"
+      ]
+    },
+    {
+      "prefix": "ESCI",
+      "name": "Alternative",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Alternative Energy"
+      ]
+    },
+    {
+      "prefix": "MDET",
+      "name": "Engine",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Diesel Engines &amp; the Vessel",
+        "Engine Mtg, Perc Align, &amp; Cplg",
+        "Gears &amp; Engine Couplings",
+        "Marine Vessels"
+      ]
+    },
+    {
+      "prefix": "MUSB",
+      "name": "MUSB",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Music Business",
+        "Live Audio Engineering",
+        "Sem. in Recordin Techniques I"
+      ]
+    },
+    {
+      "prefix": "FINA",
+      "name": "Financial",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Financial Management"
+      ]
+    },
+    {
+      "prefix": "GPHY",
+      "name": "Geography",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Physical Geography",
+        "Regional Geography"
+      ]
+    },
+    {
+      "prefix": "HLPE",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "First Aid"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "Hospitality",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Hospitality Law",
+        "Hospitality Management",
+        "Lodging Operations",
+        "Resorts and Tourism"
+      ]
+    },
+    {
+      "prefix": "HURM",
+      "name": "HURM",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "central-louisiana-technical-community-college",
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Employment Law and Regulations",
+        "Human Resources",
+        "Training and Development"
+      ]
+    },
+    {
+      "prefix": "ISAF",
+      "name": "Indust",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "bossier-parish-community-college"
+      ],
+      "sample_titles": [
+        "Indust Saf and OSHA Standards",
+        "Industrial Safety"
+      ]
+    },
+    {
+      "prefix": "ITRN",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Industrial Technology Internsh"
+      ]
+    },
+    {
+      "prefix": "SOCW",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "AGRB",
+      "name": "Agricultural",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Intro Agricultural Economics",
+        "Intro to Agricultural Business",
+        "Technology in Agriculture"
+      ]
+    },
+    {
+      "prefix": "BTEC",
+      "name": "BTEC",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Bioinformatics and Bioethics",
+        "Biomolecules",
+        "Intro: Nucleic Acids"
+      ]
+    },
+    {
+      "prefix": "BUSO",
+      "name": "Records",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Records and Information Mgmt"
+      ]
+    },
+    {
+      "prefix": "CMCA",
+      "name": "Cardiovascular",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Cardiovascular Med Asst I",
+        "Cardiovascular Med Cln Asst II",
+        "Medical Clinical Assistant III"
+      ]
+    },
+    {
+      "prefix": "ENTP",
+      "name": "Foundation",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Foundation of Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "LIBS",
+      "name": "Info",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Lib Info Serv 1st 7-Wks ONLINE"
+      ]
+    },
+    {
+      "prefix": "RELG",
+      "name": "Relgions",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Relgions of the Wrld"
+      ]
+    },
+    {
+      "prefix": "RNRE",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Natural Resources Conservation"
+      ]
+    },
+    {
+      "prefix": "SOLR",
+      "name": "Solar",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Solar Fundamentals"
+      ]
+    },
+    {
+      "prefix": "AGSC",
+      "name": "Plant",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Horticulture",
+        "Introduction to Plant Science"
+      ]
+    },
+    {
+      "prefix": "CIST",
+      "name": "Spreadsheets",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "(12 wks) Spreadsheets I"
+      ]
+    },
+    {
+      "prefix": "CPLT",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Computer Literacy"
+      ]
+    },
+    {
+      "prefix": "DWLD",
+      "name": "Welding",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Basic Welding for Mechanics"
+      ]
+    },
+    {
+      "prefix": "ENRE",
+      "name": "Comp",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Eng Comp I: Non-Nat. Speakers"
+      ]
+    },
+    {
+      "prefix": "ENVS",
+      "name": "Environmental Science",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science"
+      ]
+    },
+    {
+      "prefix": "HSAS",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "Health Studies Internship"
+      ]
+    },
+    {
+      "prefix": "HSEM",
+      "name": "Homeland",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Homeland Security"
+      ]
+    },
+    {
+      "prefix": "ICVT",
+      "name": "Invasive",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Invasive Clinical Rotation II",
+        "Invasive Procedures III"
+      ]
+    },
+    {
+      "prefix": "LISR",
+      "name": "Library",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Library &amp; Information Literacy"
+      ]
+    },
+    {
+      "prefix": "MILL",
+      "name": "Millwright",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Millwright Level 3 Part 1",
+        "Millwright Level 3 Part 2"
+      ]
+    },
+    {
+      "prefix": "MILS",
+      "name": "Armyampcritical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Intro Army&amp;Critical Thinking",
+        "Intro to Army &amp; Crit Think Lab"
+      ]
+    },
+    {
+      "prefix": "MWLD",
+      "name": "Welding",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Basic Welding for Mechanics"
+      ]
+    },
+    {
+      "prefix": "NRSA",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "fletcher-technical-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Fundamentals",
+        "Skills Application"
+      ]
+    },
+    {
+      "prefix": "SAFE",
+      "name": "Craft",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "south-louisiana-community-college"
+      ],
+      "sample_titles": [
+        "General Craft Safety"
+      ]
+    },
+    {
+      "prefix": "SPCA",
+      "name": "Released",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Released Time (COMM)"
+      ]
+    },
+    {
+      "prefix": "WGNS",
+      "name": "Womenrsquos",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "river-parishes-community-college"
+      ],
+      "sample_titles": [
+        "Women&rsquo;s &amp; Gender Studies"
+      ]
+    },
+    {
+      "prefix": "WWTC",
+      "name": "Water",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "Water Production Operator I",
+        "Water Treatment Operator I"
+      ]
+    },
+    {
+      "prefix": "DCUN",
+      "name": "Dccuno",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "delgado-community-college"
+      ],
+      "sample_titles": [
+        "DCC-UNO Cross Enrollment"
+      ]
+    },
+    {
+      "prefix": "DSCI",
+      "name": "Data",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "sowela-technical-community-college"
+      ],
+      "sample_titles": [
+        "Data Science Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ENVN",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science"
+      ]
+    },
+    {
+      "prefix": "FORS",
+      "name": "Forensic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "louisiana-delta-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Forensic Science"
+      ]
+    },
+    {
+      "prefix": "HUDV",
+      "name": "Livinglearningworking",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "nunez-community-college"
+      ],
+      "sample_titles": [
+        "Living-Learning-Working Skills"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Management"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-louisiana-technical-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Marketing"
+      ]
+    },
+    {
+      "prefix": "PIPE",
+      "name": "Pipefitting",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "Pipefitting Level 3 Part I"
+      ]
+    },
+    {
+      "prefix": "YAUT",
+      "name": "Supply",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "EV Supply Equipment"
+      ]
+    },
+    {
+      "prefix": "YCPS",
+      "name": "April",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "baton-rouge-community-college"
+      ],
+      "sample_titles": [
+        "(April) Google AI Essentials"
+      ]
+    }
+  ],
+  "program_titles": [
+    "3G-4G FCAW Welder, CTC",
+    "3G-4G SMAW Welder, CTC",
+    "A/C & Refrigeration - Commercial Refrigeration, TD 470201",
+    "A/C & Refrigeration - Residential Refrigeration, TD 470201",
+    "A/C & Refrigeration Technician - Domestic, CTS",
+    "AALT Fine Arts",
+    "AALT Math Analytical Reasoning",
+    "AALT Social/Behavioral Science and Business Electives",
+    "AAS Criminal Justice and AAS Criminal Justice w/Forensic Science Concentration",
+    "Account Clerk, CTS",
+    "Accounting Clerk, Certificate of Technical Studies — Associate of Applied Science",
+    "Accounting Concentration, Associate of Applied Science — Associate of Applied Science",
+    "Accounting Office Assistant, CTS",
+    "Accounting Technology",
+    "Accounting Technology, AAS",
+    "Administrative Office Management, AAS",
+    "Administrative Professional Studies, AAS",
+    "Advanced Application Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+    "Advanced Welding Technology",
+    "Aerospace Manufacturing Technology, Associate of Applied Science — Associate of Applied Science",
+    "Aerospace Manufacturing Technology, Certificate of Technical Studies — Associate of Applied Science",
+    "Aerospace Manufacturing Technology, Technical Diploma — Associate of Applied Science",
+    "Agriculture Equipment Technology, TD",
+    "AGS AgriScience 240102",
+    "AGS Applied Science Minor Concentration",
+    "AGS Arts and Humanities Minor Concentration",
+    "AGS Behavioral Science Minor Concentration",
+    "AGS Business Minor Concentration",
+    "AGS Natural Science Minor Concentration",
+    "American Sign Language Studies",
+    "Application Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+    "Application Software Development, AAS",
+    "Applied Sciences",
+    "Apprentice Electrician, CTC",
+    "ARC Welding GMAW, CTS",
+    "ARC Welding GTAW, CTS",
+    "ARC Welding SMAW, CTS",
+    "ASN Curriculum",
+    "Associate of General Studies — Associate of Applied Science",
+    "Auto Body Repair Technician",
+    "Auto Engine Performance Technician, CTS",
+    "Automatic Transmission & Transaxle Technician Track",
+    "Automotive Electrical Technician, CTC",
+    "Automotive Electrical Technician, CTS",
+    "Automotive Engine Performance Technician, CTC",
+    "Automotive Engine Performance Technician, CTS",
+    "Automotive Engine Repair Technician, CTC",
+    "Automotive Heating and Air Conditioning, CTC",
+    "Automotive Power Train Technician, CTS",
+    "Automotive Steering and Brakes, CTC",
+    "Automotive Technician",
+    "Automotive Technician, TD 470604",
+    "Automotive Technology, TD",
+    "Automotive Transmission Technician, CTC",
+    "Aviation Maintenance Technician, Airframe",
+    "Aviation Maintenance Technician, Powerplant",
+    "Aviation Maintenance Technology",
+    "Aviation Maintenance Technology, AAS",
+    "Baker, Career and Technical Certificate — Associate of Applied Science",
+    "Bank Teller, CTS",
+    "Basic Accounting, CTC",
+    "Biological Sciences",
+    "Brake Technician Track",
+    "Business",
+    "Business & Technology, AAS 520101",
+    "Business Administration",
+    "Business Administration Concentration, Associate of Applied Science — Associate of Applied Science",
+    "Business Administration, AAS",
+    "Business Administrative Assistant, CTS",
+    "Business Application & Desktop Support, CTC",
+    "Business Elective Courses",
+    "Business Entrepreneurship, CTC",
+    "Business Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+    "Business Information Technology, Technical Diploma — Associate of Applied Science",
+    "Business Management, Associate of Applied Science (Accounting Concentration) — Associate of Applied Science",
+    "Business Management, Associate of Applied Science (Business Administration Concentration) — Associate of Applied Science",
+    "Business Management, Associate of Applied Science (Entrepreneurship/Small Business Concentration) — Associate of Applied Science",
+    "Business Minor Concentration",
+    "Business Office Administration, AAS 520401",
+    "Business Office Technology, TD",
+    "Business Technology, Certificate of Applied Science — Associate of Applied Science",
+    "Business Technology: Medical Office Management Concentration, Associate of Applied Science — Associate of Applied Science",
+    "Business, AS",
+    "Cardiovascular Sonography, AAS",
+    "Care and Development of Young Children",
+    "Care and Development of Young Children, AAS",
+    "Care and Development of Young Children, Associate of Applied Science — Associate of Applied Science",
+    "Care and Development of Young Children, Technical Diploma — Associate of Applied Science",
+    "Carpentry",
+    "Carpentry, Certificate of Technical Studies — Associate of Applied Science",
+    "CDYC Electives",
+    "Certificate of General Studies - Cardiopulmonary Care Track, CGS",
+    "Certificate of General Studies — Associate of Applied Science",
+    "Certificate of General Studies Electives",
+    "Certificate of General Studies in Nursing, CGS",
+    "Certificate of General Studies, CGS",
+    "Certified Nursing Assistant, CNA, Career and Technical Certificate — Associate of Applied Science",
+    "Child Care Teacher, CTS",
+    "Child Care Teacher, TD",
+    "CINS/CNET/CSCI Electives",
+    "Cisco Certified Network Associate, CTC",
+    "Civil, Surveying and Mapping Technology, AAS",
+    "Civil, Surveying and Mapping Technology, TD",
+    "Client Implementation and Support Specialist, CTS",
+    "Cloud Computing Foundations, Certificate of Technical Studies — Associate of Applied Science",
+    "Coastal Restoration, Certificate of Technical Studies — Associate of Applied Science",
+    "Coastal Studies and GIS Technology, Associate of Applied Science — Associate of Applied Science",
+    "Coastal Studies and GIS Technology, Technical Diploma — Associate of Applied Science",
+    "Coastal Surveying Skills, Career and Technical Certificate — Associate of Applied Science",
+    "Combo Welding, Technical Diploma — Associate of Applied Science",
+    "Commercial Diving, CTS",
+    "Computer & Information Technology, AAS 110901",
+    "Computer Information Systems, AAS",
+    "Computer Networking",
+    "Computer Science",
+    "Computer Support Specialist, CTC",
+    "Computing and Information Systems, Application Software Development concentration",
+    "Computing and Information Systems, Cloud Computing concentration",
+    "Computing and Information Systems, Cybersecurity concentration",
+    "Construction Management",
+    "Cosmetology",
+    "Cosmetology, TD",
+    "Criminal Justice",
+    "Criminal Justice, AS",
+    "Criminal Justice, CTS",
+    "Culinarian, Career and Technical Certificate — Associate of Applied Science",
+    "Culinary Arts and Occupations",
+    "Culinary Arts and Occupations, AAS",
+    "Culinary Arts and Occupations, TD",
+    "Culinary Arts, Certificate of Technical Studies — Associate of Applied Science",
+    "Culinary Entrepreneurship, Technical Diploma — Associate of Applied Science",
+    "Customer Service and Sales",
+    "Customer Service for Business Professionals, CTC",
+    "Customer Service Representative, CTS",
+    "Cybersecurity and Information Assurance, Associate of Applied Science — Associate of Applied Science",
+    "Cybersecurity Defender, CTS",
+    "Cybersecurity Specialist, CTC",
+    "Cybersecurity Support, CTC",
+    "Cybersecurity, AAS",
+    "Databases, Certificate of Technical Studies — Associate of Applied Science",
+    "Diagnostic Medical Sonography",
+    "Diesel Engine Technician, CTS",
+    "Diesel Heavy Truck Technician",
+    "Diesel Mechanic Apprentice, CTC",
+    "Diesel Mechanic, CTS",
+    "Diesel Powered Equipment Technology, TD",
+    "Diesel Powered Equipment Technology, TD 470605",
+    "Digital Media Design, AAS",
+    "Digital Media Design, TD",
+    "Domestic A/C & Refrigeration, CTS",
+    "Domestic Refrigeration Helper II, Certificate of Technical Studies — Associate of Applied Science",
+    "Drafting & Design Technology: Engineering Aid II, CTS",
+    "Drafting and Design Technician",
+    "Drafting and Design Technology, AAS",
+    "Drafting and Design Technology, AAS 151301",
+    "Drafting and Design Technology, TD",
+    "Drafting and Design Technology, TD 151301",
+    "Drafting Technology, CTS",
+    "Early Childhood Teaching Skills, Career and Technical Certificate — Associate of Applied Science",
+    "EKG Technician, Career and Technical Certificate — Associate of Applied Science",
+    "Electrical Construction - Advanced, Certificate of Technical Studies — Associate of Applied Science",
+    "Electrical Construction, Associate of Applied Science — Associate of Applied Science",
+    "Electrical Construction, Certificate of Technical Studies — Associate of Applied Science",
+    "Electrical Technician Track",
+    "Electrician - Commercial Wiring II, TD 460302",
+    "Electrician - Industrial, TD 460302",
+    "Electrician: Commercial/Industrial Electrical Technician, TD",
+    "Emergency Medical Services Education - Paramedic, Associate of Applied Science — Associate of Applied Science",
+    "Emergency Medical Services Education - Paramedic, Certificate of Technical Studies — Associate of Applied Science",
+    "Emergency Medical Technician Paramedic, AAS",
+    "Emergency Medical Technician Paramedic, TD",
+    "EMT - Advanced, Career and Technical Certificate — Associate of Applied Science",
+    "EMT - Basic, Career and Technical Certificate — Associate of Applied Science",
+    "Energy Production Technologies, AAS",
+    "Energy Production Technologies, TD",
+    "Engine Performance Technician Track",
+    "Engine Repair Technician Track",
+    "English Composition",
+    "English General Education",
+    "Enrolled Agent",
+    "Entrepreneurship Concentration, Associate of Applied Science — Associate of Applied Science",
+    "Entrepreneurship/Small Business Management, Certificate of Technical Studies — Associate of Applied Science",
+    "FCAW Pipe Welder, CTC",
+    "Film and New Media Production",
+    "Fine Arts",
+    "Food Service Manager, Career and Technical Certificate — Associate of Applied Science",
+    "Forensic Science Electives",
+    "General Business",
+    "General Business, CTS",
+    "General Clerk, CTC",
+    "General Education Course Categories and Matrix",
+    "General Education Curriculum",
+    "General Education Requirements",
+    "General Industry Technician, CTS",
+    "General Science",
+    "General Studies",
+    "General Studies, AGS",
+    "GIS & Facilities Planning Program, Certificate of Technical Studies — Associate of Applied Science",
+    "GIS Technology, Certificate of Technical Studies — Associate of Applied Science",
+    "Graphic Arts",
+    "HACR Energy Systems Technician, CTS",
+    "Health Studies",
+    "Heating, Air Conditioning & Refrigeration, TD",
+    "Heating, Air Conditioning, and Refrigeration, Associate of Applied Science — Associate of Applied Science",
+    "Heating, Air Conditioning, and Refrigeration, Technical Diploma — Associate of Applied Science",
+    "Heating, Ventilation, Air Conditioning, and Refrigeration (HVACR), TD",
+    "Horticulture Technician",
+    "Hotel, Restaurant, and Tourism Admin, Career and Technical Certificate — Associate of Applied Science",
+    "Hotel, Restaurant, and Tourism Concentration, Associate of Applied Science — Associate of Applied Science",
+    "Human Resource Specialist, CTS",
+    "Humanities",
+    "Humanities- All",
+    "Humanities- History",
+    "Humanities- Literature",
+    "Humanities- Literature/History",
+    "Humanities- No Speech, English Composition or Foreign Language",
+    "Humanities- Speech/Interpersonal Communication",
+    "HVAC Helper I, CTC",
+    "HVAC Helper II, CTS",
+    "HVAC/R Technician",
+    "Industrial Electronics Technology, AAS",
+    "Industrial Electronics Technology, TD",
+    "Industrial Instrumentation Technology, AAS 150404",
+    "Industrial Instrumentation, TD 150404",
+    "Industrial Maintenance Technology (Pneumatics/Hydraulics Apprentice), CTS",
+    "Industrial Maintenance Technology, AAS 470303",
+    "Industrial Maintenance Technology, TD 470303",
+    "Industrial Marine Electronics Technology, TD",
+    "Industrial Technology, AS",
+    "Industrial/Agriculture Mechanics Technology, TD",
+    "Industrial/Commercial Electrician, TD",
+    "Information Systems Security Professional, Certificate of Technical Studies — Associate of Applied Science",
+    "Information Technology, AAS",
+    "Information Technology, TD",
+    "Instrumentation Apprentice, CTC",
+    "Instrumentation Helper, Certificate of Technical Studies — Associate of Applied Science",
+    "Instrumentation Skills, Career and Technical Certificate — Associate of Applied Science",
+    "Instrumentation Technician, CTS",
+    "Instrumentation Technology, TD",
+    "Instrumentation, Associate of Applied Science — Associate of Applied Science",
+    "Intermediate Welder, CTS",
+    "Intermediate Welding, Certificate of Technical Studies — Associate of Applied Science",
+    "Legal Assistant, Certificate of Technical Studies — Associate of Applied Science",
+    "Legal Office Specialist, CTS",
+    "Liberal Arts",
+    "Louisiana Transfer - Biology Concentration, ASLT",
+    "Louisiana Transfer - Humanities Concentration, AALT",
+    "Louisiana Transfer - Physical Science Concentration, ASLT",
+    "Louisiana Transfer - Social Sciences Concentration, AALT",
+    "Louisiana Transfer Associate of Arts, AALT",
+    "Louisiana Transfer Associate of Science, ASLT",
+    "Louisiana Transfer Degree, Biological Sciences Concentration, Associate of Science — Associate of Science",
+    "Louisiana Transfer Degree, Business Concentration, Associate of Arts — Associate of Arts",
+    "Louisiana Transfer Degree, Fine Arts Concentration, Associate of Arts — Associate of Arts",
+    "Louisiana Transfer Degree, Humanities Concentration, Associate of Arts — Associate of Arts",
+    "Louisiana Transfer Degree, Physical Sciences Concentration, Associate of Science — Associate of Science",
+    "Louisiana Transfer Degree, Social Sciences Concentration, Associate of Arts — Associate of Arts",
+    "Louisiana Transfer Humanities Courses",
+    "Machine Operator, CTS",
+    "Machine Shop Helper, CTC",
+    "Machine Tool Technology, TD",
+    "Manual Drive Train Technician Track",
+    "Marine Diesel Equipment Technology, TD",
+    "Math; ASLT Physical Science",
+    "Math/Analytical Reasoning",
+    "Medical Assistant",
+    "Medical Assistant to Practical Nursing (MA to PN), TD",
+    "Medical Assistant, AAS",
+    "Medical Assistant, TD",
+    "Medical Billing and Coding, Certificate of Applied Science — Associate of Applied Science",
+    "Medical Clinical Assistant, CTC",
+    "Medical Coding/Insurance Specialist, CTS",
+    "Medical Laboratory Science, AAS",
+    "Medical Laboratory Technician, AAS",
+    "Medical Office Assistant, CTC",
+    "Medical Office Specialist, CTS",
+    "Microsoft OS, Certificate of Technical Studies — Associate of Applied Science",
+    "Mortgage Documents Specialist, CTS",
+    "Music Studio Production",
+    "Natural Science",
+    "Natural Sciences",
+    "NCCER Electrical Level 4",
+    "NCCER Instrumentation - Advanced, Certificate of Technical Studies — Associate of Applied Science",
+    "NCCER Instrumentation and Electrical, Technical Diploma — Associate of Applied Science",
+    "NCCER Instrumentation Level 4",
+    "NCCER Millwright Level 4",
+    "NCCER Pipefitting Level 4",
+    "Network and Security Analyst, CTS",
+    "Network Security, Career and Technical Certificate — Associate of Applied Science",
+    "Nondestructive Testing Technology, TD",
+    "Nurse Aide (Nursing), CTC",
+    "Nurse Aide (Practical Nursing), CTC",
+    "Nursing",
+    "Nursing Assistant, CTC",
+    "Nursing Fine Arts",
+    "Nursing Humanities",
+    "Nursing, AS",
+    "Nursing, LPN to RN, ASN",
+    "Nursing, Practical, AAS and TD",
+    "Nursing, Registered, ASN",
+    "Office Assistant Specialist, CTS",
+    "Office Assistant, CTS",
+    "Offshore Safety and Survival, Career and Technical Certificate — Associate of Applied Science",
+    "Oil and Gas Production Technology, TD",
+    "Paralegal Skills, Career and Technical Certificate — Associate of Applied Science",
+    "Paralegal Studies",
+    "Paralegal Studies, Associate of Applied Science — Associate of Applied Science",
+    "Patient Care Technician, Certificate of Technical Studies — Associate of Applied Science",
+    "Payroll and Timekeeping Clerk, Career and Technical Certificate — Associate of Applied Science",
+    "Payroll Clerk, CTS",
+    "Phlebotomy Technician, Career and Technical Certificate — Associate of Applied Science",
+    "Phlebotomy, CTS",
+    "Physical Science",
+    "Power Train Technician, CTS",
+    "Practical Nursing",
+    "Practical Nursing - Limited Enrollment, Technical Diploma — Associate of Applied Science",
+    "Practical Nursing to Associate of Science in Nursing (LPN to ASN), AS",
+    "Practical Nursing, TD",
+    "Pre-Engineering",
+    "Process Technology",
+    "Process Technology (PTEC), AAS 150699",
+    "Process Technology Support Technician, Certificate of Technical Studies — Associate of Applied Science",
+    "Process Technology, Associate of Applied Science — Associate of Applied Science",
+    "Process Technology, Associate of Applied Science, Fast Track — Associate of Applied Science",
+    "Process Technology, Technical Diploma — Associate of Applied Science",
+    "Production Helper, CTC",
+    "Production Technician, CTS",
+    "Radiologic Technology, AAS",
+    "Real Estate Sales, Career and Technical Certificate — Associate of Applied Science",
+    "Refrigeration Helper I, Certificate of Technical Studies — Associate of Applied Science",
+    "Residential Electrician, CTS",
+    "Respiratory Therapy, AS",
+    "Retail & Relationship Banking, CTS",
+    "Retail Management",
+    "Secure Software Design, CTS",
+    "Shielded Metal Arc Welding, Career and Technical Certificate — Associate of Applied Science",
+    "Social and Behavioral Science",
+    "Social and Behavioral Sciences",
+    "Social Sciences",
+    "Social/Behavioral Sciences",
+    "Software Applications, CTC",
+    "Software Development, Certificate of Technical Studies — Associate of Applied Science",
+    "Spreadsheets, Certificate of Technical Studies — Associate of Applied Science",
+    "Steering and Suspension Technician Track",
+    "Sterile Processing",
+    "Sterile Processing Technician, CTS",
+    "Structural and Pipe Welding, TD 480508",
+    "Structural Welding, TD 480508",
+    "Surgical Technology",
+    "Surgical Technology, AAS",
+    "Teaching (Grades 1-5)- Associate of Science — Associate of Science",
+    "Teaching, Gr 1-5",
+    "Technical Studies",
+    "Technical Studies - Practical Nursing Track, AAS",
+    "Technical Studies, AAS",
+    "Technical Studies, AAS 479999",
+    "TIG Pipe Welder, CTC",
+    "Vehicle Maintenance and Repair Technologies",
+    "Veterinary Technology",
+    "Wastewater Plant Operator, Career and Technical Certificate — Associate of Applied Science",
+    "Water Plant Operator, Career and Technical Certificate — Associate of Applied Science",
+    "Web Design",
+    "Welding",
+    "Welding, TD",
+    "Wind Energy Technology, Associate of Applied Science — Associate of Applied Science",
+    "Wind Turbine Mechanics and Maintenance, Technical Diploma — Associate of Applied Science",
+    "Word Processing, Certificate of Technical Studies — Associate of Applied Science",
+    "Word Processor Operator, CTS"
+  ]
+}

--- a/data/mn/subject-vocab.json
+++ b/data/mn/subject-vocab.json
@@ -1,0 +1,9182 @@
+{
+  "state": "mn",
+  "generated_at": "2026-06-06T15:41:40.448Z",
+  "subjects": [
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 221,
+      "section_count": 2266,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "lake-superior-college",
+        "leech-lake-tribal-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "A Well Examined Life: Reading and Writing Memoir",
+        "A Writer's Life: Publication Capstone",
+        "Academic Reading and Writing Corequisite-CoReq w/ENGL 100 15",
+        "Accelerated English (must also register for ENGL1101 CID #000801)",
+        "Adolescent Literature and Diversity"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 193,
+      "section_count": 2099,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Advanced Physiology",
+        "Anatomy",
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology II",
+        "Anatomy and Physiology I"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 226,
+      "section_count": 1822,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Algebra and Trigonometry",
+        "Applications of Quantitative Reasoning",
+        "Applied Calculus",
+        "Applied Mathematics",
+        "Applied Mathematics - DHET students only"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 285,
+      "section_count": 1128,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Accordion: 30 Minute Lesson",
+        "Accordion: 60 Minute Lesson",
+        "Advanced Applied Music Lessons: Guitar",
+        "Advanced Aural Comprehension I",
+        "Advanced Aural Comprehension II"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 129,
+      "section_count": 1071,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adolescent Development",
+        "Adulthood, Aging and Death",
+        "Behavior Modification",
+        "Biopsychology"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 79,
+      "section_count": 963,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Aspects of Chemistry I",
+        "Biochemistry",
+        "Biochemistry-Theory and Principles",
+        "Chemical Principles I",
+        "Chemical Principles II"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 73,
+      "section_count": 802,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "pine-technical-and-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Argumentation and Public Advocacy",
+        "Cinema as Communication",
+        "College Speech",
+        "Communication for Career Success",
+        "Communications Capstone"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 194,
+      "section_count": 741,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Acute and Complex Care",
+        "Acute and Complex Care Experiential",
+        "Acute and Complex Care for the Professional Nurse",
+        "Acute and Complex Nursing",
+        "Acute Care and Leadership Clinical"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 85,
+      "section_count": 682,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "African Philosophy",
+        "American Indian Philosophy",
+        "American Philosophy",
+        "Bioethical Issues in Contemporary Society",
+        "Bioethics"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 162,
+      "section_count": 601,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "leech-lake-tribal-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Ceramics",
+        "Advanced Graphic Design I",
+        "Advanced Graphic Design II",
+        "AFA in Art Capstone: Exhibition",
+        "AFA in Art Capstone: Portfolio and Professional Practices"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 180,
+      "section_count": 564,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Accounting and Business Information Technology",
+        "Accounting Basics - EARLY END",
+        "Accounting Capstone",
+        "Accounting Capstone - Early 8 Week",
+        "Accounting Comprehensive Review"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 86,
+      "section_count": 534,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Accelerated Nursing Assistant Training - Winona",
+        "AHA CPR and First Aid Certification",
+        "American Heart Association Basic Life Support",
+        "Anatomy and Physiology for Allied Health",
+        "Basic Life Support & First Aid"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 110,
+      "section_count": 520,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "leech-lake-tribal-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "north-hennepin-community-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Management",
+        "Advanced Keyboarding",
+        "Beginning Keyboarding",
+        "Benefits and Compensation",
+        "Business Analytics and Data Visualization"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 144,
+      "section_count": 508,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-state-college-southeast",
+        "normandale-community-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Access: Information Management",
+        "Advertising and Promotion - Early 8 Week",
+        "Advertising and Promotional Strategies - First 8 Weeks",
+        "Business Analytics",
+        "Business Capstone - Early 8 Week"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 54,
+      "section_count": 483,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Consumer Economics and Finance",
+        "Economics of Crime",
+        "Essentials of Economics",
+        "Introduction to Economics",
+        "Introduction to Macroeconomics"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 114,
+      "section_count": 468,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "African American History",
+        "African-American History from 1865: Civil Rights and Black Power",
+        "African-American History to 1865: Diaspora and Liberation",
+        "Afro-Indigenous History of the United States",
+        "America's War in Vietnam"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 77,
+      "section_count": 423,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Community and Environmental Sociology",
+        "Corrections",
+        "Criminology",
+        "Criminology and Criminal Behavior",
+        "Death and Dying"
+      ]
+    },
+    {
+      "prefix": "CMST",
+      "name": "Communication",
+      "course_count": 35,
+      "section_count": 418,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "ridgewater-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Argument and Reasoning",
+        "Argumentation and Advocacy",
+        "Basic Media Writing",
+        "Communication and Gender",
+        "Environmental Communication"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 140,
+      "section_count": 363,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-state-college-southeast",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "ABB Robotic Welding",
+        "Advanced Blueprint Reading and Welding Symbols",
+        "Advanced Gas Metal Arc Welding (GMAW) and Flux Cored Arc Welding (FCAW)",
+        "Advanced Gas Metal Arc Welding/Flux Cored Arc Welding Shop",
+        "Advanced Gas Tungsten Arc Welding Shop"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 66,
+      "section_count": 314,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Classical Physics I",
+        "Classical Physics II",
+        "College Physics 1",
+        "College Physics 2",
+        "College Physics I"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "ITEC",
+      "course_count": 101,
+      "section_count": 300,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college",
+        "hennepin-technical-college",
+        "minneapolis-community-and-technical-college",
+        "northwest-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "A+ Software Support",
+        "Advanced Networking",
+        "Advanced Programming with Python",
+        "Android Mobile Programming",
+        "Application Development"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 101,
+      "section_count": 295,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Custom Application",
+        "Advanced Farm Management",
+        "Advanced Meat Technology",
+        "Ag Commodity Marketing",
+        "Ag Industry Machinery Maintenance"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 80,
+      "section_count": 276,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "A+ Hardware/Operating System Preparation",
+        "Advanced Programming Principles - IN ZOOM",
+        "ANSI C Language Programming",
+        "C/C++ Prog for Sci & Engr",
+        "C++ for Scientists and Engineers"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 101,
+      "section_count": 273,
+      "colleges": [
+        "anoka-technical-college",
+        "dakota-county-technical-college",
+        "hennepin-technical-college",
+        "lake-superior-college",
+        "leech-lake-tribal-college",
+        "minnesota-state-college-southeast",
+        "minnesota-west-community-and-technical-college",
+        "riverland-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "A.C. Electricity Theory and Lab",
+        "A.C. Motor Control II",
+        "AC Motor Control I",
+        "Alternative Energies",
+        "Analog and Digital Electronics Lab"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 85,
+      "section_count": 270,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-state-college-southeast",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "riverland-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "2 Dimensional Design",
+        "2-D Design",
+        "3 Dimensional Design",
+        "3-D Design",
+        "A.F.A. Portfolio"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 67,
+      "section_count": 261,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "lake-superior-college",
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Aerobic Fitness",
+        "Anatomy of Movement",
+        "Applied Nutrition",
+        "Bicycling",
+        "BLS Provider Certification"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "COSM",
+      "course_count": 101,
+      "section_count": 230,
+      "colleges": [
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "riverland-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Advanced Esthetic Clinic IV Capstone",
+        "Advanced Esthetics",
+        "Advanced Esthetics Clinic I",
+        "Advanced Esthetics Clinic II",
+        "Advanced Esthetics Clinic III"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 39,
+      "section_count": 229,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "American Government (Early Finish)",
+        "American Government & Politics",
+        "American Government and Politics",
+        "American National Government",
+        "American Politics and Government"
+      ]
+    },
+    {
+      "prefix": "ENGC",
+      "name": "Writing",
+      "course_count": 9,
+      "section_count": 218,
+      "colleges": [
+        "hennepin-technical-college",
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "AutoCAD for Engineering",
+        "Business and Technical Writing",
+        "College Writing (Co-Req with EAP 1100-96)",
+        "Engineering Drawing",
+        "Integrated Reading and Writing 1 (Co-Req with NCC 1000-11)"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 96,
+      "section_count": 218,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-west-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Anatomy for Sports",
+        "Archery",
+        "Baseball/Softball Theory and Coaching",
+        "Beginning Golf",
+        "Beginning Yoga"
+      ]
+    },
+    {
+      "prefix": "FBMT",
+      "name": "Farm",
+      "course_count": 46,
+      "section_count": 215,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "minnesota-west-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Application of Productive Enterprise Information",
+        "Applying Commodity Marketing Fundamentals",
+        "Directed Study-Applying Commodity Marketing Fundamentals",
+        "Directed Study-Evaluating Farm Commodity Marketing Tools",
+        "Directed Study-Intro to Farm Commodity Marketing"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 61,
+      "section_count": 210,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Cartography",
+        "Cartography and Visualization",
+        "Cities",
+        "Climate Change: Science, Human Impacts and Adaptations",
+        "Earth's Natural Environments - LATE START"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 69,
+      "section_count": 189,
+      "colleges": [
+        "century-college",
+        "northwest-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Esthetics 2",
+        "Advanced Esthetics I",
+        "Advanced Esthetics II",
+        "Advanced Esthetics III",
+        "Advanced Practice Esthetics 3"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 97,
+      "section_count": 175,
+      "colleges": [
+        "anoka-technical-college",
+        "minnesota-state-college-southeast",
+        "minnesota-west-community-and-technical-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Adaptive Driver Assist System Technology",
+        "ADAS Technology and Applications",
+        "Advanced Electronic Systems",
+        "Advanced Electronics",
+        "Alignment & Suspension"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 86,
+      "section_count": 173,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Assistive Technology in Early Childhood Special Education",
+        "Behavior Guidance",
+        "Child and Adolescent Development",
+        "Child Growth and Development",
+        "Child Growth and Development: Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 42,
+      "section_count": 171,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "dakota-county-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Spanish 1",
+        "Beginning Spanish 2",
+        "Beginning Spanish I",
+        "Beginning Spanish II",
+        "Beginning Spanish Language and Culture I"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 71,
+      "section_count": 164,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "normandale-community-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Acting 1",
+        "Acting 2",
+        "Acting for the Camera",
+        "Acting I",
+        "Acting II"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 41,
+      "section_count": 163,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "minneapolis-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "riverland-community-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "American Minority Relations",
+        "Contemporary Indian Concerns",
+        "Criminology",
+        "Cultural Diversity",
+        "Diversity and Intercultural Leadership"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 13,
+      "section_count": 162,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "American Literature: The Civil War to the Present",
+        "Fiction Writing",
+        "FYC/FYE- Writing And Research Skills (paired with INTS 1102-68)",
+        "Introduction to Academic Writing",
+        "Introduction to Creative Writing"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 53,
+      "section_count": 151,
+      "colleges": [
+        "century-college",
+        "dakota-county-technical-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Refrigeration I",
+        "Advanced Refrigeration II",
+        "Air Conditioning and Heat Pump Service",
+        "Alternative Heating and Cooling Methods",
+        "Basic Motor Technology and Residential Controls"
+      ]
+    },
+    {
+      "prefix": "HSER",
+      "name": "HSER",
+      "course_count": 57,
+      "section_count": 149,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "inver-hills-community-college",
+        "minneapolis-community-and-technical-college",
+        "north-hennepin-community-college",
+        "riverland-community-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Approaches to Mental Health with Clients in Human Services",
+        "Basic Counseling Skills",
+        "Basic Interviewing Skills",
+        "Case Management",
+        "Case Management Skills - Late 8 Week"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 75,
+      "section_count": 137,
+      "colleges": [
+        "century-college",
+        "lake-superior-college",
+        "minnesota-state-college-southeast",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "ridgewater-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Imaging",
+        "Advanced Modalities",
+        "Advanced Radiographic Imaging",
+        "Anatomy and Positioning I",
+        "Anatomy and Positioning II"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 59,
+      "section_count": 129,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-college-southeast",
+        "northwest-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Autism Spectrum Disorder (ASD)",
+        "Child and Family Relations in a Diverse World",
+        "Child Development and Learning",
+        "Child Growth and Development",
+        "Child Health, Safety, and Nutrition"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 38,
+      "section_count": 127,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college",
+        "minnesota-state-community-and-technical-college",
+        "northwest-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Chairside Assisting I",
+        "Chairside Assisting II",
+        "Clinical Affiliation",
+        "Clinical Assisting I",
+        "Credentialing Exam Preparation"
+      ]
+    },
+    {
+      "prefix": "BLGY",
+      "name": "BLGY",
+      "course_count": 8,
+      "section_count": 120,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "General Biology I",
+        "General Biology II",
+        "Genetics",
+        "Human Anatomy/Physiology I - Must also register for BLGY 2320-03",
+        "Human Anatomy/Physiology II - Must also register for BLGY 2310-03"
+      ]
+    },
+    {
+      "prefix": "MACH",
+      "name": "MACH",
+      "course_count": 66,
+      "section_count": 120,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college",
+        "hennepin-technical-college",
+        "minnesota-state-college-southeast",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD/CAM I",
+        "Advanced CNC Milling",
+        "Advanced CNC Turning",
+        "Advanced Machining",
+        "Blueprint Design/CAD II"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 37,
+      "section_count": 119,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Anthropology of Religion",
+        "Archaeology - Prehistory and Humanity's Cultural Origins",
+        "Archaeology of Minnesota - Prehistoric Native Cultures",
+        "Cultural Anthropology",
+        "Cultural Anthropology - The Global Human Experience"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 64,
+      "section_count": 119,
+      "colleges": [
+        "hennepin-technical-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Advanced Decorating and Pastry",
+        "Applied Restaurant Operations 1",
+        "Applied Restaurant Operations 2",
+        "Artisan Baking and Pastry",
+        "Baking Externship 1"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 37,
+      "section_count": 118,
+      "colleges": [
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "minnesota-state-community-and-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Strength Training",
+        "Athletic Injury, Care and Prevention",
+        "Badminton",
+        "Brazilian Jiu Jitsu (Late start)",
+        "Cardio and Core Training"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 59,
+      "section_count": 117,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "century-college",
+        "inver-hills-community-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis",
+        "Circuits I (Partially Online)",
+        "Circuits II",
+        "Climate Crisis: Implementing Solutions",
+        "Deformable Body Mechanics"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "CARP",
+      "course_count": 83,
+      "section_count": 115,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "hennepin-technical-college",
+        "lake-superior-college",
+        "leech-lake-tribal-college",
+        "minnesota-state-college-southeast",
+        "riverland-community-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "3D Layout for Shop and Construction",
+        "Architectural Drafting",
+        "Architectural Drawings 1",
+        "Blueprint Reading",
+        "Blueprint Reading I"
+      ]
+    },
+    {
+      "prefix": "HIMC",
+      "name": "Health",
+      "course_count": 40,
+      "section_count": 110,
+      "colleges": [
+        "minnesota-west-community-and-technical-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "CCA/CPC Review",
+        "Computerized Health Information",
+        "Computerized Health Information II",
+        "CPT Coding"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 43,
+      "section_count": 107,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "century-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "ridgewater-college",
+        "rochester-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "American Film",
+        "Arab History and Cultures",
+        "Classical Greek and Roman Mythology",
+        "Compassion Studies",
+        "Film Appreciation"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 19,
+      "section_count": 106,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college",
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "rochester-community-and-technical-college",
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "College Reading-Paired with STSC 1200-03: College Success Strategies",
+        "College Textbook Reading",
+        "Critical Literacy-EARLY END",
+        "Critical Reading",
+        "Critical Reading for Academics"
+      ]
+    },
+    {
+      "prefix": "NPRO",
+      "name": "Concepts",
+      "course_count": 6,
+      "section_count": 105,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Complex Health Concepts",
+        "Concepts of Health Assessment",
+        "Introduction to Health Concepts",
+        "Nursing Transitions",
+        "Synthesis of Health Concepts in Nursing"
+      ]
+    },
+    {
+      "prefix": "HITM",
+      "name": "Health",
+      "course_count": 47,
+      "section_count": 104,
+      "colleges": [
+        "anoka-technical-college",
+        "minnesota-state-community-and-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Terminology",
+        "Advanced Coding",
+        "Advanced Medical Coding",
+        "Anatomy and Physiology for Health Information",
+        "Billing and Reimbursement"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 25,
+      "section_count": 101,
+      "colleges": [
+        "century-college",
+        "inver-hills-community-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Pharmacology",
+        "AHA BLS Provider (CPR) (Late Start/Early Finish)",
+        "Cardiovascular Emergencies",
+        "Emergency Medical Responder",
+        "Emergency Medical Responder (Partially Online)(Late Start/Early Finish)"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "EXSC",
+      "course_count": 39,
+      "section_count": 94,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "minnesota-state-college-southeast",
+        "normandale-community-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Adult Fitness",
+        "Advanced Fitness Assessment & Exercise Prescription",
+        "Advanced Weight Training - Late Start",
+        "Applications of Personal Training - EARLY END",
+        "Aspects of Fitness - LATE START"
+      ]
+    },
+    {
+      "prefix": "VNTE",
+      "name": "Veterinary",
+      "course_count": 19,
+      "section_count": 93,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology I",
+        "Anatomy and Physiology II",
+        "Avian, Exotic and Lab Animal Care",
+        "Clinical Proficiency",
+        "Disease Processes"
+      ]
+    },
+    {
+      "prefix": "ISTC",
+      "name": "ISTC",
+      "course_count": 30,
+      "section_count": 90,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        ".NET I",
+        ".NET II",
+        "Business Communication",
+        "Computer Forensics",
+        "Cross-Platform Web Application Development"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "COMP",
+      "course_count": 36,
+      "section_count": 87,
+      "colleges": [
+        "anoka-technical-college",
+        "central-lakes-college-brainerd",
+        "minnesota-state-college-southeast",
+        "rochester-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Algorithms and Data Structures",
+        "Cloud Technologies and Services",
+        "Command Line and Scripting",
+        "Computer Architecture",
+        "Computer Basics-Operating Systems"
+      ]
+    },
+    {
+      "prefix": "CDEV",
+      "name": "CDEV",
+      "course_count": 45,
+      "section_count": 86,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "fond-du-lac-tribal-and-community-college",
+        "hennepin-technical-college",
+        "northland-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Child Behavior and Guidance",
+        "Child Growth and Development",
+        "Child Growth-Develop",
+        "Child Health, Wellness, Safety, and Nutrition",
+        "Children with Challenging Behaviors"
+      ]
+    },
+    {
+      "prefix": "CMSV",
+      "name": "Construction",
+      "course_count": 21,
+      "section_count": 83,
+      "colleges": [
+        "dakota-county-technical-college",
+        "minnesota-north-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Building Department Administration",
+        "Building Organization and Technology",
+        "Construction Estimating",
+        "Construction Graphics",
+        "Construction Management"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 32,
+      "section_count": 82,
+      "colleges": [
+        "lake-superior-college",
+        "northland-community-and-technical-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Adult Critical Care",
+        "Advanced Simulation",
+        "Assessment of the Pulmonary Patient",
+        "Cardiopulmonary A&P",
+        "Cardiopulmonary Anatomy and Physiology"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 10,
+      "section_count": 81,
+      "colleges": [
+        "inver-hills-community-college",
+        "lake-superior-college",
+        "leech-lake-tribal-college",
+        "minneapolis-community-and-technical-college",
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Climate Change: Science, Human Impacts and Adaptations",
+        "Earth History",
+        "Environmental Geology - LATE START",
+        "Environmental Geology Laboratory",
+        "Geology of Natural Disasters"
+      ]
+    },
+    {
+      "prefix": "VT",
+      "name": "Veterinary",
+      "course_count": 23,
+      "section_count": 81,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Pharmacology and Nutrition",
+        "Clinical Lab Techniques II",
+        "Clinical Laboratory Techniques I",
+        "Comparative Veterinary Anatomy and Physiology",
+        "Diagnostic Imaging"
+      ]
+    },
+    {
+      "prefix": "DENA",
+      "name": "Dental",
+      "course_count": 18,
+      "section_count": 79,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Chairside Dental Assisting I (Partially Online)",
+        "Chairside Dental Assisting II (Partially Online)",
+        "Dental Assisting Advanced Functions I (Partially Online)",
+        "Dental Assisting Advanced Functions II (Partially Online)",
+        "Dental Assisting General Office Internship"
+      ]
+    },
+    {
+      "prefix": "VTEC",
+      "name": "Veterinary",
+      "course_count": 18,
+      "section_count": 79,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Anesthesia and Pain Management",
+        "Animal Care I",
+        "Animal Care II",
+        "Animal Care III",
+        "Animal Diseases and Nutrition"
+      ]
+    },
+    {
+      "prefix": "AUTM",
+      "name": "Systems",
+      "course_count": 29,
+      "section_count": 78,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "A1 Engine Repair-EARLY END",
+        "A3 Manual Drive Train & Axles - LATE START",
+        "A6 Electrical/Electronic Systems I-EARLY END",
+        "A6 Electrical/Electronic Systems II-LATE START",
+        "A7 Heating & Air Conditioning - EARLY END"
+      ]
+    },
+    {
+      "prefix": "ENGA",
+      "name": "Composition",
+      "course_count": 2,
+      "section_count": 78,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Accelerated Fundamentals of Composition - Early 8 Week",
+        "College Composition: Writing About Video Games"
+      ]
+    },
+    {
+      "prefix": "CRJU",
+      "name": "CRJU",
+      "course_count": 42,
+      "section_count": 76,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Firearms",
+        "Basic Firearms for Peace Officers",
+        "Behavioral Science for Peace Officers",
+        "Career Fitness 1",
+        "Community and Diversity"
+      ]
+    },
+    {
+      "prefix": "ELTN",
+      "name": "ELTN",
+      "course_count": 28,
+      "section_count": 76,
+      "colleges": [
+        "lake-superior-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "AC Electricity",
+        "Alternating Current Circuit Analysis",
+        "Automation Controllers",
+        "Commercial Wiring Methods",
+        "DC Electricity"
+      ]
+    },
+    {
+      "prefix": "HCCC",
+      "name": "Healthcare",
+      "course_count": 9,
+      "section_count": 76,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Awareness and Sensitivity to Client Needs",
+        "Behaviors for Success in Health Careers",
+        "Communication in Healthcare",
+        "Dosage Calculation",
+        "Healthcare Ethics"
+      ]
+    },
+    {
+      "prefix": "PNSG",
+      "name": "PNSG",
+      "course_count": 28,
+      "section_count": 76,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "dakota-county-technical-college",
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Adult Health",
+        "Adult Health Nursing I",
+        "Adult Health Nursing II",
+        "Adult Nursing I",
+        "Behavioral Health Concepts"
+      ]
+    },
+    {
+      "prefix": "WLDG",
+      "name": "Welding",
+      "course_count": 32,
+      "section_count": 76,
+      "colleges": [
+        "century-college",
+        "lake-superior-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Blueprint Welding Symbols/Math/Welder Qualification",
+        "CNC Plasma and Cutting Processes",
+        "Flux Cored Arc Welding (Partially Online)(Late Start)",
+        "Flux Cored Arc Welding II",
+        "Gas Metal Arc Welding 1 (Partially Online)(Early Finish)"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "ARCH",
+      "course_count": 47,
+      "section_count": 75,
+      "colleges": [
+        "anoka-technical-college",
+        "minneapolis-community-and-technical-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Modeling",
+        "Advanced Revit 3D CAD",
+        "Architect's Professional Practice",
+        "Architectural CAD I",
+        "Architectural CAD II"
+      ]
+    },
+    {
+      "prefix": "ESCI",
+      "name": "ESCI",
+      "course_count": 25,
+      "section_count": 74,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "century-college",
+        "ridgewater-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Earth Science",
+        "Earth Science (Early Finish)",
+        "Earthquakes and Volcanoes",
+        "Environmental Science"
+      ]
+    },
+    {
+      "prefix": "FBMA",
+      "name": "Management",
+      "course_count": 18,
+      "section_count": 74,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "minnesota-west-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Applications in Financial Management/Business Plans",
+        "Applied Financial Management as it Relates to Risk Management",
+        "Applied Financial Management/Strategic Planning Emphasis",
+        "Current Issues in Farm Business Management",
+        "Directed Studies - Current Issues in Farm Business Management"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "DRFT",
+      "course_count": 23,
+      "section_count": 73,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Parametrics",
+        "Applied Math",
+        "CAD I",
+        "CAD II",
+        "Casting and Forging Design"
+      ]
+    },
+    {
+      "prefix": "CJS",
+      "name": "CJS",
+      "course_count": 26,
+      "section_count": 72,
+      "colleges": [
+        "century-college",
+        "inver-hills-community-college",
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "American Corrections",
+        "Careers in Criminal Justice (Partially Online)",
+        "Crime Scene Investigations (Late Start)",
+        "Criminal Justice and Community",
+        "Criminal Justice Capstone"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Communication",
+      "course_count": 9,
+      "section_count": 72,
+      "colleges": [
+        "anoka-technical-college",
+        "fond-du-lac-tribal-and-community-college",
+        "northwest-technical-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Communication in a Diverse World",
+        "Fundamentals of Speech (In-Person and Zoom)",
+        "Intercultural Communication",
+        "Intercultural Communications",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "CNEL",
+      "name": "CNEL",
+      "course_count": 24,
+      "section_count": 71,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Applied Math for Electricians",
+        "Basic Wiring Lab 1",
+        "Basic Wiring Lab 2",
+        "Circuits 1",
+        "Circuits 2"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "PHOT",
+      "course_count": 47,
+      "section_count": 71,
+      "colleges": [
+        "century-college",
+        "dakota-county-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Adobe Lightroom",
+        "Advanced Photo Projects",
+        "Advanced Photoshop",
+        "Advanced Portrait Techniques",
+        "Advanced Software"
+      ]
+    },
+    {
+      "prefix": "ADN",
+      "name": "Nursing",
+      "course_count": 20,
+      "section_count": 69,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "AD Clinical I",
+        "AD Clinical II",
+        "Advanced Nursing Care",
+        "Advanced Nursing Care Clinical",
+        "Advanced Nursing Skills"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 36,
+      "section_count": 69,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "century-college",
+        "fond-du-lac-tribal-and-community-college",
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Advertising & Promotion",
+        "Advertising and Sales Promotion",
+        "Building Your Personal and Professional Brand",
+        "Business Math"
+      ]
+    },
+    {
+      "prefix": "PRSG",
+      "name": "Nursing",
+      "course_count": 20,
+      "section_count": 67,
+      "colleges": [
+        "pine-technical-and-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nursing Concepts (PART TIME ONLY)",
+        "Bridging to Nursing Practice (PART TIME ONLY)",
+        "Clinical Application I (PART TIME ONLY)",
+        "Clinical Application II (PART TIME ONLY)",
+        "Clinical Lab I"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surgical",
+      "course_count": 35,
+      "section_count": 67,
+      "colleges": [
+        "anoka-technical-college",
+        "lake-superior-college",
+        "saint-paul-college",
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Career & Exam Prep",
+        "Foundations of Professional Practice in Surgical Technology",
+        "Introduction to Surgical Technology",
+        "Medical Microbiology",
+        "Microbiology for the Surgical Technologist"
+      ]
+    },
+    {
+      "prefix": "INTS",
+      "name": "INTS",
+      "course_count": 8,
+      "section_count": 64,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "dakota-county-technical-college",
+        "inver-hills-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Adults with Disabilities",
+        "FYC/FYE - College Success Strategies (paired with READ 90-01)",
+        "FYC/FYE-On Course:First Year Experience (paired with COMM1100-01) EARLY END",
+        "FYC/FYE: Online Learning Success Strategies (paired with COMM 1100-65)",
+        "FYE - Educational Planning and Assessment"
+      ]
+    },
+    {
+      "prefix": "COUN",
+      "name": "Counseling",
+      "course_count": 10,
+      "section_count": 63,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Addiction Counseling Group Practicum 1",
+        "Addiction Counseling Group Practicum 2",
+        "Assessment and Interviewing",
+        "Case Management and Legal and Ethical Standards",
+        "Drugs in the Community - Early 8 Week"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "ESOL",
+      "course_count": 17,
+      "section_count": 62,
+      "colleges": [
+        "century-college",
+        "minneapolis-community-and-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Bridge to Composition I for English Language Learners",
+        "English Pronunciation for Professionals",
+        "Foundations for Grammar and Writing",
+        "Foundations of Reading and Vocabulary",
+        "Foundations of Speaking and Listening"
+      ]
+    },
+    {
+      "prefix": "NAST",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 61,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant & Home Health Aide",
+        "Nursing Assistant-Clinical"
+      ]
+    },
+    {
+      "prefix": "CPRO",
+      "name": "CPRO",
+      "course_count": 37,
+      "section_count": 60,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Administering Active Directory Services (In-Person, Online and Zoom)",
+        "Artificial Intelligence for Cybersecurity",
+        "Business Analytics",
+        "Cisco Network Security",
+        "Cisco Networking 1 (In-Person or Zoom)"
+      ]
+    },
+    {
+      "prefix": "HDTT",
+      "name": "HDTT",
+      "course_count": 20,
+      "section_count": 60,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Air Brake Electronics",
+        "Air Brake Systems",
+        "D.O.T. Certification",
+        "Diesel Electronics",
+        "Diesel Engine Fundamentals"
+      ]
+    },
+    {
+      "prefix": "COMS",
+      "name": "Communication",
+      "course_count": 3,
+      "section_count": 58,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Public Speaking",
+        "Intercultural Communication",
+        "Interpersonal Communication (Accelerated- late start)"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "FST",
+      "course_count": 22,
+      "section_count": 58,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Basic Pneumatic/Hydraulics",
+        "Boiler Theory",
+        "Commercial Refrigeration Lab",
+        "Commercial Refrigeration Theory"
+      ]
+    },
+    {
+      "prefix": "EAPP",
+      "name": "EAPP",
+      "course_count": 13,
+      "section_count": 57,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Academic Reading & Writing-Learning Community Paired with Composition 1",
+        "Academic Reading and Writing-Learning Community Paired with Composition 1",
+        "Advanced Reading and Vocabulary",
+        "Advanced Speaking and Listening",
+        "Advanced Writing and Grammar"
+      ]
+    },
+    {
+      "prefix": "EMED",
+      "name": "EMED",
+      "course_count": 27,
+      "section_count": 57,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Airway Clinical",
+        "Ambulance Clinical I",
+        "Ambulance Clinical II",
+        "Ambulance Clinical III",
+        "BLS for the Healthcare Provider"
+      ]
+    },
+    {
+      "prefix": "BUSA",
+      "name": "Business",
+      "course_count": 13,
+      "section_count": 56,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Business Communications (In Person or Zoom)",
+        "Business Internship",
+        "Business Law - Legal Environment (In Person or Zoom)",
+        "Computer Concepts and Applications (In Person or Zoom)",
+        "Introduction to Business (In Person or Zoom)"
+      ]
+    },
+    {
+      "prefix": "HEAL",
+      "name": "Accelerated",
+      "course_count": 7,
+      "section_count": 55,
+      "colleges": [
+        "dakota-county-technical-college",
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology (MCOD)",
+        "Health Career Mathematics (Accelerated Course- Late Start)",
+        "Medical Terminology (Flextrack)",
+        "Medical Terminology for Nursing (Accelerated Course- Late Start)",
+        "Nursing Assistant (ACCELERATED COURSE- Late Start)"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 30,
+      "section_count": 54,
+      "colleges": [
+        "lake-superior-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "A+ Core Hardware",
+        "A+ Operating System Technologies",
+        "Business Communications and Technology",
+        "Business Computer Systems I",
+        "Business Computer Systems II"
+      ]
+    },
+    {
+      "prefix": "ABCT",
+      "name": "ABCT",
+      "course_count": 44,
+      "section_count": 53,
+      "colleges": [
+        "dakota-county-technical-college",
+        "minnesota-state-college-southeast",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced and Custom Refinishing",
+        "Auto Body Basic Electrical",
+        "Auto Body Collision Tech: Skill Development",
+        "Auto Body Disassembly/Reassembly",
+        "Auto Body Mechanical 1"
+      ]
+    },
+    {
+      "prefix": "CNCT",
+      "name": "CNCT",
+      "course_count": 18,
+      "section_count": 53,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "CAD",
+        "CNC 1",
+        "CNC 2",
+        "CNC Applications",
+        "CNC Lathe"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 34,
+      "section_count": 53,
+      "colleges": [
+        "minnesota-west-community-and-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "A+ Certification Prep",
+        "Advanced Databases",
+        "Advanced Routing Technology",
+        "Applications Support",
+        "C# Programming"
+      ]
+    },
+    {
+      "prefix": "NATS",
+      "name": "NATS",
+      "course_count": 6,
+      "section_count": 53,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Energy Issues and Solutions",
+        "Geology",
+        "Meteorology",
+        "Oceanography"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "Inspection",
+      "course_count": 22,
+      "section_count": 52,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Eddy Current Inspection",
+        "Advanced Liquid Penetrant Inspection",
+        "Advanced Magnetic Particle Inspection",
+        "Advanced Phased Array Ultrasonics",
+        "Advanced Ultrasonic Inspection"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Clinical",
+      "course_count": 39,
+      "section_count": 51,
+      "colleges": [
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Applied Chemistry",
+        "Applied Coagulation",
+        "Applied Hematology",
+        "Applied Immunohematology",
+        "Applied Phlebotomy"
+      ]
+    },
+    {
+      "prefix": "ACMT",
+      "name": "ACMT",
+      "course_count": 24,
+      "section_count": 50,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aircraft Electrical Systems",
+        "Aircraft Engineering Drawing",
+        "Aircraft Instrument Systems",
+        "Airframe Inspection",
+        "Engine Fuel and Fuel Metering Systems"
+      ]
+    },
+    {
+      "prefix": "GRPH",
+      "name": "GRPH",
+      "course_count": 14,
+      "section_count": 50,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator",
+        "Adobe InDesign",
+        "Adobe Photoshop",
+        "Career Planning and Professional Practices",
+        "Color Theory"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 42,
+      "section_count": 49,
+      "colleges": [
+        "lake-superior-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aircraft Electrical",
+        "Aircraft Fuel and Landing Gear Systems",
+        "Alignment & Suspension Lab",
+        "Alignment & Suspension Theory",
+        "Alignment and Suspension Application"
+      ]
+    },
+    {
+      "prefix": "PTE",
+      "name": "Skills",
+      "course_count": 11,
+      "section_count": 49,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigations",
+        "Criminal Investigations - Skills",
+        "Criminal Investigations Lab",
+        "Firearms - Skills",
+        "Firearms/Officer Survival Tactics"
+      ]
+    },
+    {
+      "prefix": "CNET",
+      "name": "CNET",
+      "course_count": 14,
+      "section_count": 48,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Client Operating Systems",
+        "Cyber Operations",
+        "Digital Literacy",
+        "Enterprise Networking, Security, and Automation",
+        "Ethical Hacking"
+      ]
+    },
+    {
+      "prefix": "HEOM",
+      "name": "HEOM",
+      "course_count": 26,
+      "section_count": 48,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Backhoe Theory",
+        "CDL",
+        "Class A CDL Theory",
+        "Competent Person",
+        "Construction Theory"
+      ]
+    },
+    {
+      "prefix": "MHTT",
+      "name": "MHTT",
+      "course_count": 33,
+      "section_count": 48,
+      "colleges": [
+        "saint-paul-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chassis Electrical Diagnostics",
+        "Advanced Driver Assist Systems",
+        "Automatic and Automated Manual Transmissions",
+        "Automatic Transmissions",
+        "Brakes"
+      ]
+    },
+    {
+      "prefix": "NSCI",
+      "name": "NSCI",
+      "course_count": 14,
+      "section_count": 48,
+      "colleges": [
+        "inver-hills-community-college",
+        "minnesota-north-college",
+        "minnesota-west-community-and-technical-college",
+        "north-hennepin-community-college",
+        "northland-community-and-technical-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Concepts of the Stars and Universe",
+        "Earth Science",
+        "Environmental Science",
+        "Introduction to Astronomy"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 13,
+      "section_count": 47,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "anoka-technical-college",
+        "century-college",
+        "minnesota-state-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "north-hennepin-community-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "American Sign Language 1",
+        "American Sign Language and Culture I",
+        "American Sign Language and Culture II",
+        "American Sign Language I",
+        "American Sign Language II"
+      ]
+    },
+    {
+      "prefix": "CPTR",
+      "name": "CPTR",
+      "course_count": 26,
+      "section_count": 47,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Networking",
+        "Business Applications of Artificial Intelligence",
+        "Cisco I",
+        "Cisco II",
+        "Computerized Business Applications"
+      ]
+    },
+    {
+      "prefix": "EMSP",
+      "name": "EMSP",
+      "course_count": 18,
+      "section_count": 47,
+      "colleges": [
+        "ridgewater-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Airway and Pulmonology",
+        "Ambulance Operations 2",
+        "Cardiology",
+        "Clinical 1-BLS",
+        "Clinical 2-ALS"
+      ]
+    },
+    {
+      "prefix": "MSM",
+      "name": "MSM",
+      "course_count": 20,
+      "section_count": 47,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advertising and Promotion",
+        "Applied Social Media Management",
+        "Basic Sales Techniques",
+        "Business Math and Accounting",
+        "Business Presentations"
+      ]
+    },
+    {
+      "prefix": "PRNU",
+      "name": "Nursing",
+      "course_count": 14,
+      "section_count": 46,
+      "colleges": [
+        "minnesota-north-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Clinical I",
+        "Clinical II",
+        "Foundations of Practical Nursing",
+        "Medical Math",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "DEHY",
+      "name": "Dental",
+      "course_count": 29,
+      "section_count": 45,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Clinical Dental Hygiene IV",
+        "Clinical Seminar III",
+        "Community Dental Health I"
+      ]
+    },
+    {
+      "prefix": "EAP",
+      "name": "Reading",
+      "course_count": 14,
+      "section_count": 45,
+      "colleges": [
+        "inver-hills-community-college",
+        "normandale-community-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Academic Listening and Speaking",
+        "Academic Reading and Study Skills",
+        "Academic Reading and Writing for English Learners",
+        "College Communication for English Language Learners",
+        "College Reading and Studying Skills"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 28,
+      "section_count": 45,
+      "colleges": [
+        "leech-lake-tribal-college",
+        "minnesota-state-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Behavior Guidance",
+        "Capstone",
+        "Child Growth and Development",
+        "Children with Challenging Behaviors",
+        "Children with Exceptionalities"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "HUMA",
+      "course_count": 16,
+      "section_count": 45,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "dakota-county-technical-college",
+        "minnesota-state-college-southeast",
+        "riverland-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "American Film",
+        "Exploring World Cultures",
+        "Humanities I (In-Person and Zoom)",
+        "International Film",
+        "Introduction to Humanities"
+      ]
+    },
+    {
+      "prefix": "PLBG",
+      "name": "Plumbing",
+      "course_count": 38,
+      "section_count": 45,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "northwest-technical-college",
+        "ridgewater-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Plumbing Procedures",
+        "Basic Plumbing Procedures",
+        "Blueprint Reading",
+        "Blueprint Reading and Estimating I",
+        "Blueprint Reading and Estimating II"
+      ]
+    },
+    {
+      "prefix": "PSCI",
+      "name": "Politics",
+      "course_count": 14,
+      "section_count": 45,
+      "colleges": [
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "American Government and Politics",
+        "American Government and Politics - Early 8 Week",
+        "Community Organizing: History, Theory and Practice",
+        "Constitutional Law",
+        "Environment, Politics and Society"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 19,
+      "section_count": 44,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aging Issues in Human Services",
+        "Alcohol and Drug Counseling Practicum I",
+        "Alcohol and Drug Counseling Practicum II",
+        "At-Risk Children, Youth, and their Families",
+        "Behavioral Health, Society, and The Justice System"
+      ]
+    },
+    {
+      "prefix": "MASS",
+      "name": "Massage",
+      "course_count": 20,
+      "section_count": 44,
+      "colleges": [
+        "riverland-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "(MBLEX) Massage and Bodywork Licensing Exam Preparation",
+        "Advanced Massage",
+        "Body and Mind Connection in Massage",
+        "Business and Ethics in Massage Therapy",
+        "CBE: Introduction to Therapeutic Massage"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 5,
+      "section_count": 43,
+      "colleges": [
+        "lake-superior-college",
+        "minneapolis-community-and-technical-college",
+        "riverland-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Astronomy - Early 8 Week",
+        "Astronomy Lab",
+        "Introduction to Astronomy"
+      ]
+    },
+    {
+      "prefix": "AVIA",
+      "name": "Pilot",
+      "course_count": 35,
+      "section_count": 43,
+      "colleges": [
+        "lake-superior-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Aircraft Systems",
+        "Air Navigation",
+        "Aviation Human Factors",
+        "Aviation Safety",
+        "Aviation Weather"
+      ]
+    },
+    {
+      "prefix": "ELLW",
+      "name": "ELLW",
+      "course_count": 17,
+      "section_count": 43,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Construction Planning and Practices",
+        "Distribution I",
+        "Distribution IIA",
+        "Distribution IIB"
+      ]
+    },
+    {
+      "prefix": "MEDS",
+      "name": "MEDS",
+      "course_count": 21,
+      "section_count": 43,
+      "colleges": [
+        "minnesota-state-college-southeast",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Advanced Medical Documentation",
+        "Alternative Health Record Systems",
+        "Anatomy and Physiology/Medical Office",
+        "Billing and Reimbursement"
+      ]
+    },
+    {
+      "prefix": "SBMT",
+      "name": "SBMT",
+      "course_count": 25,
+      "section_count": 42,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advertising and Promotion",
+        "Computerization for Accounting",
+        "Conflict Resolution",
+        "Corporate Compliance",
+        "Current Business Issues"
+      ]
+    },
+    {
+      "prefix": "ESTH",
+      "name": "Estheticians",
+      "course_count": 9,
+      "section_count": 41,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinic 1 for Estheticians",
+        "Advanced Clinic 2 for Estheticians",
+        "Advanced Exfoliation",
+        "Advanced Skin Care Techniques",
+        "Clinic 1 for Estheticians"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "Nursing",
+      "course_count": 17,
+      "section_count": 41,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Clinical II",
+        "Clinical II A",
+        "Clinical II B",
+        "Foundations of PN Lab",
+        "Foundations of Practical Nursing"
+      ]
+    },
+    {
+      "prefix": "CINE",
+      "name": "CINE",
+      "course_count": 19,
+      "section_count": 40,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Cinematic Lighting",
+        "Commercial and Alternative Filmmaking",
+        "Documentary Production",
+        "Internship",
+        "Post-Production Tools"
+      ]
+    },
+    {
+      "prefix": "PLEG",
+      "name": "PLEG",
+      "course_count": 17,
+      "section_count": 39,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Alternative Dispute Resolution",
+        "Computer Applications in the Legal Profession",
+        "Contracts and Business Organizations",
+        "Criminal Law and Procedure",
+        "Employment Search for Paralegals"
+      ]
+    },
+    {
+      "prefix": "PTAC",
+      "name": "PTAC",
+      "course_count": 19,
+      "section_count": 39,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Clinical Practice II",
+        "Communication & Documentation for the Physical Therapist Assistant Part II",
+        "Communication and Documentation for the Physical Therapist Assistant I",
+        "Introduction to Physical Therapist Assisting (Theory)"
+      ]
+    },
+    {
+      "prefix": "ASLS",
+      "name": "American",
+      "course_count": 10,
+      "section_count": 38,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "American Sign Language 1-First 8 Weeks",
+        "American Sign Language 2-Second 8 Weeks",
+        "American Sign Language 3-First 8 Weeks",
+        "American Sign Language 4-Second 8 Weeks",
+        "American Sign Language 5-Second 5 Weeks"
+      ]
+    },
+    {
+      "prefix": "DNTA",
+      "name": "Dental",
+      "course_count": 10,
+      "section_count": 38,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Chairside Dental Assisting 1",
+        "Chairside Dental Assisting 2",
+        "Clinical Internship 1",
+        "Clinical Internship 2",
+        "Dental Assistant Expanded Functions 1"
+      ]
+    },
+    {
+      "prefix": "ITC",
+      "name": "ITC",
+      "course_count": 23,
+      "section_count": 38,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Administering Linux Servers",
+        "Cisco CyberOps Associate",
+        "Cloud Computing Architecture, Implementation, and Security",
+        "Computer Careers",
+        "Configuring Windows Server Hybrid Advanced Services"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 10,
+      "section_count": 38,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Customer Service",
+        "Entrepreneurship",
+        "Human Resource Management",
+        "Introduction to Business",
+        "Introduction to Sales"
+      ]
+    },
+    {
+      "prefix": "MTHE",
+      "name": "Massage",
+      "course_count": 13,
+      "section_count": 38,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Massage I",
+        "Advanced Massage II",
+        "Anatomy & Kinesiology for Massage Therapy",
+        "Anatomy & Physiology for Massage Therapy",
+        "Ancillary Treatments"
+      ]
+    },
+    {
+      "prefix": "ARET",
+      "name": "ARET",
+      "course_count": 19,
+      "section_count": 37,
+      "colleges": [
+        "hennepin-technical-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Automation Controls",
+        "Advanced Programmable Logic Controllers",
+        "Automation Controls",
+        "Computer Integrated Manufacturing",
+        "Engineering Design and Fabrication"
+      ]
+    },
+    {
+      "prefix": "IMMR",
+      "name": "IMMR",
+      "course_count": 13,
+      "section_count": 37,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Distribution and HVAC Systems",
+        "Gas Metal Arc Welding",
+        "Gas Tungsten Arc Welding",
+        "High Pressure Boiler"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Procedures",
+      "course_count": 17,
+      "section_count": 37,
+      "colleges": [
+        "century-college",
+        "minnesota-west-community-and-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures for Medical Assistants",
+        "Administrative Skills for Medical Assistants",
+        "Clinical Procedures I",
+        "Clinical Procedures I (Early Finish)(Partially Online)",
+        "Clinical Procedures II"
+      ]
+    },
+    {
+      "prefix": "PRNS",
+      "name": "Clinical",
+      "course_count": 10,
+      "section_count": 37,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Clinical 1",
+        "Clinical 2",
+        "Clinical 3",
+        "Essentials of Clinical Pharmacology",
+        "Foundations of Nursing"
+      ]
+    },
+    {
+      "prefix": "STSK",
+      "name": "STSK",
+      "course_count": 6,
+      "section_count": 37,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "inver-hills-community-college",
+        "minneapolis-community-and-technical-college",
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Freshman Seminar",
+        "FYE - College Study Skills (Accelerated course- late start)",
+        "How to Study and Think Critically",
+        "Increasing College Vocabulary",
+        "Reading Improvement II"
+      ]
+    },
+    {
+      "prefix": "CMAE",
+      "name": "CMAE",
+      "course_count": 7,
+      "section_count": 36,
+      "colleges": [
+        "hennepin-technical-college",
+        "minnesota-state-college-southeast",
+        "pine-technical-and-community-college",
+        "ridgewater-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Career Success Skills",
+        "Maintenance Awareness",
+        "Manufacturing Associate",
+        "Manufacturing Processes and Production",
+        "Print Reading"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "DESL",
+      "course_count": 24,
+      "section_count": 36,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural Equipment Technologies I",
+        "Agricultural Equipment Technologies II",
+        "Air & Hydraulic Brakes",
+        "Applied Diesel Engines Lab",
+        "Applied Electrical Systems Lab"
+      ]
+    },
+    {
+      "prefix": "DVRS",
+      "name": "Diversity",
+      "course_count": 3,
+      "section_count": 36,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Diversity and Inclusion in Sports - 8 week course",
+        "Diversity and Social Justice",
+        "Human Relations for a Diverse Workplace"
+      ]
+    },
+    {
+      "prefix": "MCOD",
+      "name": "MCOD",
+      "course_count": 12,
+      "section_count": 36,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Coding Capstone",
+        "Diagnostic Coding (ICD-10-CM)",
+        "Health Information Management Essentials",
+        "Human Diseases"
+      ]
+    },
+    {
+      "prefix": "MDLT",
+      "name": "MDLT",
+      "course_count": 22,
+      "section_count": 36,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "CBE: Medical Laboratory Math",
+        "Clinical Chemistry 1",
+        "Clinical Chemistry 2",
+        "Clinical Microbiology",
+        "Clinical Practice"
+      ]
+    },
+    {
+      "prefix": "MDAS",
+      "name": "MDAS",
+      "course_count": 11,
+      "section_count": 35,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Capstone",
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Disease Condition and Medical Treatment, Incl. Nutrition"
+      ]
+    },
+    {
+      "prefix": "TRDR",
+      "name": "TRDR",
+      "course_count": 18,
+      "section_count": 35,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "minnesota-state-college-southeast",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Driving",
+        "Advanced Operating Procedures",
+        "Advanced Vehicle Driving",
+        "Employment Skills",
+        "Fork Lift Operations"
+      ]
+    },
+    {
+      "prefix": "ABOD",
+      "name": "ABOD",
+      "course_count": 27,
+      "section_count": 34,
+      "colleges": [
+        "century-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Auto Body Paint Concerns (Late Start)",
+        "Auto Body Workplace Safety, Tool Usage, and Shop Operations (Part Online)",
+        "Automotive Trade Skills",
+        "Body and Glass Service",
+        "Body Panels and Interior (Partially Online)(Late Start)"
+      ]
+    },
+    {
+      "prefix": "ADNG",
+      "name": "Nursing",
+      "course_count": 8,
+      "section_count": 34,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical I",
+        "Clinical II",
+        "Foundations of Nursing",
+        "Foundations of Nursing Skills",
+        "Maternal-Newborn Nursing"
+      ]
+    },
+    {
+      "prefix": "DENH",
+      "name": "DENH",
+      "course_count": 31,
+      "section_count": 34,
+      "colleges": [
+        "century-college",
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Clinic 1 (Co-Req with DENH 1150-10)",
+        "Clinic 1 Theory",
+        "Clinic 2 (Co-Req with DENH 2252-11)",
+        "Clinic 2 Theory",
+        "Clinic 3 (Co-Req with DENH 2254-10)"
+      ]
+    },
+    {
+      "prefix": "HART",
+      "name": "HART",
+      "course_count": 34,
+      "section_count": 34,
+      "colleges": [
+        "northwest-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Career Planning & Job Safety",
+        "Career Planning & Job Safety Lab",
+        "Commercial Air Conditioning",
+        "Commercial Electrical and Controls",
+        "Commercial Heating and HVAC Systems"
+      ]
+    },
+    {
+      "prefix": "HCEM",
+      "name": "HCEM",
+      "course_count": 22,
+      "section_count": 34,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Failure Analysis",
+        "Brakes",
+        "Climate Control",
+        "Diesel Engine Overhaul I",
+        "Diesel Engine Overhaul II"
+      ]
+    },
+    {
+      "prefix": "ECYD",
+      "name": "ECYD",
+      "course_count": 13,
+      "section_count": 33,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Child and Family Relations in a Diverse World",
+        "Child Growth and Development",
+        "Children with Differing Abilities",
+        "Field Experience",
+        "Guiding Young Children"
+      ]
+    },
+    {
+      "prefix": "GRDT",
+      "name": "Adobe",
+      "course_count": 14,
+      "section_count": 33,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator I",
+        "Adobe Illustrator II",
+        "Adobe InDesign I",
+        "Adobe InDesign II",
+        "Adobe Photoshop I"
+      ]
+    },
+    {
+      "prefix": "IDES",
+      "name": "IDES",
+      "course_count": 27,
+      "section_count": 33,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Kitchen & Bath Studio",
+        "Business Practices",
+        "CAD Drawing in Design III",
+        "Color and Light",
+        "Commercial Studio I"
+      ]
+    },
+    {
+      "prefix": "MKTC",
+      "name": "MKTC",
+      "course_count": 14,
+      "section_count": 33,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Advertising Practices and Procedures",
+        "Consumer and Professional Buying Behavior",
+        "Data Analytics",
+        "Digital Marketing",
+        "Digital Media Tools"
+      ]
+    },
+    {
+      "prefix": "ADMS",
+      "name": "ADMS",
+      "course_count": 18,
+      "section_count": 32,
+      "colleges": [
+        "dakota-county-technical-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Microcomputer Technology",
+        "Basic Computer Applications",
+        "Business Communications",
+        "Business English Skills",
+        "Business Office Mgmt"
+      ]
+    },
+    {
+      "prefix": "DGIM",
+      "name": "Weeks",
+      "course_count": 20,
+      "section_count": 32,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "2D Web Animation",
+        "3D Animation Capstone",
+        "3D Animation Fundamentals",
+        "3D Character Animation",
+        "Adobe Animate 2 - Second 8 Weeks"
+      ]
+    },
+    {
+      "prefix": "EMEC",
+      "name": "EMEC",
+      "course_count": 12,
+      "section_count": 32,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "AC/DC Fundamentals",
+        "Advanced PLC Programming",
+        "Automated Process Controls",
+        "Electrical Motors",
+        "Electromechanical Troubleshooting and Maintenance"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "ETEC",
+      "course_count": 22,
+      "section_count": 32,
+      "colleges": [
+        "anoka-technical-college",
+        "pine-technical-and-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "AC Power",
+        "Advanced Programmable Logic Controllers (PLCs)",
+        "Automated Systems Technology Capstone",
+        "Circuit Analysis",
+        "Computer Troubleshooting A+"
+      ]
+    },
+    {
+      "prefix": "MACT",
+      "name": "MACT",
+      "course_count": 19,
+      "section_count": 32,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC",
+        "Advanced Manual Lathe and Mill Operations",
+        "CNC Programming and Setup-Lathe",
+        "CNC Programming and Setup-Mill",
+        "CNC Turning Centers"
+      ]
+    },
+    {
+      "prefix": "PHMO",
+      "name": "PHMO",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Camera Techniques",
+        "Advanced Editing Software",
+        "Business of Photography",
+        "Camera Techniques",
+        "Fashion Content Production"
+      ]
+    },
+    {
+      "prefix": "STSC",
+      "name": "College",
+      "course_count": 3,
+      "section_count": 32,
+      "colleges": [
+        "century-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "College Success Strategies (Early Finish)",
+        "College Success Strategies-Paired with READ 0925-03: College Reading",
+        "Essential Study Skills for College Success"
+      ]
+    },
+    {
+      "prefix": "BTEC",
+      "name": "Applications",
+      "course_count": 8,
+      "section_count": 31,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Advanced Keyboarding Applications - Second 8 Weeks",
+        "Business Digital Applications and AI Essentials",
+        "Business Information Applications 1 - Second 8 Weeks",
+        "Business Information Applications 2",
+        "Business Information Applications 3"
+      ]
+    },
+    {
+      "prefix": "MATS",
+      "name": "Math",
+      "course_count": 7,
+      "section_count": 31,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "College Algebra (co-req MATS 0810-01)",
+        "College Algebra Support Lab (co-req MATS 1300-01)",
+        "Math for Electricians",
+        "Math for Engineering Technology (Reserved for CIVL)",
+        "Math for Welders"
+      ]
+    },
+    {
+      "prefix": "MCOM",
+      "name": "Mass",
+      "course_count": 12,
+      "section_count": 31,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "lake-superior-college",
+        "minnesota-state-college-southeast",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Audio for the Media",
+        "Digital Video Production",
+        "Introduction to Mass Communication",
+        "Introduction to Mass Communications",
+        "Introduction to Public Relations"
+      ]
+    },
+    {
+      "prefix": "AOP",
+      "name": "AOP",
+      "course_count": 12,
+      "section_count": 30,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Customer Service Fundamentals",
+        "Emerging Technologies",
+        "Employment Strategies",
+        "Integrated Office Procedures"
+      ]
+    },
+    {
+      "prefix": "CFI",
+      "name": "CFI",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced IDS Techniques (Partially Online)",
+        "Advanced Windows Forensics (Partially Online)",
+        "Cloud Computing and Virtualization Forensics (Partially Online)",
+        "Cyber Forensics",
+        "Information Storage Management and Security"
+      ]
+    },
+    {
+      "prefix": "CONE",
+      "name": "CONE",
+      "course_count": 10,
+      "section_count": 30,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical Circuit Theory",
+        "Building Automation",
+        "Capstone I",
+        "Electrical Blueprint/Estimating",
+        "Electronic Motor Control"
+      ]
+    },
+    {
+      "prefix": "EMSE",
+      "name": "Late",
+      "course_count": 16,
+      "section_count": 30,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced Assessment, Communication and Documentation",
+        "Advanced EMS Operations (Late Start/Early Finish)",
+        "Advanced EMS Pharmacology (Late Start)",
+        "Advanced Life Support Practicum I (Late Start/Early Finish)",
+        "Advanced Life Support Practicum II (Late Start/Early Finish)"
+      ]
+    },
+    {
+      "prefix": "OPCA",
+      "name": "Finish",
+      "course_count": 20,
+      "section_count": 30,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Allied Prosthetic, Orthotic, Pedorthic Care (Late Start/Early Finish)",
+        "Clinical Applications of Lower Extremity Foot Orthoses (Partially Online)",
+        "Clinical Applications of Lower Extremity Orthoses (Partially Online)",
+        "Clinical Applications of Spinal Orthoses (Partially Online)",
+        "Clinical Applications of Trans-Femoral Prostheses (Partially Online)"
+      ]
+    },
+    {
+      "prefix": "PHAR",
+      "name": "Pharmacy",
+      "course_count": 16,
+      "section_count": 30,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Drug Use and Reactions-LEC/LAB",
+        "Foundations of Pharmaceutical Calculations",
+        "Fundamentals of Pharmacy Technology 1",
+        "Fundamentals of Pharmacy Technology 2",
+        "Pharmacotherapy of Disease Processes"
+      ]
+    },
+    {
+      "prefix": "SAMG",
+      "name": "SAMG",
+      "course_count": 14,
+      "section_count": 30,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Branding and Promotion",
+        "Entrepreneurship",
+        "Financial Strategy Fundamentals",
+        "Internship I",
+        "Internship II"
+      ]
+    },
+    {
+      "prefix": "FADE",
+      "name": "FADE",
+      "course_count": 15,
+      "section_count": 29,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Garment Construction",
+        "Clothing Line Design",
+        "Computer-Aided Design",
+        "Draping and Pattern Construction",
+        "Fashion Imaging"
+      ]
+    },
+    {
+      "prefix": "FYEX",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 29,
+      "colleges": [
+        "minnesota-state-college-southeast",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "College Success Strategies"
+      ]
+    },
+    {
+      "prefix": "HC",
+      "name": "HC",
+      "course_count": 9,
+      "section_count": 29,
+      "colleges": [
+        "minnesota-west-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Body Structure & Function",
+        "Disease Conditions",
+        "Electronic Health Records",
+        "Health Care & Society",
+        "Health Care Core Foundations"
+      ]
+    },
+    {
+      "prefix": "JRBC",
+      "name": "Realtime",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Business Success for Realtime Careers",
+        "Foundations of Law",
+        "Judicial Reporting Internship",
+        "Judicial Reporting Procedures",
+        "Realtime Report VI"
+      ]
+    },
+    {
+      "prefix": "PA",
+      "name": "PA",
+      "course_count": 10,
+      "section_count": 29,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Contracts, UCC and Business Organizations",
+        "Criminal Justice System",
+        "Employment Law",
+        "Family Law",
+        "Introduction to the Law and Paralegal Profession"
+      ]
+    },
+    {
+      "prefix": "BMGT",
+      "name": "Business",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Business Communications (Early Finish)",
+        "Human Relations in Business",
+        "Human Resources Management",
+        "International Business (Partially Online)",
+        "Introduction to Business (Partially Online)"
+      ]
+    },
+    {
+      "prefix": "HCNA",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 28,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Medication Aide",
+        "Nursing Assistant"
+      ]
+    },
+    {
+      "prefix": "HERB",
+      "name": "Herbal",
+      "course_count": 11,
+      "section_count": 28,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applications of Herbal Medicine 1",
+        "Applications of Herbal Medicine 2",
+        "Comparative Herbalism",
+        "Foundations of Herbal Medicine",
+        "Herbal Pharmacy 1"
+      ]
+    },
+    {
+      "prefix": "IETA",
+      "name": "IETA",
+      "course_count": 14,
+      "section_count": 28,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Boiler Operations and Power Distributions",
+        "Fluid Power",
+        "Fundamentals of AC/DC Electricity I",
+        "Fundamentals of AC/DC Electricity II",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "ADM",
+      "name": "ADM",
+      "course_count": 18,
+      "section_count": 27,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Additive Manufacturing Processes",
+        "Advanced Additive Concepts - VP (Late Start)",
+        "Advanced Additive Processes - PBF (Early Finish)",
+        "Advanced SolidWorks",
+        "Bioprinting Processes (Late Start)"
+      ]
+    },
+    {
+      "prefix": "CRTK",
+      "name": "Critical",
+      "course_count": 2,
+      "section_count": 27,
+      "colleges": [
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking",
+        "Introduction to Critical Thinking - Late Start"
+      ]
+    },
+    {
+      "prefix": "IHH",
+      "name": "IHH",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Coaching Skills for a Diverse World",
+        "Aromatherapy",
+        "Basics in Business and Ethics for the Holistic Practitioner",
+        "Energy Healing",
+        "Food as Medicine/Biologically Based Therapies"
+      ]
+    },
+    {
+      "prefix": "MCAP",
+      "name": "MCAP",
+      "course_count": 17,
+      "section_count": 27,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "4WD and AWD Systems",
+        "Body Systems",
+        "Chassis",
+        "Dealer Work Experience",
+        "Diesel"
+      ]
+    },
+    {
+      "prefix": "PIPE",
+      "name": "Pipe",
+      "course_count": 12,
+      "section_count": 27,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Basic Gas",
+        "Basic Refrigeration",
+        "Electric Controls",
+        "Heating and Cooling 1"
+      ]
+    },
+    {
+      "prefix": "PNM",
+      "name": "Nursing",
+      "course_count": 6,
+      "section_count": 27,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adult Nursing",
+        "Family and Mental Health Concepts",
+        "Integrated Clinical Application",
+        "Nursing Fundamentals in the Care of the Older Adult",
+        "Pharmacology for Practical Nursing"
+      ]
+    },
+    {
+      "prefix": "ADMM",
+      "name": "Medical",
+      "course_count": 19,
+      "section_count": 26,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "AAPC Coding I",
+        "AAPC Medical Coding I",
+        "Advanced Medical Coding",
+        "CPT-HCPCS Coding",
+        "Digital Tools in Healthcare"
+      ]
+    },
+    {
+      "prefix": "EXER",
+      "name": "EXER",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Exercise Physiology",
+        "Exercise for Special Populations",
+        "Health and Aging",
+        "Health and Lifestyle Coach",
+        "Introduction to Human Performance Studies"
+      ]
+    },
+    {
+      "prefix": "GRDP",
+      "name": "Design",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator for Industry (Partially Online)",
+        "Color Concepts for Graphic Design",
+        "Fundamentals of Applied Design",
+        "Graphic Design 1: Typography",
+        "Graphic Design 2: Profession and Process"
+      ]
+    },
+    {
+      "prefix": "OTEC",
+      "name": "OTEC",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business English",
+        "Computer Software for College",
+        "Computer Technology",
+        "Employment Portfolio"
+      ]
+    },
+    {
+      "prefix": "ADS",
+      "name": "ADS",
+      "course_count": 18,
+      "section_count": 25,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Procedures",
+        "Administrative Support Internship",
+        "Advanced Legal Practices",
+        "Business Environment",
+        "Civil Litigation and Criminal Law"
+      ]
+    },
+    {
+      "prefix": "CTSA",
+      "name": "CTSA",
+      "course_count": 12,
+      "section_count": 25,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Administering Windows Server Operating System",
+        "Configuring Advanced Windows Server",
+        "CTSA Internship",
+        "Desktop Client Virtualization and Mobile Device Support",
+        "Introduction to PowerShell Scripting"
+      ]
+    },
+    {
+      "prefix": "INTP",
+      "name": "Interpreting",
+      "course_count": 16,
+      "section_count": 25,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Consecutive Interpreting 1",
+        "Consecutive Interpreting 2",
+        "Deaf/Blind Interpreting",
+        "English Grammar for Sign Language Interpreters",
+        "Internship Seminar"
+      ]
+    },
+    {
+      "prefix": "NVP",
+      "name": "Video",
+      "course_count": 15,
+      "section_count": 25,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced Video Editing",
+        "Audio Editing for Narrative Video",
+        "Fundamentals of Applied Design",
+        "Independent Study for Narrative Video Production",
+        "Introduction to Adobe Photoshop"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 17,
+      "section_count": 25,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Advanced Physical Therapy Techniques",
+        "Clinical Experience I",
+        "Clinical Experience III",
+        "Clinical Skills Review",
+        "Documentation for PTAs"
+      ]
+    },
+    {
+      "prefix": "ADSC",
+      "name": "ADSC",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "anoka-technical-college",
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Procedures",
+        "Business Communications",
+        "Business English Skills",
+        "Electronic Health Records",
+        "Introduction to Keyboarding and Speedbuilding"
+      ]
+    },
+    {
+      "prefix": "CIVL",
+      "name": "CIVL",
+      "course_count": 16,
+      "section_count": 24,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Basic CAD",
+        "Beginning Survey",
+        "Civil Drafting",
+        "Construction Inspection and Project Management",
+        "Construction Surveying"
+      ]
+    },
+    {
+      "prefix": "DA",
+      "name": "Dental",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "rochester-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Chairside Assisting I",
+        "Chairside Assisting II",
+        "Dental Assisting Internship",
+        "Dental Communications",
+        "Dental Infection Control"
+      ]
+    },
+    {
+      "prefix": "DIES",
+      "name": "DIES",
+      "course_count": 12,
+      "section_count": 24,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Applied Failure Analysis",
+        "Applied Technical Mathematics",
+        "Brake Systems",
+        "DC Electricity",
+        "Diesel Engine II"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "First",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "lake-superior-college",
+        "minnesota-state-community-and-technical-college",
+        "north-hennepin-community-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "First Year Experience - TRIO",
+        "First Year Experience for Adult Learners",
+        "First Year Experience: How to College",
+        "Student Success Strategies"
+      ]
+    },
+    {
+      "prefix": "AMST",
+      "name": "Automotive",
+      "course_count": 8,
+      "section_count": 23,
+      "colleges": [
+        "minneapolis-community-and-technical-college",
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Automotive Electrical II",
+        "Automotive Welding",
+        "Ethnic America - Early 8 Week",
+        "Intro to Automotive Repair",
+        "Introduction to Automotive Electrical/Electronics"
+      ]
+    },
+    {
+      "prefix": "ASEP",
+      "name": "ASEP",
+      "course_count": 16,
+      "section_count": 23,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Diagnostics/New Model Update",
+        "Automatic Transmissions",
+        "Automotive Fundamentals",
+        "Body Electronics",
+        "Brake Systems"
+      ]
+    },
+    {
+      "prefix": "CABT",
+      "name": "CABT",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Cabinetmaking - Open Lab",
+        "CAD/CNC",
+        "Capstone Project/Open Lab",
+        "Casework & Millwork",
+        "CNC Cabinet Design"
+      ]
+    },
+    {
+      "prefix": "CJPO",
+      "name": "CJPO",
+      "course_count": 14,
+      "section_count": 23,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigation",
+        "Criminal Procedures",
+        "Emergency Response/First Responder",
+        "Introduction to Criminal Justice",
+        "Juvenile Justice"
+      ]
+    },
+    {
+      "prefix": "HSCI",
+      "name": "Finish",
+      "course_count": 4,
+      "section_count": 23,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Interventions in Mental and Behavioral Health (Early Finish)",
+        "Introduction to Healthcare Careers (Online)",
+        "Nursing Assistant (Late Start/Early Finish)",
+        "Phlebotomy Technician (Late Start/Early Finish)"
+      ]
+    },
+    {
+      "prefix": "NAHA",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 23,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant - Early 8 Week"
+      ]
+    },
+    {
+      "prefix": "POED",
+      "name": "POED",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigations",
+        "Criminal Procedures",
+        "Homeland Security",
+        "Introduction to Corrections",
+        "Introduction to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "SNDA",
+      "name": "Sound",
+      "course_count": 10,
+      "section_count": 23,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Internship",
+        "Project Studio Design",
+        "Sound Arts 1: The Nature and Control of Sound",
+        "Sound Arts 2: Digital Principles of Sound",
+        "Sound Arts 3: Recording and Digital Production"
+      ]
+    },
+    {
+      "prefix": "APRL",
+      "name": "APRL",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Bridal and Special Occasion",
+        "Clothing Line Design",
+        "Computer-Aided Design",
+        "Draping and Pattern Workroom",
+        "Fashion Imaging"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 21,
+      "section_count": 22,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning (Late Start)",
+        "Automatic Transmissions (Late Start)",
+        "Automotive Brakes",
+        "Automotive Engines (Partially Online)",
+        "Automotive Service"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "inver-hills-community-college",
+        "normandale-community-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Beginning French 1",
+        "Beginning French 2",
+        "Beginning French Language and Culture II",
+        "French Culture and Civilization",
+        "Intermediate French 2"
+      ]
+    },
+    {
+      "prefix": "FRPT",
+      "name": "Emergency",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Fire Investigation",
+        "Building Construction for Emergency Services",
+        "Emergency Services Internship",
+        "Fire Behavior and Combustion",
+        "Fire Protection Systems"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "MECH",
+      "course_count": 22,
+      "section_count": 22,
+      "colleges": [
+        "anoka-technical-college",
+        "minnesota-state-college-southeast",
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD",
+        "Advanced PLC Programming",
+        "Basic Industrial Controls",
+        "DC Electricity",
+        "Design Projects"
+      ]
+    },
+    {
+      "prefix": "OJIB",
+      "name": "Ojibwe",
+      "course_count": 13,
+      "section_count": 22,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college",
+        "minneapolis-community-and-technical-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Beginning Ojibwe 1",
+        "Beginning Ojibwe 2",
+        "Ojibwe 1",
+        "Ojibwe 2",
+        "Ojibwe Culture and History"
+      ]
+    },
+    {
+      "prefix": "ALTH",
+      "name": "ALTH",
+      "course_count": 6,
+      "section_count": 21,
+      "colleges": [
+        "lake-superior-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "First Aid and CPR/AED for Health Care Professionals",
+        "Introduction to Eastern Healing",
+        "Medical Ethics and Law",
+        "Medical Terminology",
+        "Phlebotomy Practicum - Late Start"
+      ]
+    },
+    {
+      "prefix": "COTA",
+      "name": "COTA",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Children and Youth Practice",
+        "Clinical Conditions",
+        "Community Practice",
+        "Introduction to Occupational Therapy I",
+        "Introduction to Occupational Therapy II"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "FIRE",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "lake-superior-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician",
+        "Fire Behavior and Combustion",
+        "Fire Fighter I and II",
+        "Firefighter I",
+        "Firefighter II"
+      ]
+    },
+    {
+      "prefix": "INTD",
+      "name": "Design",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Design and Color",
+        "Design-Build Partnership",
+        "Elements of Interior Design",
+        "Furniture Styles and Periods",
+        "Interior Design Industry Topics and Practices"
+      ]
+    },
+    {
+      "prefix": "PUBH",
+      "name": "Health",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "ridgewater-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Consumer Health",
+        "Drug Education",
+        "Environmental Health",
+        "Global Health",
+        "Personal & Community Health"
+      ]
+    },
+    {
+      "prefix": "AMIN",
+      "name": "AMIN",
+      "course_count": 7,
+      "section_count": 20,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college"
+      ],
+      "sample_titles": [
+        "Anishinaabeg of Lake Superior",
+        "Contemporary Indian Concerns",
+        "Federal Laws and the American Indian",
+        "Foundations of Amn & ANSH Educational Systems",
+        "Introduction to Gidizhitwaawinaanin (Our Cultural Standards)"
+      ]
+    },
+    {
+      "prefix": "HMRS",
+      "name": "Weeks",
+      "course_count": 9,
+      "section_count": 20,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Digital HR - First 8 Weeks",
+        "Employee/Labor Relations - Second 8 Weeks",
+        "Employment Law and HR Policies - Second 8 Weeks",
+        "Human Resource Management - First 8 Weeks",
+        "Human Resources Capstone - IN ZOOM"
+      ]
+    },
+    {
+      "prefix": "INFS",
+      "name": "INFS",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Alternative Knowledge: How Radical Ideas Are Communicated in Society",
+        "Artificial Intelligence and Society",
+        "Ideas, Censorship and Politics",
+        "Information Literacy and Research Skills",
+        "Research Methods with Ethical and Civic Responsibility Focus"
+      ]
+    },
+    {
+      "prefix": "NCC",
+      "name": "Paths",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Paths to College Success - NPowered Program (Co-Req with MATH 0601-13)"
+      ]
+    },
+    {
+      "prefix": "WGSS",
+      "name": "Gender",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Captive Bodies: Gender and Mass Incarceration",
+        "Gender, Health, and Environment",
+        "Gender, Media, and Pop Culture - Late Start",
+        "Introduction to Lesbian Culture",
+        "Introduction to Women, Gender, and Sexuality Studies - Late Start"
+      ]
+    },
+    {
+      "prefix": "ADCO",
+      "name": "Counseling",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Addiction Counseling Assessments",
+        "Addiction Counseling Internship I",
+        "Addiction Counseling Internship II",
+        "Case Management for Addiction Counseling Treatment",
+        "Co-Occurring Disorders: Substance Abuse and Mental Health (Early Finish)"
+      ]
+    },
+    {
+      "prefix": "ADEV",
+      "name": "Learning",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Academic Learning Strategies",
+        "Academic Learning Strategies II",
+        "College Reading and Learning Strategies I",
+        "College Reading and Learning Strategies II - Paired with COMM 1110-35",
+        "Reading Texts Critically"
+      ]
+    },
+    {
+      "prefix": "ARCT",
+      "name": "ARCT",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Architectural Studio III",
+        "Architectural Studio IV",
+        "Architectural Technology Studio I",
+        "Architectural Technology Studio II",
+        "Building Codes and Regulations"
+      ]
+    },
+    {
+      "prefix": "DDCM",
+      "name": "DDCM",
+      "course_count": 15,
+      "section_count": 19,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Advanced Web Development",
+        "Animation for Visual Communication",
+        "Basic Digital Photography",
+        "Business of Design",
+        "Digital Illustration"
+      ]
+    },
+    {
+      "prefix": "HCOP",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 19,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Healthcare Office Documentation",
+        "Healthcare Office Fundamentals",
+        "Medical Terminology for Health Professions",
+        "Medical Terminology: Body Systems and Diseases"
+      ]
+    },
+    {
+      "prefix": "LLAB",
+      "name": "Learning",
+      "course_count": 2,
+      "section_count": 19,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Math 1020 Learning Lab",
+        "THFAAS Learning Community"
+      ]
+    },
+    {
+      "prefix": "MAST",
+      "name": "MAST",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Externship",
+        "Introduction to Laboratory Skills",
+        "Introduction to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "MLTN",
+      "name": "MLTN",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Collection Skills",
+        "Immunology and Serology",
+        "Medical Laboratory Assistant Basics",
+        "Medical Laboratory Assistant Clinical Practicum",
+        "Medical Laboratory Procedures"
+      ]
+    },
+    {
+      "prefix": "NA",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 19,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Hospital Nursing Assistant",
+        "Nursing Assistant for Surgical Technology",
+        "Nursing Assistant Theory and Clinical"
+      ]
+    },
+    {
+      "prefix": "RAST",
+      "name": "RAST",
+      "course_count": 17,
+      "section_count": 19,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Application Planning & Layout-EARY START",
+        "Computers in Industry - RAST students only",
+        "Fluid Power",
+        "HMI Programming",
+        "Industrial Electronics I"
+      ]
+    },
+    {
+      "prefix": "RICT",
+      "name": "RICT",
+      "course_count": 19,
+      "section_count": 19,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "AC Electronics",
+        "Advance Mechanical Systems",
+        "Automated Manufacturing Systems",
+        "DC Electronics",
+        "Digital Electronics"
+      ]
+    },
+    {
+      "prefix": "BMET",
+      "name": "Biomedical",
+      "course_count": 14,
+      "section_count": 18,
+      "colleges": [
+        "anoka-technical-college",
+        "dakota-county-technical-college",
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Administrative Functions",
+        "Biomedical Equipment and Terminology",
+        "Biomedical Equipment I",
+        "Biomedical Equipment Technology Internship",
+        "Biomedical Instrumentation"
+      ]
+    },
+    {
+      "prefix": "CADD",
+      "name": "CADD",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Drawing Principles I",
+        "Advanced Drawing Principles II",
+        "AutoCAD Foundations",
+        "Basic Electric Circuits",
+        "Computer- Aided Design"
+      ]
+    },
+    {
+      "prefix": "HRES",
+      "name": "HRES",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Benefits Administration",
+        "Employee/Labor Relations",
+        "HR Internship",
+        "Human Resource Competency Evaluation",
+        "Human Resource Systems"
+      ]
+    },
+    {
+      "prefix": "MASG",
+      "name": "Massage",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Basics in Business and Ethics for the Holistic Practitioner",
+        "Clinical Massage for Special Populations",
+        "Clinical Massage Internship",
+        "Clinical Massage Practicum On-Campus Clinic",
+        "Clinical Massage Techniques I"
+      ]
+    },
+    {
+      "prefix": "MECA",
+      "name": "Systems",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Electricity - Devices and Circuits I",
+        "Electricity - Devices and Circuits II",
+        "Fluid Power 1",
+        "Fluid Power II",
+        "Mechanical Systems 1"
+      ]
+    },
+    {
+      "prefix": "OSP",
+      "name": "OSP",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Applied Job Search",
+        "Basic Consumer Skills",
+        "Career Assessment and Planning",
+        "Communication",
+        "Community and Leisure Res."
+      ]
+    },
+    {
+      "prefix": "TFT",
+      "name": "TFT",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "American Cinema",
+        "Digital Video Production",
+        "International Production Practicum"
+      ]
+    },
+    {
+      "prefix": "WEBD",
+      "name": "WEBD",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "century-college",
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Web Concepts",
+        "App Design for Mobile Devices",
+        "CMS Websites",
+        "Multimedia",
+        "UX/UI Design"
+      ]
+    },
+    {
+      "prefix": "ATEC",
+      "name": "ATEC",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Alternating Current (AC) Electricity",
+        "Analog Electronics and Batteries",
+        "Aviation Math",
+        "Aviation Physics",
+        "Cleaning and Corrosion Control"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "Dental",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Community Dental Health",
+        "Dental Hygiene Practice II",
+        "Dental Hygiene Practice III",
+        "Dental Hygiene Practice IV",
+        "Dental Imaging for Interpretation"
+      ]
+    },
+    {
+      "prefix": "DMSG",
+      "name": "Ultrasound",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Ultrasound Internship I",
+        "Clinical Ultrasound Internship II",
+        "Clinical Ultrasound Lab I",
+        "Clinical Ultrasound Lab II",
+        "Diagnostic Medical Sonography I"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college",
+        "inver-hills-community-college",
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Educational Technology",
+        "Instructional Strategies for Diverse Learners",
+        "Introduction to Education & Reflective Teaching",
+        "Introduction to Special Education",
+        "Learning Technology for Educators"
+      ]
+    },
+    {
+      "prefix": "ENVR",
+      "name": "Environmental",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Chemistry",
+        "Environmental Issues",
+        "Environmental Science",
+        "Field Methods in Environmental Science",
+        "Internship in Environmental Science"
+      ]
+    },
+    {
+      "prefix": "FACM",
+      "name": "FACM",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced Motors and Controls",
+        "Basic Electricity",
+        "Basic Locksmithing",
+        "Building Automation and Control Systems",
+        "Construction Fundamentals"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "northland-community-and-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Film and United States Culture",
+        "Holocaust and Genocide Studies - 8 week course",
+        "Intro to Humanities",
+        "Introduction to Latin American Studies",
+        "Middle Eastern Cultures"
+      ]
+    },
+    {
+      "prefix": "WEBI",
+      "name": "Design",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Client-Side Scripting",
+        "HTML/CSS Authoring 1",
+        "HTML/CSS Authoring 2",
+        "JavaScript Libraries and Frameworks",
+        "User Experience - UX Design"
+      ]
+    },
+    {
+      "prefix": "ADCS",
+      "name": "Substance",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Pharmacology and Co-Occurring Disorders",
+        "Professional Ethics and Pre-Practicum Issues",
+        "Substance Use Disorder Assessment",
+        "Substance Use Disorder Case Management",
+        "Substance Use Disorder Counseling"
+      ]
+    },
+    {
+      "prefix": "ARAB",
+      "name": "Arabic",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "minneapolis-community-and-technical-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Arab History and Cultures",
+        "Beginning Arabic 1",
+        "Beginning Arabic 2",
+        "Intermediate Arabic 1"
+      ]
+    },
+    {
+      "prefix": "BUSM",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Applied Business Mathematics",
+        "Introduction to Business",
+        "Job Seeking/Keeping Skills",
+        "Leadership and Strategic Planning",
+        "Legal Environment of Business"
+      ]
+    },
+    {
+      "prefix": "CCDS",
+      "name": "Skills",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "How to Succeed in College",
+        "Individualized Studies Degree Planning",
+        "Interviewing Skills",
+        "Job Seeking Skills",
+        "Student Success"
+      ]
+    },
+    {
+      "prefix": "CCLS",
+      "name": "First",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Expanded First Year Experience",
+        "First Year Experience"
+      ]
+    },
+    {
+      "prefix": "CR",
+      "name": "CR",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Carpentry Theory I",
+        "Carpentry Theory II",
+        "Construction Estimating",
+        "Exterior Finishing",
+        "Footing and Foundation"
+      ]
+    },
+    {
+      "prefix": "ECCE",
+      "name": "ECCE",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Child Growth and Development",
+        "Diverse Children and Family Relations",
+        "Foundations of Language and Literacy",
+        "Health, Safety and Wellness",
+        "Intentional Teaching Through Learning Environments"
+      ]
+    },
+    {
+      "prefix": "ECHO",
+      "name": "Echocardiography",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Adult Echocardiography Clinical l",
+        "Adult Echocardiography Clinical ll",
+        "Adult Echocardiography l",
+        "Adult Echocardiography Lab l",
+        "Adult Echocardiography Lab ll"
+      ]
+    },
+    {
+      "prefix": "EMSC",
+      "name": "First",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "AHA BLS for Healthcare Providers",
+        "AHA Heartsaver CPR and First Aid",
+        "Emergency Medical Responder (First Responder)",
+        "EMT-1",
+        "EMT-2"
+      ]
+    },
+    {
+      "prefix": "EMSV",
+      "name": "EMSV",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Ambulance Clinical",
+        "Community Paramedic Quality Improvement",
+        "Community Paramedicine I",
+        "Community Paramedicine II",
+        "Emergency Vehicle Driving Skills"
+      ]
+    },
+    {
+      "prefix": "ENLT",
+      "name": "Literature",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "African American Literature: 1965-Present",
+        "African American Literature: Beginnings-1965",
+        "American Literature: 1865-Present",
+        "Children's Literature",
+        "Introduction to Literature: Novel"
+      ]
+    },
+    {
+      "prefix": "GSWS",
+      "name": "First",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "First Aid and Workplace Safety",
+        "First Aid/Safety",
+        "OSHA Construction Industry/First Aid",
+        "OSHA General Industry/First Aid"
+      ]
+    },
+    {
+      "prefix": "HINS",
+      "name": "Medical",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Body Structures and Functions",
+        "Document Fundamentals of Editing and Scribing",
+        "Health Information Privacy and Security",
+        "Healthcare Management & Organization"
+      ]
+    },
+    {
+      "prefix": "LSCE",
+      "name": "LSCE",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Survey",
+        "Civil CADD I",
+        "Civil CADD II",
+        "Civil CADD III",
+        "Civil Drafting Methods"
+      ]
+    },
+    {
+      "prefix": "MTTC",
+      "name": "MTTC",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Lathe and Introduction to CNC",
+        "Advanced Mill and Introduction to CNC",
+        "Applied Machine Shop Math 1",
+        "Applied Machine Shop Math 2",
+        "Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "NURA",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant"
+      ]
+    },
+    {
+      "prefix": "SMET",
+      "name": "Sheet",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Architectural Sheet Metal",
+        "Duct System Fabrication",
+        "Duct System Layout & Design",
+        "OSHA 30 Hour Training",
+        "Power Machine Operation"
+      ]
+    },
+    {
+      "prefix": "WETT",
+      "name": "Water",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Automated Control Systems",
+        "Basic Laboratory Skills",
+        "Collection and Disinfection Systems Operation",
+        "Introduction to Water/Wastewater Technology",
+        "Source Water Treatment and Development"
+      ]
+    },
+    {
+      "prefix": "CCST",
+      "name": "CCST",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Career Internship Experience",
+        "Career Planning",
+        "College Success Skills",
+        "Employment Strategies - EARLY END - HEOM students only",
+        "Honors Leadership Development"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "Computer",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Algorithms and Data Structures",
+        "Computer Programming with C++",
+        "Computer Programming with Java",
+        "Computer Programming with Python",
+        "Computer System Architecture"
+      ]
+    },
+    {
+      "prefix": "CULN",
+      "name": "CULN",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "south-central-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Basic Baking",
+        "Basic Cooking Principles",
+        "Basic Food Production Principles",
+        "Foodservice Internship",
+        "Garde Manger"
+      ]
+    },
+    {
+      "prefix": "DHET",
+      "name": "DHET",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Diesel Equipment Fundamentals",
+        "Diesel Internship",
+        "Electrical Lab",
+        "Electrical Theory",
+        "Engine Lab"
+      ]
+    },
+    {
+      "prefix": "FYST",
+      "name": "Strategies",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Career Planning - Early End",
+        "ESOL Strategies for College Success",
+        "Orientation to Higher Education for TRIO Starting Point Students",
+        "Strategies for College Success - Late Start"
+      ]
+    },
+    {
+      "prefix": "LWMP",
+      "name": "Sheep",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Equipment and Facilities",
+        "Ewe Ration Formulation",
+        "Introduction to Sheep Health",
+        "Introduction To Sheep Management",
+        "Pasture and Grazing Management"
+      ]
+    },
+    {
+      "prefix": "MSNA",
+      "name": "MSNA",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Networking II",
+        "Hardware Support",
+        "Introduction to Networks II",
+        "Introduction to Virtualization",
+        "Linux Server"
+      ]
+    },
+    {
+      "prefix": "NATR",
+      "name": "NATR",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Animal Behavior",
+        "Dendrology",
+        "Herpetology-EARLY END",
+        "Internship",
+        "Introduction to GPS & GIS"
+      ]
+    },
+    {
+      "prefix": "PHRM",
+      "name": "Pharmacy",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "minneapolis-community-and-technical-college",
+        "minnesota-west-community-and-technical-college",
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Fund Concepts of Pharmacy",
+        "Hospital Externship",
+        "Introduction to Pharmacy Practice - Early End",
+        "Pharmacy Calculations",
+        "Pharmacy Prin-Prac I"
+      ]
+    },
+    {
+      "prefix": "SOCY",
+      "name": "Sociology",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "dakota-county-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Criminology",
+        "Introduction to Sociology (Reserved for ASEP)",
+        "Social Issues Changing World",
+        "Sociology of Diversity in American Society",
+        "Sociology of Marriage and the Family"
+      ]
+    },
+    {
+      "prefix": "BHHS",
+      "name": "BHHS",
+      "course_count": 13,
+      "section_count": 14,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker Role, Advocacy, Outreach, and Resources",
+        "Direct Service Professionalism",
+        "Documentation, Legal, and Ethical Issues",
+        "Facilitating Positive Behaviors",
+        "Health Communication, Teaching, and Capacity Building"
+      ]
+    },
+    {
+      "prefix": "BUSO",
+      "name": "BUSO",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Current Office Technologies",
+        "Four-Credit Internship",
+        "Introduction to Computer Applications",
+        "Medical Terminology",
+        "Multimedia Business Presentations"
+      ]
+    },
+    {
+      "prefix": "CDEP",
+      "name": "Chemical",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college"
+      ],
+      "sample_titles": [
+        "Chemical Dependency Assessment and Counseling",
+        "Chemical Dependency Practicum I",
+        "Chemical Dependency Practicum II",
+        "Chemical Dependency Theories",
+        "Co-Occurring Disorders"
+      ]
+    },
+    {
+      "prefix": "CHSN",
+      "name": "Body",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Body Systems and Diseases",
+        "Preclinic Introduction"
+      ]
+    },
+    {
+      "prefix": "CMSC",
+      "name": "Programming",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Python Programming",
+        "C# Programming I",
+        "C# Programming II",
+        "Client-Side Programming",
+        "Database Modeling I"
+      ]
+    },
+    {
+      "prefix": "CSEC",
+      "name": "CSEC",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "pine-technical-and-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Network Defense",
+        "Advanced Security Concepts",
+        "Cloud Computing Fundamentals",
+        "Cybersecurity Essentials",
+        "Ethics in Information Technology"
+      ]
+    },
+    {
+      "prefix": "CVNP",
+      "name": "CVNP",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Cisco 1",
+        "Cisco 2",
+        "Computer Hardware",
+        "Defensive Security",
+        "Linux Administration"
+      ]
+    },
+    {
+      "prefix": "ENCW",
+      "name": "Writing",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Creative Nonfiction Writing",
+        "Introduction to Creative Writing",
+        "Introduction to Writing Fiction",
+        "Introduction to Writing Literature for Children",
+        "Introduction to Writing Poetry"
+      ]
+    },
+    {
+      "prefix": "GERO",
+      "name": "Gerontology",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "northwest-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Biology of Aging",
+        "Intro to Gerontology",
+        "Introduction to Gerontology",
+        "Psychosocial Aspects of Aging"
+      ]
+    },
+    {
+      "prefix": "MTTP",
+      "name": "MTTP",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Applied Machining Theory",
+        "Basic Machine Shop",
+        "Blue Print Reading I",
+        "CNC Programming",
+        "Cutting Tool Technology"
+      ]
+    },
+    {
+      "prefix": "ADR",
+      "name": "Activity",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Activity Ideas for Program Development",
+        "Activity Interventions and Engagement Techniques",
+        "Career Success for Activity Professionals",
+        "Community Agencies and Resources for Older Adults",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "ADSA",
+      "name": "ADSA",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Office Applications",
+        "College Keyboarding I",
+        "College Keyboarding II",
+        "Customer Service",
+        "Digital Publishing"
+      ]
+    },
+    {
+      "prefix": "BIKE",
+      "name": "Bicycle",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Ball Bearing Systems - Late Start",
+        "Basic Bicycle Mechanics - Late Start",
+        "Bicycle Braking Systems - Late Start",
+        "Bicycle Drivetrain Systems - Late Start",
+        "Bicycle Wheel Repair and Assembly - Early End"
+      ]
+    },
+    {
+      "prefix": "COMT",
+      "name": "COMT",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Database Management Systems",
+        "Data Base Management",
+        "Intro to Visual Basic",
+        "Introduction to Computer Technology",
+        "PC Architecture Operations&Interfaces"
+      ]
+    },
+    {
+      "prefix": "ENGW",
+      "name": "Writing",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "AFA Capstone",
+        "Fiction Writing",
+        "Introduction to Creative Writing",
+        "Play and Screen Writing",
+        "Poetry Writing"
+      ]
+    },
+    {
+      "prefix": "GCST",
+      "name": "GCST",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "American Indian Culture - Indigenous Peoples of Minnesota",
+        "Community Organizing I",
+        "Environmental Justice and Nature Immersion Experience",
+        "Introduction to Japanese Culture",
+        "Japanese Literature"
+      ]
+    },
+    {
+      "prefix": "GISC",
+      "name": "GISC",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Cartography",
+        "GPS Field Techniques",
+        "Introduction to GIS",
+        "Introduction to Remote Sensing",
+        "Object-Based Image Analysis"
+      ]
+    },
+    {
+      "prefix": "GSCI",
+      "name": "Artificial",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Artificial Intelligence (AI) Ethics",
+        "Artificial Intelligence (AI) Integration",
+        "Artificial Intelligence (AI) Literacy",
+        "Artificial Intelligence (AI) Media Generation",
+        "Computer Technology"
+      ]
+    },
+    {
+      "prefix": "KBD",
+      "name": "Kitchen",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD for Kitchen and Bath Design (Late Start)",
+        "Advanced Kitchen and Bath Design",
+        "Basic CAD for Kitchen and Bath Design (Early Finish)",
+        "Basic CAD II for Kitchen and Bath Design",
+        "Basic Kitchen and Bath Design"
+      ]
+    },
+    {
+      "prefix": "MAIN",
+      "name": "MAIN",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Accuracies",
+        "CNC Automation and Safety",
+        "Electrical Troubleshooting",
+        "Interfaces and Sensors",
+        "Machining For CNC Maintenance"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "MFGT",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Design for Mechatronics Systems",
+        "Engineering Drafting",
+        "Industrial Distribution",
+        "Mechatronics I",
+        "Programmable Logic Controls"
+      ]
+    },
+    {
+      "prefix": "NSGA",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Nursing Assistant",
+        "Nursing Assistant - LATE START"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Application of Medical Terminology",
+        "Medical Dosages for Nursing",
+        "Pre-Nursing Pharmacology"
+      ]
+    },
+    {
+      "prefix": "RNEW",
+      "name": "RNEW",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "century-college",
+        "minnesota-west-community-and-technical-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Biodiesel Process Fundamentals",
+        "Biodiesel Technologies and Regulatory Issues",
+        "Ethanol Process Fundamentals",
+        "Ethanol Separation Technology",
+        "Industrial Safety"
+      ]
+    },
+    {
+      "prefix": "SLPA",
+      "name": "SLPA",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy of Speech/Language and Hearing",
+        "Certificate Practicum I",
+        "Certificate Seminar I",
+        "Clinical Practicum I",
+        "Clinical Seminar I"
+      ]
+    },
+    {
+      "prefix": "TURF",
+      "name": "TURF",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Golf Course Construction and Design",
+        "Golf Course Planning and Operations",
+        "Introduction to Turfgrass Species",
+        "Irrigation Installation and Design",
+        "Landscape Construction"
+      ]
+    },
+    {
+      "prefix": "VACT",
+      "name": "Vacuum",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Concepts of Rough Vacuum Systems - EARLY END",
+        "Foundations of Vacuum Science - EARLY END",
+        "High Vacuum Applications - LATE START",
+        "High Vacuum Equipment - EARLY END",
+        "High Vacuum Measurement - LATE START/EARLY END"
+      ]
+    },
+    {
+      "prefix": "CAOR",
+      "name": "Career",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "fond-du-lac-tribal-and-community-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Career Exploration and Planning",
+        "Career Exploration Workshop",
+        "Career Explorations"
+      ]
+    },
+    {
+      "prefix": "DMKT",
+      "name": "Marketing",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Content Marketing",
+        "Content Marketing in the Age of Al",
+        "Digital Marketing Analytics",
+        "Digital Marketing Capstone",
+        "Email and MMS Marketing"
+      ]
+    },
+    {
+      "prefix": "ELL",
+      "name": "Writing",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Academic Vocabulary",
+        "Elements of College Reading",
+        "Elements of College Writing",
+        "English Language Learner Listening Comprehension and Speaking",
+        "English Language Learner Writing I"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "dakota-county-technical-college",
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Business Plan Development (Accelerated course- late start)",
+        "Capitalizing and Financial Management for Small Business (Late Start)",
+        "Entrepreneurship 1: Finding Your Opportunity",
+        "Entrepreneurship ll: Starting Your Business",
+        "Introduction to Small Business (Accelerated course- early end)"
+      ]
+    },
+    {
+      "prefix": "ESLA",
+      "name": "ESLA",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Listening and Speaking",
+        "Advanced Reading and Vocabulary",
+        "Advanced Writing and Grammar",
+        "Intermediate Listening and Speaking",
+        "Intermediate Reading & Vocabulary"
+      ]
+    },
+    {
+      "prefix": "INET",
+      "name": "INET",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "DevNet",
+        "INET Internship",
+        "Introduction to IoT - Connecting Things",
+        "Introduction to Networks (CCNA-1)",
+        "IT Capstone"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "minneapolis-community-and-technical-college",
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese 1",
+        "Beginning Japanese 2",
+        "Intermediate Japanese 1",
+        "Intermediate Japanese 2",
+        "Introduction to Interpreting and Translation"
+      ]
+    },
+    {
+      "prefix": "MDAD",
+      "name": "Design",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Autocad",
+        "Geometric Tolerances",
+        "Inventor",
+        "Manufacturing Processes for CAD Design",
+        "Mold Design for CAD Design"
+      ]
+    },
+    {
+      "prefix": "MKAD",
+      "name": "MKAD",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator",
+        "Adobe InDesign",
+        "Adobe Photoshop",
+        "Content Creation",
+        "Copywriting and Design"
+      ]
+    },
+    {
+      "prefix": "NWAT",
+      "name": "NWAT",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Cisco Networking II",
+        "Computer Forensic Investigation",
+        "Cybersecurity Fundamentals",
+        "IT Fundamentals",
+        "Network Security II"
+      ]
+    },
+    {
+      "prefix": "SOCS",
+      "name": "Sociology",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Critical Thinking in Society",
+        "Diversity and Social Change",
+        "Introduction to Sociology",
+        "Sociology of the Family"
+      ]
+    },
+    {
+      "prefix": "TRAN",
+      "name": "TRAN",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Electricity and Electronic Principles",
+        "General Service",
+        "Scan Tool Data Acquisition",
+        "Transportation Hazardous Materials",
+        "Workplace Perceptions and Expectations"
+      ]
+    },
+    {
+      "prefix": "WGST",
+      "name": "Women",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Biology of Women",
+        "Foundations in Women's Studies",
+        "Gender in Society",
+        "History of Women in Modern America",
+        "Psychology of Women"
+      ]
+    },
+    {
+      "prefix": "AMIS",
+      "name": "Native",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "American Indian Education: Past & Present",
+        "Community Development and Indigenous Cultures",
+        "Native America",
+        "Native American Art and Art History",
+        "Native American Literature"
+      ]
+    },
+    {
+      "prefix": "AMSL",
+      "name": "American",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "American Sign Language 1",
+        "American Sign Language 2",
+        "American Sign Language I",
+        "Conversational ASL",
+        "Deaf Culture"
+      ]
+    },
+    {
+      "prefix": "CAPL",
+      "name": "Microsoft",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Introduction to Software Applications (Early Finish)",
+        "Microsoft Excel",
+        "Microsoft Outlook (Late Start/Early Finish)",
+        "Microsoft PowerPoint"
+      ]
+    },
+    {
+      "prefix": "GDES",
+      "name": "GDES",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator",
+        "Adobe InDesign",
+        "Adobe Photoshop",
+        "Art Direction",
+        "Concepts of Design"
+      ]
+    },
+    {
+      "prefix": "GSCM",
+      "name": "Oral",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "ridgewater-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Oral and Written Communications",
+        "Workplace Human Relations"
+      ]
+    },
+    {
+      "prefix": "HCTC",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant"
+      ]
+    },
+    {
+      "prefix": "INDS",
+      "name": "INDS",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "dakota-county-technical-college",
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Career and Education Exploration",
+        "Critical Thinking for Student Success",
+        "Introduction to Interpreting and Translation"
+      ]
+    },
+    {
+      "prefix": "OFFT",
+      "name": "Office",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Document Formatting Essentials (Early Finish)",
+        "Electronic Health Records",
+        "Healthcare Documentation Fundamentals",
+        "Introduction to Health Information"
+      ]
+    },
+    {
+      "prefix": "QUAL",
+      "name": "QUAL",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Applied GD and T Concepts",
+        "Continuous Improvement",
+        "Fixturing for Inspection",
+        "Gauging Calibration",
+        "Measurement and Test Equipment"
+      ]
+    },
+    {
+      "prefix": "SMLI",
+      "name": "Somali",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "normandale-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Beginning Somali 1",
+        "Beginning Somali 2",
+        "Intermediate Somali 1",
+        "Intermediate Somali 2",
+        "Somali Culture and Civilization"
+      ]
+    },
+    {
+      "prefix": "ALHE",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Applied Medical Terminology",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "CCD",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Chinese",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "century-college",
+        "normandale-community-college",
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Beginning Chinese 1",
+        "Beginning Chinese I",
+        "Chinese Culture and Civilization",
+        "Introduction to Interpreting and Translation",
+        "Tutorial: Beginning Chinese 2"
+      ]
+    },
+    {
+      "prefix": "CHWN",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker Navigator Internship",
+        "Cultural Health Communication, Teaching, and Capacity Building - LATE START",
+        "Documentation, Legal and Ethical Issues in Community Health Work - LATE",
+        "The Community Health Worker: Health Promotion Competencies",
+        "The Community Health Worker: Role, Advocacy, Outreach, & Resources - EARLY"
+      ]
+    },
+    {
+      "prefix": "COCP",
+      "name": "COCP",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Computer Concepts and Applications",
+        "Computer Hardware Support",
+        "Introduction to Programming",
+        "Microsoft Server Operating System",
+        "Network Administration 1"
+      ]
+    },
+    {
+      "prefix": "CONS",
+      "name": "Construction",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Building Systems",
+        "Advanced Construction Principles",
+        "Basic Building Design",
+        "Building Plans, Specifications, and Codes",
+        "Construction Internship 1"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emergency",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "pine-technical-and-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician I",
+        "Emergency Medical Technician II",
+        "Emergency Medical Technician: Basic",
+        "Emergency Vehicle Operations",
+        "First Aid/BLS for Healthcare Providers"
+      ]
+    },
+    {
+      "prefix": "HPPC",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Medical Dosages",
+        "Medical Terminology",
+        "Pharmacology"
+      ]
+    },
+    {
+      "prefix": "ICVT",
+      "name": "Cardiovascular",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Applied Clinical Internship",
+        "Cardiovascular Anatomy & Physiology",
+        "Cardiovascular Clinical I",
+        "Cardiovascular Clinical II",
+        "Cardiovascular Instrumentation"
+      ]
+    },
+    {
+      "prefix": "MTTS",
+      "name": "Operations",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "CAD/CAM",
+        "CNC Milling and Turning",
+        "CNC Operations Theory",
+        "Geometric Dimensioning and Tolerancing",
+        "Intro to Machining Processes"
+      ]
+    },
+    {
+      "prefix": "NUPN",
+      "name": "Nursing",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Adult Nursing I",
+        "Gerontology in Nursing",
+        "Medication Concepts",
+        "PN Technical Skills I",
+        "Practical Nursing Clinical I"
+      ]
+    },
+    {
+      "prefix": "POFS",
+      "name": "POFS",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Crime Scene Processing",
+        "Defensive Tactics",
+        "Firearms for SKILLS",
+        "Patrol Practicals",
+        "Traffic Enforcement"
+      ]
+    },
+    {
+      "prefix": "PRSW",
+      "name": "Social",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "anoka-ramsey-community-college",
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Field Experience in Social Work",
+        "Introduction to Social Work",
+        "Social Work Field Experience"
+      ]
+    },
+    {
+      "prefix": "STER",
+      "name": "Sterile",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Endoscope Reprocessing",
+        "Fundamentals of Sterile Processing",
+        "Infection Control for Sterile Processing",
+        "Inventory Management in Sterile Processing",
+        "Sterile Processing Internship"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "College",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "lake-superior-college",
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "College Ready Math I",
+        "College Ready Math II",
+        "Pathways to College Success: Math Essentials I",
+        "Pathways to College Success: Read/Write",
+        "Writing Lab"
+      ]
+    },
+    {
+      "prefix": "AGSC",
+      "name": "Agriculture",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Agriculture Internship",
+        "Crop Production",
+        "Intro to Precision Agriculture, GPS, and GIS",
+        "Introduction to Agriculture, Food, and Natural Resources",
+        "Introduction to Animal Science"
+      ]
+    },
+    {
+      "prefix": "ASTE",
+      "name": "ASTE",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Applied Safety and Environmental Stewardship",
+        "Automotive Fundamentals and Maintenance",
+        "Electrical and Electronics Principles",
+        "Electronic Control Units and Scan Tools",
+        "Gas and Diesel Engine Service and Repair"
+      ]
+    },
+    {
+      "prefix": "AUMO",
+      "name": "AUMO",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Computers",
+        "Auto Transmission-Axle I",
+        "Basic Electricity-Battery",
+        "Body Electrical",
+        "Brakes"
+      ]
+    },
+    {
+      "prefix": "BIT",
+      "name": "Inspections",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Building Inspection Internship",
+        "Commercial Plan Review and Field Inspections",
+        "Foundations of Construction Codes and Inspections",
+        "Legal and Administrative Aspects of Construction Codes",
+        "Residential Plan Review and Field Inspections"
+      ]
+    },
+    {
+      "prefix": "BOPM",
+      "name": "Management",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Keyboarding",
+        "Operations Management 1: The Professional Office",
+        "Operations Management 2: Business Accounting with QuickBooks",
+        "Operations Management 3: Customer Relations in a Global Environment",
+        "Project Management 1: Microsoft Word"
+      ]
+    },
+    {
+      "prefix": "CIST",
+      "name": "History",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Cinema History 1",
+        "Cinema History 2",
+        "History of Photography - Early End",
+        "World Cinema History"
+      ]
+    },
+    {
+      "prefix": "FNCR",
+      "name": "FNCR",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Consumer Lending",
+        "Finance Law, Regulations and Ethics",
+        "Financial Statement Analysis",
+        "Internship",
+        "Investments"
+      ]
+    },
+    {
+      "prefix": "GWS",
+      "name": "Gender",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "inver-hills-community-college",
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Analyzing Gender Identities",
+        "Constructions of Masculinity and Femininity",
+        "Gender, Race, and American Culture",
+        "Global Feminism",
+        "Introduction to Gender and Women's Studies"
+      ]
+    },
+    {
+      "prefix": "MGEM",
+      "name": "Systems",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Basic Engine Principles I",
+        "Internship",
+        "Intro to Powersports Electrical Systems",
+        "Intro to Powersports Fuel Systems",
+        "Marine Drive Systems"
+      ]
+    },
+    {
+      "prefix": "ORTE",
+      "name": "Orthoses",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Advanced Thermoplastic Lower Extremity Orthoses",
+        "Emerging Technologies in Orthotic Care (Partially Online)(Early Finish)",
+        "Finish Orthoses for Patient Fitting",
+        "Foot Orthosis Fabrication and Shoe Modification",
+        "Metal System Ankle Foot Orthoses"
+      ]
+    },
+    {
+      "prefix": "POFC",
+      "name": "Peace",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Firearms for Peace Officers",
+        "Community Policing and Service",
+        "Human Behavior and Ethics for Peace Officers",
+        "Introduction to Criminal Investigation",
+        "Introduction to Peace Officers and the Criminal Justice System"
+      ]
+    },
+    {
+      "prefix": "WMST",
+      "name": "Women",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "normandale-community-college",
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Global Perspectives of Women",
+        "Introduction to Women Studies",
+        "Introduction to Women's and Gender Studies",
+        "Introduction to Women's Studies",
+        "Women Across Cultures"
+      ]
+    },
+    {
+      "prefix": "BDAT",
+      "name": "Data",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Business Intelligence",
+        "Data Analysis Fundamentals",
+        "Data Preparation for Analytics",
+        "Data Visualization",
+        "Integrated Business Software"
+      ]
+    },
+    {
+      "prefix": "COMC",
+      "name": "COMC",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Computer Careers Internship",
+        "Database Application Development",
+        "Introduction to Programming with .Net",
+        "Introduction to Visual Database Application Tools",
+        "Java/C++/C# Programming II"
+      ]
+    },
+    {
+      "prefix": "CSBM",
+      "name": "Small",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Accounts Receivable for Small Business",
+        "Bank Reconciliation for Small Business",
+        "Desktop Publishing for Small Business",
+        "Disk Operating Systems for Small Business",
+        "Hardware Analysis for Small Business"
+      ]
+    },
+    {
+      "prefix": "DIAG",
+      "name": "Control",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Diagnosing Body Control Systems",
+        "Diagnosing Chassis Control Systems",
+        "Diagnosing Driveline Control Systems",
+        "Diagnosing Powertain Control Systems",
+        "Hybrid and Electric Vehicle Service"
+      ]
+    },
+    {
+      "prefix": "EMER",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Care/First Responder",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "EMTS",
+      "name": "Emergency",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "AHA Healthcare Provider CPR",
+        "Emergency Medical Responder",
+        "Emergency Medical Technician",
+        "Emergency Response Technician Practicum",
+        "General OSHA Safety and First Aid"
+      ]
+    },
+    {
+      "prefix": "FLPO",
+      "name": "Pneumatic",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Hydraulic Components",
+        "Hydraulic Components Lab",
+        "Instrumentation",
+        "Pneumatic Componentry",
+        "Pneumatic Componentry Lab"
+      ]
+    },
+    {
+      "prefix": "GLST",
+      "name": "Global",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "central-lakes-college-brainerd",
+        "minnesota-state-community-and-technical-college",
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Honors Global Studies: Nobel Conference Experience",
+        "Introduction to Global Studies",
+        "Many Faces of Mexico"
+      ]
+    },
+    {
+      "prefix": "GNDR",
+      "name": "Gender",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Gender and Public Power",
+        "Gender Studies Certificate Capstone (Late Start)",
+        "Introduction to Gender Studies (Early Finish)",
+        "Introduction to LGBTQ+ Studies"
+      ]
+    },
+    {
+      "prefix": "GSCL",
+      "name": "Skills",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "minnesota-west-community-and-technical-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Employment Search Skills",
+        "Job Seeking Skills"
+      ]
+    },
+    {
+      "prefix": "LGST",
+      "name": "Legal",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Business Law - An Introduction",
+        "Civil Litigation",
+        "Family Law",
+        "Law Office Applications",
+        "Legal Studies I: Terminology and Procedures"
+      ]
+    },
+    {
+      "prefix": "MEDR",
+      "name": "MEDR",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Computer Assisted Drafting 2-D",
+        "Engineering Drawing I",
+        "Engineering Drawing II",
+        "Machine Design (with CAD)",
+        "Practicum"
+      ]
+    },
+    {
+      "prefix": "MMVP",
+      "name": "Animation",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "2D Animation Rigging and Compositing",
+        "3D Animation",
+        "3D Modeling",
+        "Advanced After Effects",
+        "Animation"
+      ]
+    },
+    {
+      "prefix": "SJS",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Social Justice",
+        "Social Justice in Action: Methods, Skills, and Practice"
+      ]
+    },
+    {
+      "prefix": "SOCL",
+      "name": "Sociology",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Criminology",
+        "Honors Introduction to Sociology",
+        "Introduction to Sociology - for Upward Bound students only",
+        "Social Problems",
+        "Sociology of the Family"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "TECH",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Basic CADD",
+        "Basic Manual - Automated Machining",
+        "Basic Metal Joining and Fabrication",
+        "Technical Computations"
+      ]
+    },
+    {
+      "prefix": "ATMP",
+      "name": "ATMP",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions",
+        "Basic Electricity",
+        "Chassis",
+        "Drivetrain",
+        "Scan Tools"
+      ]
+    },
+    {
+      "prefix": "BMED",
+      "name": "Industry",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "anoka-ramsey-community-college"
+      ],
+      "sample_titles": [
+        "Design and Manufacturing in the Medical Device Industry",
+        "Introduction to Biomedical Devices and Industry",
+        "Introduction to Medical Device Regulations and Ethics",
+        "Introduction to Quality Assurance",
+        "Technical Writing for Regulated Industries"
+      ]
+    },
+    {
+      "prefix": "CADE",
+      "name": "CADE",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "3D Process Piping Design",
+        "AutoCAD",
+        "AutoCAD Design Project",
+        "Industrial/Mechanical CAD Applications II",
+        "Revit Industrial/Structural (BIM) Applications"
+      ]
+    },
+    {
+      "prefix": "CEST",
+      "name": "Estimating",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Computer Estimating",
+        "Construction Document Management",
+        "Construction Estimating I",
+        "Construction Estimating II",
+        "Drone Survey for Estimating"
+      ]
+    },
+    {
+      "prefix": "CRLT",
+      "name": "CRLT",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "alexandria-technical-and-community-college",
+        "northland-community-and-technical-college",
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Communicating for Results",
+        "Contemporary Career Search",
+        "Job Seeking / Keeping Skills",
+        "Job Seeking-Keeping"
+      ]
+    },
+    {
+      "prefix": "DNTL",
+      "name": "Dental",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Dental Health",
+        "Dental Science",
+        "Dental Team/Practice Management"
+      ]
+    },
+    {
+      "prefix": "DSCI",
+      "name": "Data",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "normandale-community-college",
+        "north-hennepin-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applications for Analyzing Data",
+        "Data Science I",
+        "Data Science II",
+        "Foundations of Data Science",
+        "Interdisciplinary Applications in Data Science - Late Start"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "anoka-ramsey-community-college",
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Beginning German Language and Culture II",
+        "German Culture and Civilization",
+        "Introduction to Interpreting and Translation"
+      ]
+    },
+    {
+      "prefix": "HEOP",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking in Healthcare",
+        "Nursing Assistant Comprehensive"
+      ]
+    },
+    {
+      "prefix": "HONR",
+      "name": "Martial",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Honors Seminar: Martial Arts Mindset for College Success"
+      ]
+    },
+    {
+      "prefix": "INMG",
+      "name": "INMG",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Design Application Concepts I",
+        "Introduction to Manufacturing Technology",
+        "Mechanical Print Reading",
+        "Prototyping Processes"
+      ]
+    },
+    {
+      "prefix": "MAPS",
+      "name": "Start",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Electrical Systems and Diagnostics-LATE START",
+        "Engine Theory and Diagnostics-LATE START",
+        "Fuel Systems and Diagnostics-LATE START",
+        "Inboards, Inboard/Outboards, & Personal Watercraft-LATE START",
+        "Industry Certifications I-LATE START"
+      ]
+    },
+    {
+      "prefix": "MCAB",
+      "name": "Meat",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Food Animal Processing - EARLY END",
+        "Food Safety and Sanitation - EARLY END",
+        "Full Service and Retail Meat Cutting - LATE START",
+        "Introduction to Meat Cutting - EARLY END",
+        "Meat Cutting Internship - LATE START"
+      ]
+    },
+    {
+      "prefix": "MELT",
+      "name": "Phlebotomy",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Phlebotomy",
+        "Diagnostic Chemistry",
+        "Diagnostic Microbiology",
+        "Immunology",
+        "MLT Seminar"
+      ]
+    },
+    {
+      "prefix": "MTP",
+      "name": "Massage",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Adjunctive Therapies of the Massage Profession",
+        "Basic Therapeutic Massage",
+        "Ethics, Communication, and Professionalism in Massage Therapy",
+        "Massage Therapy Anatomy I, Physiology, and Kinesiology",
+        "Massage Therapy Awareness and Injury Prevention I"
+      ]
+    },
+    {
+      "prefix": "OPMT",
+      "name": "Ophthalmic",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Rotation III",
+        "Eye Diseases and Ocular Emergencies",
+        "Introduction to Ophthalmology",
+        "Ophthalmic Clinical Rotation I",
+        "Ophthalmic Imaging Techniques"
+      ]
+    },
+    {
+      "prefix": "PDEV",
+      "name": "PDEV",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "minnesota-north-college",
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Contemporary Career Search",
+        "Employment Strategies",
+        "Service Learning Experience"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "American Government"
+      ]
+    },
+    {
+      "prefix": "PRTE",
+      "name": "Prosthetic",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Clinical Internship: Prosthetics",
+        "Emerging Technologies in Prosthetic Care",
+        "Foundations of the Prosthetic Device",
+        "Prosthetic Technology Simulation",
+        "Transfemoral Prosthetic Fabrication"
+      ]
+    },
+    {
+      "prefix": "ADDS",
+      "name": "ADDS",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Adolescent Substance Use: Misuse, Addiction, and Prevention",
+        "Pharmacology, Medicated Assisted Therapy, and Drug Use",
+        "Racial, Cultural, and Ethical Considerations in Addictions Counseling"
+      ]
+    },
+    {
+      "prefix": "DAS",
+      "name": "Dental",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Dental Anatomy 2",
+        "Dental Science",
+        "Infection Control",
+        "Nitrous Oxide-Oxygen Inhalation Sedation",
+        "Nutrition and Dental Health"
+      ]
+    },
+    {
+      "prefix": "EMSB",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician (Partially Online)(Early Finish)"
+      ]
+    },
+    {
+      "prefix": "FRTA",
+      "name": "Partially",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Firefighter I (Partially Online)(Early Finish)",
+        "Firefighter II (Partially Online)(Late Start/Early Finish)",
+        "Hazardous Materials Operations (Partially Online)(Late Start)"
+      ]
+    },
+    {
+      "prefix": "FSCI",
+      "name": "Food",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "normandale-community-college",
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Food Processing",
+        "Food Product Development",
+        "Food Quality and Safety",
+        "Introduction to Food Science",
+        "Principles of Food Science"
+      ]
+    },
+    {
+      "prefix": "GSTP",
+      "name": "GSTP",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Barreling & Chambering",
+        "Gunsmith Welding and Metallurgy",
+        "Pistolsmithing",
+        "Rifle Design and Function",
+        "Riflesmithing"
+      ]
+    },
+    {
+      "prefix": "HHP",
+      "name": "HHP",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Drug Education",
+        "Stress Management",
+        "Topics in Aerobic Conditioning:",
+        "Topics in Lifetime Fitness Activities: Sleep Strategies for Students"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Applied Plant Science Lab",
+        "Arboriculture",
+        "Bedding and Tropical Plants",
+        "Horticulture Lab I",
+        "Landscape Design"
+      ]
+    },
+    {
+      "prefix": "MMPR",
+      "name": "Production",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college"
+      ],
+      "sample_titles": [
+        "Audio Production",
+        "Internship",
+        "Intro to Digital Storytelling",
+        "Media and Society",
+        "Video Production"
+      ]
+    },
+    {
+      "prefix": "MTCC",
+      "name": "Axis",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Mill (4th Axis)",
+        "CNC Horizontal 4 Axis",
+        "CNC Machining Center (3 Axis)",
+        "CNC Mill Turn, Live Tooling",
+        "CNC Turning"
+      ]
+    },
+    {
+      "prefix": "PHLE",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Intro to Phlebotomy",
+        "Phlebotomy Internship",
+        "Phlebotomy Skills"
+      ]
+    },
+    {
+      "prefix": "SCIE",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college",
+        "riverland-community-college",
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Integrated Biology and Chemistry for Elementary Education Majors",
+        "Integrated Earth Science and Physics for Elementary Education Majors",
+        "Investigative Science I",
+        "Investigative Science II"
+      ]
+    },
+    {
+      "prefix": "SMGT",
+      "name": "SMGT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Coaching & Productivity Enhancement",
+        "Management Theories and Organizational Studies",
+        "Mastering Career Skills",
+        "Service Management",
+        "Supervision Principles"
+      ]
+    },
+    {
+      "prefix": "SOMI",
+      "name": "Somali",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Beginning Somali 1",
+        "Beginning Somali 2",
+        "Somali Civilization and Culture"
+      ]
+    },
+    {
+      "prefix": "SURT",
+      "name": "Surgical",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "minnesota-state-community-and-technical-college",
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Surgical Tech",
+        "Surgical Pathophysiology",
+        "Surgical Pharmacology",
+        "Surgical Technology III",
+        "Surgical Terminology"
+      ]
+    },
+    {
+      "prefix": "AGRG",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Agribusiness & Records",
+        "Intro to Agriculture",
+        "Intro to Animal Science",
+        "Plant Science"
+      ]
+    },
+    {
+      "prefix": "CCPD",
+      "name": "Success",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Career Exploration",
+        "Success Strategies for College & Professional Development"
+      ]
+    },
+    {
+      "prefix": "CJSP",
+      "name": "Criminal",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Crime Victims and Computer Crimes",
+        "Introduction to Criminal Justice",
+        "Introduction to Criminology/Criminal Behavior",
+        "Juvenile Justice/Delinquency",
+        "Leadership for Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "CMHW",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker Internship",
+        "Community Health Worker Role, Advocacy, Outreach & Resources",
+        "Documentation, Legal & Ethical Issues in Community Health Work",
+        "Health Communication, Teaching & Capacity Building",
+        "Health Promotion"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "Estimating",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Building Materials and Methods",
+        "Commercial Estimating and Project Analysis",
+        "Construction Management",
+        "Estimating for the Construction Trades I",
+        "Estimating for the Construction Trades II"
+      ]
+    },
+    {
+      "prefix": "DNAS",
+      "name": "Dental",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Biodental Science",
+        "Clinical Assisting II",
+        "Dental Assisting Clinical Affiliations",
+        "Dental Specialties"
+      ]
+    },
+    {
+      "prefix": "GENS",
+      "name": "Computer",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Computer Applications: Spreadsheets",
+        "Computer Applications: Word Processing",
+        "Introduction to Computer Applications"
+      ]
+    },
+    {
+      "prefix": "GLOS",
+      "name": "Global",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Global Studies",
+        "Race and Culture: A Global Perspective"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "Level",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "CNC Milling Level I",
+        "CNC Turning Level I",
+        "Job Planning, Benchwork and Layout Level I",
+        "Machining Computations",
+        "Measurement, Materials and Safety Level I"
+      ]
+    },
+    {
+      "prefix": "OSKL",
+      "name": "Skills",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Communication I",
+        "Critical Reasoning Skills I",
+        "Employability Skills I",
+        "Study Skills I",
+        "Supervised Pre-Internship I"
+      ]
+    },
+    {
+      "prefix": "POLI",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to American Government and Politics"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Sociology",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "anoka-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sociology",
+        "Sociology of Work"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work",
+        "Social Welfare Services"
+      ]
+    },
+    {
+      "prefix": "ADSM",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Healthcare Documentation",
+        "Medical Office Procedures"
+      ]
+    },
+    {
+      "prefix": "AENG",
+      "name": "Engineering",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Aided Design (CAD)",
+        "Applied Engineering Capstone",
+        "Material & Manufacturing Process",
+        "Reverse Engineering"
+      ]
+    },
+    {
+      "prefix": "AGBS",
+      "name": "Commercial",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "riverland-community-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Commercial Driver's License",
+        "Commercial Driver's License II",
+        "Introduction to Agribusiness Management"
+      ]
+    },
+    {
+      "prefix": "AGEC",
+      "name": "Commodity",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Commodity Marketing Principles",
+        "Commodity Marketing Strategies",
+        "Introduction to Agricultural Economics"
+      ]
+    },
+    {
+      "prefix": "ANI",
+      "name": "ANI",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Anishinaabe Studies",
+        "Indigenous American Intership",
+        "Nationhood & Gathering of Manoomin"
+      ]
+    },
+    {
+      "prefix": "ARBC",
+      "name": "Arabic",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Arab Cultures",
+        "Arabic I"
+      ]
+    },
+    {
+      "prefix": "AUBO",
+      "name": "Auto",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Body Mechanical",
+        "General Auto Body Lab",
+        "Shop Operations",
+        "Unibody and Frame"
+      ]
+    },
+    {
+      "prefix": "CDES",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "2D Foundations",
+        "Communication Design I",
+        "Design Production I",
+        "Design Technology I"
+      ]
+    },
+    {
+      "prefix": "COAR",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Communication Design III",
+        "Design Production III",
+        "Design Technology III",
+        "Portfolio I"
+      ]
+    },
+    {
+      "prefix": "CRDV",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration and Planning (Accelerated Course- Early End)"
+      ]
+    },
+    {
+      "prefix": "DEN",
+      "name": "Dental",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Dental Ethics and Jurisprudence",
+        "Dental Practice Management"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "Education",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Education Technology",
+        "Introduction to Education"
+      ]
+    },
+    {
+      "prefix": "ENSC",
+      "name": "Environment",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "lake-superior-college"
+      ],
+      "sample_titles": [
+        "The Environment and Sustainability",
+        "World Health and the Environment"
+      ]
+    },
+    {
+      "prefix": "HCM",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "inver-hills-community-college"
+      ],
+      "sample_titles": [
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "HCST",
+      "name": "Technology",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Healthcare Systems Technology Capstone",
+        "Introduction to Health Information Technology",
+        "Privacy and Security in HIT"
+      ]
+    },
+    {
+      "prefix": "HSPM",
+      "name": "Weeks",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Event Management and Planning - Second 8 Weeks",
+        "Hotel and Lodging Operations - Second 8 Weeks",
+        "Introduction to Hospitality Management - First 8 Weeks"
+      ]
+    },
+    {
+      "prefix": "LIBT",
+      "name": "Information",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Collection Organization and Metadata",
+        "Information Ethics and Legal Issues",
+        "Library/Information Agency Internship",
+        "Topics in Library and Information Technology - Early 8 Week"
+      ]
+    },
+    {
+      "prefix": "RDNG",
+      "name": "Reading",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Bridge to Composition I - Reading Focused",
+        "Excellent Reading"
+      ]
+    },
+    {
+      "prefix": "SSSC",
+      "name": "Choosing",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "Choosing a Major and Career",
+        "Introduction to Personal Finance"
+      ]
+    },
+    {
+      "prefix": "ST",
+      "name": "Surgical",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Surgical Procedures I",
+        "Surgical Procedures II"
+      ]
+    },
+    {
+      "prefix": "UNIV",
+      "name": "UNIV",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Athletic Fee",
+        "Health Services Fee",
+        "Northwest Technical College - Super Fee",
+        "Student Activity Fee"
+      ]
+    },
+    {
+      "prefix": "ACCP",
+      "name": "Accounting",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Financial Accounting",
+        "Managerial Accounting",
+        "Principles of Accounting I"
+      ]
+    },
+    {
+      "prefix": "ANSI",
+      "name": "ANSI",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Backyard Poultry: Biology and Management",
+        "Food Safety: From Farm to Fork",
+        "Introduction to Animal Science"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Ethnobiology",
+        "General Biology I + lab"
+      ]
+    },
+    {
+      "prefix": "DNHY",
+      "name": "Clinical",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Affiliation I",
+        "Clinical Affiliation II",
+        "Dental Hygiene Principles V"
+      ]
+    },
+    {
+      "prefix": "EMC",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Responder (First Responder)"
+      ]
+    },
+    {
+      "prefix": "GSIS",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ridgewater-college"
+      ],
+      "sample_titles": [
+        "Human Relations"
+      ]
+    },
+    {
+      "prefix": "HASL",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II"
+      ]
+    },
+    {
+      "prefix": "INSP",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Career and Educational Planning"
+      ]
+    },
+    {
+      "prefix": "IPP",
+      "name": "Interpreting",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Ethics and Decision-Making for Interpreters",
+        "Introduction to Interpreting",
+        "Topics in Interpreting"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Medical Office Procedures"
+      ]
+    },
+    {
+      "prefix": "PLSC",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "northland-community-and-technical-college",
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "American Govt-Politics",
+        "Soils II"
+      ]
+    },
+    {
+      "prefix": "PSAF",
+      "name": "Public",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Community Service Principles",
+        "Foundations of Public Safety",
+        "Project Management in Public Safety"
+      ]
+    },
+    {
+      "prefix": "SSAC",
+      "name": "Summer",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Summer Scholars Academy Reading",
+        "Summer Scholars Academy Workshop",
+        "Summer Scholars Academy Writing"
+      ]
+    },
+    {
+      "prefix": "AIDA",
+      "name": "Data",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Data Analytic Essentials",
+        "Excel and Data Visualization"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Animal",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Animal Anat and Phys",
+        "Animal Feeds-Nutrition"
+      ]
+    },
+    {
+      "prefix": "BIOC",
+      "name": "Biochemistry",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "saint-paul-college"
+      ],
+      "sample_titles": [
+        "Biochemistry"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "Design",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Dimensioning and Design",
+        "Product and Machine Design"
+      ]
+    },
+    {
+      "prefix": "CPLT",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Computer Essentials"
+      ]
+    },
+    {
+      "prefix": "CTLS",
+      "name": "Autocad",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Basic AutoCAD"
+      ]
+    },
+    {
+      "prefix": "DAKO",
+      "name": "Dakota",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "minneapolis-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Dakota Culture and History"
+      ]
+    },
+    {
+      "prefix": "ENER",
+      "name": "Energy",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Intro to Renewable Energy",
+        "Intro to Solar Energy"
+      ]
+    },
+    {
+      "prefix": "FOR",
+      "name": "Woodland",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "GIS Applications",
+        "Woodland Plants"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "History of Leech Lake",
+        "US History"
+      ]
+    },
+    {
+      "prefix": "HUCF",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Health Unit Coordinator Procedures",
+        "Introduction to Health Unit Coordinating"
+      ]
+    },
+    {
+      "prefix": "INDV",
+      "name": "Individualized",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Independent Studies",
+        "Individualized Studies Internship"
+      ]
+    },
+    {
+      "prefix": "ISCI",
+      "name": "Indigenous",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Indigenous Science",
+        "Indigenous Science Careers"
+      ]
+    },
+    {
+      "prefix": "LE",
+      "name": "Minnesota",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Introduction to Criminal Justice",
+        "Minnesota Statutes and Traffic Law"
+      ]
+    },
+    {
+      "prefix": "LNDC",
+      "name": "Specialized",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Specialized Lab",
+        "Sustainable Food and Plant Production - Summer"
+      ]
+    },
+    {
+      "prefix": "LSR",
+      "name": "Radiation",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Radiation Protection",
+        "Radiobiology"
+      ]
+    },
+    {
+      "prefix": "MCS",
+      "name": "Multicultural",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Multicultural America"
+      ]
+    },
+    {
+      "prefix": "METS",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Industrial Manufacturing Processes"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Special Education"
+      ]
+    },
+    {
+      "prefix": "SSCI",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Human Relations"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work/Social Welfare"
+      ]
+    },
+    {
+      "prefix": "ABED",
+      "name": "Adult",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-lakes-college-brainerd"
+      ],
+      "sample_titles": [
+        "Adult Education Math"
+      ]
+    },
+    {
+      "prefix": "BLTD",
+      "name": "Construction",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "leech-lake-tribal-college"
+      ],
+      "sample_titles": [
+        "Construction Safety"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "Associate",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Associate of Arts Capstone Class"
+      ]
+    },
+    {
+      "prefix": "CONM",
+      "name": "Construction",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Construction Management Principles"
+      ]
+    },
+    {
+      "prefix": "CRD",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-hennepin-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration and Planning"
+      ]
+    },
+    {
+      "prefix": "DIGI",
+      "name": "Creative",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "riverland-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Creative Digital Media"
+      ]
+    },
+    {
+      "prefix": "ECOL",
+      "name": "Ecology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Ecology of Minnesota Raptors"
+      ]
+    },
+    {
+      "prefix": "ELWT",
+      "name": "Wind",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Wind Energy"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "Fluid",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "normandale-community-college"
+      ],
+      "sample_titles": [
+        "Fluid Mechanics"
+      ]
+    },
+    {
+      "prefix": "ETHN",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "American Racial Minorities"
+      ]
+    },
+    {
+      "prefix": "FASH",
+      "name": "Fashion",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Fashion Retailing"
+      ]
+    },
+    {
+      "prefix": "FCS",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Nutrition and Healthy Living"
+      ]
+    },
+    {
+      "prefix": "FDAS",
+      "name": "Ford",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Ford Warranty Responsibilities"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "GIS Internship"
+      ]
+    },
+    {
+      "prefix": "GSDV",
+      "name": "Individualized",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "alexandria-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Individualized Degree Plan"
+      ]
+    },
+    {
+      "prefix": "GST",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Introduction to Global Studies"
+      ]
+    },
+    {
+      "prefix": "GTEC",
+      "name": "Automobile",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "st-cloud-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "The Automobile in America"
+      ]
+    },
+    {
+      "prefix": "GTRB",
+      "name": "Guitar",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Guitar Electronics"
+      ]
+    },
+    {
+      "prefix": "HEMS",
+      "name": "HEMS",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "CPR"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Math for Trades"
+      ]
+    },
+    {
+      "prefix": "LASL",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "pine-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I"
+      ]
+    },
+    {
+      "prefix": "MGDP",
+      "name": "Graphic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Graphic Design Internship"
+      ]
+    },
+    {
+      "prefix": "MMP",
+      "name": "MMP",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college"
+      ],
+      "sample_titles": [
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "MMST",
+      "name": "Service",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hennepin-technical-college"
+      ],
+      "sample_titles": [
+        "Service Management"
+      ]
+    },
+    {
+      "prefix": "POE",
+      "name": "Post",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-north-college"
+      ],
+      "sample_titles": [
+        "POST Prep"
+      ]
+    },
+    {
+      "prefix": "PSWK",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-state-college-southeast"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "REC",
+      "name": "Outdoor",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "rochester-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Outdoor Education and Recreation"
+      ]
+    },
+    {
+      "prefix": "SGNL",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "American Sign Language (ASL) I"
+      ]
+    },
+    {
+      "prefix": "SOLR",
+      "name": "Photovoltaic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Photovoltaic Systems"
+      ]
+    },
+    {
+      "prefix": "SUPL",
+      "name": "Supervisory",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-technical-college"
+      ],
+      "sample_titles": [
+        "Supervisory Leadership"
+      ]
+    },
+    {
+      "prefix": "SUST",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "fond-du-lac-tribal-and-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Ethics"
+      ]
+    },
+    {
+      "prefix": "SWPR",
+      "name": "Swine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-central-college"
+      ],
+      "sample_titles": [
+        "Swine Records and Analysis"
+      ]
+    },
+    {
+      "prefix": "SWRK",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-west-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Human Services: Social Work"
+      ]
+    },
+    {
+      "prefix": "THPY",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "minnesota-state-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Nutrition and Wellness"
+      ]
+    },
+    {
+      "prefix": "TRIN",
+      "name": "Interpreting",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "century-college"
+      ],
+      "sample_titles": [
+        "Interpreting in Education"
+      ]
+    }
+  ],
+  "program_titles": [
+    "3D Modeling and Animation Diploma",
+    "3D Modeling and Animation, AAS",
+    "Academic English Proficiency Certificate",
+    "Accountant Diploma",
+    "Accountant, A.A.S.",
+    "Accountant, Diploma",
+    "Accounting Associate of Applied Science Degree",
+    "Accounting Certificate",
+    "Accounting Clerk Certificate",
+    "Accounting Clerk, Diploma",
+    "Accounting Practitioner, AAS",
+    "Accounting Technician Certificate",
+    "Accounting Technician Diploma",
+    "Accounting Transfer Pathway, A.S.",
+    "Accounting Transfer Pathway, AS",
+    "Accounting, AAS",
+    "Addiction Counseling Certificate",
+    "Addiction Counseling, AS",
+    "Additive and Digital Manufacturing, AAS",
+    "Administrative Assistant, AAS",
+    "Administrative Assistant, Diploma",
+    "Administrative Office Specialist AAS Degree",
+    "Administrative Office Specialist Certificate",
+    "Administrative Office Specialist Diploma",
+    "Administrative Specialist Certificate",
+    "Advanced CNC Machine Technology Diploma",
+    "Advanced Computer Technology Certificate",
+    "Advanced Practice Esthetics Associate of Applied Science Degree",
+    "Advanced Practice Esthetics Certificate",
+    "Advanced Solar Photovoltaic Energy Systems Certificate",
+    "Advanced Solar Thermal Energy Systems Certificate",
+    "Alcohol & Drug Counseling Certificate",
+    "Alcohol & Drug Counseling Studies, AS",
+    "American Sign Language Studies Certificate",
+    "Anthropology, A.A. with Emphasis",
+    "Applied Big Data Analytics Certificate",
+    "Applied Big Data Analytics, AAS",
+    "Applied Engineering Technology-Biomedical Design & Manufacturing, AS",
+    "Architectural & Construction Technician Diploma",
+    "Architectural 2D CAD Certificate",
+    "Architectural Drafting, Certificate",
+    "Architectural Technology AAS Degree",
+    "Architectural Technology, A.A.S.",
+    "Art Transfer Pathway, A.F.A.",
+    "Art Transfer Pathway, AFA",
+    "Associate of Arts Degree",
+    "Associate of Arts in Liberal Arts & Sciences, AA",
+    "Associate of Arts, A.A.",
+    "Athletic Coaching Certificate",
+    "Auto Body Collision Technology, A.A.S.",
+    "Auto Body Collision Technology, Diploma",
+    "Auto Body Technician Diploma",
+    "Auto Body Technology, AAS",
+    "Automotive Electronic Diagnostic Specialist Diploma",
+    "Automotive Service (GM-ASEP), A.A.S.",
+    "Automotive Service Technician Associate of Applied Science Degree",
+    "Automotive Service Technician Diploma",
+    "Automotive Service Technology, A.A.S.",
+    "Automotive Services Technician Diploma",
+    "Automotive Technician AAS Degree",
+    "Automotive Technician Diploma",
+    "Basic Automotive Service Certificate",
+    "Basic Welding Certificate",
+    "Behavioral Health & Human Services AAS Degree",
+    "Biofabrication Technologist Certificate",
+    "Biology Transfer Pathway Associate of Science Degree",
+    "Biology Transfer Pathway, A.S.",
+    "Biology Transfer Pathway, AS",
+    "Biomedical Core Certificate",
+    "Biomedical Equipment Technician AAS Degree",
+    "Biomedical Equipment Technology, A.A.S.",
+    "Biomedical Equipment Technology, Certificate",
+    "Biomedical Technology Certificate",
+    "Biomedical Technology, AS",
+    "Business Administration, A.S.",
+    "Business Analytics, Certificate",
+    "Business Certificate",
+    "Business Communication Certificate",
+    "Business Computer Applications Certificate",
+    "Business Crisis & Emergency Management Certificate",
+    "Business Data Analyst AAS Degree",
+    "Business Data Analyst Diploma",
+    "Business Generalist Certificate",
+    "Business Management, A.A.S.",
+    "Business Management, AAS",
+    "Business Transfer Pathway Associate of Science Degree",
+    "Business Transfer Pathway, A.S.",
+    "Business Transfer Pathway, AS",
+    "Business, Industry & Technology, AS",
+    "Business: Management/Marketing Emphasis, AAS",
+    "Business: Workplace & Technology Emphasis, AAS",
+    "Cabinetmaking Diploma",
+    "Carpentry Diploma",
+    "CART & Broadcast Captioning Certificate",
+    "Chemistry Transfer Pathway Associate of Science Degree",
+    "Chemistry Transfer Pathway, A.S.",
+    "Chemistry Transfer Pathway, AS",
+    "Child & Family Studies, A.S.",
+    "Child Development Careers ASL Associate of Science Degree",
+    "Child Development Careers Associate of Applied Science Degree",
+    "Child Development Careers Certificate",
+    "Child Development Careers Diploma",
+    "Civil Engineering & Land Survey Technology, A.A.S.",
+    "Civil Engineering & Land Survey Technology, Certificate",
+    "Climate Change Studies, A.A. with Emphasis",
+    "Climate Change, Certifcate",
+    "Clinical Massage Therapy Diploma",
+    "Clinical Research Professional Certificate",
+    "CNC Design & Manufacturing Technology AAS Degree",
+    "CNC Service Technician Diploma",
+    "CNC Toolmaking Diploma",
+    "Commercial HVAC/R, Diploma",
+    "Communication Studies Transfer Pathway Associate of Arts Degree",
+    "Communication Studies Transfer Pathway, A.A.",
+    "Communication Studies Transfer Pathway, AA",
+    "Community Health Worker Certificate",
+    "Community Paramedic Certificate",
+    "Community Paramedic, Certificate",
+    "Computer Animation Certificate",
+    "Computer Graphics and Visualization Associate of Science Degree",
+    "Computer Information Systems, AS",
+    "Computer Network Engineering Associate of Applied Science Degree",
+    "Computer Networking, AS",
+    "Computer Programmer, A.A.S.",
+    "Computer Programming Associate of Applied Science Degree",
+    "Computer Programming Certificate",
+    "Computer Science Transfer Pathway Associate of Science Degree",
+    "Computer Science Transfer Pathway, A.S.",
+    "Computer Science Transfer Pathway, AS",
+    "Computer Skills Certificate",
+    "Computer Technology Support and Administration Diploma",
+    "Computer Technology Support and Administration, AAS",
+    "Computer Technology Support Specialist Certificate",
+    "Construction Codes & Inspection, Certificate",
+    "Construction Codes & Permitting Specialist, Certificate",
+    "Construction Electrician Diploma",
+    "Construction Estimating Certificate",
+    "Construction Estimating Technician Diploma",
+    "Construction Management, A.A.S.",
+    "Construction Management, A.S.",
+    "Contemporary Business Practice A.A.S.",
+    "Cooling Certificate",
+    "Corrections Certificate",
+    "Corrections, Certifcate",
+    "Cosmetology Associate of Applied Science Degree",
+    "Cosmetology Diploma",
+    "Cosmetology, AAS",
+    "Creative Writing Certificate",
+    "Creative Writing, AFA",
+    "Criminal Justice Transfer Pathway Associate of Science Degree",
+    "Criminal Justice Transfer Pathway, A.S.",
+    "Criminal Justice, AS",
+    "Cross-Platform Mobile Development Certificate",
+    "Culinary Arts Associate of Applied Science Degree",
+    "Culinary Arts Diploma",
+    "Culinary Entrepreneurship Certificate",
+    "Culturally Responsive Professional Peace Officer, A.S.",
+    "Culturally Responsive Professional Peace Officer, Certificate",
+    "Customer Service Office Support Certificate",
+    "Cybersecurity Analysis and Techniques Certificate",
+    "CyberSecurity Associate of Applied Science Degree",
+    "CyberSecurity Certificate",
+    "Cybersecurity, AS",
+    "Cybersecurity, Forensics, and Information Assurance, AAS",
+    "Data Science Associate of Science Degree",
+    "Data Science Certificate",
+    "Dental Assistant Diploma",
+    "Dental Assistant, A.A.S.",
+    "Dental Assistant, AAS",
+    "Dental Assistant, Diploma",
+    "Dental Hygiene, AAS",
+    "Desktop Programming, Certificate",
+    "Digital Forensics Analysis and Techniques Certificate",
+    "Digital Illustration, Certificate",
+    "Digital Manufacturing Certificate",
+    "Digital Marketing Certificate",
+    "Digital Marketing Specialist, A.A.S.",
+    "Diversity Studies Certificate",
+    "Early Childhood & Youth Development, A.A.S.",
+    "Early Childhood & Youth Development, Certificate",
+    "Early Childhood & Youth Development, Diploma",
+    "Early Childhood Education Transfer Pathway Associate of Science Degree",
+    "Early Childhood Education Transfer Pathway, A.S.",
+    "Earth Science, AS",
+    "Economics Transfer Pathway Associate of Arts Degree",
+    "Economics Transfer Pathway, A.A.",
+    "Education, AS",
+    "Electrical Construction & Maintenance, A.A.S.",
+    "Electrical Construction & Maintenance, Diploma",
+    "Electrical Lineworker, A.A.S.",
+    "Electrical Lineworker, Diploma",
+    "Electrical Technology Diploma",
+    "Electromechanical Automation Systems Associate of Applied Science Degree",
+    "Electromechanical Automation Systems Diploma",
+    "Electromechanical Systems: Electrical Certificate",
+    "Electromechanical Systems: Industrial Programming Certificate",
+    "Electromechanical Systems: Mechanical Certificate",
+    "Electronic Technology Diploma",
+    "Elementary Education Foundations Transfer Pathway, A.S.",
+    "Elementary Education Foundations Transfer Pathway, AS",
+    "Emergency Medical Services Certificate",
+    "Emergency Medical Services, A.S. (Accelerated Track)",
+    "Emergency Medical Services, A.S. (Traditional Track)",
+    "Emergency Medical Technician Certificate",
+    "Emergency Medical Technician, Certificate",
+    "Energy Technical Specialist, Solar Power Track, AAS",
+    "Engineering Broad Field",
+    "Engineering Broad Field Associate of Science Degree",
+    "Engineering CAD Technology, AAS",
+    "Engineering Fundamentals, A.S.",
+    "Engineering, AS",
+    "English for Academic Purposes",
+    "English Transfer Pathway Associate of Arts Degree",
+    "English Transfer Pathway, A.A.",
+    "English Transfer Pathway, AA",
+    "Enterprise Networking and Security, Certificate",
+    "Entrepreneurial Certificate",
+    "Entrepreneurship Certificate",
+    "Environmental Science, A.S.",
+    "Environmental Science, AS",
+    "Esthetician Certificate",
+    "Event and Meeting Management Certificate",
+    "Executive Administrative Specialist, A.A.S.",
+    "Exercise & Sport Science, A.A.S.",
+    "Exercise Science Transfer Pathway, A.S.",
+    "Exercise Science Transfer Pathway, AS",
+    "Facilities Maintenance Engineer Certificate",
+    "Facilities Maintenance Engineer Diploma",
+    "Facilities Maintenance Engineer, AAS",
+    "Finance Associate of Science Degree",
+    "Finance Certificate",
+    "Fire Services Certificate",
+    "Fitness and Wellness Professional Certificate",
+    "Fitness Specialist Certificate",
+    "Gender and Women’s Studies, A.A. with Emphasis",
+    "Gender Studies Certificate",
+    "Geographic Information Science Associate of Applied Science Degree",
+    "Geographic Information Science Certificate",
+    "Global Studies Certificate",
+    "Global Trade Professional Certificate",
+    "Global Trade Specialist Associate of Applied Science Degree",
+    "Graphic Design & Production Diploma",
+    "Graphic Design & Production, AAS",
+    "Graphic Design Technology, A.A.S.",
+    "Hair Technician Certificate",
+    "Hair Technician Diploma",
+    "Health Data Analytics Certificate",
+    "Health Information Management AAS Degree",
+    "Health Information Technology Associate of Applied Science Degree",
+    "Health Sciences (Broad Field) Degree, AS",
+    "Health Sciences Broad Field Associate of Science Degree",
+    "Health Sciences Broad Field, A.S.",
+    "Health Sciences Broad Field, AS",
+    "Health Technology Certificate",
+    "Health Unit Coordinator Certificate",
+    "Healthcare Administration Associate of Science Degree",
+    "Healthcare Documentation Specialist Certificate",
+    "Healthcare Informatics Associate of Applied Science Degree",
+    "Heating Certificate",
+    "Heating, Ventilation, Air Conditioning and Refrigeration Technician Diploma",
+    "Heating, Ventilation, Air Conditioning and Refrigeration Technology, AAS",
+    "Heavy Construction Equip. Maintenance, Certificate",
+    "Heavy Construction Equip. Mechanic, Diploma",
+    "Heavy Construction Equip. Technology, A.A.S.",
+    "Heavy Duty Truck Technology, A.A.S.",
+    "Heavy Duty Truck Technology, Diploma",
+    "History Transfer Pathway Associate of Arts Degree",
+    "History Transfer Pathway, A.A.",
+    "History Transfer Pathway, AA",
+    "Home Furnishing Sales Certificate",
+    "Hospitality Management Certificate",
+    "Human Resource Management, AS",
+    "Human Resource Management, Certificate",
+    "Human Resources Associate of Applied Science Degree",
+    "Human Resources Certificate",
+    "Human Services Technician Certificate",
+    "Human Services Volunteer Certificate",
+    "Human Services, AS",
+    "HVAC & Refrigeration, A.A.S.",
+    "HVAC & Refrigeration, Diploma",
+    "Hybrid and Electric Vehicle Technology Certificate",
+    "Individualized Professional Studies, A.A.S.",
+    "Individualized Professional Studies, A.S.",
+    "Individualized Studies Diploma",
+    "Individualized Studies, A.S.",
+    "Individualized Studies, AAS",
+    "Individualized Studies, AS",
+    "Industrial Engineering Technician, A.A.S.",
+    "Information Systems Management, A.A.S.",
+    "Information Technology Support, A.A.S.",
+    "Integrative Health & Healing Certificate",
+    "Integrative Health & Healing, AS",
+    "Integrative Health & Wellness Coaching Certificate",
+    "Integrative Health & Wellness Coaching, AS",
+    "Intelligence and Crime Analysis Certificate",
+    "Interior Design Associate Diploma",
+    "Interior Design, A.A.S.",
+    "Interior Design, AAS",
+    "Interior Design: NCIDQ Pathway, Certificate",
+    "Internet Programming Certificate",
+    "InterNetwork Emerging Technologies, AAS",
+    "Intrusion Detection & Incident Handling Certificate",
+    "Investigation Certificate",
+    "IT HelpDesk & Cybersecurity Operations, Certificate",
+    "IT Support Certificate",
+    "IT Support Specialist Certificate",
+    "IT System Administrator, Certificate",
+    "Java Programming Certificate",
+    "Judicial Reporting AAS Degree",
+    "Kitchen and Bath Design Certificate",
+    "Legal Administrative Assistant, A.A.S.",
+    "Legal Administrative Assistant, Diploma",
+    "Liberal Arts and Sciences, AA",
+    "Linux System Administrator Certificate",
+    "Machine Technology 1 Certificate",
+    "Machine Technology 2 Certificate",
+    "Machine Technology 3 Certificate",
+    "Management and Leadership Certificate",
+    "Management Associate of Applied Science Degree",
+    "Management Information Systems Transfer Pathway Associate of Science Degree",
+    "Marketing & Sales, Certificate",
+    "Marketing Associate of Applied Science Degree",
+    "Marketing Certificate",
+    "Marketing Communications Technology, AAS",
+    "Marketing Management, AAS",
+    "Marketing Specialty Diploma",
+    "Marketing, A.S.",
+    "Mass Communication Transfer Pathway, AA",
+    "Massage Therapy Certificate",
+    "Mathematics Transfer Pathway Associate of Arts Degree",
+    "Mathematics Transfer Pathway, A.A.",
+    "Mathematics Transfer Pathway, AA",
+    "Mechanical CAD Drafter Diploma",
+    "Mechanical CAD Operator Certificate",
+    "Mechanical Drafting & Design AAS Degree",
+    "Medical Administrative Specialist, A.A.S.",
+    "Medical Administrative Specialist, Diploma",
+    "Medical Administrative Support Diploma",
+    "Medical Assistant AAS Degree",
+    "Medical Assistant Diploma",
+    "Medical Assistant, A.A.S.",
+    "Medical Assistant, Diploma",
+    "Medical Coding Diploma",
+    "Medical Coding Specialist Diploma",
+    "Medical Coding Specialist, A.A.S.",
+    "Medical Coding Specialist, Certificate",
+    "Medical Coding Specialist, Diploma",
+    "Medical Laboratory Technician Associate of Applied Science Degree",
+    "Medical Office Assistant, AAS",
+    "Medical Office Certificate",
+    "Medical Office Professional Associate of Applied Science Degree",
+    "Medical Office Specialist AAS Degree",
+    "Medical Office Support Certificate",
+    "Medical Receptionist Diploma",
+    "Medium and Heavy Duty Truck Technician Diploma",
+    "Mental and Behavioral Health Worker Certificate",
+    "Mental Health Practitioner Certificate",
+    "Microsoft Office Applications Management, Certificate",
+    "Minnesota Transfer Curriculum (MnTC)",
+    "Minnesota Transfer Curriculum (MnTC) Course List",
+    "MnTC Minnesota Transfer Curriculum Notation",
+    "Mobile Application Development Certificate",
+    "Mopar CAP, A.A.S.",
+    "Multicultural Human Resources Management, Diploma",
+    "Multicultural Leadership, Diploma",
+    "Multicultural Quality Management, Diploma",
+    "Multicultural Supervision, Certificate",
+    "Music Associate of Fine Arts Degree",
+    "Music, A.F.A.",
+    "Music, AFA",
+    "Nail Care and Eyelash Extensions Technician Certificate",
+    "Nail Care Technician Certificate",
+    "Narrative Video Production Diploma",
+    "Narrative Video Production, AAS",
+    "Network Administration Certificate",
+    "Network Management & Security AAS Degree",
+    "Network Management & Security Diploma",
+    "Network Security Certificate",
+    "Network Support & Administration Certificate",
+    "Network Technology and Security, A.A.S.",
+    "Networking & Cybersecurity Operations, Certificate",
+    "Networking Administration, A.A.S.",
+    "Nursing Assistant / Home Health Aide Certificate",
+    "Nursing Assistant Certificate",
+    "Nursing Assistant, Certificate",
+    "Nursing Assistant/Home Health Aide Certificate",
+    "Nursing Assisting, Certificate",
+    "Nursing Mobility-License Practical Nurse (LPN), A.S.",
+    "Nursing, A.S.",
+    "Nursing, AS",
+    "Occupational Therapy Assistant AAS Degree",
+    "Office Assistant Certificate",
+    "Office Communications Specialist Certificate",
+    "Office Management Professional Associate of Applied Science Degree",
+    "Office Software Specialist Certificate",
+    "Office Support Diploma",
+    "Online Video Content Creator Certificate",
+    "Orthotic and Prosthetic Clinical Applications Advanced Certificate",
+    "Paraeducation Certificate",
+    "Paralegal, A.S.",
+    "Paralegal, Certificate",
+    "Paramedic AAS Degree",
+    "Paramedic Diploma",
+    "Paramedic Fire Science, AAS",
+    "Paramedic, AAS",
+    "Paramedic, Diploma",
+    "Pastry and Baking Certificate",
+    "PC Technician, Certificate",
+    "Peace Officer Academic Certificate",
+    "Peace Officer\\Public Safety Transfer Pathway, AS",
+    "Personal Training, Certificate",
+    "Pharmacy Technician Associate of Applied Science Degree",
+    "Pharmacy Technician Certificate",
+    "Pharmacy Technician Diploma",
+    "Pharmacy Technician, AS",
+    "Photographic Careers Diploma",
+    "Photographic Careers, AAS",
+    "Photography, Diploma",
+    "Physical Therapist Assistant, AAS",
+    "Pipe Welder Certificate",
+    "Political Science Transfer Pathway, A.A.",
+    "Political Science Transfer Pathway, AA",
+    "Practical Nursing Diploma",
+    "Practical Nursing, Diploma",
+    "Pre-Social Work Transfer Pathway, A.S.",
+    "Pre-Social Work Transfer Pathway, AS",
+    "Private Security Certificate",
+    "Process Technology, A.A.S.",
+    "Professional Nursing Program, AS",
+    "Professional Photography, A.A.S.",
+    "Project Management, Certificate",
+    "Prosthetic, Orthotic, and Pedorthic Allied Healthcare Diploma",
+    "Prosthetic, Orthotic, and Pedorthic Allied Healthcare, AAS",
+    "Psychology Transfer Pathway, A.A.",
+    "Psychology Transfer Pathway, AA",
+    "Public & Community Health, AS",
+    "Public Administration, Certificate",
+    "Public Safety Leadership Certificate",
+    "Public Safety, AAS",
+    "Quality Improvement, Certificate",
+    "Quality Inspector Certificate",
+    "Quality Technician AAS Degree",
+    "Radiologic Technology, AAS",
+    "Reverse Engineering Malware Analysis and Techniques Certificate",
+    "Robotic & Electronic Engineering AAS Degree - Special Electronics Technician Emphasis",
+    "Robotic & Electronic Engineering Technology AAS Degree",
+    "Robotic & Laser Welding AAS Degree",
+    "Robotic & Laser Welding Certificate",
+    "Sales Specialist, Certificate",
+    "Scoping/Proofreading Certificate",
+    "Small Business Accounting Certificate",
+    "Small Business Accounting, Certificate",
+    "Small Business Development, Certificate",
+    "Small Business Entrepreneur, Certificate",
+    "Social Justice, A.A. with Emphasis",
+    "Social Justice, Certificate",
+    "Social Media Marketing Certificate",
+    "Sociology Transfer Pathway, A.A.",
+    "Sociology Transfer Pathway, AA",
+    "Software Applications Certificate",
+    "Software Development AAS Degree",
+    "Software Development Diploma",
+    "Software Development, A.A.S.",
+    "Software Development, Diploma",
+    "Solar Assessor Certificate",
+    "Solar Sales and Marketing Certificate",
+    "Spanish Transfer Pathway, A.A.",
+    "Spanish Transfer Pathway, AA",
+    "Spanish, Certificate",
+    "Special Education Foundations Transfer Pathway, A.S.",
+    "Special Education Transfer Pathway, AS",
+    "Sport Management, A.S.",
+    "Sterile Processing Certificate",
+    "Structural Design Certificate",
+    "Supervision, Certificate",
+    "Supervisory Leadership, Certificate",
+    "Surgical Technology AAS Degree",
+    "Sustainability Certificate",
+    "System Administration, AAS",
+    "Technical Management, A.A.S.",
+    "Theatre Transfer Pathway, A.F.A.",
+    "Theatre Transfer Pathway, AFA",
+    "Therapeutic Massage Diploma",
+    "Translation and Interpreting Certificate",
+    "Translation and Interpreting Diploma",
+    "Truck Fleet Maintenance, Certificate",
+    "Turf & Golf Course Management AAS Degree",
+    "Turf & Golf Course Technician Diploma",
+    "Veterinary Technician, A.A.S.",
+    "Web Design & Development AAS Degree",
+    "Web Design & Development Diploma",
+    "Web Design Diploma",
+    "Web Design, AAS",
+    "Web Design, Certificate",
+    "Web Programming, Certificate",
+    "Welding AAS Degree",
+    "Welding Certificate",
+    "Welding Fabricator Certificate",
+    "Welding Technology Diploma",
+    "Welding Technology, Diploma",
+    "Workplace Writing, Certificate"
+  ]
+}

--- a/data/mt/subject-vocab.json
+++ b/data/mt/subject-vocab.json
@@ -1,0 +1,3193 @@
+{
+  "state": "mt",
+  "generated_at": "2026-06-06T15:41:40.458Z",
+  "subjects": [
+    {
+      "prefix": "NRSG",
+      "name": "Nursing",
+      "course_count": 40,
+      "section_count": 128,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health Nursing",
+        "Adult Health Nursing Cl",
+        "Adult Nursing I",
+        "Adult Nursing I Cl",
+        "Adult Nursing II"
+      ]
+    },
+    {
+      "prefix": "M",
+      "name": "M",
+      "course_count": 26,
+      "section_count": 117,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Applied Calculus",
+        "Calculus I",
+        "Calculus II",
+        "Co-Req Support for M 105",
+        "Co-req Support for M115/M140"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 40,
+      "section_count": 98,
+      "colleges": [
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Applied Music I",
+        "Applied Music II",
+        "Aural Perception I",
+        "Aural Perception II",
+        "Aural Perception IV"
+      ]
+    },
+    {
+      "prefix": "WRIT",
+      "name": "Writing",
+      "course_count": 11,
+      "section_count": 88,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "College Writing Co",
+        "College Writing I",
+        "College Writing I Studio",
+        "College Writing II",
+        "Composing Mindfully: Writ Fund"
+      ]
+    },
+    {
+      "prefix": "WLDG",
+      "name": "Welding",
+      "course_count": 26,
+      "section_count": 84,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Fabrication",
+        "Aluminum Welding Processes",
+        "Applied Metallurgy",
+        "Blueprint Rdng & Weldng Symbls",
+        "Fabrication Basics"
+      ]
+    },
+    {
+      "prefix": "NASD",
+      "name": "NASD",
+      "course_count": 40,
+      "section_count": 67,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "638 Contracts and Compacts",
+        "Beading",
+        "Cultural Resource Management",
+        "Dance Outfit Construction",
+        "Drumming and Singing"
+      ]
+    },
+    {
+      "prefix": "ARTZ",
+      "name": "ARTZ",
+      "course_count": 14,
+      "section_count": 53,
+      "colleges": [
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Ceramic Fundamentals",
+        "Ceramics I",
+        "Ceramics Studio: Tools & Tech",
+        "Ceramics Studio: Wheel Throw",
+        "Drawing I: Life Drawing"
+      ]
+    },
+    {
+      "prefix": "BIOH",
+      "name": "Human",
+      "course_count": 9,
+      "section_count": 52,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Phys II La",
+        "Basic Human Biology & Lab",
+        "Human Anat Phys I/Lab (= 301)",
+        "Human Anat Phys II & Lab(=311)",
+        "Human Anatomy & Physiology I (equiv to 301)"
+      ]
+    },
+    {
+      "prefix": "CHMY",
+      "name": "Chemistry",
+      "course_count": 17,
+      "section_count": 51,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Co-Req Support for CHMY 141",
+        "College Chem II Lab",
+        "College Chemistry I",
+        "College Chemistry I Lab",
+        "College Chemistry I w/Lab"
+      ]
+    },
+    {
+      "prefix": "SC",
+      "name": "SC",
+      "course_count": 32,
+      "section_count": 49,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Anato& Phys I/Lab",
+        "Anatomy & Phys Lab",
+        "Antmy/Phys II",
+        "Antmy/Phys II Lab",
+        "Chemistry"
+      ]
+    },
+    {
+      "prefix": "PSYX",
+      "name": "Psychology",
+      "course_count": 9,
+      "section_count": 48,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Developmental Psychology",
+        "Drugs and Society",
+        "Fund of Abnormal Psychology",
+        "Fund of Biological Psychology"
+      ]
+    },
+    {
+      "prefix": "BIOB",
+      "name": "BIOB",
+      "course_count": 17,
+      "section_count": 47,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Biotechnology BACE Preparation",
+        "Cellular and Molecular Biology",
+        "Discover Biology",
+        "Discover Biology Laboratory",
+        "Discover Biology/Lab"
+      ]
+    },
+    {
+      "prefix": "NASL",
+      "name": "Salish",
+      "course_count": 26,
+      "section_count": 43,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Adv Salish Immersion Lab - Spring I",
+        "Adv Salish Immersion Lab - SpringII",
+        "Adv Salish Immersion Lab - Summer I",
+        "Adv Salish Immersion Lab - Sumr II",
+        "Advanced Salish Language - Spring I"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "Crow",
+      "course_count": 22,
+      "section_count": 42,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Amer Ind Pol Sci",
+        "Anthro of Amer Ind",
+        "Apsaalooke Science",
+        "Contemporary Issues of Amer Indians",
+        "Conversational Crow"
+      ]
+    },
+    {
+      "prefix": "BLDG",
+      "name": "BLDG",
+      "course_count": 17,
+      "section_count": 40,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical",
+        "Basic Plumbing",
+        "Building Trades Practicum I",
+        "Building Trades Practicum II",
+        "Communication Employability Skills"
+      ]
+    },
+    {
+      "prefix": "HEO",
+      "name": "Commercial",
+      "course_count": 12,
+      "section_count": 40,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Commercial Drvr Licensd (Bus)",
+        "Commercial Transportation Basics",
+        "Commercial Transportation Basics Lab",
+        "Commercial Transportation of Hazardous Materials",
+        "Commercial Truck Driver"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 28,
+      "section_count": 39,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Action Research In Education",
+        "Computers in Education",
+        "CulturesDiversityAndEducactnlEthics",
+        "Curriculum",
+        "Diversity in Education Practicum"
+      ]
+    },
+    {
+      "prefix": "ECP",
+      "name": "ECP",
+      "course_count": 18,
+      "section_count": 37,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician",
+        "EMS Case Studies",
+        "EMS Operations",
+        "Field Experience: Clinical III",
+        "Hospital Clinical I"
+      ]
+    },
+    {
+      "prefix": "AHXR",
+      "name": "Radiographic",
+      "course_count": 22,
+      "section_count": 35,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Intro to Diagnostic Imaging",
+        "Intro to Radiologic Sciences",
+        "Patient Care in Radiology",
+        "Radiobiology/Radiation Protctn",
+        "Radiographic Clinical I"
+      ]
+    },
+    {
+      "prefix": "CAS",
+      "name": "CAS",
+      "course_count": 12,
+      "section_count": 35,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "dawson-community-college",
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Addiction Assess/Documentation",
+        "Addictions and Diversity",
+        "Assess and Case Mgmt Processes",
+        "Co-occurring Disorders in SAC",
+        "Fund Addic Couns"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 24,
+      "section_count": 35,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Catering",
+        "Artisan Breads",
+        "Baking and Pastry",
+        "Baking and Pastry II",
+        "Capstone"
+      ]
+    },
+    {
+      "prefix": "ELCT",
+      "name": "ELCT",
+      "course_count": 20,
+      "section_count": 35,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "AC Measurements",
+        "Advanced Current Theory",
+        "Basic Electricity I",
+        "Basic Industrial Controls",
+        "Basic Wiring"
+      ]
+    },
+    {
+      "prefix": "MCH",
+      "name": "MCH",
+      "course_count": 23,
+      "section_count": 34,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Adv Machining and Manufactur",
+        "Adv. CNC Lathe Ops.",
+        "Adv. CNC Mill Operations",
+        "Advanced CAD/CAM",
+        "Advanced Manual Lathe"
+      ]
+    },
+    {
+      "prefix": "COMX",
+      "name": "Public",
+      "course_count": 5,
+      "section_count": 33,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Interpersonal Communc",
+        "Intro to Public Speaking",
+        "Introduction to Public Speaking",
+        "Undergraduate Research: Communications Audit"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 7,
+      "section_count": 33,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Communication In The Workplace",
+        "Creative Writing I",
+        "English Composition 101 Tutorial",
+        "English Composition 202 Tutorial",
+        "English Composition 306 Tutorial"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 26,
+      "section_count": 33,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced Leadership RN/BSN",
+        "Critical Care Nursing",
+        "Culture and Caring",
+        "Diabetes Mellitus Type 2",
+        "Evidence-Based Practice"
+      ]
+    },
+    {
+      "prefix": "FORS",
+      "name": "FORS",
+      "course_count": 24,
+      "section_count": 32,
+      "colleges": [
+        "flathead-valley-community-college",
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "AdvancedSilvicultureAndEcosysMgmt",
+        "Basic Wildland Fire Training",
+        "Chainsaw/Crosscut Saw",
+        "Dendrology",
+        "Field Exper: Logging Resources"
+      ]
+    },
+    {
+      "prefix": "ITS",
+      "name": "ITS",
+      "course_count": 18,
+      "section_count": 32,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Networking",
+        "CCNA 1: Introduction to Networks",
+        "Cloud Systems",
+        "Computer Repair &amp; Maintenance",
+        "Cybersecurity Essentials"
+      ]
+    },
+    {
+      "prefix": "ACTG",
+      "name": "Accounting",
+      "course_count": 12,
+      "section_count": 31,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Accounting on Microcomputers",
+        "Accounting Procedures II",
+        "Adv Acct on Microcomputers",
+        "Applied Accounting",
+        "Computerized Accounting"
+      ]
+    },
+    {
+      "prefix": "SRVY",
+      "name": "SRVY",
+      "course_count": 18,
+      "section_count": 31,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Analyt Phot/ Rem Sens (= 375)",
+        "CAD for Surveying Profession",
+        "Capstone Surveying Seminar",
+        "GIS for Survey Analysis",
+        "GPS Mapping"
+      ]
+    },
+    {
+      "prefix": "LFSC",
+      "name": "LFSC",
+      "course_count": 21,
+      "section_count": 30,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced Microbiology",
+        "Biochemistry",
+        "Bioinformatics I",
+        "Bioinformatics II",
+        "Environmental Microbiology"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 18,
+      "section_count": 29,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Applied Mchn Lrng/Art Intel",
+        "Bsc Data Structures/Algorithms",
+        "Client Side Programming",
+        "Computational Thinking w/ lab",
+        "Databases and SQL"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Currclum IntegApp In Early Grade I",
+        "Early Childhood Advanced Practicum",
+        "Early Childhood Practicum",
+        "EarlyChildhoodCurriculumEnviromnts1",
+        "Fostering Phys Dev in Yng Children"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "Beginning",
+      "course_count": 5,
+      "section_count": 27,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Barre",
+        "Beginning Weight Training",
+        "Beginning Yoga",
+        "Functional Training",
+        "Logger Sports"
+      ]
+    },
+    {
+      "prefix": "BIOS",
+      "name": "Biology",
+      "course_count": 17,
+      "section_count": 27,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Anatomy And Physiology I",
+        "Anatomy And Physiology I Lab",
+        "Anatomy And Physiology III",
+        "Anatomy and Physiology III Lab",
+        "Biology of Living Systems"
+      ]
+    },
+    {
+      "prefix": "BUMG",
+      "name": "BUMG",
+      "course_count": 25,
+      "section_count": 27,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Ethics & Social Respons.",
+        "Business Law I",
+        "Business Law II",
+        "Career Planning"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "ED",
+      "course_count": 16,
+      "section_count": 27,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Children's Literature and Storytell",
+        "Crtive ExpresnPreSch",
+        "Education Intern",
+        "Education Technology",
+        "Except Learners/Lab"
+      ]
+    },
+    {
+      "prefix": "NATR",
+      "name": "NATR",
+      "course_count": 20,
+      "section_count": 27,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "AdvCartography And MapVisualization",
+        "Applied GIS and Spatial Systems",
+        "Comm Ecology Special Topics",
+        "DataAnalysisVisualization in NatRes",
+        "Ecological Statistics"
+      ]
+    },
+    {
+      "prefix": "AHMT",
+      "name": "Clinical",
+      "course_count": 10,
+      "section_count": 26,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Chemistry",
+        "Clinical Microbiology for MLT",
+        "Clinical: Medical Lab II MLT",
+        "Clinical: Medical Lab III MLT",
+        "Hematlgy/Coagulatn for the MLT"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Math",
+      "course_count": 15,
+      "section_count": 26,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Basic Math",
+        "Calculus I",
+        "College Algebra",
+        "Contemp Math",
+        "Contemp Math Lab"
+      ]
+    },
+    {
+      "prefix": "SCWK",
+      "name": "SCWK",
+      "course_count": 22,
+      "section_count": 26,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "AdvCounselingMethodsForNatAmClient",
+        "Adventure Based Counseling",
+        "DomesticVio: Break the Cyc of Abuse",
+        "Foster Care/Child Abuse & Neglect",
+        "Hum Behav & Soc Enviro II"
+      ]
+    },
+    {
+      "prefix": "CAPP",
+      "name": "CAPP",
+      "course_count": 8,
+      "section_count": 25,
+      "colleges": [
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college",
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Basic MS Office",
+        "Computer Applications",
+        "Computer Literacy for Allied Health",
+        "Computers for College Success",
+        "Electronic Presentations"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 11,
+      "section_count": 25,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Adv. Functions & Modeling",
+        "Calculus I",
+        "Calculus III",
+        "College Alegbra",
+        "Contemporary Math"
+      ]
+    },
+    {
+      "prefix": "AHMS",
+      "name": "Medical",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Basic Medical Coding",
+        "Career Essentials for Hlth Sci",
+        "Intro Mental Ill &amp; Addiction",
+        "Intro to Health Professions"
+      ]
+    },
+    {
+      "prefix": "FT",
+      "name": "Firearms",
+      "course_count": 15,
+      "section_count": 23,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Firearms Modification",
+        "Advanced Metal Finishing",
+        "Bench Metal Techniques",
+        "Checkering",
+        "Firearms Repair I"
+      ]
+    },
+    {
+      "prefix": "HPED",
+      "name": "HPED",
+      "course_count": 6,
+      "section_count": 23,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Beginning Golf",
+        "BeginningStregthTrainingConditionin",
+        "First Aid and CPR",
+        "Introduction to Disc Golf",
+        "Physical Fitness 1cr"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Creative Drama/Dance: K-8",
+        "Dramatic Literature",
+        "Introd to House Management",
+        "Introduction to Acting I",
+        "Introduction to Acting II"
+      ]
+    },
+    {
+      "prefix": "BGEN",
+      "name": "Business",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Applied Business Leadership",
+        "Business Fundamentals",
+        "Business Law",
+        "Business Math",
+        "Capstone: Business"
+      ]
+    },
+    {
+      "prefix": "COLS",
+      "name": "College",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Career Dev & Interpers Skills",
+        "College 101: Summer Experience",
+        "College Success Strategies",
+        "Core Experience",
+        "Hazard Communication Program"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "Photography",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Exploring Digital Photography",
+        "Inter Black - White Photo",
+        "Inter Digital Photography",
+        "Photoshop and Lightroom",
+        "The Magic of the Darkroom I"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "Sociology",
+      "course_count": 4,
+      "section_count": 21,
+      "colleges": [
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Juvenile Delinquency",
+        "Introduction to Sociology",
+        "Race, Gender, Class"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Statistics",
+      "course_count": 3,
+      "section_count": 21,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Biostatistics",
+        "Introduction to Statistics"
+      ]
+    },
+    {
+      "prefix": "AHPT",
+      "name": "AHPT",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Anat and Kinesio for the PTA",
+        "Clinical Experience I",
+        "Clinical Experience II",
+        "Clinical: Experience III",
+        "Intro to Physcl Thrpist Assist"
+      ]
+    },
+    {
+      "prefix": "ARTD",
+      "name": "ARTD",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Beginning Drawing",
+        "Beginning Silversmithing",
+        "Beginning Watercolor I",
+        "First Year Capstone",
+        "Fundamentals of Art and Design"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 17,
+      "section_count": 20,
+      "colleges": [
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "AST 136 Auto electrical/Electronic system",
+        "AST 137 Auto electrical/electronics system lab",
+        "Auto Trans/Transxls Lab",
+        "Auto Transmissions/Transaxles",
+        "Automotive Brakes"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 18,
+      "section_count": 20,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adv Research Methods in Psychology",
+        "Biological Psychology",
+        "Capstone II",
+        "ChildhoodTraumaSocialEmotionalDevel"
+      ]
+    },
+    {
+      "prefix": "ECNS",
+      "name": "Microeconomics",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Economic Way of Thinking",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics",
+        "Undergraduate Research"
+      ]
+    },
+    {
+      "prefix": "EDEC",
+      "name": "EDEC",
+      "course_count": 15,
+      "section_count": 19,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Administration of E C Programs",
+        "Creative Art for Develop Child",
+        "EC Curr Dsgn & Implemnt I",
+        "EC Developmental Themes",
+        "EC Fieldwork/Praciticum II"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Behavior Interventio",
+        "Eagle Online 01: Planning on Online Course",
+        "Eagle Online 02: Teaching an Online Course",
+        "Educational Psych Child Dev",
+        "Instructional Tech (=370)"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "CA",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Academic Literacy",
+        "College Writing I",
+        "College Writing II",
+        "Composition I",
+        "Fund of Pub Speaking"
+      ]
+    },
+    {
+      "prefix": "DDSN",
+      "name": "Drafting",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Civil Drafting",
+        "Introduction to CAD",
+        "SolidWorks",
+        "SolidWorks II",
+        "Technical Drafting"
+      ]
+    },
+    {
+      "prefix": "GDSN",
+      "name": "Digital",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Digital Illustration I",
+        "Digital Illustration II",
+        "Digital Imaging I",
+        "Digital Imaging II",
+        "Digital Portfolio Prep"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "LIT",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Children's Literatur",
+        "Intro to Lit",
+        "Intro to Science Fiction Lit",
+        "Mythologies",
+        "Poetry"
+      ]
+    },
+    {
+      "prefix": "NRMG",
+      "name": "NRMG",
+      "course_count": 14,
+      "section_count": 18,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced Fire Ecology",
+        "Advanced Topics In Hydrology",
+        "AdvancedTopicInWildlifeAndFisheries",
+        "AdvancedTopicsInForestManagement",
+        "AppliedPracticum InNaturalResources"
+      ]
+    },
+    {
+      "prefix": "BMGT",
+      "name": "Business",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Human Resource Management",
+        "Management",
+        "Sml Business Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "BU",
+      "name": "Business",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Business Law",
+        "Contemp Businss Math",
+        "Economic Way of Thinking",
+        "Intro Organiz Behav",
+        "Introduction to Business"
+      ]
+    },
+    {
+      "prefix": "SR",
+      "name": "SR",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Between the Wars: The Myth of American Isolationism",
+        "Birds of NW MT/Seniors",
+        "Creative Writing for Seniors",
+        "Desserts from Around the World",
+        "Digital Life Made Easy - Everyday Tech Skills"
+      ]
+    },
+    {
+      "prefix": "CJUS",
+      "name": "Criminal",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Criminal Evidence & Procedure",
+        "Intro to Criminal Justice",
+        "Intro to Judicial Function",
+        "Introduction to Policing",
+        "Police Organization"
+      ]
+    },
+    {
+      "prefix": "HVC",
+      "name": "Hvac",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Boiler Operator Certification",
+        "Gas Pipe Essentials",
+        "HVAC Electrical",
+        "HVAC Electrical II",
+        "HVAC Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CSTN",
+      "name": "CSTN",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Advanced Concrete Working",
+        "Blueprint Rdg, Codes, and Estm",
+        "Carp Basics &amp; Rough Frame Lab",
+        "Carpentry Bscs &amp; Rough-In Frmg",
+        "Construction Concepts & Builds"
+      ]
+    },
+    {
+      "prefix": "AHMA",
+      "name": "Clinical",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "MA in Healthcare Specialities",
+        "Med Asst Clinical Prcdrs I",
+        "Med Asst Clinical Prcdrs II",
+        "Medical Assisting Exam Prep",
+        "Medical Assisting Externship"
+      ]
+    },
+    {
+      "prefix": "AHST",
+      "name": "Surgical",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Surgical Clinical",
+        "Intro to Surgical Technology",
+        "Prof Dvlpmnt and Leadership",
+        "Surg Techniques I with Lab",
+        "Surg Techniques II"
+      ]
+    },
+    {
+      "prefix": "BIOM",
+      "name": "Microbiology",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Microbiology for Health Sciences",
+        "Microbiology for Health Sciences Lab",
+        "Microbiology for Hlth Sc",
+        "Microbiology Health"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced Chemistry",
+        "CollegeOrganicChemistryAndBiochem",
+        "Environmental Chemistry I",
+        "Environmental Toxicology and Chem",
+        "IntroTo Gen&OrganicChemAndBioChem"
+      ]
+    },
+    {
+      "prefix": "HW",
+      "name": "Only",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Advanced Strength Training/Conditio",
+        "Cardio-Training Walk, Jog, Run I",
+        "Cardio-Training Walk, Jog, Run II",
+        "Exercise for Elders",
+        "HW Men's Basketball"
+      ]
+    },
+    {
+      "prefix": "PHSX",
+      "name": "Physics",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "College Physics I w/Lab",
+        "College Physics II",
+        "Conceptual Physics",
+        "Gen Sci: Physical Science",
+        "Physics I (w/calculus)"
+      ]
+    },
+    {
+      "prefix": "PY",
+      "name": "PY",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Abnormal Psycology",
+        "Amer Ind Psych",
+        "Clinical Practicum",
+        "Educatnl Psych"
+      ]
+    },
+    {
+      "prefix": "WILD",
+      "name": "WILD",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "flathead-valley-community-college",
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced Fisheries",
+        "Aquatic Invertebrate Ecology",
+        "Aquatic Invertebrate Ecology Lab",
+        "Avian Studies",
+        "Biology of Fishes"
+      ]
+    },
+    {
+      "prefix": "CRWR",
+      "name": "Beginning",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "dawson-community-college",
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Fiction",
+        "Beginning Poetry",
+        "Intro Creative Writing Wrkshp",
+        "Intro Fiction Workshop",
+        "Intro Nonfiction Workshop"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Exercise Prescription & Health",
+        "HPP Clinical Lab",
+        "HPP Practicum I",
+        "HPP Practicum II",
+        "Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "ACTV",
+      "name": "Ivarsity",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Baseball I-Varsity",
+        "Baseball III-Varsity",
+        "Basketball I-Varsity",
+        "Basketball III-Varsity",
+        "Rodeo I-Varsity"
+      ]
+    },
+    {
+      "prefix": "BMKT",
+      "name": "Marketing",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Social Media Mktg",
+        "Marketing",
+        "Sales, Merchandising, & Retailing",
+        "Search Engine Marketing",
+        "Writing for Web Marketing"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "Electronics",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Adv Programmable Controllers",
+        "Advanced Electronics",
+        "Capstone: Electronics",
+        "Digital Electronics",
+        "Intro to Mechatronics"
+      ]
+    },
+    {
+      "prefix": "FTVP",
+      "name": "Photography",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Adv. Black & White Photography Lab",
+        "Advanced Black & White Photography",
+        "Digital Photography",
+        "Fundamental Video Production",
+        "Intermediate Photography (in B & W)"
+      ]
+    },
+    {
+      "prefix": "HSTR",
+      "name": "Western",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "The 20th Century World I",
+        "The 20th Century World II",
+        "Western Civilization I",
+        "Western Civilization II"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college",
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Basic Human Nutrition",
+        "Nutrition for the Health Profession"
+      ]
+    },
+    {
+      "prefix": "EDCI",
+      "name": "EDCI",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "AdvIntegraredLit I FieldExpPracticm",
+        "AdvIntegrated Lit I TeachrsChildrnW",
+        "AdvIntegratedLit I Know The Child",
+        "Applied Indigenous Knowledge Fall",
+        "Master's Project Design Development"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum",
+        "Drugs and Society",
+        "Elements Humn Relat",
+        "Fund of Counseling",
+        "Intro HmnSrv/Mntal H"
+      ]
+    },
+    {
+      "prefix": "HSTA",
+      "name": "History",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "American History I",
+        "American History II",
+        "Montana History"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Welfare",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Intro Soc Welfare",
+        "Intro Soc Wrk Pract",
+        "Introduction to Social Welfare"
+      ]
+    },
+    {
+      "prefix": "ANE",
+      "name": "ANE",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "(Milk Riv/Lit Riv La",
+        "(Milk River/Little R",
+        "(Sky) Lab",
+        "Intro to Ecology FM",
+        "Liv for the 7 Gener"
+      ]
+    },
+    {
+      "prefix": "BIOO",
+      "name": "BIOO",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Field Botany",
+        "General Botany (=320)",
+        "Intro to Ethnobotany",
+        "Introduction to Entomology",
+        "Practical Botany"
+      ]
+    },
+    {
+      "prefix": "EGEN",
+      "name": "Engineering",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Communications",
+        "Engineering Dynamics",
+        "Engineering Statics",
+        "Intro to General Engineering",
+        "Mechanics of Mtls (equiv 305)"
+      ]
+    },
+    {
+      "prefix": "ENSC",
+      "name": "ENSC",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "dawson-community-college",
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Environ Science Lab",
+        "Environmental Scienc",
+        "Environmental Science",
+        "Soils",
+        "Spec Topics Namibia"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "IS",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Foundatns/InfoSystms",
+        "GeographicInfoSystem",
+        "intro to Computer Hardware",
+        "Intro to Cybersecurity",
+        "Intro to NetWorking"
+      ]
+    },
+    {
+      "prefix": "MAST",
+      "name": "MAST",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "AnatomyAndPhysiologyMedicalAssistnt",
+        "Clinical Practicum & The JobSearch",
+        "Clinical Procedures I",
+        "Clinical Procedures III",
+        "HealthcareCommW/MedLegalEthicalCons"
+      ]
+    },
+    {
+      "prefix": "NRSM",
+      "name": "Resource",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Conservation Ecology",
+        "Montana Range Plants",
+        "Nat Resource Measurements I",
+        "Natural Resource Conservation",
+        "Natural Resource Ecology"
+      ]
+    },
+    {
+      "prefix": "PLUM",
+      "name": "Plumbing",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Intro to the Plumbing Trades",
+        "Plumbing Apprenticeship II",
+        "Plumbing Apprenticeship III",
+        "Plumbing Apprenticeship IV",
+        "Plumbing Apprenticeship V"
+      ]
+    },
+    {
+      "prefix": "PSCI",
+      "name": "American",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Intro to American Government",
+        "Intro to International Rel",
+        "Intro to Political Theory",
+        "Introduction to American Government"
+      ]
+    },
+    {
+      "prefix": "AC",
+      "name": "AC",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "chief-dull-knife-college",
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Adddiction Assessment and Appraisal",
+        "Addiction Counseling",
+        "Foundations of Art",
+        "Fundamentals & Theory of Group Coun",
+        "Fundamentals of Watercolor Painting"
+      ]
+    },
+    {
+      "prefix": "AIS",
+      "name": "AIS",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Aaniiih Hist & Cult",
+        "AIHEC Knowledge Bowl",
+        "Federal Indian Law",
+        "Intro to AIS",
+        "Nakoda History & Cul"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Field",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Adv Archaeological Field Methods",
+        "Indigenous Arch Field School I",
+        "Indigenous Arch Field School II",
+        "Introduction to Anthropology",
+        "Introduction to Archaeology"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Art of World Civilization I",
+        "Art of World Civilization II",
+        "Foundations of Art"
+      ]
+    },
+    {
+      "prefix": "DVSP",
+      "name": "DVSP",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Academic Literacy",
+        "Quantitative Reasoning",
+        "STEM Prep Math Skills"
+      ]
+    },
+    {
+      "prefix": "HMS",
+      "name": "HMS",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Assess Cas Manage L",
+        "Assess Case Manag",
+        "Cooperative Ed Inter",
+        "Intro Criminal Justi",
+        "Legal,Ethical&Profes"
+      ]
+    },
+    {
+      "prefix": "CDAR",
+      "name": "CDAR",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "CDAR Writing Tutorial Spring",
+        "Chem Depend Assessment & CM II",
+        "Chemical Dependency Counseling I",
+        "Chemical Dependency Counseling III",
+        "Co-Occuring Disorders in CD"
+      ]
+    },
+    {
+      "prefix": "DIGD",
+      "name": "Design",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced And Special Projects",
+        "Design Portfolio & PresentationCap",
+        "Design Project Management",
+        "Design Trends Seminar",
+        "Interactive Web Design"
+      ]
+    },
+    {
+      "prefix": "NLTE",
+      "name": "NLTE",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "CurrPlanAssesCultureLingRichContxts",
+        "DualLangLrnTheoryPracLangAcqusition",
+        "ParentCommPartnershipInNatvLanguage",
+        "Practicum for NLTE",
+        "ProIssuesEthicsNatLanguageEdSetting"
+      ]
+    },
+    {
+      "prefix": "ACSC",
+      "name": "ACSC",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Skills for College Success",
+        "Tribal Leaders Seminar",
+        "Writing Scholarship Essays"
+      ]
+    },
+    {
+      "prefix": "ANL",
+      "name": "Nakoda",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Aaniiih Lang IV/Lab",
+        "Aaniiih Language II",
+        "Aaniiih Nakoda Capst",
+        "Aaniiih/Nakoda C & P",
+        "Nakoda Lang II"
+      ]
+    },
+    {
+      "prefix": "ARTJ",
+      "name": "Jewelry",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "3D Jewelry Design & Model IV",
+        "Jewelry and Metalsmithing I",
+        "Jewelry and Metalsmithing II",
+        "Jewelry and Metalsmithing IV",
+        "Jewelry Repair I"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "dawson-community-college",
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Astronomy",
+        "Introduction to Astronomy Lab"
+      ]
+    },
+    {
+      "prefix": "CH",
+      "name": "Cheyenne",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Cheyenne Beadwork I",
+        "Cheyenne Language I",
+        "Cheyenne Language II",
+        "Cheyenne Storytelling",
+        "Ethnobotany"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Field Experience",
+        "Hardware/Security Sy",
+        "Intro Operation Sys",
+        "Intro to Computers",
+        "Software Application"
+      ]
+    },
+    {
+      "prefix": "CSCD",
+      "name": "Programming",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Database Concepts",
+        "Intro to DataVisualization&Analysis",
+        "Introduction to C Programming",
+        "Introduction to Java Programming",
+        "Programming I"
+      ]
+    },
+    {
+      "prefix": "GPHY",
+      "name": "Geography",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Geography of World Regions",
+        "Intro to GIS Science Cartog"
+      ]
+    },
+    {
+      "prefix": "HYDR",
+      "name": "Hydrology",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Applied Hydrology",
+        "Field Hydrology",
+        "Intro to Hydrology",
+        "Surface Water Groundwater Interact",
+        "Tribal Water Resource Management"
+      ]
+    },
+    {
+      "prefix": "LINE",
+      "name": "Line",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Line Ind Tools, Equipt, Mat",
+        "Line Indust Electrical Theory",
+        "Line Industry Gen Knowledge",
+        "Math For The Utility Industry",
+        "Pole Yard"
+      ]
+    },
+    {
+      "prefix": "MART",
+      "name": "Interactive",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Interactive Web I",
+        "Interactive Web II",
+        "Photoshop and Illustrator",
+        "Web Design"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "AG",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Intro to Animal Scie",
+        "Natural Resources Conservation",
+        "Principles of Rangeland Manage Lab",
+        "Range Livestock Production"
+      ]
+    },
+    {
+      "prefix": "ALLH",
+      "name": "Careerexplorationintrotodentalasst",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "CareerExploration:IntroToDentalAsst",
+        "CareerExplore:DentalReltdTheory II"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Animal",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology of Domestic Animals",
+        "Anatomy and Physiology of Domestic Animals Lab",
+        "Introduction to Animal Science"
+      ]
+    },
+    {
+      "prefix": "ANTY",
+      "name": "Anthro",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Anthro & the Human Experience",
+        "Culture & Society"
+      ]
+    },
+    {
+      "prefix": "BFIN",
+      "name": "Personal",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Fund of Entrepreneurial Fin",
+        "Personal Finance (equiv 305)"
+      ]
+    },
+    {
+      "prefix": "CJLE",
+      "name": "CJLE",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Comp Investigative Interview",
+        "Police Report Writing",
+        "Reserve Officer Training"
+      ]
+    },
+    {
+      "prefix": "EQUH",
+      "name": "Natural",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Natural Horsemanship",
+        "Livestock Handling and Ranch Roping",
+        "Natural Horsemanship: Harmony with your Horse I",
+        "Starting Colts",
+        "Western Equitation"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Geology of Northwest Montana",
+        "Intro to Physical Geologyw/Lab",
+        "Introduction to Physical Geology",
+        "Introduction to Physical Geology Laboratory"
+      ]
+    },
+    {
+      "prefix": "HU",
+      "name": "HU",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Amer Ind Rep in Film",
+        "Foundations of Art",
+        "Intro WorldReligions",
+        "Music Appreciation",
+        "Survey of Humanities"
+      ]
+    },
+    {
+      "prefix": "IDST",
+      "name": "IDST",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "SKC Seminar"
+      ]
+    },
+    {
+      "prefix": "NC",
+      "name": "Supplemental",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "NRSG 232 Foundations of Nursing Supplemental Nursing Lab",
+        "Nursing Pharmacology I Supplement",
+        "Pathophysiology I Supplement",
+        "Supplemental Instruction/Academic Support for Pre-Requisite Mathematics",
+        "Supplemental Writing Lab"
+      ]
+    },
+    {
+      "prefix": "OFED",
+      "name": "Office",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Accounting Software",
+        "Customer Service",
+        "Office CommunicationsAndProcedures",
+        "Office Essentials",
+        "Office Practicum"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Philosophy",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Ethics",
+        "Introduction to Ethics: Problems of Good and Evil",
+        "Introduction to Philosophy",
+        "Introduction to Philosophy: Reason and Reality"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "College Physics III",
+        "Physics Tutorial I"
+      ]
+    },
+    {
+      "prefix": "SCID",
+      "name": "SCID",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "IntegratedPerspctvsInScienceEduc I",
+        "IntegratedPerspctvsInScienceEducIII",
+        "IntoToScienceIndignsHealthWellBeing"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Communications",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Basic Communications",
+        "Professional Presentation Skills"
+      ]
+    },
+    {
+      "prefix": "SVLN",
+      "name": "Service",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Community Service Learning",
+        "Community Service Life Sciences",
+        "Service to the Environment I",
+        "Service to the Environment II"
+      ]
+    },
+    {
+      "prefix": "BCH",
+      "name": "Biochemistry",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Biochemistry (equiv BCH 380)"
+      ]
+    },
+    {
+      "prefix": "CTE",
+      "name": "Workforce",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Workforce Prep for Trades"
+      ]
+    },
+    {
+      "prefix": "DST",
+      "name": "Light",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "DST 260 Light duty Diesel Technologies",
+        "DST 265 Light duty Diesel Technologies"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Economic Development",
+        "International Trade",
+        "Macro Economics",
+        "PhilosophyAnd Politics of Economics"
+      ]
+    },
+    {
+      "prefix": "GNSD",
+      "name": "Citation",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "APA Citation Skills",
+        "Introduction to Grant Writing"
+      ]
+    },
+    {
+      "prefix": "HONR",
+      "name": "HONR",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Honors I: Comm Apocalypse",
+        "Honors I: Expl Psych in Art",
+        "Honors: Choices & Consequences",
+        "Honors: Science on Stage"
+      ]
+    },
+    {
+      "prefix": "HTH",
+      "name": "Health",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "flathead-valley-community-college",
+        "highlands-college-of-montana-tech",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Opport in Health Professions",
+        "Personal Health and Wellness",
+        "Pharmacology for HC Providers"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "ITEC",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Information Security",
+        "IT Soft Skills & Service Learning",
+        "Linux Client",
+        "Networking III"
+      ]
+    },
+    {
+      "prefix": "TRUK",
+      "name": "Training",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Basic CDL Training for Voc Training",
+        "Entry-Level Driver Training Theory",
+        "Intro to Truck Driving",
+        "Truck Driving Operation"
+      ]
+    },
+    {
+      "prefix": "AGSC",
+      "name": "Resources",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Ag & Env Resources"
+      ]
+    },
+    {
+      "prefix": "BIOE",
+      "name": "Environmental",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "flathead-valley-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science & Society Laboratory",
+        "Environmental Science and Society",
+        "Introductory Ecology"
+      ]
+    },
+    {
+      "prefix": "CALS",
+      "name": "CALS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "AdvAppIntSelisQlspCltLangSpngPractc",
+        "AdvIntegSelisQlispeCultrLangCap III",
+        "IntegSelisQlispeCultureLangLabSp II"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Jazz",
+        "Intro to Modern Dance"
+      ]
+    },
+    {
+      "prefix": "EELE",
+      "name": "Circuits",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Circuits I for Engineering",
+        "Intro to Logic Circuits"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Fluvial",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Fluvial Geomorphology",
+        "Physical Geology and Lab"
+      ]
+    },
+    {
+      "prefix": "GH",
+      "name": "Western",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Intro Western Humanities Ant",
+        "Intro Western Humanities Mod"
+      ]
+    },
+    {
+      "prefix": "GRMG",
+      "name": "Grant",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Grant Capstone",
+        "Grant Submission Fundamentals",
+        "Introduction to Grant Funding"
+      ]
+    },
+    {
+      "prefix": "GS",
+      "name": "Student",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Finding Place",
+        "Student Government"
+      ]
+    },
+    {
+      "prefix": "HE",
+      "name": "Core",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Core Health Concepts",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "HEE",
+      "name": "Hlth",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Hlth Issues of Child & Adoles",
+        "Instl Strat Elem PE"
+      ]
+    },
+    {
+      "prefix": "HI",
+      "name": "History",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "U S History 1",
+        "Wrld Civl since 1500"
+      ]
+    },
+    {
+      "prefix": "HMNT",
+      "name": "Humanities",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Introduction to Humanities",
+        "Social and Environmental Ethics"
+      ]
+    },
+    {
+      "prefix": "MLS",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy Fundamentals",
+        "Phlebotomy Fundamentals Lab",
+        "Phlebotomy Internship"
+      ]
+    },
+    {
+      "prefix": "MU",
+      "name": "Music",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Beginning Instrumental Studio: Guitar",
+        "General Music Pre-K to 8",
+        "Individual Music Lessons"
+      ]
+    },
+    {
+      "prefix": "NASX",
+      "name": "Native",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "dawson-community-college",
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Native American Studies"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "aaniiih-nakoda-college",
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Introduction to Philosophy",
+        "Land Ethics"
+      ]
+    },
+    {
+      "prefix": "SCLG",
+      "name": "Sociology",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sociology",
+        "Social Psychology"
+      ]
+    },
+    {
+      "prefix": "SPNS",
+      "name": "Spanish",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish II"
+      ]
+    },
+    {
+      "prefix": "UASO",
+      "name": "Remote",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Remote Pilot Ground School",
+        "UnmannedAerialSystemsBasicFlightOpr"
+      ]
+    },
+    {
+      "prefix": "BMIS",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "MIS Foundations for Business"
+      ]
+    },
+    {
+      "prefix": "BT",
+      "name": "Building",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Building Maintenance",
+        "HVAC"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Intro to Marketing",
+        "Workplace Ethics/Con"
+      ]
+    },
+    {
+      "prefix": "COOP",
+      "name": "Upper",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Advanced Internship",
+        "Upper Division Internship"
+      ]
+    },
+    {
+      "prefix": "EWLD",
+      "name": "Code",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "AWS D1.1 Code Book"
+      ]
+    },
+    {
+      "prefix": "HCTP",
+      "name": "Transitiontothehighwayconstindustry",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "HCT Advanced Field Experience",
+        "TransitionToTheHighwayConstIndustry"
+      ]
+    },
+    {
+      "prefix": "HEOP",
+      "name": "Heavy",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Heavy Equipment Operations",
+        "Heavy Equipment Operations Theory"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "American History since 1877",
+        "World History since 1500"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Electr Health Rec in Med Prac"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Intro to Humanities"
+      ]
+    },
+    {
+      "prefix": "KIN",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Exercise Science",
+        "Foundations of Exercise Science Lab"
+      ]
+    },
+    {
+      "prefix": "LS",
+      "name": "Stem",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "STEM Literacy and Research"
+      ]
+    },
+    {
+      "prefix": "NS",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Introduction to American Indian Art",
+        "Introduction to Native American Studies"
+      ]
+    },
+    {
+      "prefix": "NTS",
+      "name": "Ccna",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "CCNA 1: Intro to Networks",
+        "CCNA 3: Scaling Networks"
+      ]
+    },
+    {
+      "prefix": "RUSS",
+      "name": "Russian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Russian I",
+        "Elementary Russian II"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "Sign",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Intermediate Am Sign Lang",
+        "Intro to American Sign Lang"
+      ]
+    },
+    {
+      "prefix": "SS",
+      "name": "Sociology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Intro to Sociology"
+      ]
+    },
+    {
+      "prefix": "TRHP",
+      "name": "Tribal",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Capstone in Tribal Heritage Preserv",
+        "Intro Tribal Heritage Preservation"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Welding Theory"
+      ]
+    },
+    {
+      "prefix": "AD",
+      "name": "Counseling",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Principles of Counseling & Group Theory"
+      ]
+    },
+    {
+      "prefix": "AGED",
+      "name": "Agricultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural Internship"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Medical Coding Test Prep"
+      ]
+    },
+    {
+      "prefix": "AHHS",
+      "name": "Behav",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Behav Hlth Legal &amp; Ethical Iss"
+      ]
+    },
+    {
+      "prefix": "AN",
+      "name": "Cultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Cultural Anthro"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Science Storytelling"
+      ]
+    },
+    {
+      "prefix": "CP",
+      "name": "Programming",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "Intro to Programming"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "Microeconomics",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Microeconomics"
+      ]
+    },
+    {
+      "prefix": "EDSP",
+      "name": "Teaching",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Teaching Exceptional Learners"
+      ]
+    },
+    {
+      "prefix": "EMEC",
+      "name": "Mech",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Mech Engineering Materials"
+      ]
+    },
+    {
+      "prefix": "ENST",
+      "name": "Impact",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Env Pol Impact Analysis (=385)"
+      ]
+    },
+    {
+      "prefix": "EPYC",
+      "name": "Exceptional",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Exceptional Children"
+      ]
+    },
+    {
+      "prefix": "EQUS",
+      "name": "Equine",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Equine Studies"
+      ]
+    },
+    {
+      "prefix": "ERTH",
+      "name": "Earth",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Earth Systems Science"
+      ]
+    },
+    {
+      "prefix": "ETCC",
+      "name": "Concrete",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "highlands-college-of-montana-tech"
+      ],
+      "sample_titles": [
+        "Concrete Technology"
+      ]
+    },
+    {
+      "prefix": "FLAG",
+      "name": "Flagger",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Flagger Training for HCT"
+      ]
+    },
+    {
+      "prefix": "FRCH",
+      "name": "French",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Elementary French II"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Introduction to Geography"
+      ]
+    },
+    {
+      "prefix": "HIEP",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salish-kootenai-college"
+      ],
+      "sample_titles": [
+        "Medical Office Foundations"
+      ]
+    },
+    {
+      "prefix": "ITLN",
+      "name": "Italian",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Italian I"
+      ]
+    },
+    {
+      "prefix": "LA",
+      "name": "Liberal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Liberal Arts Capston"
+      ]
+    },
+    {
+      "prefix": "LSCI",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Information Literacy"
+      ]
+    },
+    {
+      "prefix": "LSH",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "miles-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to the Humanities Contemporary Arts and Literature"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "Comparative",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Introduction to Comparative Government"
+      ]
+    },
+    {
+      "prefix": "PTRM",
+      "name": "Recreation",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "flathead-valley-community-college"
+      ],
+      "sample_titles": [
+        "Recreation Management"
+      ]
+    },
+    {
+      "prefix": "RS",
+      "name": "World",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chief-dull-knife-college"
+      ],
+      "sample_titles": [
+        "Introduction to World Religions"
+      ]
+    },
+    {
+      "prefix": "SOCL",
+      "name": "Race",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "aaniiih-nakoda-college"
+      ],
+      "sample_titles": [
+        "Race Class & Gender"
+      ]
+    },
+    {
+      "prefix": "TRD",
+      "name": "Osha",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "little-big-horn-college"
+      ],
+      "sample_titles": [
+        "OSHA 10"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/nd/subject-vocab.json
+++ b/data/nd/subject-vocab.json
@@ -1,0 +1,2250 @@
+{
+  "state": "nd",
+  "generated_at": "2026-06-06T15:41:40.472Z",
+  "subjects": [
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 27,
+      "section_count": 324,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "- Human Anatomy & Physiology II",
+        "Anatomy & Physiology I L/L",
+        "Anatomy & Physiology II L/L",
+        "Anatomy and Physiology I Lab",
+        "Anatomy and Physiology II Lab"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 23,
+      "section_count": 261,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Applied Algebra",
+        "Applied Calculus I",
+        "Basic Mathematics I",
+        "Basic Mathematics II",
+        "Basic Mathematics III"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 48,
+      "section_count": 260,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Activity: Intermediate Level",
+        "Activity: Introductory Level",
+        "Coaching Practicum",
+        "Concepts of Fitness and Wellness",
+        "Cooperative Education/Internship"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 17,
+      "section_count": 258,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Alternative Literature",
+        "American Literature II",
+        "Children's Literature",
+        "College Composition I",
+        "College Composition II"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 53,
+      "section_count": 183,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Excel Spreadsheets / Business Analytics",
+        "Application Design",
+        "CCNA Cybersecurity Operations",
+        "Computer and Network Security",
+        "Computer Information Systems Capstone"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 35,
+      "section_count": 180,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Adult Health Nursing",
+        "Alterations in Health II",
+        "Alterations ins Health Care I",
+        "Clinical Applications I",
+        "Clinical Applications II"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 10,
+      "section_count": 133,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "- Developmental Psychology",
+        "Developmental Psychology",
+        "Educational Psychology",
+        "Human Relations In Organizations",
+        "Introduction to Behavior Modification"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 22,
+      "section_count": 122,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Video Production",
+        "Basic Video Production",
+        "Communication and Interviewing",
+        "Communication Capstone",
+        "Cooperative Education/Internship"
+      ]
+    },
+    {
+      "prefix": "BADM",
+      "name": "BADM",
+      "course_count": 28,
+      "section_count": 104,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advertising Campaigns",
+        "Advertising I",
+        "Business Ethics",
+        "Career Seminar",
+        "Collegiate DECA"
+      ]
+    },
+    {
+      "prefix": "ASC",
+      "name": "ASC",
+      "course_count": 11,
+      "section_count": 89,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Beginning Algebra",
+        "College Algebra Co-Req",
+        "College Writing Preparation",
+        "Composition Lab",
+        "Composition Support"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "AH",
+      "course_count": 32,
+      "section_count": 85,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Applied Healthcare Statistics",
+        "Clinical Procedures",
+        "Clinical Specialties",
+        "Computer Applications in Health Care",
+        "Cooperative Education/Internship"
+      ]
+    },
+    {
+      "prefix": "ENRT",
+      "name": "ENRT",
+      "course_count": 19,
+      "section_count": 82,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Applied Electronics",
+        "Automation and Control",
+        "Boiler Operations",
+        "DC Fundamentals"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 14,
+      "section_count": 82,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "American Studies 1",
+        "History of the American Frontier",
+        "History Of The Lewis & Clark Expedition",
+        "North Dakota History",
+        "Special Topics in History"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 15,
+      "section_count": 81,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Elements of Biochemistry",
+        "General Chemistry I L/L",
+        "General Chemistry I Lab",
+        "General Chemistry II",
+        "General Chemistry II Laboratory"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 24,
+      "section_count": 73,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Applied Music - Major",
+        "Applied Music (Private Instrumental Lessons) (1/term)",
+        "Applied Music (Private Voice Lessons)",
+        "Aural Skills II",
+        "Band"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 10,
+      "section_count": 69,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "American Indian Studies",
+        "Criminology",
+        "Cultural Diversity",
+        "Gerontology",
+        "Introduction to Sociology"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 44,
+      "section_count": 68,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Provider Practicum II",
+        "Airway Management and Ventilation",
+        "Airway/ventilatory Management",
+        "Cardiac Emergencies I",
+        "Cardiac Emergencies II"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 18,
+      "section_count": 65,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Accounting Information Systems",
+        "Analysis of Business Decisions",
+        "Applied Accounting",
+        "Business in the Legal Environment",
+        "Business Law I"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 20,
+      "section_count": 64,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Art History I",
+        "Art History II",
+        "Ceramics I",
+        "Ceramics II",
+        "Crafts I"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 14,
+      "section_count": 64,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Beginning Basic/Visual Basic",
+        "Beginning C++/Visual C++",
+        "Beginning Generative AI",
+        "Computer Science I",
+        "Computer Science II"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 20,
+      "section_count": 64,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "AC Analysis",
+        "AC Analysis Lab",
+        "AC Analysis/Lab",
+        "Active Devices",
+        "Active Devices Lab"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 26,
+      "section_count": 52,
+      "colleges": [
+        "bismarck-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Methods in GMAW and FCAW",
+        "Advanced Methods in GTAW",
+        "Advanced Methods in SMAW Operations",
+        "Advanced Welding Technology and Manufacturing Lab",
+        "Beginning Fabrication Lab"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 36,
+      "section_count": 51,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "A/C & Heating Diagnosis",
+        "A/C Heating Theory and Operation",
+        "Advanced Automotive Electronics",
+        "Automatic Transmission Diagnosis and Repair",
+        "Automatic Transmission Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 51,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "- Principles of Macroeconomics",
+        "Elements of Economics",
+        "Financial Econometrics and Computational Methods",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 17,
+      "section_count": 51,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Assisting Academic Instruction Experience",
+        "Assisting Math Instruction",
+        "Assisting Reading & Language Arts Instruction",
+        "Classroom Management",
+        "Curriculum and Instruction"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 13,
+      "section_count": 48,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "College Physics I Lab",
+        "College Physics II",
+        "College Physics II Lab",
+        "Concepts of Physics"
+      ]
+    },
+    {
+      "prefix": "DTEC",
+      "name": "Systems",
+      "course_count": 29,
+      "section_count": 46,
+      "colleges": [
+        "bismarck-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Air Brake Service",
+        "Air Conditioning for Diesel Technology",
+        "Diesel Engine Diag/Repair",
+        "Diesel Engine Diag/Repair Lab",
+        "Diesel Equipment Maintenance"
+      ]
+    },
+    {
+      "prefix": "ELPW",
+      "name": "ELPW",
+      "course_count": 19,
+      "section_count": 43,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrical Systems",
+        "Advanced Math",
+        "Advanced Metering Technology",
+        "Civil Design",
+        "Electric Distribution Systems"
+      ]
+    },
+    {
+      "prefix": "GDES",
+      "name": "GDES",
+      "course_count": 25,
+      "section_count": 43,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education/Internship",
+        "Current Imaging I",
+        "Current Imaging I Lab",
+        "Current Imaging II",
+        "Current Imaging II Lab"
+      ]
+    },
+    {
+      "prefix": "ECAL",
+      "name": "Electrical",
+      "course_count": 15,
+      "section_count": 40,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Advanced Drives/Lab",
+        "Advanced Electrical Code Study",
+        "Alternating Current (AC) Fundamentals",
+        "Automated Industrial Controls Lab",
+        "Basic Motor Controls Lab"
+      ]
+    },
+    {
+      "prefix": "UNIV",
+      "name": "College",
+      "course_count": 7,
+      "section_count": 36,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "College Strategies",
+        "College Study Skills",
+        "College Success",
+        "First Year Experience",
+        "Leadership Through Service I"
+      ]
+    },
+    {
+      "prefix": "ICTL",
+      "name": "ICTL",
+      "course_count": 12,
+      "section_count": 35,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Automation Overview",
+        "Automation Overview Lab",
+        "Controls",
+        "Controls Lab",
+        "Input and Output Devices"
+      ]
+    },
+    {
+      "prefix": "BOTE",
+      "name": "BOTE",
+      "course_count": 8,
+      "section_count": 34,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Mathematics",
+        "Business Portfolio",
+        "Internship",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "AGEC",
+      "name": "Management",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Agribusiness Internship Orientation II",
+        "Agribusiness Management and Entrepreneurship",
+        "Agribusiness Sales",
+        "Agricultural Accounting",
+        "Agricultural Communication and Marketing"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 10,
+      "section_count": 32,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Creativity and Innovation in Business",
+        "Electronic Commerce (E-Commerce)",
+        "Entrepreneurial Perspectives",
+        "Entrepreneurial Small Business Strategies",
+        "Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 12,
+      "section_count": 31,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advance Adult Farm Management Education",
+        "Advanced Agronomy- Fall Operations",
+        "Advanced Precision Agriculture: Fall Operations",
+        "Advanced Precision Agriculture: Spring Operations",
+        "Agricultural Cooperative Internship"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Administration of Justice",
+        "Cooperative Education/Internship",
+        "Criminal Evidence and Procedure",
+        "Criminal Law",
+        "Defensive Tactics"
+      ]
+    },
+    {
+      "prefix": "ETST",
+      "name": "Power",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Electrical Diagram Interpretation",
+        "Electrical Generation Theories",
+        "Interconnected System Operations",
+        "Power Flow",
+        "Power Industry Concepts"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "ANSC",
+      "course_count": 12,
+      "section_count": 29,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Animal Reproduction",
+        "Applied Livestock Feeding",
+        "Equine Nutrition",
+        "Feeds and Feeding",
+        "Feeds and Feeding Lab"
+      ]
+    },
+    {
+      "prefix": "PLSC",
+      "name": "PLSC",
+      "course_count": 14,
+      "section_count": 28,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Crop Production",
+        "Advanced Weed Science",
+        "Applied Agronomy",
+        "Crop Technologies",
+        "Field Scouting Techniques"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 27,
+      "section_count": 27,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography I",
+        "Abdominal Sonography I Lab",
+        "Abdominal Sonography II",
+        "Abdominal Ultrasound III",
+        "Abdominal Ultrasound III Lab"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 6,
+      "section_count": 27,
+      "colleges": [
+        "bismarck-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education/Internship",
+        "First Year Spanish I",
+        "First Year Spanish II",
+        "Independent Study",
+        "Second Year Spanish I"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 11,
+      "section_count": 25,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Financial Management",
+        "Business Finance",
+        "Cases in Finance and Risk",
+        "Cooperative Education/Internship",
+        "Financial Markets and Institutions"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 5,
+      "section_count": 25,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Contemporary Moral Issues",
+        "Ethics",
+        "Ethics in Artificial Intelligence (AI)",
+        "Introduction to Logic",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "BCT",
+      "name": "BCT",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Carpentry Fundamentals",
+        "Commercial Finishes",
+        "Commercial Print Reading",
+        "Exterior Finish Construction",
+        "Finish Carpentry"
+      ]
+    },
+    {
+      "prefix": "ENRG",
+      "name": "Energy",
+      "course_count": 10,
+      "section_count": 24,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Energy Economics and Finance",
+        "Energy Management Communications",
+        "Energy Markets and Structures",
+        "Energy Production and the Environment",
+        "Ethical Issues in the Energy Industry"
+      ]
+    },
+    {
+      "prefix": "MICR",
+      "name": "Introductory",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "bismarck-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Introductory Microbiology",
+        "Introductory Microbiology Lab"
+      ]
+    },
+    {
+      "prefix": "MLS",
+      "name": "MLS",
+      "course_count": 22,
+      "section_count": 23,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Clinical Chemistry",
+        "Clinical Chemistry Laboratory",
+        "Clinical Experience II",
+        "Clinical Immunology",
+        "Clinical Microbiology"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "NUTR",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Eating Disorders",
+        "Herbs & Supplements",
+        "Human Lactation",
+        "Human Lactation I",
+        "Human Lactation II"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Arts Entrepreneurship and Management",
+        "Experimental Course",
+        "Introduction to Arts Management",
+        "Introduction to Theatre Arts"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "UAS",
+      "course_count": 17,
+      "section_count": 22,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Flight I",
+        "Advanced Flight II",
+        "Basic UAS Flight Training",
+        "Capstone Project",
+        "Commercial UAS Applications"
+      ]
+    },
+    {
+      "prefix": "LNWK",
+      "name": "Electrical",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Distribution Overhead Construction",
+        "Applied Electrical Distribution I",
+        "Applied Electrical Distribution II",
+        "Basic Electricity and Field Safety",
+        "Electrical Apparatus and Transformers"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 4,
+      "section_count": 21,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "American Constitution-Civil Liberties",
+        "American Government",
+        "State and Local Government",
+        "Student Senate"
+      ]
+    },
+    {
+      "prefix": "CT",
+      "name": "CT",
+      "course_count": 20,
+      "section_count": 20,
+      "colleges": [
+        "bismarck-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Advanced Boundary Surveying",
+        "Applied Statics and Mechanics of Materials",
+        "Applied Statics and Mechanics of Materials Lab",
+        "Boundary and Cadastral Surveying",
+        "Construction Project Management"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Cloud Computing Fundamentals",
+        "Cooperative Education/Internship",
+        "Cybersecurity Prevention & Countermeasures",
+        "Data Center Virtualization Fundamentals",
+        "Database and Web Application Security"
+      ]
+    },
+    {
+      "prefix": "EC",
+      "name": "EC",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Administration and Leadership in Early Childhood Education",
+        "Early Childhood Internship",
+        "Home, School & Comm Relations",
+        "Infants and Toddlers",
+        "Introduction to Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "Print",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Fabrication Methods I",
+        "Industrial Shop Practices",
+        "Print Reading I",
+        "Print Reading II",
+        "Robotics I"
+      ]
+    },
+    {
+      "prefix": "PRMT",
+      "name": "Pharmacy",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Chemical/Physical Pharmacy",
+        "Chemical/Physical Pharmacy Lab",
+        "IV and Sterile Product Preparation",
+        "IV and Sterile Product Preparation Lab",
+        "Orientation to Pharmacy Practice"
+      ]
+    },
+    {
+      "prefix": "SRGT",
+      "name": "Surgical",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Operating Room Materials",
+        "Introduction to Operating Room Procedures",
+        "Introduction to Operating Room Procedures and Materials Lab",
+        "Introduction to Pharmacology for Surgical Technology",
+        "Introduction to Surgical Technology"
+      ]
+    },
+    {
+      "prefix": "CMT",
+      "name": "Construction",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "bismarck-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Building Electrical/Mechanical Systems",
+        "Codes and Inspections",
+        "Construction Diagrams",
+        "Construction Document Management",
+        "Construction Estimating I"
+      ]
+    },
+    {
+      "prefix": "SOIL",
+      "name": "Soil",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Soil Science",
+        "Introduction to Soil Science Lab",
+        "Soil Fertility and Fertilizers",
+        "Soil Fertility and Fertilizers Lab"
+      ]
+    },
+    {
+      "prefix": "AI",
+      "name": "Artificial",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Artificial Intelligence",
+        "Artificial Intelligence Capstone Project",
+        "Artificial Intelligence for Business Solutions",
+        "Introduction to Artificial Intelligence",
+        "Introduction to Computer Vision"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Dynamics",
+        "Introduction to Engineering",
+        "Mechanics of Materials",
+        "Statics",
+        "Surveying I"
+      ]
+    },
+    {
+      "prefix": "PHRM",
+      "name": "Pharmacology",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Introduction to Pharmacology",
+        "Pharmacology for Pharmacy Technicians I",
+        "Pharmacology for Pharmacy Technicians II"
+      ]
+    },
+    {
+      "prefix": "PROP",
+      "name": "Refinery",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Distillation and Refinery Operations",
+        "Ethanol and Biofuels Production",
+        "Gas Processing and Carbon Capture",
+        "Hydrocarbon Chemistry",
+        "Refinery, Ethanol and Distillation"
+      ]
+    },
+    {
+      "prefix": "ARCT",
+      "name": "ARCT",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Architectural Modeling II",
+        "Architectural Modeling IV",
+        "Architectural Portfolio",
+        "Architectural Presentations",
+        "AutoCAD for Architecture"
+      ]
+    },
+    {
+      "prefix": "DAST",
+      "name": "DAST",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "dakota-college-at-bottineau",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Advanced Functions",
+        "Biodental Science",
+        "Clinical Affiliation I",
+        "Clinical Assisting II",
+        "Clinical Training I"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "DHYG",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "dakota-college-at-bottineau",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Clinic I",
+        "Clinic I Lab",
+        "Clinic II",
+        "Head and Neck Anatomy",
+        "Oral Histology & Embryology"
+      ]
+    },
+    {
+      "prefix": "HEO",
+      "name": "HEO",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Basic Equipment Theory",
+        "Basic Equipment Theory Lab",
+        "Construction Solutions and Communication",
+        "Excavation and Trenching Operations",
+        "Grading and Dozer Operations"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "Fieldwork",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Behavioral Health: Theory/Practice-Children and Adolescents",
+        "Documentation",
+        "Fieldwork Level I - Experience II",
+        "Fieldwork Level I-Experience I",
+        "Fieldwork Level II: Experience I"
+      ]
+    },
+    {
+      "prefix": "WNDT",
+      "name": "WNDT",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Troubleshooting",
+        "Electricity I",
+        "Electricity II",
+        "Fault Analysis and Quality Improvement",
+        "Hydraulic Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ABOD",
+      "name": "ABOD",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "bismarck-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Advanced Damage Analysis Lab II",
+        "Auto Body Welding",
+        "Component Parts-Replacement and Adjustment",
+        "Estimating and Job Costing",
+        "Intermediate Metal Finishing"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III",
+        "American Sign Language IV",
+        "Finger Spelling and Numbers"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "CARP",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Cabinetmaking",
+        "Core Curriculum",
+        "Exterior Finish",
+        "Framing & Exterior Finish II"
+      ]
+    },
+    {
+      "prefix": "ELTR",
+      "name": "Electrical",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrical Concepts",
+        "Blueprints and Diagrams",
+        "Commercial/Industrial Wiring",
+        "Conduits and Practical Skills",
+        "Electrical Industry and Safety"
+      ]
+    },
+    {
+      "prefix": "RAMT",
+      "name": "RAMT",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "3D Modeling and Design",
+        "Applied DC Theory",
+        "Capstone Project",
+        "Digital and Pneumatic Systems",
+        "Drives and Servo Systems"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Culinary Mathematics",
+        "Fish and Shellfish Cookery",
+        "Garde Manager",
+        "Gourmet Foods/Catering & Banquet Service",
+        "Intro to Restaurant Operations"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "bismarck-state-college",
+        "dakota-college-at-bottineau",
+        "north-dakota-state-college-of-science",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "- Water, Land and People",
+        "- Water, Land, and People Lab",
+        "Environmental Geology",
+        "Physical Geology L/L",
+        "Physical Geology Lab"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education/Internship",
+        "Logistics and Supply Chain Management",
+        "Operations Management",
+        "Project Management Fundamentals",
+        "Quality Practices & Measurement"
+      ]
+    },
+    {
+      "prefix": "PWRP",
+      "name": "Protection",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Boilers & Environmental Protection",
+        "Power Generation Components and Protection",
+        "Turbines and Combined Cycle"
+      ]
+    },
+    {
+      "prefix": "ESRE",
+      "name": "Systems",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Analog PLCs",
+        "Distributed Power Systems",
+        "Hydraulic Fundamentals",
+        "Mechanical Drive Systems"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Basic DiagnosisCoding",
+        "Basic Procedure Coding",
+        "Health Law, Privacy and Ethics",
+        "Healthcare Delivery Systems",
+        "Intermediate Diagnosis Coding"
+      ]
+    },
+    {
+      "prefix": "HMSV",
+      "name": "Assistance",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Child Care Assistance",
+        "Cooperative Education/Internship",
+        "Introduction to Addictions",
+        "Low Income Home Energy Assistance (LIHEAP)",
+        "Medicaid I"
+      ]
+    },
+    {
+      "prefix": "JDAT",
+      "name": "John",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Internship II",
+        "Introduction to Ag Management Solutions (AMS)",
+        "Introduction to Electrical/Electronics",
+        "Introduction to John Deere Hydraulic Systems",
+        "John Deere Engine Rebuild"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "System",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Input and Output System Application",
+        "Input and Output System Application Lab",
+        "Integrated Engineering Sciences",
+        "Integrated Engineering Sciences Lab",
+        "Mechatronic System Design"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "FIRE",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Auto Extrication",
+        "Cooperative Education",
+        "Fire Department Emergency Vehicle Operations Course (EVOC)",
+        "Fire Fighter II",
+        "Firefighter Safety and Survival"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Geospatial Technologies",
+        "Physical Geography",
+        "Physical Geography Lab",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "SPED",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "dakota-college-at-bottineau",
+        "lake-region-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Exceptional Children",
+        "Introduction to Positive Behavior Support",
+        "Special Needs in Early Childhood Education"
+      ]
+    },
+    {
+      "prefix": "CD",
+      "name": "Child Development",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Speech Language Pathology Paraprofessionals",
+        "Language Disorders and Intervention for the Speech Language Pathology Paraprofessional",
+        "Language Theory & Treatment for the Speech Language Pathology Paraprofessional",
+        "Practicum",
+        "Survey of Communication Disorders"
+      ]
+    },
+    {
+      "prefix": "DCAT",
+      "name": "DCAT",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Caterpillar Engine Fundamentals",
+        "Diagnostic Testing",
+        "Engine Performance",
+        "Fundamentals of Hydraulics",
+        "Internship II"
+      ]
+    },
+    {
+      "prefix": "PAG",
+      "name": "Precision",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Advanced Mapping",
+        "Data Collection and Management",
+        "Introduction to Precision Agriculture",
+        "Mapping of Precision Agriculture Data"
+      ]
+    },
+    {
+      "prefix": "PLMB",
+      "name": "Plumbing",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Blueprint Reading I",
+        "Blueprint Reading II",
+        "Plumbing Code III",
+        "Plumbing Code IV",
+        "Plumbing Lab III"
+      ]
+    },
+    {
+      "prefix": "PST",
+      "name": "Technology",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Cooperative Education",
+        "OPE and Snowmobile Fuel Systems",
+        "Outboard Fuel Systems",
+        "Outboard Technology",
+        "Snowmobile Technology I"
+      ]
+    },
+    {
+      "prefix": "AIR",
+      "name": "AIR",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Aircraft Electrical Systems",
+        "Flight Controls",
+        "Hydraulic and Pneumatic Systems",
+        "Landing Gear",
+        "Metallic Structures"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "Employment",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Employee and Labor Relations",
+        "Employment Life Cycle",
+        "Employment Policy Administration",
+        "Employment Training and Development",
+        "Human Relations in Organizations"
+      ]
+    },
+    {
+      "prefix": "REFG",
+      "name": "Heating",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Advanced Residential Systems",
+        "Commercial Refrigeration II",
+        "Electric & Oil Heating",
+        "Gas Heating",
+        "Hydronic Heating Systems"
+      ]
+    },
+    {
+      "prefix": "RELS",
+      "name": "Testament",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "New Testament",
+        "Old Testament",
+        "Religion in America",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "TECH",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "AC Circuits",
+        "Control System Installation & Troubleshooting",
+        "Digital Fundamentals",
+        "Electronics and Instrumentation",
+        "Programmable Controllers I"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Graphical Communication",
+        "Introduction to Building Modeling",
+        "Introduction to Civil Drafting"
+      ]
+    },
+    {
+      "prefix": "CARS",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Job Search"
+      ]
+    },
+    {
+      "prefix": "COOP",
+      "name": "Cooperative",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "lake-region-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education/Internship"
+      ]
+    },
+    {
+      "prefix": "FTT",
+      "name": "Fitness",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Exercise Prescription",
+        "Fitness Trainer Internship",
+        "Techniques of Fitness Assessment"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "Humanities",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college",
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Humanities Survey (I)",
+        "Humanities Survey (II)",
+        "Integrated Cultural Studies"
+      ]
+    },
+    {
+      "prefix": "INAU",
+      "name": "Systems",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Automation Systems",
+        "Industrial Robotics",
+        "Integrated Systems, Design and Setup",
+        "Integrated Systems, Troubleshooting and Quality Control",
+        "Machine Vision and Identification"
+      ]
+    },
+    {
+      "prefix": "KMTS",
+      "name": "Komatsu",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Komatsu Advanced Hydraulic Systems",
+        "Komatsu Internship I",
+        "Komatsu Internship III",
+        "Komatsu Machine Structure and Work Equipment",
+        "Komatsu Powertrains and Undercarriage"
+      ]
+    },
+    {
+      "prefix": "MASG",
+      "name": "Massage",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Massage Techniques",
+        "Massage Therapy Clinical II",
+        "Myokinesiology II",
+        "Swedish Massage II",
+        "The Business Of Massage"
+      ]
+    },
+    {
+      "prefix": "MATL",
+      "name": "Machine",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "CNC and CAD-CAM Programming",
+        "Machine Tool Lab II",
+        "Machine Tool Theory II",
+        "Machinist Lab II",
+        "Toolmaking Theory II"
+      ]
+    },
+    {
+      "prefix": "MMAT",
+      "name": "MMAT",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Equipment and Systems II",
+        "Hand and Portable Tools",
+        "Lubrication, Bearings, and Seals",
+        "Measurements",
+        "Small Engines and Compressors"
+      ]
+    },
+    {
+      "prefix": "NUPT",
+      "name": "Nuclear",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Material Science",
+        "Nuclear Math and Physics",
+        "Nuclear Plant Equipment",
+        "Nuclear Plant System Component Design and Function",
+        "Reactor Safety Design"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "Photography",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Advertising Photography",
+        "Intermediate Photography",
+        "Photography Portfolio",
+        "Photography PracticumIV",
+        "Portrait Photography"
+      ]
+    },
+    {
+      "prefix": "PROD",
+      "name": "PROD",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Artificial Lift",
+        "Fundamentals of the Petroleum Industry",
+        "Production Equipment",
+        "Well Services"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "bismarck-state-college",
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Development of Social Welfare",
+        "Human Behavior in the Social Environment",
+        "Interpersonal Skills"
+      ]
+    },
+    {
+      "prefix": "AVIA",
+      "name": "Ground",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "lake-region-state-college"
+      ],
+      "sample_titles": [
+        "Ground School",
+        "Introduction to Flight"
+      ]
+    },
+    {
+      "prefix": "CIH",
+      "name": "Case",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Case IH Advanced Farming Systems (AFS)",
+        "Case IH Electrical/Electronics Diagnostics",
+        "Case IH Engine Rebuild",
+        "Case IH Internship I"
+      ]
+    },
+    {
+      "prefix": "FORS",
+      "name": "Urban",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Internship",
+        "Parks and Urban Greenspaces",
+        "Principles of Pruning",
+        "Urban Forest Management"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Cartographic Design and Analysis",
+        "Fundamentals of Geographic Information Systems",
+        "GIS Applications"
+      ]
+    },
+    {
+      "prefix": "RLS",
+      "name": "RLS",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Accessibility and Public Policy",
+        "Environmental Education",
+        "Internship",
+        "Recreation Administration"
+      ]
+    },
+    {
+      "prefix": "SMTL",
+      "name": "Sheet",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Practical Applications of Sheet Metal",
+        "Sheet Metal I",
+        "Sheet Metal II",
+        "Sheet Metal III"
+      ]
+    },
+    {
+      "prefix": "WATR",
+      "name": "Treatment",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Laboratory Procedures",
+        "Wastewater Treatment",
+        "Water Treatment I",
+        "Water Treatment II"
+      ]
+    },
+    {
+      "prefix": "WSC",
+      "name": "Digital",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Digital and Financial Literacy for Success"
+      ]
+    },
+    {
+      "prefix": "BH",
+      "name": "Behavioral",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Case Management and Care Coordination",
+        "Introduction to Behavioral Health",
+        "Professional Ethics in Behavioral Health"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "CET",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Internship II",
+        "Non-Structural I",
+        "Refinishing I"
+      ]
+    },
+    {
+      "prefix": "H&CE",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Leadership and Presentation Techniques"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Integrated Cultural Excursion: Regional & Cultural Studies",
+        "Introduction to Humanities I"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Leadership",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Ethical Leadership",
+        "Leadership Strategies",
+        "Relationship Building"
+      ]
+    },
+    {
+      "prefix": "AM",
+      "name": "Management",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Management of Industrial Facilities",
+        "Quality Assurance - Lean Six Sigma"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Dental Anatomy",
+        "Dental Ethics & Jurisprudence"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "Residential",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Internship",
+        "Residential Landscape Design"
+      ]
+    },
+    {
+      "prefix": "RNG",
+      "name": "Range",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Range Management"
+      ]
+    },
+    {
+      "prefix": "VETS",
+      "name": "Animal",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Animal Health",
+        "Introduction to Veterinary Science"
+      ]
+    },
+    {
+      "prefix": "ASM",
+      "name": "Agricultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bismarck-state-college"
+      ],
+      "sample_titles": [
+        "Agricultural Machinery Technology"
+      ]
+    },
+    {
+      "prefix": "BAKE",
+      "name": "Cakes",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Cakes and Cake Decorating"
+      ]
+    },
+    {
+      "prefix": "ENVT",
+      "name": "ENVT",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Introduction To GIS"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "Science",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-dakota-state-college-of-science"
+      ],
+      "sample_titles": [
+        "Science of Success"
+      ]
+    },
+    {
+      "prefix": "PH",
+      "name": "Public",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "williston-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Public Health"
+      ]
+    },
+    {
+      "prefix": "TOUR",
+      "name": "Tourism",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "dakota-college-at-bottineau"
+      ],
+      "sample_titles": [
+        "Principles of Tourism"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/ne/subject-vocab.json
+++ b/data/ne/subject-vocab.json
@@ -1,0 +1,3307 @@
+{
+  "state": "ne",
+  "generated_at": "2026-06-06T15:41:40.511Z",
+  "subjects": [
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 65,
+      "section_count": 1159,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Analytic Geometry & Calc III",
+        "Analytic Geometry & CalcI",
+        "Analytic Geometry and Calculus II",
+        "Applied Calculus",
+        "Applied Math Hospitality Ind"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 60,
+      "section_count": 929,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "20th Century Fiction",
+        "African-American Literature",
+        "Am. Literature II",
+        "American Literature since 1865",
+        "Applied Communications I"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 95,
+      "section_count": 821,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Advanced TIG",
+        "Applied Math for Welders",
+        "Arc & Oxyacetylene Welding",
+        "Arc/Gas Welding I",
+        "Arc/Gas Welding II"
+      ]
+    },
+    {
+      "prefix": "BIOS",
+      "name": "BIOS",
+      "course_count": 61,
+      "section_count": 685,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Animal Behavior",
+        "Basic Anatomy & Physiology",
+        "Basic Nutrition",
+        "Biology I",
+        "Biology I Lab"
+      ]
+    },
+    {
+      "prefix": "BSAD",
+      "name": "BSAD",
+      "course_count": 75,
+      "section_count": 652,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Proc & Mgmt",
+        "Advanced Management",
+        "Advanced Marketing",
+        "Applied Business Projects",
+        "Applied Statistics"
+      ]
+    },
+    {
+      "prefix": "INFO",
+      "name": "INFO",
+      "course_count": 175,
+      "section_count": 520,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "2D Game Programming",
+        "Administering Directory Services",
+        "Advanced Database & SQL",
+        "Advanced Windows Server",
+        "Agile Methodologies"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 34,
+      "section_count": 375,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adolescent Psychology",
+        "Behav Modif & Prin Learning",
+        "Brain & Behavior",
+        "Cognitive Development"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "Intercollegiate",
+      "course_count": 91,
+      "section_count": 296,
+      "colleges": [
+        "central-community-college",
+        "mid-plains-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Activities for Elementary PE",
+        "Bowling",
+        "Cardio Fitness",
+        "Cross Country for Men",
+        "Cross Country for Women"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 118,
+      "section_count": 272,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Beef Cattle Production",
+        "Adv Precision Ag Hardware",
+        "Adv Precision Ag Technology",
+        "Advanced Animal Nutrition",
+        "Advanced Crop Management"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 39,
+      "section_count": 269,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT (AEMT)",
+        "Advanced EMT (AEMT) Practicum",
+        "Archery/Hunting Safe",
+        "Basic Nursing Assistant",
+        "Community Health Worker I"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 60,
+      "section_count": 250,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adult Nursing I Lab",
+        "Adult Nursing II",
+        "Adult Nursing IV",
+        "Adult Nursing IV Lab",
+        "Adv Medical Surgical Clinical"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "CRIM",
+      "course_count": 41,
+      "section_count": 247,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Comm Skills in CRIM",
+        "Community-Based Corrections",
+        "Contemporary Issues in CJ",
+        "Contmp. Issues in Crim. Justic",
+        "Coop Ed/Internship CRIM"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 32,
+      "section_count": 235,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Applied Infant & Toddler Conc",
+        "CDA Pro Portfolio",
+        "Child Care Head Teach Coop Exp",
+        "Child Care Head Teacher Prac",
+        "Child Guidance Techniques"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 20,
+      "section_count": 233,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Criminology",
+        "Current Social Problems",
+        "Drugs, Society & Human Behavior",
+        "Exploring Unity and Diversity",
+        "Human Relations: People Skills"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 36,
+      "section_count": 229,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Capstone",
+        "Accounting Data Analytics",
+        "Accounting II",
+        "Accounting III",
+        "Acct Apps (QuickBooks)"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 106,
+      "section_count": 228,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "AM: String Instruments I",
+        "App Music for Majors I - Woodwind",
+        "App Music for Majors II-Stringed",
+        "App Music for Majors II-Woodwinds",
+        "App Music for Majors III-Stringed"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 26,
+      "section_count": 225,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Chem & Citizen Lab",
+        "Chemistry and the Citizen",
+        "Chemistry and the Citizen Lab",
+        "Chemistry and the Citizen Lect",
+        "DS: Gen Chem I Lecture Only"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 22,
+      "section_count": 209,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Amer Hist I (Early America)",
+        "American History II Since 1877",
+        "History of Rome",
+        "Introduction to Black History",
+        "Latin American History"
+      ]
+    },
+    {
+      "prefix": "ACFS",
+      "name": "Multi",
+      "course_count": 2,
+      "section_count": 178,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Multi HR Career Teach Cert",
+        "Success@SCC"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 48,
+      "section_count": 175,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "2-D Design",
+        "2-Dimensional Design",
+        "3-D Design",
+        "Art Fundamentals",
+        "Art History - 1400 to Present"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 9,
+      "section_count": 172,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Economic Issues",
+        "ECON 1010 Personal and Business Finance010220",
+        "Economic Understanding",
+        "Fundamentals of Investing",
+        "General Economics"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "CNST",
+      "course_count": 60,
+      "section_count": 161,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Adv Construction Est & Sched",
+        "Advanced Cabinetmaking",
+        "Advanced Roof Framing",
+        "Basic Woodworking Lab",
+        "Basic Woodworking Theory"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 7,
+      "section_count": 149,
+      "colleges": [
+        "little-priest-tribal-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Business & Professional Comm",
+        "Communicate in Groups & Teams",
+        "Fund of Human Communication",
+        "Fundamentals of Communication",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Communication",
+      "course_count": 4,
+      "section_count": 134,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Fund of Human Communication",
+        "Interpersonal Communication",
+        "U8_Human Communications",
+        "U8_Public Speaking"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 29,
+      "section_count": 128,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Applied Physics",
+        "Astronomy",
+        "Astronomy (with Lab)",
+        "Astronomy Lab",
+        "Descriptive Physics"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 24,
+      "section_count": 127,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Art Ed for Elementary Teachers",
+        "Children's Literature",
+        "Children&#39;s Literature",
+        "College Success",
+        "Educational Psychology"
+      ]
+    },
+    {
+      "prefix": "EMTL",
+      "name": "EMTL",
+      "course_count": 29,
+      "section_count": 124,
+      "colleges": [
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Airway Management/Ventilation",
+        "American Heart BLS Provider",
+        "American Heart First Aid Plus",
+        "AMLS Advanced Medical Life Support",
+        "Clinical Practicum"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 12,
+      "section_count": 123,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Applied Ethics",
+        "Bioethics",
+        "Comparative Religions",
+        "Environmental Ethics",
+        "Intro to Comparative Religion"
+      ]
+    },
+    {
+      "prefix": "FSDT",
+      "name": "FSDT",
+      "course_count": 36,
+      "section_count": 117,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Baking/Pastry Fundamentals",
+        "Adv Bread Baking & Techniques",
+        "Advanced Culinary",
+        "Advanced Culinary Fundamentals",
+        "Baking and Pastry Fundamentals"
+      ]
+    },
+    {
+      "prefix": "AUTB",
+      "name": "AUTB",
+      "course_count": 57,
+      "section_count": 108,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Adv Auto Body Painting",
+        "Adv. Auto Collision Repair",
+        "Auto Body Component Repairs",
+        "Auto Body Maj Component Rep",
+        "Auto Body Mechanics"
+      ]
+    },
+    {
+      "prefix": "ELTR",
+      "name": "ELTR",
+      "course_count": 47,
+      "section_count": 103,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Construction Wiring",
+        "Alt Current Theory",
+        "Applied Math",
+        "Automation Control Internship",
+        "Automation Fundamentals"
+      ]
+    },
+    {
+      "prefix": "DSLT",
+      "name": "DSLT",
+      "course_count": 42,
+      "section_count": 100,
+      "colleges": [
+        "central-community-college",
+        "mid-plains-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Electrical Sy",
+        "Advanced Hydraulics",
+        "Air Brake Supply & Controls",
+        "Automatic Transmissions",
+        "Brake Systems"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 59,
+      "section_count": 98,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "A/C Applications Lab",
+        "A/C Apps Refrigerant/Rec",
+        "A/C Controls Lab",
+        "A/C Controls Theory",
+        "A/C Cycle Lab"
+      ]
+    },
+    {
+      "prefix": "MEDT",
+      "name": "MEDT",
+      "course_count": 47,
+      "section_count": 98,
+      "colleges": [
+        "central-community-college",
+        "mid-plains-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Phlebotomy",
+        "Blood Banking",
+        "Clinical Blood Bank Practicum",
+        "Clinical Chemistry",
+        "Clinical Chemistry Practicum"
+      ]
+    },
+    {
+      "prefix": "CULI",
+      "name": "Culinary",
+      "course_count": 32,
+      "section_count": 97,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Baking I",
+        "Baking II",
+        "Baking III",
+        "Baking Internship I",
+        "Baking Internship II"
+      ]
+    },
+    {
+      "prefix": "UTIL",
+      "name": "UTIL",
+      "course_count": 38,
+      "section_count": 93,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Power Line Construction and Maintenance",
+        "Advanced Powerline Construction and Maintenance Lab",
+        "Ap Elec Sci Pwrln II",
+        "App Mth for Pwrln II",
+        "Commercial Drivers License"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 14,
+      "section_count": 88,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Accelerated Second Yr Spanish",
+        "Conversational Spanish",
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Intermediate Spanish I"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 49,
+      "section_count": 82,
+      "colleges": [
+        "central-community-college",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Adv Electronics & Computers",
+        "Adv. Automotive Diagnostics",
+        "Auto Air Conditioning/Climate Cntr",
+        "Auto Body Elec Syst",
+        "Auto Heating and A/C"
+      ]
+    },
+    {
+      "prefix": "HIMS",
+      "name": "HIMS",
+      "course_count": 47,
+      "section_count": 81,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "northeast-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Applied Health Informatics",
+        "Coding II",
+        "Coding III",
+        "CPC Exam Preparation",
+        "Disease Processes"
+      ]
+    },
+    {
+      "prefix": "EMSP",
+      "name": "EMSP",
+      "course_count": 27,
+      "section_count": 80,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support",
+        "Cap Ext Paramedic Clin/Fl Rot",
+        "Emergency Medical Responder",
+        "Emergency Medical Tech 1",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 8,
+      "section_count": 76,
+      "colleges": [
+        "central-community-college",
+        "little-priest-tribal-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "American National Government",
+        "Comparative Politics",
+        "Contemp Soc & Pol Issues",
+        "International Relations"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "DESL",
+      "course_count": 42,
+      "section_count": 71,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Advanced Diesel Hydraulics",
+        "Ag Electronics Lab",
+        "Ag Electronics Theory",
+        "Air Conditioning Lab",
+        "Air Conditioning Theory"
+      ]
+    },
+    {
+      "prefix": "COMS",
+      "name": "Communication",
+      "course_count": 4,
+      "section_count": 69,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Communication in Small Groups",
+        "Fundamentals of Communication",
+        "Interpersonal Communication",
+        "Public Speaking"
+      ]
+    },
+    {
+      "prefix": "AUTT",
+      "name": "AUTT",
+      "course_count": 25,
+      "section_count": 65,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Advanced Control Systems",
+        "Auto Electrical II & HVAC",
+        "Auto III: Advance Auto Maint.",
+        "Auto Shop Safety & Repair",
+        "Auto Transmission/Transaxle"
+      ]
+    },
+    {
+      "prefix": "EXPL",
+      "name": "Exploratory",
+      "course_count": 1,
+      "section_count": 62,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Exploratory Studies"
+      ]
+    },
+    {
+      "prefix": "NURA",
+      "name": "Aide",
+      "course_count": 4,
+      "section_count": 62,
+      "colleges": [
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Medication Aide",
+        "Nurse Aide",
+        "Nursing Assistant"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 28,
+      "section_count": 60,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Fundamentals of Acting I",
+        "Fundamentals of Stage Management",
+        "History of Motion Picture"
+      ]
+    },
+    {
+      "prefix": "HUSR",
+      "name": "HUSR",
+      "course_count": 28,
+      "section_count": 59,
+      "colleges": [
+        "central-community-college",
+        "northeast-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Activities Therapy",
+        "Case Assess/Plng/Mng",
+        "Case Assessment/Planning/Mgm",
+        "Clinical Treatment Issues",
+        "Community Health Needs"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 57,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Fundamentals of Geography",
+        "Human Environment Geography",
+        "Intro to Human Geography",
+        "Landforms"
+      ]
+    },
+    {
+      "prefix": "HMSV",
+      "name": "HMSV",
+      "course_count": 25,
+      "section_count": 57,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "nebraska-indian-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Group Skills",
+        "Assess, Case Plan, Management",
+        "Community Resources",
+        "Crisis Intervention",
+        "Ethical & Legal Issu"
+      ]
+    },
+    {
+      "prefix": "PRDV",
+      "name": "College",
+      "course_count": 8,
+      "section_count": 57,
+      "colleges": [
+        "central-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Basics of Money Management",
+        "Career Exploration",
+        "College Foundations",
+        "College Survival",
+        "Human Relations for Educators"
+      ]
+    },
+    {
+      "prefix": "ESLX",
+      "name": "Writing",
+      "course_count": 14,
+      "section_count": 54,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "ESL Conversation I",
+        "ESL Writing I",
+        "ESL Writing II",
+        "Listening and Speaking 2",
+        "Listening and Speaking 3"
+      ]
+    },
+    {
+      "prefix": "OFFT",
+      "name": "OFFT",
+      "course_count": 17,
+      "section_count": 52,
+      "colleges": [
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Administrative Procedures I",
+        "Adv Spreadsheet Applications",
+        "Advanced Keyboarding",
+        "AI in Business & Society",
+        "Basic Keyboarding"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 31,
+      "section_count": 49,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "AC Principles",
+        "Audio Visual Solutions",
+        "CAD & Electrical Estimating",
+        "Commercial Install & Wiring",
+        "DC Principles"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 33,
+      "section_count": 48,
+      "colleges": [
+        "central-community-college",
+        "mid-plains-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Dental Assisting Skills",
+        "Basic Principles & Techniques",
+        "Business Office Communication",
+        "Chairside Assisting Skills",
+        "Clincial Education I"
+      ]
+    },
+    {
+      "prefix": "DIMA",
+      "name": "Design",
+      "course_count": 36,
+      "section_count": 48,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "2-D Animation & Comp I",
+        "2-D Animation & Comp II",
+        "3-D Character Develop",
+        "3-D Game Development",
+        "3-D Lab"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Entrepreneurship",
+      "course_count": 4,
+      "section_count": 48,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "nebraska-indian-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Entrepreneurship Business Plan",
+        "Entrepreneurship Feasibility Study",
+        "Introduction to Entrepreneurship",
+        "Marketing for the Entrepreneur"
+      ]
+    },
+    {
+      "prefix": "HMRL",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 48,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Human Relations Skills"
+      ]
+    },
+    {
+      "prefix": "NASP",
+      "name": "NASP",
+      "course_count": 27,
+      "section_count": 47,
+      "colleges": [
+        "nebraska-indian-community-college"
+      ],
+      "sample_titles": [
+        "Contemp Native Issue",
+        "Dakota Cult & Trad",
+        "Dakota Language I",
+        "Dakota Language II",
+        "Dr. Susan LaFlesche"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "MEDA",
+      "course_count": 19,
+      "section_count": 46,
+      "colleges": [
+        "central-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Admini Medical Assisting",
+        "Administrative Medical Assist",
+        "Basic Medical Terminology",
+        "Disease Conditions",
+        "Exam Room 2"
+      ]
+    },
+    {
+      "prefix": "VACA",
+      "name": "VACA",
+      "course_count": 20,
+      "section_count": 43,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Art in Film",
+        "Audio I",
+        "Audio II",
+        "Audio III",
+        "Audio Mixing and Summing"
+      ]
+    },
+    {
+      "prefix": "DDRT",
+      "name": "DDRT",
+      "course_count": 29,
+      "section_count": 41,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "3D Civil CAD",
+        "Adv Mech Syst Theory & Drfting",
+        "Architectural Print Reading",
+        "Basic Computer Aided Drafting",
+        "Building Safety & Design"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "INDT",
+      "course_count": 14,
+      "section_count": 41,
+      "colleges": [
+        "central-community-college",
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Control Systems",
+        "Applications of Ind Sensors",
+        "AutoCAD Electrical Fund",
+        "Concepts of Electronics I",
+        "Fluid Power Fundamentals"
+      ]
+    },
+    {
+      "prefix": "HLSM",
+      "name": "HLSM",
+      "course_count": 21,
+      "section_count": 40,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Advanced Floral: Sympathy",
+        "Advanced Floral: Weddings",
+        "Entomology",
+        "Floral Design 2",
+        "Floral Design I"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "MFGT",
+      "course_count": 19,
+      "section_count": 39,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "3D Printing & Modeling",
+        "AutoCAD for Manufacturing",
+        "Basic Elec for Man/Pow/Process",
+        "CNC for Automation",
+        "Engineering Drawing & Design"
+      ]
+    },
+    {
+      "prefix": "SURT",
+      "name": "SURT",
+      "course_count": 18,
+      "section_count": 36,
+      "colleges": [
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Career Readiness for Surg Tech",
+        "Clincal Education 1",
+        "Clinical Education 2",
+        "Clinical Practice I",
+        "Intro to Surgical Technology"
+      ]
+    },
+    {
+      "prefix": "ADNR",
+      "name": "ADNR",
+      "course_count": 14,
+      "section_count": 35,
+      "colleges": [
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health and Illness III",
+        "Adult Health and Illness IV",
+        "Care of the Older Adult Theory",
+        "Fundamentals Nursing Practice",
+        "Maternal Child Nursing"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "Humanities",
+      "course_count": 8,
+      "section_count": 35,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Arts & Ideas",
+        "Film History and Appreciation",
+        "Humanities in Non-Western W",
+        "Humanities through the Arts",
+        "Introduction to Humanities"
+      ]
+    },
+    {
+      "prefix": "MART",
+      "name": "MART",
+      "course_count": 18,
+      "section_count": 35,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Layout & Design",
+        "Audio Entertainment",
+        "Audio Production & Design",
+        "Digital Illustration",
+        "Imaginative Photography/Video"
+      ]
+    },
+    {
+      "prefix": "TRUK",
+      "name": "TRUK",
+      "course_count": 7,
+      "section_count": 35,
+      "colleges": [
+        "central-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Advanced Operating Practices",
+        "Basic Operations-Class A",
+        "Basic Operations-Class B CDL",
+        "Defensive Driving",
+        "Motor Vehicle 3rd Party Exam"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "ARCH",
+      "course_count": 28,
+      "section_count": 34,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Revit",
+        "AEC Industry",
+        "AEC Internship",
+        "Appreciation of Architecture",
+        "Architectural CAD I"
+      ]
+    },
+    {
+      "prefix": "FINA",
+      "name": "Financial",
+      "course_count": 9,
+      "section_count": 34,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Business Finance",
+        "Consumer Credit",
+        "Financial Counseling",
+        "Financial Literacy",
+        "Financial Plan Dev & Case Ana"
+      ]
+    },
+    {
+      "prefix": "HDIM",
+      "name": "HDIM",
+      "course_count": 14,
+      "section_count": 33,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Clin Coding I",
+        "Clin Coding II",
+        "Clinical Coding III",
+        "Doc & Electronic Health Record",
+        "HDIM Capstone"
+      ]
+    },
+    {
+      "prefix": "HMRS",
+      "name": "HMRS",
+      "course_count": 22,
+      "section_count": 33,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "A&D Practicum & Seminar 3",
+        "A&D Practicum & Seminar 4",
+        "Assmnt/Cse Mng/Prof Ethics-A/D",
+        "Case Mngment & Ethics/Hum Serv",
+        "Child Abuse"
+      ]
+    },
+    {
+      "prefix": "VTEC",
+      "name": "VTEC",
+      "course_count": 15,
+      "section_count": 33,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology of Domestic Animals I",
+        "Anatomy and Physiology of Domestic Animals Lab",
+        "Animal Husbandry and Restraint",
+        "Clinical Nursing of Large Animals",
+        "Clinical Nursing of Large Animals Lab"
+      ]
+    },
+    {
+      "prefix": "AVIA",
+      "name": "AVIA",
+      "course_count": 26,
+      "section_count": 32,
+      "colleges": [
+        "mid-plains-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Adv Ground Training",
+        "Basic Ground Training",
+        "F1_Aircraf Drw Fld Lns",
+        "F1_Airframe Systems IV",
+        "F1_Airframe Systems V"
+      ]
+    },
+    {
+      "prefix": "FIST",
+      "name": "Fire",
+      "course_count": 18,
+      "section_count": 31,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Building Const for Fire Prot",
+        "Fire Behavior & Combustion",
+        "Fire Investigation I",
+        "Fire Investigation II",
+        "Fire Prev, Inspect & Codes"
+      ]
+    },
+    {
+      "prefix": "GDVC",
+      "name": "GDVC",
+      "course_count": 10,
+      "section_count": 31,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "3-D & Animation",
+        "Digital Imaging",
+        "Illustration",
+        "Internship",
+        "Introduction to Graphic Design"
+      ]
+    },
+    {
+      "prefix": "PTAS",
+      "name": "PTAS",
+      "course_count": 24,
+      "section_count": 30,
+      "colleges": [
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Conditions & Rehab Lab",
+        "Advanced Conditions & Rehab",
+        "Cardiopulmonary Rehabilitation",
+        "Cardiopulmonary Rehabilitation Lab",
+        "Clinical Affiliation I"
+      ]
+    },
+    {
+      "prefix": "LAWS",
+      "name": "LAWS",
+      "course_count": 18,
+      "section_count": 29,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Business Organizations",
+        "Contract Law",
+        "Criminal Law and Procedures",
+        "Electronic Discovery",
+        "Family Law"
+      ]
+    },
+    {
+      "prefix": "BLDC",
+      "name": "BLDC",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Bldg City Codes & State Standards",
+        "Blueprint Reading",
+        "Cabinetmaking",
+        "Cabinetmaking, Advanced",
+        "Cabinetry"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "PHOT",
+      "course_count": 13,
+      "section_count": 28,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Basic Analog Photography",
+        "Basic Digital Photography",
+        "Basic Experimental Photography",
+        "Basic Photography Lighting",
+        "Digital Photo & Creative Imag"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 17,
+      "section_count": 28,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Advanced Respiratory Care",
+        "Cardiopulmonary Anat & Physiol",
+        "Clin Ed: Crit Care/Spec Rot I",
+        "Clinical Practicum II",
+        "Critical Care Management"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "MRKT",
+      "course_count": 6,
+      "section_count": 27,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Advertising & Sales Promotion",
+        "Consumer Behavior",
+        "Customer Service",
+        "Global Marketing",
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "DSGN",
+      "name": "DSGN",
+      "course_count": 23,
+      "section_count": 26,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Adv Para Design/Inventor",
+        "Adv Para Design/SolidWorks",
+        "Advanced CAD",
+        "Architectural Design",
+        "Building Elements"
+      ]
+    },
+    {
+      "prefix": "LPNS",
+      "name": "Nursing",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Holistic Nursing 1",
+        "Holistic Nursing 2",
+        "Practical Nursing Clinical 2",
+        "Practical Nursing Lab 2",
+        "Practical Nursing Lab 2 Skills"
+      ]
+    },
+    {
+      "prefix": "LPNR",
+      "name": "LPNR",
+      "course_count": 8,
+      "section_count": 25,
+      "colleges": [
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "F1_Concepts of Nursing",
+        "F2_Medical/Surgical Nursing I",
+        "Pharmacology I",
+        "Pharmacology II",
+        "S1_Medical/Surgical Nurs II"
+      ]
+    },
+    {
+      "prefix": "MACH",
+      "name": "MACH",
+      "course_count": 19,
+      "section_count": 25,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Cnc & Automation Lab",
+        "Advanced CNC & Automation Des",
+        "Advanced CNC Theory",
+        "Blueprint Reading & Drawing",
+        "CNC I"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 13,
+      "section_count": 25,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Clinical Education 1",
+        "Clinical Education 4",
+        "Clinical Education 5",
+        "Clinical Education 6",
+        "Computed Tomography"
+      ]
+    },
+    {
+      "prefix": "CSCE",
+      "name": "CSCE",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Desktop Publishing",
+        "Excel Basic",
+        "Input Keyboard Technology II",
+        "Microsoft Excel",
+        "Microsoft Excel, Advanced"
+      ]
+    },
+    {
+      "prefix": "ELME",
+      "name": "ELME",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Hydraulics and Pneumatics",
+        "Internship",
+        "Intro to Motors",
+        "Mechanical Power Systems",
+        "Mechanical Print Reading"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "central-community-college",
+        "metropolitan-community-college-area",
+        "mid-plains-community-college",
+        "northeast-community-college",
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Design Fabrication Lab for Pre-Engineers",
+        "Engineering Statics",
+        "First Yr Engineering Seminar",
+        "Graphics for Engineers",
+        "Interpersonal Skills for Engineerin"
+      ]
+    },
+    {
+      "prefix": "AMDT",
+      "name": "AMDT",
+      "course_count": 18,
+      "section_count": 23,
+      "colleges": [
+        "central-community-college",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Machining",
+        "CAD/CAM Fundamentals",
+        "CNC Lathe Operations",
+        "CNC Mill Operations",
+        "Die Design I"
+      ]
+    },
+    {
+      "prefix": "PARM",
+      "name": "Paramedic",
+      "course_count": 16,
+      "section_count": 23,
+      "colleges": [
+        "central-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Advance EMS Skills",
+        "Advanced Certifications",
+        "Airway Management",
+        "Electrophysiology in Paramedic",
+        "Intro to Paramedicine"
+      ]
+    },
+    {
+      "prefix": "ENER",
+      "name": "ENER",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Boilers & Steam Turbines",
+        "Electric Power Transm Fund Lab",
+        "Electric Power Transmis Fund",
+        "Energy Industry Fundamentals",
+        "Green Energy Technologies"
+      ]
+    },
+    {
+      "prefix": "HMRM",
+      "name": "HMRM",
+      "course_count": 19,
+      "section_count": 20,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Bakeshop",
+        "Agri-Eco Tourism Opportunities",
+        "Bakeshop",
+        "Coop Ed/Internship HMRM",
+        "Culinary Concepts"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 16,
+      "section_count": 20,
+      "colleges": [
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Golf Crse Ops",
+        "Arboriculture",
+        "Cooperative Experience",
+        "Cooperative Internship I",
+        "Golf & Sports Turf Mngt"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 11,
+      "section_count": 20,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Body Conditioning",
+        "Care and Prevention of Athletic Injuries",
+        "Community Health",
+        "Introduction to Athletic Training",
+        "Introduction to Exercise Science"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Compensation and Benefits",
+        "Human Resource Development",
+        "Human Resource Management",
+        "Organizational Behavior",
+        "Principles of Management"
+      ]
+    },
+    {
+      "prefix": "PRMA",
+      "name": "Machine",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "CNC II",
+        "EDM Technology",
+        "Machine Print Reading",
+        "Machine Tool I",
+        "Machine Tool II"
+      ]
+    },
+    {
+      "prefix": "REES",
+      "name": "Real",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Building & Property Management",
+        "Real Estate Finance",
+        "Real Estate Investments",
+        "Real Estate Law",
+        "Real Estate Principles"
+      ]
+    },
+    {
+      "prefix": "ELET",
+      "name": "Electrical",
+      "course_count": 8,
+      "section_count": 19,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "ACTheo/NEC/NFPA70E/Bluprt Rea",
+        "DC Theory, Conduit Fab & NEC",
+        "Electrical Wiring Appl VII",
+        "Electrical Wiring Applic I",
+        "Electrical Wiring Applic III"
+      ]
+    },
+    {
+      "prefix": "MEDO",
+      "name": "Medical",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Comprehensive Medical Terminology",
+        "CPT Coding",
+        "ICD-10 Coding",
+        "Medical Billing & Reimbursement",
+        "Medical Office Procedures"
+      ]
+    },
+    {
+      "prefix": "UPHR",
+      "name": "Furniture",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Auto Interior Recovering",
+        "Auto Seat Upholstering",
+        "Couch Reconst & Upholstering",
+        "Furn Restyling & Upholstery",
+        "Furniture Refinishing"
+      ]
+    },
+    {
+      "prefix": "BIOT",
+      "name": "Biotechnology",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Adv Biotech & Biomanufacturing",
+        "Applied Bioscience Practicum",
+        "Intro to Biotech I Lab",
+        "Intro to Biotech II Lab",
+        "Intro to Biotechnology I"
+      ]
+    },
+    {
+      "prefix": "AMFG",
+      "name": "AMFG",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Digital Electronics in Proto",
+        "How to Build Almost Everything",
+        "Industrial Safety and Health",
+        "Intermediate SolidWorks",
+        "Intro to Prototype Design"
+      ]
+    },
+    {
+      "prefix": "ELMC",
+      "name": "ELMC",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Automation Fundamentals",
+        "Cooperative Internship I",
+        "Fluid Fundamentals",
+        "Fluid Fundamentals Lab",
+        "Fundamentals of Electricity"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Elementary French II",
+        "French I",
+        "French II",
+        "French III"
+      ]
+    },
+    {
+      "prefix": "JDAT",
+      "name": "JDAT",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "JD Adv Hydraulics/Powertrains",
+        "JD Electrical & Electronics I",
+        "JD Electrical/Electronics II",
+        "JD Engines & Fuel Systems",
+        "JD Intro Hydraul & Powertrn"
+      ]
+    },
+    {
+      "prefix": "LTCA",
+      "name": "LTCA",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Assisted Living Admin I",
+        "Death, Dying & Bereavement",
+        "Fin Mngment for Long Term Care",
+        "Food & Nutrition Serv for LTC",
+        "Foundations of Leadership"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "Beginning",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Beginning ASL I",
+        "Beginning ASL II",
+        "Second Year ASL I"
+      ]
+    },
+    {
+      "prefix": "INTD",
+      "name": "INTD",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Foundations for Interior Desg",
+        "Fundamentals of Textiles",
+        "History of Architec. & Interio",
+        "Illust. Techniq. for Interiors",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "NATV",
+      "name": "Native",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Contemporary Native American Issues",
+        "Dispelling Native American Stereotypes",
+        "Exploring Historical Trauma",
+        "Federal Indian Law",
+        "Indigenous Authors"
+      ]
+    },
+    {
+      "prefix": "PSPT",
+      "name": "Powersports",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "ATV, UTV & Snwmble Drivetrain",
+        "ATV, UTV, & Snowmobile System",
+        "Basic Engine Principles I",
+        "Cooperative Work Experience 1",
+        "Intro Powersports Fuel Syst"
+      ]
+    },
+    {
+      "prefix": "WIND",
+      "name": "WIND",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Control Systems",
+        "Control Systems Lab",
+        "Cooperative Internship I",
+        "Mechanical Systems II"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "CARP",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Codes and Blueprint Reading",
+        "Construction Safety",
+        "Doors, Trims, and Cabinets",
+        "Drywall Finishing",
+        "Drywall Installation"
+      ]
+    },
+    {
+      "prefix": "DENH",
+      "name": "DENH",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene II",
+        "Clinical Interim",
+        "Community Health I",
+        "Dental Health Education",
+        "Head & Neck Anatomy"
+      ]
+    },
+    {
+      "prefix": "DRAF",
+      "name": "Design",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "AutoCAD Fundamentals",
+        "Creo (Pro/E) Fundamentals",
+        "Design for Precision (Measmt)",
+        "Manufac. Process Design",
+        "SolidWorks for Manufacturing"
+      ]
+    },
+    {
+      "prefix": "FACS",
+      "name": "Healthy",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Healthy Lifestyles",
+        "Infant Toddler Development"
+      ]
+    },
+    {
+      "prefix": "SCET",
+      "name": "SCET",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "ArcGIS Fundamentals",
+        "AutoCAD Essentials",
+        "Civil Engineering Fundamentals",
+        "Geomatics Applications & Emerg",
+        "REVIT (Structure)"
+      ]
+    },
+    {
+      "prefix": "FASH",
+      "name": "Fashion",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Fashion Apprenticeship I",
+        "Fashion Apprenticeship II",
+        "Fashion Apprenticeship III",
+        "Fashion Design Principles",
+        "Fashion Illustration"
+      ]
+    },
+    {
+      "prefix": "GIST",
+      "name": "GIST",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Data Acquisition & Management",
+        "Geospatial Web Applications",
+        "Intro to Geospatial Tech",
+        "Location-Based Gis Apps",
+        "Spatial Analysis and Modeling"
+      ]
+    },
+    {
+      "prefix": "MDST",
+      "name": "MDST",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Administrative Procedures I",
+        "Administrative Procedures II",
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Clinical Terminology I"
+      ]
+    },
+    {
+      "prefix": "OTHA",
+      "name": "OTHA",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Documentation & Prof Skills",
+        "Ethics, Mgt & Leadership",
+        "Fieldwork Practicum Level I-A",
+        "Fieldwork Practicum Level I-B",
+        "Functional Kinesiology"
+      ]
+    },
+    {
+      "prefix": "SCIE",
+      "name": "Astronomy",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Astronomy Laboratory",
+        "Early Undergraduate Research",
+        "Intro to Meteorology",
+        "Physical Science"
+      ]
+    },
+    {
+      "prefix": "AGST",
+      "name": "AGST",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Advanced Powertrains",
+        "Cooperative Experience",
+        "Electrical Fundamentals",
+        "Fuel Sys/Spray Equip/Prec Guid",
+        "Transprt Mntnce & Repair Fund"
+      ]
+    },
+    {
+      "prefix": "PHRM",
+      "name": "Pharmacy",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "central-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Calculations for Pharmacy Tech",
+        "Introduction to Pharmacy Basic",
+        "Operations for Pharm Tech Lab",
+        "Operations for Pharmacy Techs",
+        "Pharmaceutical Calculations I"
+      ]
+    },
+    {
+      "prefix": "PLMB",
+      "name": "Plumbing",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Blueprint Reading for Plumbers",
+        "Plumbing and Pipefitting Fundamentals",
+        "Plumbing and Pipefitting Fundamentals Lab",
+        "Plumbing Code and Print Reading",
+        "Plumbing Concepts I"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "COMP",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Advanced Excel",
+        "Database Concepts, Design and Application",
+        "HTML, CSS, and JavaScript's",
+        "Introduction to Programming",
+        "Programming C++"
+      ]
+    },
+    {
+      "prefix": "ELAP",
+      "name": "Electrical",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Electrical IA",
+        "Electrical IB",
+        "Electrical IIA",
+        "Electrical IIIA",
+        "Electrical IVA"
+      ]
+    },
+    {
+      "prefix": "GCAD",
+      "name": "GCAD",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Internship I - 10814 - GCAD 1310 - 0",
+        "Design I",
+        "Digital Photography",
+        "Drawing Logic I",
+        "Graphic Arts I"
+      ]
+    },
+    {
+      "prefix": "GDMA",
+      "name": "Design",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Color Theory",
+        "Design Software I",
+        "Design Studio 1",
+        "Design Studio 2",
+        "Intro to Ui/Ux Design"
+      ]
+    },
+    {
+      "prefix": "NDTT",
+      "name": "NDTT",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Eddy Current II",
+        "Liquid Penetrant",
+        "Magnetic Particle",
+        "NDT Methods",
+        "Radiation Safety & Administrat"
+      ]
+    },
+    {
+      "prefix": "PLAP",
+      "name": "Plumbing",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Plumbing IA",
+        "Plumbing IIA",
+        "Plumbing IIIA",
+        "Plumbing IVA"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "southeast-community-college-area",
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "General Anthropology",
+        "Intro to Cultural Anthropology",
+        "Mexican-Amer Native-Amer Cult"
+      ]
+    },
+    {
+      "prefix": "SLIS",
+      "name": "SLIS",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "ASL I",
+        "ASL II"
+      ]
+    },
+    {
+      "prefix": "CINE",
+      "name": "Camera",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Camera and Lighting I",
+        "Camera and Lighting I Lab",
+        "Post Production I",
+        "Post Production III"
+      ]
+    },
+    {
+      "prefix": "HCMG",
+      "name": "Healthcare",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Fund. of Healthcare Management",
+        "Health Resourcing-Supervision",
+        "Health Systems & Organization",
+        "Healthcare Mngmt Practicum",
+        "Leadership in Healthcare"
+      ]
+    },
+    {
+      "prefix": "HEOT",
+      "name": "Site",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Basic Equipment Operations",
+        "Construction Site Operations",
+        "Coop Ed/Internship HEOT",
+        "Field Safety & Orientation",
+        "Introduction to Craft Skills"
+      ]
+    },
+    {
+      "prefix": "LNSK",
+      "name": "Skills",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "First Year Experience",
+        "Study Skills for College"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "RELS",
+      "name": "Comparative",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Comparative Religions"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Social Work",
+        "Race, Class, and Gender"
+      ]
+    },
+    {
+      "prefix": "SUFA",
+      "name": "Surgical",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Bioscience",
+        "Clinical Externship 1",
+        "Clinical Externship 2",
+        "Fund of Surgical First Assist",
+        "Prin of Surgical First Assist"
+      ]
+    },
+    {
+      "prefix": "BTEC",
+      "name": "BTEC",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Computer & Internet Literacy",
+        "Customer Service Skills",
+        "Workplace Professionalism"
+      ]
+    },
+    {
+      "prefix": "CANN",
+      "name": "Cannabis",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Cannabis Cultivation",
+        "Cannabis Production",
+        "Historical Depiction of Cannabis",
+        "Overview of Cannabis Today",
+        "Regulations and Testing Methods of Cannabis Today"
+      ]
+    },
+    {
+      "prefix": "IEVH",
+      "name": "IEVH",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "nebraska-indian-community-college"
+      ],
+      "sample_titles": [
+        "Adv Envr Health Scie",
+        "Capstone",
+        "Env Hlth Mngt & Plan",
+        "Environ Resource Mgt",
+        "Toxicology"
+      ]
+    },
+    {
+      "prefix": "JDCE",
+      "name": "Deere",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Dealer Cooperative Experience",
+        "Deere Electrical/Electron II",
+        "Deere Electrical/Electronics I",
+        "Deere Orientation & Fundament",
+        "JD C&F Adv Elec Sys/Eng Tech"
+      ]
+    },
+    {
+      "prefix": "LSCE",
+      "name": "Surveying",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Aerial Surveying",
+        "Analysis for Land Surveyors",
+        "Engineering Surveying",
+        "Highway Plan Reading",
+        "Plane Surveying"
+      ]
+    },
+    {
+      "prefix": "QUCT",
+      "name": "Statistical",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Computer Statistical App",
+        "Lean Processes",
+        "Root Cause Analysis",
+        "Statistical Process Control",
+        "Statistical Process Control II"
+      ]
+    },
+    {
+      "prefix": "AUDR",
+      "name": "Audio",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Audio and Recording Projects I",
+        "Audio and Recording Projects II",
+        "Audio and Recording Techniques I Lab",
+        "Audio Principles and Technology I",
+        "On Site Production Lab"
+      ]
+    },
+    {
+      "prefix": "CNAD",
+      "name": "Certified",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Certified Nursing Assistant Training"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "metropolitan-community-college-area",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Elementary German I",
+        "Elementary German II"
+      ]
+    },
+    {
+      "prefix": "WARE",
+      "name": "Logistics",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "mid-plains-community-college"
+      ],
+      "sample_titles": [
+        "Global Logistics",
+        "Introduction to Logistics",
+        "Purchasing Logistics",
+        "Supply Chain Management",
+        "Transportation Logistics"
+      ]
+    },
+    {
+      "prefix": "ASEP",
+      "name": "ASEP",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Dealer Cooperative Experience",
+        "Electrical Fundamentals",
+        "GM Engine Performance",
+        "Transprt Mntnce & Repair Fund"
+      ]
+    },
+    {
+      "prefix": "ASST",
+      "name": "ASST",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Dealer Cooperative Experience",
+        "Electrical Fundamentals",
+        "Ford Steering, Engine, Diesel",
+        "Transprt Mntnce & Repair Fund"
+      ]
+    },
+    {
+      "prefix": "BRDC",
+      "name": "Production",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Applied TV Production I",
+        "Introduction to Mass Media",
+        "Television Production and Performance"
+      ]
+    },
+    {
+      "prefix": "CDLT",
+      "name": "Laws",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "CDL Laws & Regulations",
+        "Class A BTW CDL Training"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Computer Science I",
+        "Intro to Computer Science"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Environmental Geology",
+        "Physical Geology",
+        "Physical Geology Lab"
+      ]
+    },
+    {
+      "prefix": "HOEC",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "ITEC",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "nebraska-indian-community-college"
+      ],
+      "sample_titles": [
+        "Comp Asst Drafting I",
+        "Eng Grph, Draft, Des",
+        "Introduction to GIS"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Beginning Japanese I",
+        "Beginning Japanese II",
+        "Intermediate Japanese III",
+        "Intermediate Japanese IV"
+      ]
+    },
+    {
+      "prefix": "MSTT",
+      "name": "MSTT",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "ATV & UTV Systems",
+        "Engine Repair II",
+        "Introduction to Powersports",
+        "Personal Watercraft"
+      ]
+    },
+    {
+      "prefix": "CSIT",
+      "name": "Practical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Practical Computer Applications"
+      ]
+    },
+    {
+      "prefix": "ENHS",
+      "name": "ENHS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Regulations II",
+        "Gen Industry Regs & Standards",
+        "Haz Mat Handling & Emer Resp"
+      ]
+    },
+    {
+      "prefix": "HCKS",
+      "name": "Hochunk",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "HoChunk History I",
+        "HoChunk Language I"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "northeast-community-college",
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Introduction to Mass Media"
+      ]
+    },
+    {
+      "prefix": "LIBR",
+      "name": "LIBR",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Library/Info",
+        "Leadership/Mgt in Libraries",
+        "Library Science Capstone Pract"
+      ]
+    },
+    {
+      "prefix": "PSGT",
+      "name": "Polysomnography",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Polysomnography 1",
+        "Polysomnography 1 Lab",
+        "Scoring Lab"
+      ]
+    },
+    {
+      "prefix": "CAPL",
+      "name": "Search",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northeast-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Job Search and Employment"
+      ]
+    },
+    {
+      "prefix": "EVOM",
+      "name": "Event",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Customers & Event Experience",
+        "Fundamentals of Event Planning"
+      ]
+    },
+    {
+      "prefix": "GLST",
+      "name": "Global",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "southeast-community-college-area"
+      ],
+      "sample_titles": [
+        "Intro to Global Studies"
+      ]
+    },
+    {
+      "prefix": "LANG",
+      "name": "Language",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Emphasis Seminar",
+        "Intro to Language Interpret"
+      ]
+    },
+    {
+      "prefix": "PLBG",
+      "name": "Plumbing",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Introduction to Plumbing"
+      ]
+    },
+    {
+      "prefix": "TDWL",
+      "name": "Logistics",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "central-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Logistics",
+        "Transportation Logistics"
+      ]
+    },
+    {
+      "prefix": "AFED",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "Math Readiness"
+      ]
+    },
+    {
+      "prefix": "CFOT",
+      "name": "Critical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Introduction to Critical Faci"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Beginning Chinese I"
+      ]
+    },
+    {
+      "prefix": "COLS",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "little-priest-tribal-college"
+      ],
+      "sample_titles": [
+        "College Success"
+      ]
+    },
+    {
+      "prefix": "HTLH",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nursing Assistant"
+      ]
+    },
+    {
+      "prefix": "MCAP",
+      "name": "Automotive",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "metropolitan-community-college-area"
+      ],
+      "sample_titles": [
+        "Automotive 6: Engine Performan"
+      ]
+    },
+    {
+      "prefix": "TRAN",
+      "name": "Ucomm",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "western-nebraska-community-college"
+      ],
+      "sample_titles": [
+        "U8_Comm Learners Permit"
+      ]
+    }
+  ],
+  "program_titles": [
+    ".The SCC CORE - General Education Requirements",
+    "Academic Transfer, A.A.",
+    "Academic Transfer, A.S.",
+    "Academic Transfer, Electives List",
+    "Accounting, A.A.",
+    "Adult & Juvenile Services and Corrections, A.A.S.",
+    "Advanced Construction Technology Certificate",
+    "Agricultural Teacher Education, A.A.S.",
+    "Agriculture Management & Production, A.A.S.",
+    "Alcohol & Drug Counseling Certificate",
+    "Artificial Intelligence for Professionals, Certificate",
+    "Associate Degree Nursing, A.A.S.",
+    "Associate Degree Nursing, A.A.S. (LPN-ADN Option)",
+    "Associate Degree of Nursing",
+    "Associate of Health Sciences",
+    "Auto Collision Repair Technology, A.A.S.",
+    "Automotive Technology and Light Repair Certificate",
+    "Automotive Technology Diploma",
+    "Automotive Technology, A.A.S.",
+    "Automotive Technology, AAS",
+    "Automotive Technology: Drivetrain and Under Hood Repair Certificate",
+    "Automotive Technology: Powertrain and Chassis Repair Certificate",
+    "AVD Low Voltage Technician Diploma",
+    "Aviation Maintenance Certificate",
+    "Aviation Maintenance, AAS",
+    "Baking/Pastry Diploma",
+    "Baking/Pastry, A.A.S.",
+    "Basic Construction Technology Certificate",
+    "Biotechnology Certificate",
+    "Biotechnology Diploma",
+    "Biotechnology, A.S.",
+    "Bookkeeping Certificate",
+    "Bookkeeping Diploma",
+    "Building Construction Technology Certificate",
+    "Building Construction Technology, A.A.S.",
+    "Business Administration, Accounting Option, AA",
+    "Business Administration, Accounting Option, AS",
+    "Business Administration, Business Administration Option, AA",
+    "Business Administration, Business Administration Option, AS",
+    "Business Administration, Management Information Systems (MIS) Option, AA",
+    "Business Administration, Management Information Systems (MIS) Option, AS",
+    "Business Certificate",
+    "Business Diploma",
+    "Business Technology, Executive Assistant I Certificate",
+    "Business Technology, Executive Assistant II Certificate",
+    "Business Technology, Executive Assistant Option Diploma",
+    "Business Technology, General Business Option, AAS",
+    "Business Technology, IT Technical Support Option Certificate",
+    "Business Technology, IT Technical Support Option Diploma",
+    "Business Technology, IT Technical Support Option, AAS",
+    "Business Technology, Staff Accountant I Certificate",
+    "Business Technology, Staff Accountant II Certificate",
+    "Business Technology, Staff Accountant Option Diploma",
+    "Business Technology, Staff Accountant Option, AAS",
+    "Business, A.A.",
+    "Business, A.A.S.",
+    "Client Relations Certificate",
+    "Computer Information Technology, Applications Development Diploma",
+    "Computer Information Technology, Applications Development, A.A.S.",
+    "Computer Information Technology, Computer Support Diploma",
+    "Computer Information Technology, Computer Support, A.A.S.",
+    "Computer Information Technology, Cybersecurity, A.A.S.",
+    "Computer Information Technology, General Technician Certificate",
+    "Computer Information Technology, Network Management Diploma",
+    "Computer Information Technology, Network Management, A.A.S.",
+    "Computer Science, AS",
+    "Concrete Construction Technician Certificate",
+    "Concrete Construction Technician Diploma",
+    "Concrete Construction Technician, A.A.S.",
+    "Construction Technology, AAS",
+    "Criminal Justice, A.A.",
+    "Criminal Justice, A.A.S.",
+    "Criminal Justice, AA",
+    "Criminal Justice, AAS",
+    "Culinary Arts, A.A.S.",
+    "Culinary Arts, Diploma",
+    "Culinary Communications, A.A.S",
+    "Culinary Communications, Diploma",
+    "Culinary/Hospitality Certificate",
+    "Data Science, A.S.",
+    "Dental Assistant (with Expanded Duties), A.A.S.",
+    "Dental Assistant Diploma",
+    "Design & Drafting Technology Certificate - Designing Software",
+    "Design & Drafting Technology Certificate - Intro to Design Software",
+    "Design & Drafting Technology Certificate - Residential Design",
+    "Design & Drafting Technology, Architectural Design, A.A.S.",
+    "Design & Drafting Technology, Computer Aided Design Drafting, A.A.S.",
+    "Diesel Technology-Truck Diploma",
+    "Diesel Technology-Truck Maintenance & Light Repair Certificate",
+    "Diesel Technology-Truck, A.A.S.",
+    "Diesel-Ag Equipment Service Tech Diploma",
+    "Diesel-Ag Equipment Service Tech Maintenance & Light Repair Certificate",
+    "Diesel-Ag Equipment Service Tech, A.A.S.",
+    "Diesel, Truck and Heavy Equipment Technology: Advanced Electrical/Mechanical Certificate",
+    "Diesel, Truck and Heavy Equipment Technology: Engine and Powertrain Certificate",
+    "Diesel, Truck, and Heavy Equipment Technology Diploma",
+    "Diesel, Truck, and Heavy Equipment Technology, AAS",
+    "Dietary Manager Certificate",
+    "Early Childhood Education - Certificate",
+    "Early Childhood Education Certificate - In Home Care Provider",
+    "Early Childhood Education Certificate - Infant/Toddler",
+    "Early Childhood Education Certificate - Preschool",
+    "Early Childhood Education Diploma",
+    "Early Childhood Education, A.A.",
+    "Early Childhood Education, A.A.S.",
+    "Education (Early Childhood) Certificate",
+    "Education (Early Childhood), AA",
+    "Education (Early Childhood), AAS",
+    "Education (Elementary), AA",
+    "Education (Music), AA",
+    "Education (Secondary), Art Endorsement Area, AA",
+    "Education (Secondary), Biology Endorsement Area, AA",
+    "Education (Secondary), Business, Marketing, & Information Technology Endorsement Area, AA",
+    "Education (Secondary), Chemistry Endorsement Area, AA",
+    "Education (Secondary), English Language Arts Endorsement Area, AA",
+    "Education (Secondary), Math Endorsement Area, AA",
+    "Education (Secondary), Social Science Endorsement Area, AA",
+    "Education (Secondary), Spanish Endorsement Area, AA",
+    "Electrical & Electromechanical Technology, Automation & Robotics Certificate",
+    "Electrical & Electromechanical Technology, Automation & Robotics, A.A.S.",
+    "Electrical & Electromechanical Technology, Electrical Technician Certificate",
+    "Electrical & Electromechanical Technology, Electrical Technician, A.A.S.",
+    "Electrical & Electromechanical Technology, Electromechanical Industrial Maintenance Technician Certificate",
+    "Electrical & Electromechanical Technology, Electromechanical Industrial Maintenance Technician, A.A.S.",
+    "Electrician Construction Apprenticeship - LEJATC Certificate",
+    "Electrician Construction Apprenticeship - LEJATC Option",
+    "Electronic Systems Technology Technician Diploma",
+    "Electronic Systems Technology, AVD and Low Voltage Systems Certificate",
+    "Electronic Systems Technology, AVD and Low Voltage Systems, A.A.S.",
+    "Electronic Systems Technology, Electronic System Technician Certificate",
+    "Electronic Systems Technology, Electronic Systems Technician, A.A.S.",
+    "Emergency Medical Services, AAS",
+    "Energy Generation Operations Certificate",
+    "Energy Generation Operations Diploma",
+    "Energy Generation Operations, A.A.S.",
+    "Entrepreneurship Certificate",
+    "Event-Venue Operations Management Certificate",
+    "Exercise Science, Health & Fitness Studies Option, AS",
+    "Exercise Science, Physical Education Option, AS",
+    "Fine Arts, Interdisciplinary AFA Option, AFA",
+    "Fine Arts, Music AFA Option, AFA",
+    "Fine Arts, Music Performance AFA Option, AFA",
+    "Fine Arts, Musical Theatre Performance AFA Option, AFA",
+    "Fine Arts, Theatre AFA Option, AFA",
+    "Fine Arts, Visual Arts AFA Option, AFA",
+    "Ford Automotive Student Service Educational Training, A.A.S.",
+    "Fundamentals of Agriculture Certificate",
+    "General Motors Automotive Service Educational Program, A.A.S.",
+    "General Studies (Language and Fine Arts), AA",
+    "General Studies (Math and Science), AS",
+    "General Studies (Social Sciences), AA",
+    "Geographic Information Systems Technician Certificate",
+    "Geographic Information Systems Technician Diploma",
+    "Geographic Information Systems Technician, A.A.S.",
+    "Global Studies Certificate",
+    "Graphic Design Media Arts, A.A.S.",
+    "Health Information Technology, AAS",
+    "Health Professions (Pre), Chiropractic Medicine (Pre) Emphasis Area, AS",
+    "Health Professions (Pre), Dentistry (Pre) Emphasis Area, AS",
+    "Health Professions (Pre), Medicine (Pre) Emphasis Area, AS",
+    "Health Professions (Pre), Nursing (Pre-Professional) Emphasis Area, AS",
+    "Health Professions (Pre), Pharmacy (Pre) Emphasis Area, AS",
+    "Health Professions (Pre), Physical Therapy (Pre) Emphasis Area, AS",
+    "Health Professions (Pre), Veterinary/ Comparative (Pre) Medicine Emphasis Area, AS",
+    "Health Sciences, Biomedical Research (Pre) Emphasis Area, AS",
+    "Health Sciences, Dental Hygiene (Pre) Emphasis Area, AS",
+    "Health Sciences, Dietetics (Pre) Emphasis Area, AS",
+    "Health Sciences, Food Science (Pre) Emphasis Area, AS",
+    "Health Sciences, Medical Laboratory Science (Pre) Emphasis Area, AS",
+    "Health Sciences, Radiologic Technology (Pre) Emphasis, AS",
+    "Healthcare Management, A.A.S.",
+    "Healthcare Services Certificate",
+    "Heating, Ventilation, Air Conditioning & Refrigeration Technology Diploma",
+    "Heating, Ventilation, Air Conditioning & Refrigeration Technology, A.A.S.",
+    "Horticulture & Turfgrass Management, A.A.S.",
+    "Hospitality Management, A.A.S.",
+    "Hospitality Management, Diploma",
+    "Human Services, A.A.S.",
+    "Human Services, AA",
+    "Human Services, AAS",
+    "Human Services, Drug and Alcohol Counseling Certificate",
+    "Information Technology, Cybersecurity Option, AA",
+    "Information Technology, Information Technology Option, AA",
+    "Integrated Technologies, A.A.S.",
+    "John Deere Construction & Forestry Equipment Tech, A.A.S.",
+    "John Deere Tech, A.A.S.",
+    "Land Surveying/GIS/Civil Engineering Technology, A.A.S.",
+    "Law Enforcement & Homeland Security, A.A.S.",
+    "Life Sciences & Natural Resources, Agriculture (Pre) Emphasis Area, AS",
+    "Life Sciences & Natural Resources, Biology/Ecology Emphasis Area, AS",
+    "Life Sciences & Natural Resources, Forestry/Wildlife Management Emphasis Area, AS",
+    "Life Sciences & Natural Resources, Rangeland Management Emphasis Area, AS",
+    "Livestock Management & Production, A.A.S.",
+    "Long Term Care Administration Certificate",
+    "Long Term Care Administration, A.A.S.",
+    "Manufacturing Engineering Technology Certificate",
+    "Manufacturing Engineering Technology Diploma",
+    "Manufacturing Engineering Technology, A.A.S.",
+    "Medical Assisting Diploma",
+    "Medical Coding Certificate",
+    "Medical Laboratory Technician, AAS",
+    "Medical Laboratory Technology, A.A.S.",
+    "Microsoft Office Specialist (MOS) Preparation Certificate",
+    "Nondestructive Testing Technology, A.A.S.",
+    "Nursing (Practical) Diploma",
+    "Nursing, Full-Time (Advanced Placement Option), AD-N",
+    "Nursing, Traditional Student Option (Full-Time), AD-N",
+    "Occupational Therapy Assistant, A.A.S.",
+    "Office Professional Certificate",
+    "Office Professional Diploma",
+    "Office Professional, A.A.S.",
+    "Operations and Service Management, A.A.S.",
+    "Paramedic Certificate",
+    "Paramedic Diploma",
+    "Paramedic, A.A.S.",
+    "Peer Support Certificate",
+    "Pharmacy Technician Diploma",
+    "Phlebotomy Technician Certificate",
+    "Physical Sciences & Math, Chemistry Emphasis Area, AS",
+    "Physical Sciences & Math, Engineering (Pre) Emphasis Area, AS",
+    "Physical Sciences & Math, Mathematics Emphasis Area, AS",
+    "Physical Sciences & Math, Physics Emphasis Area, AS",
+    "Physical Therapist Assistant, A.A.S.",
+    "Plumbing Technology, Diploma",
+    "Plumbing, Heating, and Air Conditioning Technology, A.A.S",
+    "Polysomnographic (Sleep) Technology Certificate",
+    "Powerline Construction & Maintenance Technology Certificate",
+    "Powerline Construction & Maintenance Technology Diploma",
+    "Powerline Construction & Maintenance Technology, AAS",
+    "Powersports Technology Diploma",
+    "Powersports Technology, A.A.S.",
+    "Practical Nursing Diploma",
+    "Precision Agriculture Certificate",
+    "Precision Agriculture Diploma",
+    "Precision Machining and Automation General Machinist Certificate",
+    "Precision Machining and Automation Technology Diploma",
+    "Precision Machining and Automation Technology, Advanced CNC & Automation, A.A.S.",
+    "Precision Machining and Automation Technology, Tool Maker Mold and Die, A.A.S.",
+    "Professional Truck Driver Training Certificate",
+    "Psychology, A.A.",
+    "Psychology, AA",
+    "Radiologic Technology, A.A.S.",
+    "Respiratory Care, A.A.S.",
+    "Social Work",
+    "Surgical First Assist Certificate",
+    "Surgical Technology, A.A.S.",
+    "Surgical Technology, AAS",
+    "Technical Skills Instructor, A.O.S.",
+    "Utility Lineworker, A.A.S.",
+    "Water Quality and Wastewater Treatment Operations Certificate",
+    "Welding Technology Certificate",
+    "Welding Technology Diploma",
+    "Welding Technology, A.A.S.",
+    "Welding Technology, AAS"
+  ]
+}

--- a/data/nm/subject-vocab.json
+++ b/data/nm/subject-vocab.json
@@ -1,0 +1,3398 @@
+{
+  "state": "nm",
+  "generated_at": "2026-06-06T15:41:40.529Z",
+  "subjects": [
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 36,
+      "section_count": 436,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) COMPOSITION I",
+        "(CNM ONLINE COLLEGE STUDENTS) COMPOSITION II",
+        "(CNM ONLINE COLLEGE STUDENTS) TECHNICAL COMMUNICATIONS",
+        "(INTERSESSION FROM APR 27 - MAY 10) PRO AND TECH COMMUNICATION",
+        "Accelerate Basic Comp II"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 55,
+      "section_count": 401,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) APPLICATIONS OF CALCULUS I",
+        "(INTERSESSION FROM APR 27 - MAY 17) COLLEGE ALGEBRA",
+        "(INTERSESSION FROM APR 27 - MAY 17) INTERMEDIATE ALGEBRA",
+        "(INTERSESSION FROM APR 27 - MAY 17) INTRODUCTION TO STATISTICS",
+        "(INTERSESSION FROM APR 27 - MAY 17) SURVEY OF MATHEMATICS"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 53,
+      "section_count": 349,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) BIOLOGY FOR HLTH SCIENCES",
+        "(INTERSESSION FROM APR 27 - MAY 17) GENERAL BIOLOGY",
+        "(INTERSESSION FROM APR 27 - MAY 17) GENERAL BIOLOGY LAB",
+        "(INTERSESSION FROM APR 27 - MAY 17) MICROBIOLOGY",
+        "Biology Capstone Project"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 31,
+      "section_count": 235,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) ABNORMAL PSYCHOLOGY",
+        "(CNM ONLINE COLLEGE STUDENTS) COGNITIVE PSYCHOLOGY",
+        "(CNM ONLINE COLLEGE STUDENTS) DEVELOPMENTAL PSYCHOLOGY",
+        "(CNM ONLINE COLLEGE STUDENTS) STATISTICAL PRINCIPLES FOR PSY",
+        "(INTERSESSION FROM APR 27 - MAY 10) INTRODUCTION TO PSYCHOLOGY"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 64,
+      "section_count": 193,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "ART PRACTICES I",
+        "Arts and Design Advanced Projects",
+        "Black and White Photography",
+        "Book Arts",
+        "Camera Use and the Art of Seeing"
+      ]
+    },
+    {
+      "prefix": "VETT",
+      "name": "VETT",
+      "course_count": 30,
+      "section_count": 170,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Emergency & Critical Care Med",
+        "Intro to Animal Nursing Care",
+        "Intro Vet Diagnostic Image",
+        "Lab Animal/Sm Exotic Clin Pro",
+        "Large Animal Clinical Assist"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 46,
+      "section_count": 152,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM EMPLOYEE WELLNESS)",
+        "Aqua Fit: Aqua Zumba",
+        "Aqua Fit: Deep and Shallow Combo",
+        "Aqua Fit: Swimming Fitness Program",
+        "Aqua Fit: Warm Water Exercise"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 32,
+      "section_count": 149,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "ADV GTAW &amp; FAB",
+        "ADV PROJECT &amp; FABRICATION LAB",
+        "Adv Welding Fabrication &amp; Proj",
+        "Advanced Pipe Welding",
+        "ADVANCED SMAW"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 10,
+      "section_count": 143,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) BUS &amp; PROF COMM",
+        "(CNM ONLINE COLLEGE STUDENTS) INTERCULTURAL COMM",
+        "(CNM ONLINE COLLEGE STUDENTS) PUBLIC SPEAKING",
+        "(INTERSESSION FROM MAY 04 - MAY 17) INTERPERSONAL COMM",
+        "(INTERSESSION FROM MAY 04 - MAY 17) INTRODUCTION TO COMMUNICATION"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 28,
+      "section_count": 135,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(BILINGUAL PROGRAM) ASSESSMENT OF CHLD &amp; EVAL/PRGM",
+        "(BILINGUAL PROGRAM) FAMILY COMMUNITY COLLABORATION",
+        "(BILINGUAL PROGRAM) GUIDING YOUNG CHILDREN",
+        "(BILINGUAL PROGRAM) HEALTH SAFETY AND NUTRITION",
+        "(BILINGUAL PROGRAM) PROF RELTNSHP PRACTICUM"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "Sociology",
+      "course_count": 18,
+      "section_count": 108,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) CONTEMPORARY SOCIAL PROBLEMS",
+        "(CNM ONLINE COLLEGE STUDENTS) INTRODUCTION TO CRIMINOLOGY",
+        "(INTERSESSION FROM APR 27 - MAY 17) INTRODUCTION TO SOCIOLOGY",
+        "(INTERSESSION FROM APR 27 - MAY 17) SOCIOLOGY OF DEVIANCE",
+        "Contemporary Social Problems"
+      ]
+    },
+    {
+      "prefix": "BUSA",
+      "name": "BUSA",
+      "course_count": 33,
+      "section_count": 104,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) BUSINESS MATH",
+        "(INTERSESSION FROM APR 27 - MAY 17) BUSINESS PROFESSIONALISM",
+        "(INTERSESSION FROM APR 27 - MAY 17) INTRODUCTION TO BUSINESS",
+        "AGILE PROJECT MANAGEMENT",
+        "BUSINESS CAPSTONE"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 52,
+      "section_count": 104,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(BILINGUAL PROGRAM) INSTR METHODS BIL",
+        "(BILINGUAL PROGRAM) THRY/PRINC BIL ED",
+        "Assmnt and Eval Stud Lrng",
+        "Bilingual Methods",
+        "CHILDREN&#39;S LITERATURE"
+      ]
+    },
+    {
+      "prefix": "FYEX",
+      "name": "FYEX",
+      "course_count": 3,
+      "section_count": 103,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Acad & Pers Effect",
+        "College Success",
+        "FIRST YEAR SEMINAR"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 17,
+      "section_count": 99,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) INTRO TO CHEMISTRY",
+        "Biochemistry",
+        "Biochemistry Lab",
+        "CHEM IN OUR COMM LAB",
+        "CHEM IN OUR COMMUNITY"
+      ]
+    },
+    {
+      "prefix": "FDMA",
+      "name": "FDMA",
+      "course_count": 57,
+      "section_count": 86,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "2D ANIMATION &amp; SOUND",
+        "Adv Digital Video Production",
+        "Advanced Digital Projects",
+        "Advanced Film and Television Pre-Production",
+        "Advanced Grip Training"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 9,
+      "section_count": 81,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 10) SURVEY OF NEW MEXICO HISTORY",
+        "(INTERSESSION FROM APR 27 - MAY 10) UNITED STATES HISTORY II",
+        "American History Through Film",
+        "G-United States History I",
+        "G-Western Civilization I"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 28,
+      "section_count": 77,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) PRINCIPLES OF ACCOUNTING I",
+        "(CNM ONLINE COLLEGE STUDENTS) PRINCIPLES OF ACCOUNTING II",
+        "(INTERSESSION FROM APR 27 - MAY 17) PAYROLL ACCOUNTING",
+        "ACCOUNTING APPLIC",
+        "ACCOUNTING INTERNSHIP"
+      ]
+    },
+    {
+      "prefix": "CIST",
+      "name": "CIST",
+      "course_count": 39,
+      "section_count": 77,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        ".NET I/C#",
+        "(CNM ONLINE COLLEGE STUDENTS) CAPSTONE",
+        "(CNM ONLINE COLLEGE STUDENTS) CLOUD COMPUTING",
+        "(CNM ONLINE COLLEGE STUDENTS) CYBER DEFENSE BASICS",
+        "(CNM ONLINE COLLEGE STUDENTS) CYBERSECURITY FUNDAMENTALS"
+      ]
+    },
+    {
+      "prefix": "BCIS",
+      "name": "BCIS",
+      "course_count": 16,
+      "section_count": 75,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) FUND OF INFO LIT &amp; SYSTEMS",
+        "Adv Computer App",
+        "Business Computer Applications",
+        "Business Technology",
+        "Computer Literacy"
+      ]
+    },
+    {
+      "prefix": "EMSS",
+      "name": "EMSS",
+      "course_count": 29,
+      "section_count": 72,
+      "colleges": [
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Advanced Care of Special Populations",
+        "Advanced Care of Special Populations Laboratory",
+        "Advanced EMT Clinical",
+        "Advanced EMT Lab",
+        "Advanced EMT Lecture"
+      ]
+    },
+    {
+      "prefix": "NMNC",
+      "name": "Concepts",
+      "course_count": 12,
+      "section_count": 72,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "ADN CAPSTONE",
+        "ASSESSMENT &amp; HLTH PROMOTION",
+        "Care of Patients with Chronic Conditions",
+        "CLINICAL INTENSIVE I",
+        "HEALTH &amp; ILLNESS CONCEPTS I"
+      ]
+    },
+    {
+      "prefix": "CJUS",
+      "name": "CJUS",
+      "course_count": 41,
+      "section_count": 67,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Advanced Penology",
+        "Basic Firearms",
+        "Community-Based Corrections",
+        "CONSTITUTIONAL POLICING",
+        "CORRECTIONS SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 5,
+      "section_count": 62,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) SPANISH I",
+        "CONVERSATIONAL SPANISH I",
+        "G-Spanish II",
+        "SPANISH III",
+        "SPANISH IV"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 54,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) MACROECONOMIC PRINCIPLES",
+        "(CNM ONLINE COLLEGE STUDENTS) MICROECONOMIC PRINCIPLES",
+        "Macroeconomic Principles",
+        "Microeconomic Principles",
+        "Survey of Economics"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 19,
+      "section_count": 54,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Applied Lessons I",
+        "Class Guitar I",
+        "College and Community Band",
+        "G-Amer Popular Music History",
+        "G-Fundament of Music for Non-"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 12,
+      "section_count": 49,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "G-Physical Geology",
+        "GEOLOGY OF NEW MEXICO",
+        "Historical Geology",
+        "Historical Geology Laboratory",
+        "Intro to Oceanography Lab"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "FIRE",
+      "course_count": 19,
+      "section_count": 48,
+      "colleges": [
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Adv Pumping App Driver/Oper",
+        "Advanced Fire Lab",
+        "Basic Pumping App Driver/Oper",
+        "Basic Vehicle Extrication",
+        "Basic Wildland Firefighting"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 8,
+      "section_count": 48,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(CNM MY PACE STUDENTS) LOGIC REASONING &amp; CRIT THINK",
+        "CONTEMPORARY MORAL ISSUES",
+        "ENVIRONMENTAL ETHICS",
+        "G-Biomedical Ethics",
+        "G-Introduction to Ethics"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 27,
+      "section_count": 46,
+      "colleges": [
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Comm and Global Health II",
+        "Concepts of Nursing II",
+        "Fundamental of Nursing Lec/Lab",
+        "Health Assessment",
+        "Integ Approach Evid-based Prac"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 14,
+      "section_count": 43,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Algebra-based Physics I",
+        "Algebra-based Physics I Lab",
+        "Calculus-based Physics I Laboratory",
+        "CALCULUS-BASED PHYSICS II LAB",
+        "G-Algbra-Based Physics I Lab"
+      ]
+    },
+    {
+      "prefix": "ELTR",
+      "name": "ELTR",
+      "course_count": 20,
+      "section_count": 40,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "AC CIRC MOTORS GEN",
+        "ADVANCED PV",
+        "Applied Industrial Electricity I",
+        "Applied Industrial Electricity II",
+        "Basic Electricity and Controls"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 8,
+      "section_count": 38,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) ART APPRECIATION",
+        "Art Foundations(Drawing)",
+        "Art Traditions of the American Southwest",
+        "G-Orientation in Art",
+        "HISTORY OF ART I"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 10,
+      "section_count": 36,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) COMPUTER PROG FUND: PYTHON",
+        "C++ Programming I",
+        "COMP PROG FUND: JAVA2",
+        "Computer Programming Fundamentals",
+        "Computer Programming Fundamentals: Java I"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Intersession",
+      "course_count": 5,
+      "section_count": 36,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 10) CLINICAL PREP",
+        "(INTERSESSION FROM APR 27 - MAY 10) CPR FIRST AID &amp; SAFETY",
+        "HEALTH SERVICES MGMT PRACTICUM",
+        "INTRO TO HEALTHCARE CAREERS",
+        "MEDICAL ETHICS AND LAW"
+      ]
+    },
+    {
+      "prefix": "SAFE",
+      "name": "SAFE",
+      "course_count": 12,
+      "section_count": 36,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Emergency Preparedness",
+        "Environmental Management",
+        "Ergonomics and Human Factors",
+        "Fire Prevention and Protection",
+        "Fleet Safety"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "BARB",
+      "course_count": 23,
+      "section_count": 35,
+      "colleges": [
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Barbering I",
+        "Barbering III",
+        "Barbering Level 1",
+        "Barbering Level 2",
+        "Chemical Texture I"
+      ]
+    },
+    {
+      "prefix": "COSD",
+      "name": "COSD",
+      "course_count": 21,
+      "section_count": 35,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Chemical Texture I",
+        "Chemical Texture II",
+        "Haircoloring I",
+        "Haircoloring II",
+        "Haircutting I"
+      ]
+    },
+    {
+      "prefix": "HMSV",
+      "name": "HMSV",
+      "course_count": 20,
+      "section_count": 35,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "(CNM MY PACE STUDENTS) CASE MGMT &amp; PROF SKILL IN SUB",
+        "(CNM MY PACE STUDENTS) CLIN EVAL OF SUBST ABUSE TREAT",
+        "(CNM MY PACE STUDENTS) COUNSEL SUBSTANCE ABUSE FIELD",
+        "Behavioral Health Capstone",
+        "Case Management"
+      ]
+    },
+    {
+      "prefix": "ENGY",
+      "name": "ENGY",
+      "course_count": 8,
+      "section_count": 34,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Intro to Instrumentation Tech",
+        "Intro to Oil and Gas Industry",
+        "Introduction to Electricity",
+        "Natural Gas Compression",
+        "Princ of Mechanical Systems"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 9,
+      "section_count": 33,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) HUMAN NUTRITION",
+        "(INTERSESSION FROM APR 27 - MAY 17) PERSONAL AND PRACT NUTR LAB",
+        "(INTERSESSION FROM APR 27 - MAY 17) PERSONAL AND PRACTICAL NUTR",
+        "Culinary Nutrition",
+        "Diabetes Management"
+      ]
+    },
+    {
+      "prefix": "HITP",
+      "name": "HITP",
+      "course_count": 22,
+      "section_count": 31,
+      "colleges": [
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Advanced Revenue Cycle Mgmt",
+        "Basic Prin CPT HCPCS Coding",
+        "Basic Princ of ICD-10-CM/PCS",
+        "Coding Seminar"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 9,
+      "section_count": 29,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) INTRODUCTION TO ANTH",
+        "ANTHRO OF DRUGS",
+        "Anthropology 1135 Intro to Biological Anthropology",
+        "G-Intro to Biologi Anthro Lab",
+        "G-Navajo Culture"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "INTRO STELLAR &amp; GALACTIC ASTR",
+        "INTRO STELLAR &amp; GALACTIC LAB",
+        "Intro to Astronomy Lec/Lab",
+        "INTRO TO SOLAR SYS ASTRONOMY",
+        "Introduction to Astronomy"
+      ]
+    },
+    {
+      "prefix": "PLMB",
+      "name": "Plumbing",
+      "course_count": 9,
+      "section_count": 27,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Basic Plmb, Safety, Pipe Fitng",
+        "BLDG MAINT/REPAIR",
+        "MECHANICAL CODE",
+        "Plumbing Apprenticeship I",
+        "Plumbing Apprenticeship III"
+      ]
+    },
+    {
+      "prefix": "WOOD",
+      "name": "WOOD",
+      "course_count": 16,
+      "section_count": 27,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Furniture Making",
+        "Advanced Wood Turning",
+        "Bandsawn Veneers",
+        "Basic Woodworking Projects",
+        "Characteristics of Wood"
+      ]
+    },
+    {
+      "prefix": "ESTH",
+      "name": "ESTH",
+      "course_count": 12,
+      "section_count": 26,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Facials, Makeup & Hair Rem I",
+        "Facials, Makeup & Hair Rem II",
+        "Facials/Makeup/Hair Removal 2",
+        "Facials/Makeup/Hair Removal I",
+        "Industry Topics I"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 20,
+      "section_count": 25,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "ADV NAIL TECH THEORY II",
+        "ADV SALON LAB",
+        "ADV SALON THEORY",
+        "ADVANCED NAIL TECH THEORY I",
+        "COSMETOLGY FUND II"
+      ]
+    },
+    {
+      "prefix": "HLED",
+      "name": "HLED",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "santa-fe-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "American Red Cross First Aid and CPR/AED",
+        "Concepts of Health &amp; Wellness",
+        "Concepts of Health and Wellness",
+        "Fitness and Wellness",
+        "INDEPENDENT STUDY"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "RESP",
+      "course_count": 23,
+      "section_count": 23,
+      "colleges": [
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary Diagnostics",
+        "Cardiopulmonary Path I",
+        "Cardiopulmonary Pathophysiology II",
+        "Cardiopulmonary Pharmacology II",
+        "Clinical Practicum II"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surg",
+      "course_count": 13,
+      "section_count": 23,
+      "colleges": [
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Intro to Surg Tech I",
+        "Intro to Surg Tech Lab I",
+        "Introduction to Surgical Technology Lecture & Laboratory I",
+        "Pharmacology for Surgical Technology",
+        "Surg Tech Clin III"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "CNST",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "(CNM MY PACE STUDENTS) CONST COST ESTIMATING",
+        "(CNM MY PACE STUDENTS) CONST PROJ MGMT II",
+        "(CNM MY PACE STUDENTS) CONSTRUCTION DRAWINGS",
+        "(CNM MY PACE STUDENTS) CONSTRUCTION PROJ MGMT I",
+        "CABINET MAKING"
+      ]
+    },
+    {
+      "prefix": "LEAC",
+      "name": "LEAC",
+      "course_count": 12,
+      "section_count": 22,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "1st Aid &amp; CPR for Public Safet",
+        "Case Prep &amp; Presentation",
+        "Criminal Investigation I",
+        "Criminal Procedure",
+        "Cust Cntrl Chem Ag Off Sfty"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 17,
+      "section_count": 21,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Dental Hygiene Seminar II",
+        "Dental Hygiene Seminar III",
+        "Dental Materials"
+      ]
+    },
+    {
+      "prefix": "SAFT",
+      "name": "Constr",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Commercial Constr Aspects",
+        "Commercial Constr Consider I",
+        "Commercial Constr Consider II",
+        "Commercial Constr Safety Proc",
+        "Intro Commercial Constr Safety"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology for Health Careers",
+        "Introduction to health Careers",
+        "Medical Terminology",
+        "Pathophysiology for Health Sciences"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "American National Government",
+        "AMERICAN NATIONAL GOVERNMENT",
+        "G-Intro to Political Science",
+        "INTERNATIONAL RELATIONS"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "Sign",
+      "course_count": 7,
+      "section_count": 20,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language III",
+        "Basic American Sign Language Linguistics",
+        "G-American Sign Language I",
+        "G-American Sign Language II",
+        "INTRO DEAF CULTURE &amp; COMMUNITY"
+      ]
+    },
+    {
+      "prefix": "AUTE",
+      "name": "AUTE",
+      "course_count": 6,
+      "section_count": 19,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Automotive Electrical Systems",
+        "Brakes",
+        "Engine Repair",
+        "Heating and Air Conditioning",
+        "Introduction to Automotive"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 18,
+      "section_count": 19,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking Techniques",
+        "Advanced Cake Decoration and Display",
+        "Advanced International Cuisine",
+        "Alternative Baking",
+        "American Country Cooking"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "ADV EMT CLINICAL",
+        "ADV EMT THEORY",
+        "ADVANCED EMT LAB",
+        "BEHAVIORAL EMERGENCIES &amp; COMM",
+        "CARDIOVASCULR THRY"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 18,
+      "section_count": 19,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Circuit Analysis I",
+        "Circuit Analysis I Lab",
+        "Engineer & Project Management",
+        "Engineering Circuit Analysis",
+        "Engineering Graphics and Design"
+      ]
+    },
+    {
+      "prefix": "MASS",
+      "name": "Massage",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology for Massage Therapy",
+        "Business in Massage Therapy",
+        "Clinical Intensive in Massage Therapy",
+        "Contraindications of Massage Therapy",
+        "Massage Therapy III"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 6,
+      "section_count": 19,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Digital Marketing Fundamentals",
+        "Int Social Media Marketing",
+        "PRINCIPLES OF MARKETING",
+        "SOC MEDIA STRAT",
+        "Social Media Marketing"
+      ]
+    },
+    {
+      "prefix": "PHLB",
+      "name": "Phlebotomy",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "CLINICAL PHLEBOTOMY",
+        "Introduction to Phlebotomy",
+        "Phlebotomy Clinical",
+        "Phlebotomy Clinical Internship",
+        "Phlebotomy Concepts"
+      ]
+    },
+    {
+      "prefix": "CDLT",
+      "name": "Class",
+      "course_count": 2,
+      "section_count": 18,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Class A Comm Drivers License",
+        "Class A Driving CDL License"
+      ]
+    },
+    {
+      "prefix": "MATT",
+      "name": "MATT",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "ADV MACHINING",
+        "ADV MANUF METH &amp; INDUS EXPL",
+        "ADV SUPP MATT PRIN",
+        "BASIC CAD/CAM",
+        "INTERM MILLNG MACH"
+      ]
+    },
+    {
+      "prefix": "AHAC",
+      "name": "Life",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support for Health Care Providers"
+      ]
+    },
+    {
+      "prefix": "AUTC",
+      "name": "AUTC",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "AIR COND &amp; HEATING",
+        "AUTO ELECTRICAL",
+        "AUTO INTERNSHIP",
+        "AUTOMATIC TRANSMSNS",
+        "AUTOMOTVE ELECTRON"
+      ]
+    },
+    {
+      "prefix": "DAST",
+      "name": "Dental",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Bio Dental Science I",
+        "Clinical Experience I",
+        "Clinical Procedures I",
+        "Clinical Procedures I Laboratory",
+        "Dental Materials Laboratory"
+      ]
+    },
+    {
+      "prefix": "INST",
+      "name": "INST",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Applied Basic AC Circuits",
+        "Applied Basic DC Circuits",
+        "Basic Industrial Electronics",
+        "Industrial Measurement",
+        "Motors and Motor Control"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "MECH",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "ADV ELEC MTR CTRL",
+        "ADV MECH DRIVES",
+        "ADV PLCS",
+        "ADV PNEUMATICS AND HYDRAULICS",
+        "IND ELEC"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Intrnl Business and Mgmt",
+        "Marketing Management",
+        "Operations Management",
+        "PRINCIPLES OF MANAGEMENT",
+        "T: Management"
+      ]
+    },
+    {
+      "prefix": "BLAW",
+      "name": "Online",
+      "course_count": 1,
+      "section_count": 15,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) BUSINESS LAW I"
+      ]
+    },
+    {
+      "prefix": "MCAP",
+      "name": "Coop",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Automatic Trans/Transaxles",
+        "Coop Work Experience",
+        "Coop Work Experience II",
+        "Coop Work Experience III",
+        "Coop Work Experience IV"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CLINICAL EXPERIENCE I",
+        "CLINICAL EXPERIENCE II",
+        "CLINICAL EXPERIENCE III",
+        "PATIENT CARE FOR RADIOGRAPHY",
+        "RADIATION BIOLOGY &amp; PROTECTION"
+      ]
+    },
+    {
+      "prefix": "ASEP",
+      "name": "ASEP",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "ASE Tests",
+        "Automatic Transmissions",
+        "GM Coop Work Education III",
+        "GM Coop Work Education IV",
+        "GM Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "ATEC",
+      "name": "Automotive",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Brake System",
+        "Automotive Computer Management Systems I",
+        "Automotive Electrical/Electronic Systems I",
+        "Automotive Steering and Suspension Systems",
+        "Engine Repair"
+      ]
+    },
+    {
+      "prefix": "DISL",
+      "name": "Career",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical",
+        "Career Readiness Capstone",
+        "Career Readiness Semester I",
+        "Career Readiness Semester II",
+        "Career Readiness Semester III"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "Drafting",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Civil Drafting I",
+        "Computer-Aided Drafting (CAD)",
+        "Construction Take-Offs and Estimating",
+        "Cooperative Education",
+        "Drafting for Industry"
+      ]
+    },
+    {
+      "prefix": "TTEN",
+      "name": "Toyota",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Automatic Trans/Transaxles",
+        "Engines & Related Systems",
+        "Heating & Air Conditioning",
+        "Introduction to Toyota",
+        "Manual Trans/Transaxles"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Comparative Religion",
+        "Foundations of Integrated Stud",
+        "Genesis of Math and Science",
+        "Humanity and Creativity",
+        "Integrated Studies II"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "AC AND CONTROLS",
+        "AIR FLOW PRINC/DUCT DES",
+        "CODE AND SAFETY I",
+        "GAS HEATING FURNACES",
+        "Introduction to Fundamentals of Electricity"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "Cosmetology",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Cosmetology I",
+        "Cosmetology III",
+        "Cosmetology IV",
+        "Cosmetology Level 1",
+        "Cosmetology Level 2"
+      ]
+    },
+    {
+      "prefix": "DA",
+      "name": "DA",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CHAIRSIDE ASST II",
+        "CHRSIDE ASST L II",
+        "CLINICAL EXPERIENCE I",
+        "CLINICAL EXPERIENCE II",
+        "DANB PREPARATION"
+      ]
+    },
+    {
+      "prefix": "ENVS",
+      "name": "Environmental Science",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "northern-new-mexico-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Environmental Geology",
+        "Environmental Law and Regs",
+        "Environmental Science I",
+        "Environmental Science I Lab",
+        "Environmental Science Internship"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "DATA ANAL QUAL",
+        "HLTH DATA CONTENT &amp; STRUCTURE",
+        "HLTH INFO MGT SYS",
+        "HLTH INFO SUPRVISR",
+        "Introduction to Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "NAVA",
+      "name": "Gnavajo",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "san-juan-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "G-Navajo I",
+        "G-Navajo II",
+        "Navajo Government"
+      ]
+    },
+    {
+      "prefix": "OTAP",
+      "name": "OTAP",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Analysis of OT Intervent I",
+        "Elders & OT Interventions II",
+        "Fieldwork Level I-B",
+        "Functional Kinesiology in OT",
+        "Health Care Management in OT"
+      ]
+    },
+    {
+      "prefix": "SUFA",
+      "name": "Surgical",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Pharmacology and Anesthesia",
+        "Principles of Surgical Assist",
+        "SFA Clinicals",
+        "Surg Assist Business Practice",
+        "Surgical Anatomy"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) INTRODUCTION TO THEATRE",
+        "ADVANCED COSTUMING &amp; SEWING",
+        "BEGINNING ACTING",
+        "Practicum"
+      ]
+    },
+    {
+      "prefix": "BFIN",
+      "name": "Finance",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college",
+        "northern-new-mexico-college",
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) PERS FIN PLAN FOR COLL STDNT",
+        "Corporate Finance",
+        "Introduction to Finance"
+      ]
+    },
+    {
+      "prefix": "ENMT",
+      "name": "ENMT",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Computers and Music I",
+        "ENMT Internship I",
+        "ENMT Internship II",
+        "Intro to Video Prod &amp; Editing",
+        "Introduction to Audio"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Medical",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "MED ASSIST CLINICAL SKILLS I",
+        "MED ASSIST CLINICAL SKILLS II",
+        "MEDICAL ASSIST ADMIN SKILLS",
+        "MEDICAL ASSIST LAB SKILLS LAB",
+        "MEDICAL ASSIST PROF OVERVIEW"
+      ]
+    },
+    {
+      "prefix": "PT",
+      "name": "Pharmacy",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "INDEPENDENT STUDY",
+        "INTERMEDIATE PHARMACY TECH",
+        "NON-STERILE USP COMPOUNDING L",
+        "PHARM TECH PHARMACOLOGY II",
+        "PHARMACY TECH PHARMACOLOGY III"
+      ]
+    },
+    {
+      "prefix": "RT",
+      "name": "Therapy",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "ADV CLINICAL EXPERIENCES II",
+        "ADV RESPIRATORY THERAPY LAB II",
+        "ADVANCED RESP THERAPY II",
+        "CARDIO PATHOPHYSIOLOGY II",
+        "CARDIO PATHOPHYSIOLOGY IV"
+      ]
+    },
+    {
+      "prefix": "CULN",
+      "name": "Skills",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "CULINARY SKILLS",
+        "INTERNSHIP",
+        "INTRO CULINARY SKILLS",
+        "Skills I Lab Basic Food Preparation",
+        "Skills I Lecture"
+      ]
+    },
+    {
+      "prefix": "DETC",
+      "name": "DETC",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "AUTO TRANS/HYDRAUL",
+        "DIESEL ENG PERFORM",
+        "DIESEL EQP INTERN",
+        "ELECTRICAL SYS",
+        "INTRO/DIESEL EQUIP"
+      ]
+    },
+    {
+      "prefix": "MAST",
+      "name": "Medical",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Intravenous (IV) Therapy Training",
+        "Medical Assistant Administrative Skills",
+        "Medical Assistant Capstone",
+        "Medical Assistant Clinical Procedures I",
+        "Medical Assistant Clinical Procedures II"
+      ]
+    },
+    {
+      "prefix": "NA",
+      "name": "Nursing",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 10) NURSING ASSISTANT SUPP SKILLS",
+        "NURSING ASSISTANT CLINICAL",
+        "PRINCIPLES NURSING ASSISTANT",
+        "PRINCIPLES OF NURSING ASST LAB"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "PN",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CLINICAL FUND OF PN PRACTICE",
+        "FUNDAMENTALS OF PN PRACTICE",
+        "INTRODUCTION TO PN CONCEPTS",
+        "PN CARE OF PT W CHRONIC COND",
+        "PN CARE OF THE ACUTE PATIENT"
+      ]
+    },
+    {
+      "prefix": "RDNG",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "College Reading"
+      ]
+    },
+    {
+      "prefix": "BEV",
+      "name": "Production",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "BEER PRODUCTION &amp; STYLES",
+        "BEER PRODUCTION I",
+        "BEER PRODUCTION II",
+        "BEVERAGE SERVICE I",
+        "DISTILLED SPIRITS PROD &amp; STYLS"
+      ]
+    },
+    {
+      "prefix": "EFDA",
+      "name": "Dental",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Allied Dental Skills",
+        "Dental Fluoride, Polishing and Sealants Review",
+        "Dental Infection Control Review",
+        "Dental Insurance Billing and Coding",
+        "Dental Radiation Health and Safety Review"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "ENGT",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Fund of Prints &amp; Drawings",
+        "Introduction to Oil &amp; Gas",
+        "Mechanical Science",
+        "METHODS IN ENG TECH II",
+        "METHODS IN ENGINEERING TECH I"
+      ]
+    },
+    {
+      "prefix": "FORD",
+      "name": "FORD",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Auto Transmissions/Transaxles",
+        "Automotive Fundamentals",
+        "Brake Systems",
+        "Coop Work Experience III",
+        "Cooperative Work Experience I"
+      ]
+    },
+    {
+      "prefix": "NTSC",
+      "name": "Science",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(INTERSESSION FROM APR 27 - MAY 17) ENVIR SCIENCE FOR TEACHERS",
+        "(TAUGHT IN SPANISH) LIFE SCIENCE FOR TEACHERS",
+        "PHYSICAL SCIENCE FOR TEACHERS"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "Spec",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college",
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "FOUNDATIONS OF SPEC EDUCATION",
+        "INTRO TO STUDENTS WITH EXCEPTI",
+        "METHODS &amp; MATERIALS FOR SPED",
+        "The Spec Ed Prog Self-Contain",
+        "TWCE EXCEP SPECPOP"
+      ]
+    },
+    {
+      "prefix": "AUBO",
+      "name": "Auto",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Advanced Auto Sheet Metal Fab",
+        "Auto Overall Refinishing",
+        "Intermediate Auto Refinishing",
+        "Intro to Auto Refinishing",
+        "Intro to Auto Sheet Metal Fab"
+      ]
+    },
+    {
+      "prefix": "EQIN",
+      "name": "Equine",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Applied Horsemanship I",
+        "Colt Starting I",
+        "Equine Anatomy",
+        "Equine Evaluation",
+        "Equine Internship (6 hours)"
+      ]
+    },
+    {
+      "prefix": "GIST",
+      "name": "Suas",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "3D SUAS Processes",
+        "Advanced Database Concepts",
+        "GIS I",
+        "GIS Internship",
+        "Map Use, Interpretation & Des"
+      ]
+    },
+    {
+      "prefix": "GRHS",
+      "name": "Greenhouse",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Greenhouse Design and Operation",
+        "Greenhouse Internship",
+        "Hydroponic Plant Growth",
+        "Introduction to CEA Operational Procedures",
+        "Introduction to Soilless Production Systems"
+      ]
+    },
+    {
+      "prefix": "IPOP",
+      "name": "IPOP",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Electrical Power Generation",
+        "Environmental Processes",
+        "Gas Processing & Petroleum Ref",
+        "Intro to Instrumentation",
+        "Maint Overview for Operations"
+      ]
+    },
+    {
+      "prefix": "RDPR",
+      "name": "Radiation",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Intro to Radiation Protection",
+        "Practical Radiation Program II",
+        "Practical Radiation Programs I",
+        "Radiation Biology",
+        "Radiation Instruments I"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Human",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Ethics for Social Work and Human Services",
+        "INTRO TO HUMAN SRVCS &amp; SOC WRK",
+        "Introduction to Human Services and Social Work",
+        "Social Justice and Community Engagement"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "Agriculture",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "new-mexico-junior-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Ag Mechanics",
+        "Agriculture Internship",
+        "International Agriculture",
+        "Livestock Evaluation",
+        "Ranch Management: Law &amp; Ethics"
+      ]
+    },
+    {
+      "prefix": "AMST",
+      "name": "Culture",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(CNM ONLINE COLLEGE STUDENTS) INTRO TO CRI RACE &amp; INDIG STUD",
+        "INTRO TO POL IN POP CULTURE"
+      ]
+    },
+    {
+      "prefix": "BPCS",
+      "name": "Pace",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(CNM MY PACE STUDENTS) BASIC PATIENT CARE SKILLS"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "DMS",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CLINICAL SONOGRAPHY II",
+        "FETAL ECHO/NEO/PED SON",
+        "SONO CONCEPTS LAB III",
+        "SONOGRAPHIC PHYSICS II",
+        "SONOGRAPHIC PHYSICS III"
+      ]
+    },
+    {
+      "prefix": "EDBE",
+      "name": "EDBE",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Formal/Informal Assessment",
+        "Foundations Bil/ESL Multi Educ",
+        "Ling & Phon for Bil Teacher",
+        "Meth Mats Teaching Bilin/ESL",
+        "Second Language Acquisition"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "Legal",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Constitutional Law",
+        "Criminal Litigation",
+        "Introduction to Law for Legal Professionals",
+        "Legal Research and Writing I",
+        "Legal Secretarial Skills"
+      ]
+    },
+    {
+      "prefix": "MANI",
+      "name": "MANI",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Industry Topics",
+        "Mani, Pedi, Nail Enhancement",
+        "Salon/Shop Business & Retail",
+        "Steri, Sani & Bacteriology",
+        "Theory I"
+      ]
+    },
+    {
+      "prefix": "PTAP",
+      "name": "PTAP",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Applied Modalities",
+        "Career Readiness",
+        "Clinical I",
+        "Clinical Neuroanatomy",
+        "Functional Anatomy"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "ARCH",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Building Information Modeling with Revit I",
+        "DESIGN FUNDAMENTALS",
+        "INTRO ARCHITECTURAL GRAPHICS",
+        "INTRO TO ARCHITECTURE",
+        "Technical Documentation with AutoCAD I"
+      ]
+    },
+    {
+      "prefix": "ARDR",
+      "name": "ARDR",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "A/E/C SOFTWARE FOR COM DEV",
+        "BLD MAT/METHDS III",
+        "BLD MAT/METHODS I",
+        "CONST DOCS FOR COMM DEV",
+        "INTRO TO A/E/C SOFTWARE"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Basic Electronics",
+        "Brake Systems",
+        "Heating/Air Conditioning Sys",
+        "Suspension/Steering Sys"
+      ]
+    },
+    {
+      "prefix": "ENDT",
+      "name": "ENDT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "EEG III",
+        "ELECTRICAL CONCEPTS II",
+        "EVOKED POTENTIALS",
+        "NEURODIAGNOSTIC CLINICIAL II",
+        "NEURODIAGNOSTIC SKILLS LAB III"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Human Geography",
+        "HUMAN GEOGRAPHY",
+        "PHYSICAL GEOGRAPHY",
+        "PHYSICAL GEOGRAPHY LAB"
+      ]
+    },
+    {
+      "prefix": "IRW",
+      "name": "Integrated",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "INTEGRATED RDG &amp; WRTG I",
+        "INTEGRATED RDG &amp; WRTG II"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "IT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Capstone I (WIC)",
+        "COMPUTER &amp; KEYBOARD BASICS",
+        "Database Management",
+        "Information Tech Essentials",
+        "Network Security and Tools"
+      ]
+    },
+    {
+      "prefix": "RELG",
+      "name": "Religions",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "EASTERN RELIGIONS",
+        "INTRO TO WORLD RELIGIONS"
+      ]
+    },
+    {
+      "prefix": "ST",
+      "name": "Tech",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "BEGINNING SURGICAL TECH I",
+        "INTRO SURGICL TECH",
+        "SURG TECH CLIN II",
+        "SURG TECH III",
+        "SURG TECH LAB I"
+      ]
+    },
+    {
+      "prefix": "VT",
+      "name": "VT",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED THERAPEUTICS &amp; CARE I",
+        "CLINICAL PATHOLOGY VET TECH I",
+        "INTRO TO VETERINARY PROFESSION",
+        "PREP/PROFSN SUCCES",
+        "VET RECEPTION BASIC SKILLS"
+      ]
+    },
+    {
+      "prefix": "BLDG",
+      "name": "Construction",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Construction Industry Workplace Health and Safety",
+        "Trades Mathematics"
+      ]
+    },
+    {
+      "prefix": "CSYS",
+      "name": "CSYS",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Advanced Networking",
+        "Computer Repair &amp; Upgrade I",
+        "Network Security",
+        "Server Networks",
+        "Spreadsheets"
+      ]
+    },
+    {
+      "prefix": "EECE",
+      "name": "Computer",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Computer Networks I",
+        "Computer Programming I",
+        "Human Computer Interaction",
+        "T:Intro to Machine Learning&AI",
+        "Web Engineering"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Entrepreneurship",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "ENTREPRENEURSHIP"
+      ]
+    },
+    {
+      "prefix": "HT",
+      "name": "HT",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "GUEST SERVICE MANAGEMENT",
+        "INTERNSHIP",
+        "PURCHSNG/COST CONT"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Prep",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "ADV MLT TOPICS &amp; EXAM PREP",
+        "BASIC PHLEBOTOMY SKILLS",
+        "MLT CLINICAL EXPERIENCE",
+        "PREP MED LAB SCIENCES"
+      ]
+    },
+    {
+      "prefix": "NUAS",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "san-juan-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant Clinical",
+        "Nursing Assistant Theory and Laboratory"
+      ]
+    },
+    {
+      "prefix": "PHLS",
+      "name": "Training",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "santa-fe-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker Training",
+        "Community Health Worker Training II",
+        "Home Visitor Training I",
+        "Home Visitor Training II Specialty Care",
+        "Personal Health & Wellness"
+      ]
+    },
+    {
+      "prefix": "WATR",
+      "name": "Water",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Industrial Wastewater Pretreatment",
+        "Intro to Water Treatment and Distribution Systems",
+        "Introduction to Applied Hydraulics",
+        "Water Chemistry",
+        "Water Technologies Internship"
+      ]
+    },
+    {
+      "prefix": "ADOB",
+      "name": "Adobe",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Adobe Building Practicum",
+        "Adobe Construction Basics",
+        "Adobe Wall Construction",
+        "Passive Solar Adobe Design"
+      ]
+    },
+    {
+      "prefix": "AIML",
+      "name": "Fund",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "FUND OF AI",
+        "INTRO TO AI"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Equine Science",
+        "Intro to Animal Science",
+        "Intro to Animal Science Lab",
+        "Meat Science"
+      ]
+    },
+    {
+      "prefix": "AVMT",
+      "name": "Systems",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "A/C ENVIRONMENTAL SYSTEMS",
+        "A/C INSTRUMENTS",
+        "A/C LANDING GEAR SYSTEMS",
+        "AIRFRAME INSPECTION"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "Carp",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "ADV FURNITURE MAKG",
+        "BASIC WOODWORKING THEORY",
+        "CARP BLUEPRINT READING",
+        "CARP FUNDAMENTALS"
+      ]
+    },
+    {
+      "prefix": "CEPY",
+      "name": "Learning",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Human Growth and Behavior",
+        "LEARNING IN THE CLASSROOM"
+      ]
+    },
+    {
+      "prefix": "CVS",
+      "name": "Sonography",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CARDIAC PATHOPHYSIOLOGY I",
+        "CV CLINICAL SONOGRAPHY I",
+        "ECHO-VASCULAR LAB II",
+        "VASCULAR SONOGRAPHY II"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "EXSC",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "GROUP EXERCISE",
+        "INDEPENDENT STUDY",
+        "PRACTICUM",
+        "STRUCTURAL KINESIOLOGY"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "FRENCH I",
+        "FRENCH II"
+      ]
+    },
+    {
+      "prefix": "FS",
+      "name": "Fire",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "BLDG CONSTRUCT FIRE PREVENTION",
+        "FIRE PREVENTION",
+        "PRINC FIRE &amp; EMER SERV SAFETY",
+        "PRINC OF EMERGENCY SERVICES"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CAD FOR SURVEYING &amp; GIS",
+        "FUND OF GEOSPATIAL TECHNOLOGY",
+        "GEOGRAPHIC INFO SYSTEMS I",
+        "GEOSPATIAL TECH"
+      ]
+    },
+    {
+      "prefix": "HRTM",
+      "name": "HRTM",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "INTRO TO HOSPITALITY MGMT",
+        "Introduction to Tourism",
+        "SFTY SAN &amp; HLTH N THE HOSP IND"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "CLINICAL PRACTICUM I",
+        "PRE-PTA ANATOMY FUNDAMENTALS",
+        "PROFESSION OF PHYS THERAPY",
+        "PTA PROCEDURES II"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Developmental reading",
+        "GED Literature",
+        "Reading and Critical Thinking with Lab",
+        "Reading Improvement with Lab"
+      ]
+    },
+    {
+      "prefix": "TRST",
+      "name": "English",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Basic English Skills",
+        "English as 2nd Lang I",
+        "English as 2nd Lang I Lab"
+      ]
+    },
+    {
+      "prefix": "AGED",
+      "name": "AGED",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Careers in Agriculture",
+        "Farm and Ranch Mgmnt &amp; Finance",
+        "Forage, Crops &amp; Pasture"
+      ]
+    },
+    {
+      "prefix": "ALTF",
+      "name": "Algae",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Algae Cultivation",
+        "Algae Culture Capstone",
+        "Introduction to Algae Cultivation"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "Draw",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Advanced Engineer Draw & CAD",
+        "Eng Draw & CAD Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CCST",
+      "name": "Chicana",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "INTRO CHICANA &amp; CHICANO STU"
+      ]
+    },
+    {
+      "prefix": "CM",
+      "name": "Pace",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(CNM MY PACE STUDENTS) CONST MATT/TECH",
+        "(CNM MY PACE STUDENTS) INTRO TO BLDG INFO MODELING",
+        "(CNM MY PACE STUDENTS) SUSTAINABLE BUILDING PRACTICES"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Belly Dance",
+        "FLAMENCO I",
+        "Hip-Hop Dance"
+      ]
+    },
+    {
+      "prefix": "ENER",
+      "name": "Well",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Intro to Leases, Regs, & Locat",
+        "Well Const and Fluid Flow",
+        "Well Const/Fluid Flow Lab"
+      ]
+    },
+    {
+      "prefix": "ENVR",
+      "name": "Water",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Active Water Harvesting and Distribution Systems",
+        "Instrumentation and Controls",
+        "Water Supply and Water Conservation"
+      ]
+    },
+    {
+      "prefix": "HSCI",
+      "name": "Care",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Art and Science of Self Care",
+        "Herbal Therapeutics",
+        "Intro to Health Care Prof"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "Spin",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Spin: (special Interest)"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Mechanics",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Applied Mechanics I",
+        "Fluid Mechanics",
+        "Strength and Properties of Mat"
+      ]
+    },
+    {
+      "prefix": "NRSN",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "LPN to ADN Transition",
+        "Pathophysiology for Nursing",
+        "Pharmacology in Nursing"
+      ]
+    },
+    {
+      "prefix": "OFTC",
+      "name": "Essentials",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Excel Essentials I",
+        "PowerPoint Essentials I",
+        "Word Essentials I"
+      ]
+    },
+    {
+      "prefix": "OTEC",
+      "name": "OTEC",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "COMPUTERS IN MEDICAL OFFICE",
+        "INTRO TO PRAC AND ETHI AI USAG",
+        "KEYBOARDING"
+      ]
+    },
+    {
+      "prefix": "PL",
+      "name": "PL",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "(CNM MY PACE STUDENTS) INTRO/PARALEGAL",
+        "AMERICAN LAW/ETHIC",
+        "TORTS"
+      ]
+    },
+    {
+      "prefix": "AGRO",
+      "name": "Plant",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Introduction to Plant Science",
+        "Introduction to Plant Science Lab"
+      ]
+    },
+    {
+      "prefix": "ARBC",
+      "name": "Arabic",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Arabic I",
+        "Arabic III"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "Surv",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "SURV OF APPL TECH"
+      ]
+    },
+    {
+      "prefix": "CMPR",
+      "name": "Natural",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Adv Naturl Gas Engine Overhaul",
+        "Intro to Natural Gas Engines"
+      ]
+    },
+    {
+      "prefix": "COSC",
+      "name": "Spin",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "san-juan-college",
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Introduction to Programming",
+        "Spin: (special Interest)"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "Electrical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Control Syst & Instrument Lab",
+        "Electrical Systems I with Lab"
+      ]
+    },
+    {
+      "prefix": "GIT",
+      "name": "Gisgps",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Advanced GIS/GPS with Applications",
+        "Cooperative Education Internship"
+      ]
+    },
+    {
+      "prefix": "HRMG",
+      "name": "Controlling",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Controlling Cost and Purchasing Food and Beverage"
+      ]
+    },
+    {
+      "prefix": "ITCT",
+      "name": "Network",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Network Management/CISCO III",
+        "Network Management/CISCO IV"
+      ]
+    },
+    {
+      "prefix": "MNPD",
+      "name": "Manicuristpedicurist",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Manicurist/Pedicurist Level 3",
+        "Manicurist/Pedicurist Level 4"
+      ]
+    },
+    {
+      "prefix": "NATR",
+      "name": "Trees",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Natural Resources Internship",
+        "Trees of North America"
+      ]
+    },
+    {
+      "prefix": "NATV",
+      "name": "Gintro",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "G-Intro Native American Studie"
+      ]
+    },
+    {
+      "prefix": "OPTI",
+      "name": "Ophthalmic",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Ophthalmic Finishing & Surfacing I and La M-Th 09:30-11:50",
+        "Opthalmic Sales"
+      ]
+    },
+    {
+      "prefix": "PORT",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college",
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "BEGINNING PORTUGUESE I"
+      ]
+    },
+    {
+      "prefix": "PSD",
+      "name": "Public",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "PUBLIC SAFETY DSPCH ADV SKILLS",
+        "PUBLIC SAFETY DSPCH FND SKILLS"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Gedhse",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "GED/HSE Social Science",
+        "Introduction to Native American Studies"
+      ]
+    },
+    {
+      "prefix": "SPLI",
+      "name": "Simultaneous",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "BEG CONSECUTIVE INTERPRETATION",
+        "BEG SIMULTANEOUS INTERP"
+      ]
+    },
+    {
+      "prefix": "SPT",
+      "name": "Sterile",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "BASICS OF STERILE PROC",
+        "STERILE PROCESSING LAB"
+      ]
+    },
+    {
+      "prefix": "SUST",
+      "name": "Sustainable",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Sustainable Energy Technologies"
+      ]
+    },
+    {
+      "prefix": "TMP",
+      "name": "Masters",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "The Masters Program"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "Unmanned",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "INTRO UNMANNED AIRCRAFT SYSTEM",
+        "UAS FOR DESIGN &amp; CONSTRUCTION"
+      ]
+    },
+    {
+      "prefix": "AFST",
+      "name": "Africana",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO AFRICANA STUDIES"
+      ]
+    },
+    {
+      "prefix": "BLED",
+      "name": "Bilingual",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Introduction with Internship in Bilingual Education/ESL"
+      ]
+    },
+    {
+      "prefix": "BUED",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "Business Math"
+      ]
+    },
+    {
+      "prefix": "CACS",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "College and Career Success"
+      ]
+    },
+    {
+      "prefix": "CCDM",
+      "name": "Algebra",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Algebra Skills"
+      ]
+    },
+    {
+      "prefix": "CDHC",
+      "name": "Community",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Community Dental health Coordinator Internship"
+      ]
+    },
+    {
+      "prefix": "CHSS",
+      "name": "Service",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Service Learning"
+      ]
+    },
+    {
+      "prefix": "EMET",
+      "name": "Electromechanical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Adv Electromechanical Design"
+      ]
+    },
+    {
+      "prefix": "GNDR",
+      "name": "Gndr",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO WMN, GNDR AND SEXUALI"
+      ]
+    },
+    {
+      "prefix": "HNRS",
+      "name": "Legacy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "HONORS: LEGACY SEMINAR"
+      ]
+    },
+    {
+      "prefix": "HZMT",
+      "name": "Safety",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "Safety and Haz Materials"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Japanese I"
+      ]
+    },
+    {
+      "prefix": "LIBR",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Information Literacy in Electronic Environment"
+      ]
+    },
+    {
+      "prefix": "NMPS",
+      "name": "Telecom",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "new-mexico-junior-college"
+      ],
+      "sample_titles": [
+        "NM PS Telecom Cert"
+      ]
+    },
+    {
+      "prefix": "OSH",
+      "name": "Occup",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "central-new-mexico-community-college"
+      ],
+      "sample_titles": [
+        "OCCUP SAFE GEN INDUST 30 HOUR"
+      ]
+    },
+    {
+      "prefix": "PINS",
+      "name": "Pueblo",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northern-new-mexico-college"
+      ],
+      "sample_titles": [
+        "Intro to Pueblo Indian Studies"
+      ]
+    },
+    {
+      "prefix": "RUSS",
+      "name": "Russian",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "san-juan-college"
+      ],
+      "sample_titles": [
+        "Russian I"
+      ]
+    },
+    {
+      "prefix": "SCIE",
+      "name": "Gedhse",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southwestern-indian-polytechnic-institute"
+      ],
+      "sample_titles": [
+        "GED/HSE Science"
+      ]
+    },
+    {
+      "prefix": "ZCVB",
+      "name": "Canvas",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "Canvas Blueprint"
+      ]
+    },
+    {
+      "prefix": "ZPIB",
+      "name": "Pilas",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "santa-fe-community-college"
+      ],
+      "sample_titles": [
+        "PILAS Blueprint"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/nv/subject-vocab.json
+++ b/data/nv/subject-vocab.json
@@ -1,0 +1,1449 @@
+{
+  "state": "nv",
+  "generated_at": "2026-06-06T15:41:40.568Z",
+  "subjects": [
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 57,
+      "section_count": 1298,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Creative Writing",
+        "American Literature I",
+        "American Literature II",
+        "British Literature I",
+        "British Literature II"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 31,
+      "section_count": 820,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Applied Mathematics",
+        "Applied Topics in Math",
+        "Calculus I",
+        "Calculus II",
+        "Calculus III"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 89,
+      "section_count": 812,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Nursing I Clinical",
+        "Advanced Clinical Nursing I Theory",
+        "Advanced Medical Surgical Nursing II Clinical",
+        "Advanced Medical Surgical Nursing II Theory",
+        "Advanced Pharmacology for Urban Nursing Practice"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 34,
+      "section_count": 700,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Basic Biology",
+        "Biology for Non-Majors",
+        "DNA, Gene Technology, And You",
+        "Evolution",
+        "Fundamentals of Life Science"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 15,
+      "section_count": 475,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Applied Communication",
+        "Careers in Communication",
+        "Cinema as Art and Communication",
+        "Communication Disabilities and Film",
+        "Critical Reasoning in Daily Life"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 28,
+      "section_count": 466,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced General Psychology I",
+        "Aging in Modern American Society",
+        "Capstone Course",
+        "Child Psychology",
+        "Elementary Analysis of Behavior"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 40,
+      "section_count": 425,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "Beginning Printmaking: Relief",
+        "Ceramics I",
+        "Ceramics II",
+        "Cinema II/the Sound Era"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "PSC",
+      "course_count": 13,
+      "section_count": 290,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "American Public Policy",
+        "Capstone in Political Science",
+        "Government Internship",
+        "Introduction to American Politics",
+        "Introduction to Comparative Politics"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 48,
+      "section_count": 285,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Ableton Live",
+        "Advanced Musicianship I E",
+        "Advanced Musicianship I F",
+        "Advanced Musicianship II E",
+        "Advanced Musicianship II F"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 22,
+      "section_count": 277,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "American Environmental History",
+        "European Civilization since 1648",
+        "European Civilization to 1648",
+        "Historical Issues and Contemporary Society",
+        "History of Sexuality in the United States"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 54,
+      "section_count": 276,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "A+ Hardware",
+        "Advanced C Programming",
+        "Advanced C# Programming",
+        "Advanced Java",
+        "Advanced Project and Earned Value Management"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 49,
+      "section_count": 270,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support (ACLS)",
+        "Advanced Cardiology for Paramedics",
+        "Advanced ECG Interpretation",
+        "Advanced Emergency Medical Technician",
+        "Advanced Emergency Medical Technician (AEMT)"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 27,
+      "section_count": 264,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Analytical Chemistry",
+        "Analytical Chemistry",
+        "Beginning Chemistry Laboratory",
+        "Chemistry,Man and Society",
+        "Environmental Chemistry"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 25,
+      "section_count": 250,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Archaeological Field Methods Excavation",
+        "Archaeology of Food",
+        "Art in Small-Scale Societies",
+        "Biological Anthropology Laboratory",
+        "Capstone Course in Anthropology"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 17,
+      "section_count": 245,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Bookkeeping I",
+        "Bookkeeping II",
+        "Certified Bookkeeper Course",
+        "Cost Accounting",
+        "Excel for Accounting"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 40,
+      "section_count": 240,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced GTAW",
+        "Advanced Welding Principles and Practices",
+        "Basic Arc Welding Principles and Practices",
+        "Basic Metals",
+        "Blueprint Reading, Layout and Sketching"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 13,
+      "section_count": 217,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Contemporary Moral Issues",
+        "Critical Thinking and Reasoning",
+        "Ethics for Engineers and Scientists",
+        "Intermediate Reasoning and Critical Thinking",
+        "Introduction to Ethics"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 23,
+      "section_count": 182,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Assessment in Gifted Education",
+        "Classroom Learning Environments",
+        "Curriculum and Instructional Planning in Gifted Education",
+        "Early Foundations in Mathematics",
+        "Education Portfolio"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 29,
+      "section_count": 178,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Topics in Organizational and Interpersonal Behavior",
+        "Applied Business Ethics",
+        "BAS Leadership Capstone",
+        "Business and Society",
+        "Business Plan Creation"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 13,
+      "section_count": 171,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Aging in Modern American Society",
+        "Applied Skills in Sociology",
+        "Conflict Resolution",
+        "Contemporary Social Issues",
+        "Ethnic Groups in Contemporary Societies"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 22,
+      "section_count": 166,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Business Calculations and Methods",
+        "Business Capstone",
+        "Business English",
+        "Business Law I",
+        "Business Law II"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "Information",
+      "course_count": 4,
+      "section_count": 162,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Computer Applications",
+        "Core Computing Competency",
+        "Introduction to Information Systems",
+        "Management Information Systems"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 26,
+      "section_count": 160,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "911 Dispatch Emergency Telecommunicator Academy",
+        "Communication Within the Criminal Justice Field",
+        "Community Relations",
+        "Crime Scene Investigation",
+        "Criminal Evidence"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 13,
+      "section_count": 159,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Environmental Economics",
+        "History and Comparison of Economic Systems",
+        "Internship in Financial Economics",
+        "Introduction to Economics",
+        "Investment Economics"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 11,
+      "section_count": 146,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Conceptual Physics",
+        "General Physics I",
+        "General Physics II",
+        "Introductory Physics",
+        "Physics for Scientists and Engineers I"
+      ]
+    },
+    {
+      "prefix": "GRC",
+      "name": "GRC",
+      "course_count": 38,
+      "section_count": 127,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "3D Character Animation I",
+        "3D Character Animation II",
+        "3D Modeling and Texturing",
+        "Advanced Design and Production",
+        "Advanced Design with Illustrator"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "DH",
+      "course_count": 39,
+      "section_count": 121,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Education Concepts",
+        "Board Review",
+        "Capstone Seminar I",
+        "Capstone Seminar II",
+        "Clinical Dental Hygiene I"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 29,
+      "section_count": 114,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Acting Practicum",
+        "Acting Studio I: Technique",
+        "Beginning Improvisation",
+        "Cinema as Art and Communication"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 35,
+      "section_count": 113,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Auto Electronics",
+        "Advanced Automotive Electronics",
+        "Auto Air Conditioning and Heating",
+        "Auto Electricity & Electronics I",
+        "Auto Heating and Air Conditioning"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 11,
+      "section_count": 109,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Basics of Spanish I",
+        "First Year Spanish I",
+        "First Year Spanish II",
+        "Hispanic-America and Its Culture",
+        "Iberia and Its Cultures"
+      ]
+    },
+    {
+      "prefix": "PEX",
+      "name": "PEX",
+      "course_count": 36,
+      "section_count": 96,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baseball",
+        "Advanced Basketball",
+        "Advanced Cross Country",
+        "Advanced Soccer",
+        "Advanced Softball"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "GEOL",
+      "course_count": 13,
+      "section_count": 94,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Earth and Life Through Time",
+        "Earth Resources & The Environment",
+        "Earthquakes, Volcanoes, and Natural Disasters",
+        "Environmental Geology",
+        "Field Geology I"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 31,
+      "section_count": 90,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking",
+        "American Regional Cuisine",
+        "Aromatics/Restaurant Experience",
+        "Basic Cookery",
+        "Basic Skills Development"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 22,
+      "section_count": 84,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Healthcare Documentation",
+        "Advanced Medical Coding",
+        "Advanced Outpatient Coding",
+        "Beginning Healthcare Documentation",
+        "Coding Practice Experience"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 12,
+      "section_count": 84,
+      "colleges": [
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Community and Lifecycle Nutrition",
+        "Cultural Considerations in Nutrition and Health Care",
+        "Food Service Systems Management",
+        "Human Nutrition",
+        "Introduction to Dietetic Technician Program"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 7,
+      "section_count": 80,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "General Astronomy",
+        "Introduction to Astrobiology",
+        "Introductory Astronomy Laboratory",
+        "Introductory Astronomy: Stars and Galaxies",
+        "Introductory Astronomy: the Solar System"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 7,
+      "section_count": 65,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Environmental Assessment Methods",
+        "Environmental Measurement and Analysis",
+        "Environmental Regulations, History, Law, and Methods",
+        "Environmental Toxicology and Risk Assessment",
+        "Humans and the Environment"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "Science",
+      "course_count": 8,
+      "section_count": 64,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Computer Organization",
+        "Computer Science I",
+        "Computer Science II",
+        "Digital Forensics Fundamentals",
+        "Introduction to Computing"
+      ]
+    },
+    {
+      "prefix": "EGG",
+      "name": "Technical",
+      "course_count": 3,
+      "section_count": 56,
+      "colleges": [
+        "college-of-southern-nevada"
+      ],
+      "sample_titles": [
+        "Technical Physics I",
+        "Technical Physics I Lab",
+        "Technical Physics II"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 8,
+      "section_count": 53,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Climate Change and its Environmental Impacts",
+        "Introduction to Cartography",
+        "Introduction to Cultural Geography",
+        "Introduction to Geotechnology",
+        "Meteorology/Climatology"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 7,
+      "section_count": 52,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Competitive Strategies for Product and Price Management",
+        "Introduction to Professional Sales",
+        "Introduction to Public Relations",
+        "Introduction to Retailing",
+        "Marketing Principles"
+      ]
+    },
+    {
+      "prefix": "CONS",
+      "name": "Construction",
+      "course_count": 25,
+      "section_count": 49,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Advanced Internship in Construction",
+        "Commercial Building Codes",
+        "Commercial Building Codes (IBC)",
+        "Cons Materials & Methods I",
+        "Construction Capstone Course"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "LAW",
+      "course_count": 20,
+      "section_count": 45,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Law",
+        "Bankruptcy",
+        "Business Structures",
+        "Civil Evidence",
+        "Civil Procedure II"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 15,
+      "section_count": 40,
+      "colleges": [
+        "college-of-southern-nevada"
+      ],
+      "sample_titles": [
+        "Grammar I",
+        "Grammar II",
+        "Integrated Skills II",
+        "Integrated Skills III",
+        "Integrated Skills IV"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 13,
+      "section_count": 35,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Critical Analysis of the Mass Media",
+        "Design Principles of Advertising/Publications",
+        "Electronic Media Production I",
+        "Fundamentals of Applied Media Aesthetics",
+        "Internship in Journalism"
+      ]
+    },
+    {
+      "prefix": "RE",
+      "name": "Real",
+      "course_count": 11,
+      "section_count": 32,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Capstone - Real Estate Salesperson License Exam Practice and Preparation",
+        "Real Estate Appraising",
+        "Real Estate Brokerage",
+        "Real Estate Contracts, Transactions, and Ethics",
+        "Real Estate Investments"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 5,
+      "section_count": 29,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Conversational French I",
+        "First Year French I",
+        "First Year French II",
+        "Second Year French I",
+        "Second Year French II"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Applied Accounting and Finance",
+        "Introduction to Investments",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 4,
+      "section_count": 23,
+      "colleges": [
+        "great-basin-college",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Humanities I",
+        "Special Topics in Humanities",
+        "Studies in Humanities",
+        "The Art of Film"
+      ]
+    },
+    {
+      "prefix": "WMST",
+      "name": "Womens",
+      "course_count": 4,
+      "section_count": 23,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Capstone in Women's and Gender Studies",
+        "Gender, Race, and Class",
+        "Introduction to Women's Studies",
+        "The American Women's Movement"
+      ]
+    },
+    {
+      "prefix": "EPY",
+      "name": "Educational",
+      "course_count": 5,
+      "section_count": 22,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Educational Psychology",
+        "Educational, Career, and Personal Development",
+        "Principles of Educational Psychology",
+        "Principles of Elementary Educational Psychology",
+        "Strategies for Academic Success"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Statistics",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Introduction to Statistics"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Year",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "college-of-southern-nevada"
+      ],
+      "sample_titles": [
+        "First Year Japanese I",
+        "First Year Japanese II",
+        "Second Year Japanese I",
+        "Second Year Japanese II",
+        "Special Topics"
+      ]
+    },
+    {
+      "prefix": "CPD",
+      "name": "Substance",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Career Choices and Changes",
+        "Substance Abuse - Fundamental Facts and Insights"
+      ]
+    },
+    {
+      "prefix": "EE",
+      "name": "Circuits",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "college-of-southern-nevada",
+        "great-basin-college",
+        "truckee-meadows-community-college",
+        "western-nevada-college"
+      ],
+      "sample_titles": [
+        "Circuits I",
+        "Circuits I Discussion Circuits I Discussion",
+        "Circuits I Laboratory",
+        "Circuits II",
+        "Circuits II Laboratory"
+      ]
+    },
+    {
+      "prefix": "NRES",
+      "name": "Environmental",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "college-of-southern-nevada",
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "Analysis of Environmental Contaminants",
+        "Analysis of Environmental Contaminants Laboratory",
+        "Compliance with the National Environmental Policy Act",
+        "Environmental Pollution",
+        "Natural Resource Ecology"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "truckee-meadows-community-college"
+      ],
+      "sample_titles": [
+        "College Reading Strategies"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "great-basin-college"
+      ],
+      "sample_titles": [
+        "Introduction to Geographic Information Systems"
+      ]
+    },
+    {
+      "prefix": "CJE",
+      "name": "Criminal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "college-of-southern-nevada"
+      ],
+      "sample_titles": [
+        "- Criminal Justice and Emergency Services Release IUs"
+      ]
+    }
+  ],
+  "program_titles": [
+    "Accounting, AAS",
+    "Administrative Assistant, SC",
+    "Advanced Emergency Medical Technician (Skills Certificate)",
+    "Advanced EMT, SC",
+    "Advanced Manufacturing, CA",
+    "Advanced Manufacturing: Automation, AAS",
+    "Advanced Manufacturing: Automation, SC",
+    "Advanced Manufacturing: Machining, AAS",
+    "Advanced Manufacturing: Machining, CA",
+    "Air Conditioning Technology, AAS",
+    "Air Conditioning Technology, CA",
+    "Air Conditioning Technology: Building Automation, AAS",
+    "Air Conditioning Technology: Central Plant, AAS",
+    "Air Conditioning Technology: Central Plant, CA",
+    "Air Conditioning Technology: Critical Systems, AAS",
+    "Air Conditioning Technology: Critical Systems, CA",
+    "Air Conditioning Technology: Food Service Refrigeration, AAS",
+    "Air Conditioning Technology: Food Service Refrigeration, CA",
+    "American Sign Language (Certificate of Achievement)",
+    "Anthropology, AA",
+    "Applied Psychology: Mental Health Services, AAS",
+    "Applied Psychology: Mental Health Services, CA",
+    "Art, AA",
+    "Artificial Intelligence and Machine Learning, CA",
+    "Associate of Arts",
+    "Associate of Arts, AA",
+    "Associate of Business",
+    "Associate of Business, AB",
+    "Associate of General Studies",
+    "Associate of General Studies Degree, AGS",
+    "Associate of Science",
+    "Associate of Science, AS",
+    "Auto Maintenance and Light Repair, CA",
+    "Automotive Brakes (Skills Certificate)",
+    "Automotive Collision Repair (Skills Certificate)",
+    "Automotive Electrical/Electronic Systems (Skills Certificate)",
+    "Automotive Engine Performance (Skills Certificate)",
+    "Automotive Heating and Air Conditioning (Skills Certificate)",
+    "Automotive Mechanics (Associate of Applied Science - Technology)",
+    "Automotive Mechanics (Certificate of Achievement)",
+    "Automotive Suspension and Steering (Skills Certificate)",
+    "Automotive Technology: Collision Repair, AAS",
+    "Automotive Technology: Master Technician, AAS",
+    "Automotive Transmission/Transaxle (Skills Certificate)",
+    "Aviation Technology: Cabin Service, AAS",
+    "Aviation Technology: Flight Operations, AAS",
+    "Aviation Technology: Professional Pilot Development, AAS",
+    "Biological Science, AS",
+    "Bookkeeping, CA",
+    "Bookkeeping, SC",
+    "Bricklayer: Journeyman, SC",
+    "Bricklayers, AAS",
+    "Bricklayers, CA",
+    "Building Inspection, SC",
+    "Business - Accounting (Associate of Applied Science)",
+    "Business - Bookkeeping (Certificate of Achievement)",
+    "Business - Management (Associate of Applied Science)",
+    "Business (Certificate of Achievement)",
+    "Business Management, AAS",
+    "Business Management, CA",
+    "CADD Technology, CA",
+    "Cardiorespiratory Sciences, AAS",
+    "Cardiorespiratory Sciences, BAS",
+    "Carpentry, AAS",
+    "Carpentry, CA",
+    "Casino Dealing, SC",
+    "Casino Management, AAS",
+    "Casino Management, CA",
+    "Cement Mason, AAS",
+    "Cement Mason, CA",
+    "Cement Mason: Journeyman, SC",
+    "Certified Inspector of Structures - Residential (Skills Certificate)",
+    "Certified Nursing Assistant (Skills Certificate)",
+    "Cisco Certified Network Associate, SC",
+    "Cisco Certified Network Professional, SC",
+    "Cisco Routing and Switching (Skills Certificate)",
+    "Collision Repair, CA",
+    "Collision Repair: Level 1, SC",
+    "Communication, AA",
+    "CompTIA A+ and Network+, SC",
+    "CompTIA Project+, SC",
+    "CompTIA Security+, SC",
+    "Computer Information Technology (Associate of Applied Science - Technology)",
+    "Computer Information Technology (Certificate of Achievement)",
+    "Computer Numerical Controls Machining (Skills Certificate)",
+    "Computer Science, AA",
+    "Computer Science, CA",
+    "Computing and Information Technology: Cyber Security-Compliance, AAS",
+    "Computing and Information Technology: Cyber Security-Digital Forensics, AAS",
+    "Computing and Information Technology: Cyber Security-Digital Forensics, CA",
+    "Computing and Information Technology: Cyber Security-Network Security, AAS",
+    "Computing and Information Technology: Information Management-Network Infrastructure Analyst, CA",
+    "Computing and Information Technology: Information Management-Virtual Computing Analyst, CA",
+    "Computing and Information Technology: Networking-Cloud Systems Administration, AAS",
+    "Computing and Information Technology: Networking-Cloud Systems Administration, CA",
+    "Computing and Information Technology: Networking-Network Administration, AAS",
+    "Computing and Information Technology: Software-Database, AAS",
+    "Computing and Information Technology: Software-Programming, AAS",
+    "Computing and Information Technology: Software-Web Development, AAS",
+    "Construction (Associate of Applied Science - Technology)",
+    "Construction (Certificate of Achievement)",
+    "Construction Estimating, SC",
+    "Construction Gateway Program (Skills Certificate)",
+    "Construction Management (Bachelor of Applied Science)",
+    "Construction Management, AAS",
+    "Construction Management: Construction Technology, AAS",
+    "Construction Management: Facilities Management, AAS",
+    "Construction Skills (Skills Certificate)",
+    "Construction Technology, SC",
+    "Creative Writing, AA",
+    "Criminal Justice (Associate of Applied Science)",
+    "Criminal Justice (Certificate of Achievement)",
+    "Criminal Justice, AA",
+    "Criminal Justice, AAS",
+    "Criminal Justice, CA",
+    "Criminal Justice: Law Enforcement Training Academy, AAS",
+    "Criminal Justice: Law Enforcement Training Academy, CA",
+    "CTE Classroom Teaching (Certificate of Achievement)",
+    "CTE Teacher Licensure, Business and Industry (Skills Certificate)",
+    "CTE Teacher Training for Business & Industry Professionals (Associate of Applied Science)",
+    "CTE Teaching I (Skills Certificate)",
+    "CTE Teaching II (Skills Certificate)",
+    "Culinary Arts, AAS",
+    "Culinary Arts, BAS",
+    "Culinary Arts, CA",
+    "Cultural Resource Management, CA",
+    "Cybersecurity (Skills Certificate)",
+    "Dance, CA",
+    "Deaf Studies (Associate of Applied Science)",
+    "Deaf Studies, AAS",
+    "Deaf Studies: American Sign Language/English Interpreting, BAS",
+    "Dental Assisting, CA",
+    "Dental Hygiene, AS",
+    "Dental Hygiene, BS",
+    "Dental Hygiene: Education Specialist, BS",
+    "Dental Hygiene: Public Health Specialist, BS",
+    "Dental Science, AS",
+    "Developmental Support Technician, SC",
+    "Diagnostic Medical Sonography: Cardiac/Vascular Ultrasound Track, AAS",
+    "Diagnostic Medical Sonography: General/Vascular Ultrasound Track, AAS",
+    "Diesel Heavy Equipment Maintenance Technician, CA",
+    "Diesel Heavy Equipment Master Technician, AAS",
+    "Drywall Applicator, AAS",
+    "Drywall Applicator, CA",
+    "Early Childhood Education (Certificate of Achievement)",
+    "Early Childhood Education, AA",
+    "Early Childhood Education: Director, AAS",
+    "Early Childhood Education: Early Care and Education, AAS",
+    "Early Childhood Education: Infant/Toddler Education, CA",
+    "Early Childhood Education: Preschool Education, CA",
+    "Early Childhood Educator I (Skills Certificate)",
+    "Early Childhood Educator II (Skills Certificate)",
+    "Economics, AA",
+    "Economics: Applied Financial Economics, AA",
+    "Elementary Education (Certificate of Achievement)",
+    "Elementary Education, AA",
+    "Emergency Medical Services (Certificate of Achievement)",
+    "Emergency Medical Technician (EMT), SC",
+    "Emergency Medical Technician Basic (Skills Certificate)",
+    "Energy Audit Inspection (Skills Certificate)",
+    "Energy Auditor Leadership (Skills Certificate)",
+    "Engineering Technology: Electronics-Bench Technician, AAS",
+    "Engineering Technology: Electronics-Biomedical Equipment Technician, AAS",
+    "Engineering Technology: Electronics-Defense Contractor Technician, AAS",
+    "Engineering Technology: Electronics, CA",
+    "Engineering Technology: Electronics, SC",
+    "Engineering Technology: Entertainment Technician, AAS",
+    "Engineering Technology: Entertainment, CA",
+    "Engineering Technology: Management, CA",
+    "Engineering Technology: Manufacturing-Industrial and Operations, AAS",
+    "Engineering Technology: Network Electronics, AAS",
+    "Engineering Technology: Network Electronics, CA",
+    "Engineering Technology: Self-Service Device Technicians, AAS",
+    "Engineering Technology: Slot Repair, CA",
+    "Engineering Technology: Slot Technology Technicians, AAS",
+    "Engineering Technology: Unmanned Systems-Unmanned Aviation Systems Technology, AAS",
+    "Engineering Technology: Unmanned Systems-Unmanned Aviation Systems Technology, CA",
+    "Engineering Technology: Unmanned Systems-Unmanned Aviation Systems Technology, SC",
+    "Engineering Technology: Utilities-Electrical Power, AAS",
+    "Engineering Technology: Utilities-Electrical Power, CA",
+    "Engineering Technology: Utilities-Natural Gas, AAS",
+    "Engineering Technology: Utilities-Natural Gas, CA",
+    "Engineering Technology: Utility-Natural Gas, SC",
+    "English, AA",
+    "Entry-Level Air Conditioning Technician, SC",
+    "Entry-Level Tourism, Convention, and Event Planning, SC",
+    "Environmental and Construction Laborer, AAS",
+    "Environmental and Construction Laborer, CA",
+    "Environmental Conservation, BAS",
+    "Environmental Laboratory Sciences, BAS",
+    "Environmental Management, AAS",
+    "Environmental Management, BAS",
+    "Equipment Operators, AAS",
+    "Equipment Operators, CA",
+    "Facilities Management, SC",
+    "Fire and Emergency Services Administration, BAS",
+    "Fire Instructor 1, SC",
+    "Fire Officer 1, SC",
+    "Fire Science Technology (Associate of Applied Science)",
+    "Fire Science Technology: Fire Fighting, CA",
+    "Fire Technology Management, AAS",
+    "Firefighter 1, SC",
+    "Firefighter I (Skills Certificate)",
+    "Floor Coverer, AAS",
+    "Floor Coverer, CA",
+    "Floor Coverer: Journeyman, SC",
+    "Food and Beverage Management, AAS",
+    "Food and Beverage Management, CA",
+    "Food Service Operations, BAS",
+    "Forensic Anthropology, CA",
+    "Foundations in Elementary Education (Skills Certificate)",
+    "Front End Developer (Skills Certificate)",
+    "Fundamentals of Culinary Arts, SC",
+    "Funeral Services, AAS",
+    "General Business (Associate of Applied Science)",
+    "General Construction Inspector, AAS",
+    "General Construction Inspector, CA",
+    "Glazier, AAS",
+    "Glazier, CA",
+    "Global Studies, AA",
+    "Graphic Communications: Graphic Design, AAS",
+    "Graphic Communications: Web Design, AAS",
+    "Graphic Design (Associate of Applied Science)",
+    "Graphic Design (Certificate of Achievement)",
+    "Health Information Technology, AAS",
+    "Health Science (Associate of Applied Science)",
+    "Healthcare Documentation Specialist, CA",
+    "Healthcare Documentation Specialist, CA (begins Jan. 1, 2026)",
+    "Heat and Frost Insulator, AAS",
+    "Heat and Frost Insulator, CA",
+    "Heating Ventilation Air-Conditioning/Refrigeration (Skills Certificate)",
+    "Heating, Ventilation, Air Conditioning (HVAC) (Certificate of Achievement)",
+    "Heavy Duty Repairman, AAS",
+    "Heavy Duty Repairman, CA",
+    "Highly Qualified Substitute Teaching, SC",
+    "History, AA",
+    "Hospitality Management, AA",
+    "Hotel Management, AAS",
+    "Hotel Management, CA",
+    "Industrial Electronics Technology (Certificate of Achievement)",
+    "Industrial Electronics Technology (Skills Certificate)",
+    "Inside Wireman, AAS",
+    "Inside Wireman, CA",
+    "Installer/Technician, CA",
+    "IT Essentials (Skills Certificate)",
+    "IT Project Management (Skills Certificate)",
+    "IT Security: Ethical Hacking (Skills Certificate)",
+    "IT Security: General Security (Skills Certificate)",
+    "Journalism/Media Studies: Advertising/Public Relations, AA",
+    "Journalism/Media Studies: News Production, AA",
+    "Land Surveying and Geomatics, BAS",
+    "Latinx and Latin American Studies, AA",
+    "Law Enforcement Training Academy (LETA) Category 1, SC",
+    "Law Enforcement Training Academy (LETA) Category 3, SC",
+    "Machine Tool Technology (Associate of Applied Science - Technology)",
+    "Machine Tool Technology (Certificate of Achievement)",
+    "Machining Skills: Lathe (Turning), SC",
+    "Machining Skills: Milling, SC",
+    "Machinist, AAS",
+    "Machinist, CA",
+    "Manual Machining (Skills Certificate)",
+    "Manufacturing Technician (Skills Certificate)",
+    "Marketing, AAS",
+    "Mechatronics & Electronics Technology (Associate of Applied Science)",
+    "Mechatronics Foundation (Skills Certificate)",
+    "Mechatronics Technology (Certificate of Achievement)",
+    "Medical Assisting, CA",
+    "Medical Coding, CA",
+    "Medical Laboratory Scientist, BAS",
+    "Medical Laboratory Technician, AAS",
+    "Mental Health Technician, SC",
+    "Microsoft Certified IT Professional - Server Administrator (Skills Certificate)",
+    "Microsoft Cloud Specialist, SC",
+    "Millwright, AAS",
+    "Millwright, CA",
+    "Motorsports Technology, CA",
+    "Music Business and Technology, CA",
+    "Music, AA",
+    "Network Support (Skills Certificate)",
+    "Nursing (Associate of Applied Science)",
+    "Nursing Assistant, SC",
+    "Nursing, AAS",
+    "Nursing: LPN to RN, AAS",
+    "Nursing: RN to BSN, BS",
+    "Office Assistant, SC",
+    "Oil Well Drillers, AAS",
+    "Oil Well Drillers, CA",
+    "Online Teaching Skills Certificate: Level 1, SC",
+    "Online Teaching Skills Certificate: Level 2, SC",
+    "Ophthalmic Technology: Contact Lens Technician, SC",
+    "Ophthalmic Technology: Ophthalmic Dispensing Technician, AAS",
+    "Ophthalmic Technology: Ophthalmic Dispensing Technician, SC",
+    "Optical Laboratory Technician, SC",
+    "Organization & Project Management (Bachelor of Applied Science)",
+    "Painter, AAS",
+    "Painter, CA",
+    "Painter: Journeyman, SC",
+    "Paralegal/Law, AAS",
+    "Paramedic Medicine, AAS",
+    "Paramedic Medicine, CA",
+    "Pastry Arts, AAS",
+    "Pastry Arts, CA",
+    "Philosophy, AA",
+    "Phlebotomy (Skills Certificate)",
+    "Phlebotomy, SC",
+    "Phlebotomy: National Healthcareer Association (NHA) Certificate Preparation, SC",
+    "Photography: Commercial Photography, AAS",
+    "Physical Sciences, AS",
+    "Physical Therapist Assistant, AAS",
+    "Pile Driver, AAS",
+    "Pile Driver, CA",
+    "Piping Trades, AAS",
+    "Piping Trades, CA",
+    "Plasterer, AAS",
+    "Plasterer, CA",
+    "Political Science, AA",
+    "Practical Nursing - Military Medic/Corpsman to LPN, CA",
+    "Practical Nursing, CA",
+    "Private Pilot Development, CA",
+    "Project Management, BAS",
+    "Psychology, AA",
+    "Radiation Therapy Technology, AAS",
+    "Real Estate Salesperson (Skills Certificate)",
+    "Real Estate Salesperson Post-Licensing, SC",
+    "Real Estate Salesperson Pre-Licensing, SC",
+    "Real Estate, AAS",
+    "Real Estate, CA",
+    "Red Hat Linux Administrator, SC",
+    "Registered Behavior Technician, SC",
+    "Reinforcing Ironworker, AAS",
+    "Reinforcing Ironworker, CA",
+    "Residential Energy Auditor Advanced (Skills Certificate)",
+    "Residential Energy Auditor Foundation (Skills Certificate)",
+    "Residential Energy Auditor Infiltration & Duct Leakage (Skills Certificate)",
+    "Residential Wireman: Journeyman, SC",
+    "Residential, CA",
+    "Roofer and Waterproofer, AAS",
+    "Roofer and Waterproofer, CA",
+    "Scaffold Erector, AAS",
+    "Scaffold Erector, CA",
+    "Secondary Education Endorsement - Programming (Skills Certificate)",
+    "Secondary Education, AA",
+    "Sheet Metal, AAS",
+    "Sheet Metal, CA",
+    "Sign, CA",
+    "Sociology, AA",
+    "Special Education, AA",
+    "Stationary Engineers, AAS",
+    "Stationary Engineers, CA",
+    "Sterile Processing Technology/Technician Certification, SC",
+    "Structural Steel Ironworker, AAS",
+    "Structural Steel Ironworker, CA",
+    "Surgical Technology, AAS",
+    "Surveyors, AAS",
+    "Surveyors, CA",
+    "Teamster Convention Training, AAS",
+    "Teamster Convention Training, CA",
+    "Teamster: Journeyman, SC",
+    "Theatre, AA",
+    "Theatre: Technology and Production, CA",
+    "Tile Setter, AAS",
+    "Tile Setter, CA",
+    "Tile Setter: Journeyman, SC",
+    "Tourism, Convention and Event Planning, AAS",
+    "Tourism, Convention and Event Planning, BAS",
+    "Tourism, Convention and Event Planning, CA",
+    "Veterinary Nursing, AAS",
+    "Videography and Film, AAS",
+    "Water/Wastewater Treatment: Wastewater Treatment, AAS",
+    "Water/Wastewater Treatment: Wastewater Treatment, CA",
+    "Water/Wastewater Treatment: Water Treatment, AAS",
+    "Water/Wastewater Treatment: Water Treatment, CA",
+    "Welding - Fluxed-Core Welding and Gas Tungston Arc-Welding (Skills Certificate)",
+    "Welding - Shielded Metal Arc-Welding and Gas Metal Arc-Welding (Skills Certificate)",
+    "Welding (Associate of Applied Science - Technology)",
+    "Welding Preparation Certificate (Skills Certificate)",
+    "Welding Technology (Certificate of Achievement)",
+    "Welding Technology: Advanced Level Welder, AAS",
+    "Welding Technology: Entry-Level Pipe Welding, SC",
+    "Welding Technology: Entry-Level Structural Welding, SC",
+    "Welding Technology: Entry-Level Weld Manufacturing, SC",
+    "Welding Technology: Entry-Level Welder, CA",
+    "Welding Technology: Gas Tungsten Arc Welding, SC",
+    "Women’s Studies, AA",
+    "World Languages, AA"
+  ]
+}

--- a/data/ok/subject-vocab.json
+++ b/data/ok/subject-vocab.json
@@ -1,0 +1,2871 @@
+{
+  "state": "ok",
+  "generated_at": "2026-06-06T15:41:40.585Z",
+  "subjects": [
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 30,
+      "section_count": 693,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "African American Literature",
+        "American Literature from 1865",
+        "American Literature to 1865",
+        "British Literature from 1800",
+        "British Literature to 1800"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 47,
+      "section_count": 653,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Analytic Geometry & Calculus",
+        "Analytic Geometry and Calculus I",
+        "Analytic Geometry and Calculus II",
+        "Analytic Geometry and Calculus III",
+        "Applied Mathematics Co-Req"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 35,
+      "section_count": 285,
+      "colleges": [
+        "connors-state-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology II",
+        "Anatomy/Physiology I",
+        "Anatomy/Physiology I Lab",
+        "Anatomy/Physiology II",
+        "Anatomy/Physiology II Lab"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 17,
+      "section_count": 254,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "African-American History",
+        "Amer Thought & Culture: Survey",
+        "Ancient and Medieval Western Civilization",
+        "Early Western Civilization",
+        "History of Oklahoma"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 20,
+      "section_count": 165,
+      "colleges": [
+        "connors-state-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Aging, Death, and Dying",
+        "Behavioral Statistics",
+        "Conflict Resolution",
+        "Dev Psychology",
+        "Developmental Psychology"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 63,
+      "section_count": 140,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "American Popular Music",
+        "Aural Theory I",
+        "Aural Theory III",
+        "Beginning Guitar",
+        "Chamber Ensemble: New Music"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 4,
+      "section_count": 140,
+      "colleges": [
+        "connors-state-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "HONORS American Federal Government",
+        "International Relations",
+        "Introduction to International Relations",
+        "Introduction to State and Local Government"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 18,
+      "section_count": 130,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Gen Chemistry I Lab",
+        "General Chemistry for Engineers",
+        "General Chemistry I",
+        "General Chemistry I Lab",
+        "General Chemistry I With Lab"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 17,
+      "section_count": 127,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Applications of Case Mgmt",
+        "Developmental Psychology",
+        "Families and Societies",
+        "Foundations of Case Management"
+      ]
+    },
+    {
+      "prefix": "COLL",
+      "name": "College",
+      "course_count": 4,
+      "section_count": 107,
+      "colleges": [
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "College Success: Social Science",
+        "HONORS College Success",
+        "Orientation to US Higher Education",
+        "Pioneer Purpose"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 42,
+      "section_count": 106,
+      "colleges": [
+        "connors-state-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Adult Health I Clinical",
+        "Adult Health II",
+        "Adult Health II Clinical",
+        "Adult Health III Clinical",
+        "Adult Health IV &amp; Leadership"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 10,
+      "section_count": 89,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "General Biology",
+        "General Biology (Non-Majors)",
+        "General Biology I (Majors)",
+        "General Biology Lab",
+        "Human Anatomy & Physiology I"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 3,
+      "section_count": 86,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "HONORS Introduction to Communication",
+        "Intercultural Communication",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 22,
+      "section_count": 78,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation II",
+        "Art Foundations: 2-D Design",
+        "Art Foundations: 3-D Design",
+        "Art History Survey I",
+        "Art History Survey II"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 8,
+      "section_count": 75,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "American Literature Since 1865",
+        "Applied Technical Writing",
+        "English Composition I",
+        "English Composition II",
+        "Found of Reading & Writing I"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 14,
+      "section_count": 75,
+      "colleges": [
+        "connors-state-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Aging, Death, and Dying",
+        "Behavioral Statistics",
+        "HONORS Introduction to Sociology",
+        "Human Sexuality",
+        "Intro Social Services"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 19,
+      "section_count": 74,
+      "colleges": [
+        "connors-state-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Business Analytics Fundamentals",
+        "Business Communications",
+        "Business Finance",
+        "Business Law",
+        "Business Mathematics"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 36,
+      "section_count": 74,
+      "colleges": [
+        "carl-albert-state-college",
+        "redlands-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Athl/Personal Train Pract I",
+        "Athletic Training Level 2",
+        "Athletic Training Level 3",
+        "Bowling",
+        "Cardio-Circuit Training"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 11,
+      "section_count": 64,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "American Cinema",
+        "Comparative Religions",
+        "Film Studies",
+        "Folklore",
+        "General Humanities I"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 13,
+      "section_count": 62,
+      "colleges": [
+        "connors-state-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "American Popular Culture",
+        "Art Appreciation",
+        "Art of Film",
+        "Cultural Identities and the Arts in America",
+        "Hollywood&#39;s America"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 13,
+      "section_count": 59,
+      "colleges": [
+        "carl-albert-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Accounting I / Financial",
+        "Accounting II / Managerial",
+        "Accounting Information Systems",
+        "Financial Accounting",
+        "Fundamentals of Accounting"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 11,
+      "section_count": 58,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Engineering Physics I",
+        "ENGR Physics II",
+        "Gen Physics I",
+        "Gen Physics I Lab",
+        "General Astronomy"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 10,
+      "section_count": 56,
+      "colleges": [
+        "carl-albert-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Personal Finance",
+        "Prin - Microeconomics",
+        "Principles of Macroeconomics",
+        "Principles Of Macroeconomics"
+      ]
+    },
+    {
+      "prefix": "CHLD",
+      "name": "Child",
+      "course_count": 19,
+      "section_count": 55,
+      "colleges": [
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Behavior & Guidance",
+        "Capstone Practicum",
+        "Child and Family in the Community",
+        "Child Development and Parenting",
+        "Child Development in the Lifespan"
+      ]
+    },
+    {
+      "prefix": "HWP",
+      "name": "HWP",
+      "course_count": 43,
+      "section_count": 53,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Adv Women's Cross Country I",
+        "Advanced Academic Team I",
+        "Advanced Bass Fishing I",
+        "Advanced E-Sports I",
+        "Advanced Men's Baseball I"
+      ]
+    },
+    {
+      "prefix": "CD",
+      "name": "Child Development",
+      "course_count": 26,
+      "section_count": 49,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Admin of Child Care Centers",
+        "Bhv/Guid of Young Child",
+        "Child and Family Development",
+        "Child Development Fieldwork",
+        "Child Development Mgmt & Budg"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 13,
+      "section_count": 49,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Courtroom Interpreting Skills Introduction",
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Intermediate Spanish Grammar and Conversation",
+        "Intermediate Spanish I"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 18,
+      "section_count": 48,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "AI And Ethics",
+        "AI Content Creation",
+        "Beginning Programming",
+        "Computer Operating Systems",
+        "Computer-Based Info Systems"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "Success",
+      "course_count": 5,
+      "section_count": 45,
+      "colleges": [
+        "murray-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Aggie Day",
+        "College Success",
+        "Education Technology",
+        "Student Leadership",
+        "Success Strategies"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 10,
+      "section_count": 44,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Death, Dying and Grief",
+        "Families and Societies",
+        "Introduction to Sociology",
+        "Marriage & Family Relationship",
+        "Marriage and Family"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 9,
+      "section_count": 42,
+      "colleges": [
+        "oklahoma-city-community-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Dynamics",
+        "Engineering Design with Computer Aided Design",
+        "Engineering Statics",
+        "Engineering Strength of Materials",
+        "Introduction to Electrical Science"
+      ]
+    },
+    {
+      "prefix": "MU",
+      "name": "MU",
+      "course_count": 13,
+      "section_count": 41,
+      "colleges": [
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Applied Piano Music I",
+        "Applied Vocal Music I",
+        "Applied Vocal Music II",
+        "Band I",
+        "College Choir"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 9,
+      "section_count": 41,
+      "colleges": [
+        "carl-albert-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking",
+        "HONORS Introduction to Philosophy",
+        "Introduction to Ethical Thinking",
+        "Introduction to Philosophy",
+        "Logic"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 9,
+      "section_count": 40,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Applied Discrete Mathematics for Computing",
+        "C Language",
+        "C++ Programming Language",
+        "Computer Concepts and Applications",
+        "Data Structures"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Speech",
+      "course_count": 2,
+      "section_count": 37,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "redlands-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communications",
+        "Intro to Speech Communication"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 31,
+      "section_count": 35,
+      "colleges": [
+        "connors-state-college",
+        "redlands-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Agri Orientation",
+        "Agriculture Capstone",
+        "Agriculture Intern",
+        "Agriculture Internship",
+        "Agriculture Orientation"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 11,
+      "section_count": 34,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Calculus I With Analytic Geo",
+        "Finite Math for Elem Education",
+        "Foundations of Algebra",
+        "Foundations of General Math",
+        "Math Functions Co-Requisite"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 9,
+      "section_count": 34,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals for Nursing",
+        "Health Illness Nursing III",
+        "Health Promotion & Nursing I",
+        "Health Promotion & Nursing II",
+        "Leadership & Nursing Process"
+      ]
+    },
+    {
+      "prefix": "VN",
+      "name": "VN",
+      "course_count": 17,
+      "section_count": 34,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Anatomy of Domest Clin Skills",
+        "Anatomy of Domestic Animals",
+        "Anesth & Surg Nurs Clin Skills",
+        "Anesthesia and Pain Management",
+        "Diseases & Clinical Nutrition"
+      ]
+    },
+    {
+      "prefix": "PHTA",
+      "name": "PHTA",
+      "course_count": 16,
+      "section_count": 28,
+      "colleges": [
+        "carl-albert-state-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology for PTAs",
+        "Clinical Experience I",
+        "Clinical Experience II",
+        "Clinical Orientation",
+        "Clinical Practice I"
+      ]
+    },
+    {
+      "prefix": "ASLE",
+      "name": "American",
+      "course_count": 7,
+      "section_count": 26,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III",
+        "American Sign Language IV",
+        "Cultural Diversity in the Deaf Community"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "History",
+      "course_count": 3,
+      "section_count": 26,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Early World History",
+        "US Hist Since Civil War Era",
+        "US History to Civil War Era"
+      ]
+    },
+    {
+      "prefix": "POLSC",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 26,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "American Federal Govt",
+        "Intro to Intn'l Relations"
+      ]
+    },
+    {
+      "prefix": "DGMD",
+      "name": "Digital",
+      "course_count": 14,
+      "section_count": 25,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "3D Digital Foundations",
+        "Adobe Acrobat",
+        "Advertising in Photography and Video",
+        "Digital Foundations 2: Illustrator",
+        "Digital Foundations 3:InDesign"
+      ]
+    },
+    {
+      "prefix": "GS",
+      "name": "GS",
+      "course_count": 23,
+      "section_count": 25,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Accurizing Factory Rifles",
+        "Advanced AutoCAD",
+        "Advanced Firearms Repair I",
+        "American Firearm and Law",
+        "Assess & Imprv for Mod Shotgun"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college",
+        "oklahoma-city-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Human Geograp",
+        "Geography (Physical)",
+        "Introduction to Cultural Geography",
+        "Introduction to Geographic Information Systems",
+        "Meteorology"
+      ]
+    },
+    {
+      "prefix": "GVT",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 24,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "American Federal Government"
+      ]
+    },
+    {
+      "prefix": "AVST",
+      "name": "AVST",
+      "course_count": 20,
+      "section_count": 23,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Theory of Flight",
+        "Air Traffic Control Radar Operations",
+        "Air Traffic Control Tower Operations I",
+        "Air Traffic Control Tower Operations III",
+        "Aviation Meteorology"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "carl-albert-state-college",
+        "oklahoma-city-community-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Bus Communication",
+        "Business Communications",
+        "Business Ethics",
+        "Business Mathematics",
+        "Intro To Bus Analytics"
+      ]
+    },
+    {
+      "prefix": "AHS",
+      "name": "AHS",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "carl-albert-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nutrition",
+        "Basic Pharmacology",
+        "Intro to Medical Terminology",
+        "Medical Terminology",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "ESLA",
+      "name": "ESLA",
+      "course_count": 20,
+      "section_count": 22,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "ESL Grammar Advanced 1",
+        "ESL Grammar Basics 1",
+        "ESL Grammar Intermediate 1",
+        "ESL Grammar Intermediate 3",
+        "ESL Listening Advanced 1"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "connors-state-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Foundations Of Physical Educ",
+        "Sports Nutrition",
+        "Theory Coaching Cheerleading",
+        "Theory Of Coaching Baseball",
+        "Walking for Fitness I"
+      ]
+    },
+    {
+      "prefix": "ALDH",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "AP",
+      "name": "Anatomy",
+      "course_count": 3,
+      "section_count": 20,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Applied Anatomy",
+        "Human Anatomy & Physiology I",
+        "Human Anatomy & Physiology II"
+      ]
+    },
+    {
+      "prefix": "CSYS",
+      "name": "CSYS",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "C# Programming",
+        "Data Visualization",
+        "Database Design and SQL",
+        "HTML and CSS",
+        "Introduction to Computer Programming"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "connors-state-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "College Orientation",
+        "Foundations of Education",
+        "Independent Study",
+        "Leadership Development",
+        "President Leadership Class I"
+      ]
+    },
+    {
+      "prefix": "MDLT",
+      "name": "Clinical",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Immunohematology and Blood Bank Lab",
+        "Clinical Immunohematology/Blood Bank",
+        "Clinical Laboratory Operations- Laboratory Skills",
+        "Clinical Microbiology",
+        "Clinical Microbiology Lab"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Critical",
+      "course_count": 1,
+      "section_count": 19,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Critical Academic Reading"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Costume Techniques I",
+        "Fundamentals of Stage Lighting",
+        "Improvisation",
+        "Introduction to Theatre"
+      ]
+    },
+    {
+      "prefix": "AHP",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 18,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "First Aid & CPR",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "POS",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 18,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "American Federal Government"
+      ]
+    },
+    {
+      "prefix": "ZOO",
+      "name": "Human",
+      "course_count": 3,
+      "section_count": 18,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "General Zoology",
+        "Human Anatomy",
+        "Human Physiology"
+      ]
+    },
+    {
+      "prefix": "BM",
+      "name": "BM",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Bus Management Internship I",
+        "Business Ethics",
+        "Human Resource Management",
+        "Intro to Hospitality Managemnt",
+        "Introduction to Business"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "carl-albert-state-college",
+        "murray-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigation",
+        "Criminal Investigations",
+        "Criminal Justice Seminar",
+        "Criminal Law",
+        "Criminal Law for Law Enforcem"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "Criminal",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Evidence",
+        "Criminal Law I",
+        "Criminal Law II",
+        "Criminal Procedures I",
+        "Criminalistics"
+      ]
+    },
+    {
+      "prefix": "HSVC",
+      "name": "Human",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Basic Counseling Skills",
+        "Chemical Dependency and Treatment",
+        "Crisis Intervention Strategies and Practice",
+        "Human Services Applications/Case Management",
+        "Human Services Internship"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Business Leadership",
+        "Interpersonal Skills for Managers",
+        "Leadership Development",
+        "Organizational Behavior",
+        "Prin of Management"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "carl-albert-state-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Advertising and Promotion Management",
+        "Consumer Behavior",
+        "Customer Service",
+        "Introduction to Marketing",
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Fieldwork IIA",
+        "Clinical Fieldwork IIB",
+        "Crtcl Reason Activity Analysis",
+        "Fieldwork I",
+        "Fieldwork IA"
+      ]
+    },
+    {
+      "prefix": "SCL",
+      "name": "Success",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Success in College and Life"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Pharmacology",
+        "Intro to Health Professions",
+        "Math for Meds",
+        "Medical Terminology I",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "MSIS",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Business Data Science Technologies"
+      ]
+    },
+    {
+      "prefix": "COMS",
+      "name": "COMS",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Computers 101",
+        "Fundamentals of Computer Usage",
+        "Spreadsheet Analysis"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "Radiographic",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Radiography",
+        "Introduction to Radiography Laboratory",
+        "Radiographic Anatomy and Positioning I",
+        "Radiographic Biology and Pathology",
+        "Radiographic Clinical Education I"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Topics in Mechanical Ventilation",
+        "Cardiopulmonary Anatomy and Physiology",
+        "Clinical II",
+        "Clinical Procedures Laboratory",
+        "Clinical Simulations Lab"
+      ]
+    },
+    {
+      "prefix": "ANSI",
+      "name": "Animal",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "connors-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Artificial Insemination",
+        "Beef Production",
+        "Into to Animal Diseases",
+        "Intro Comp Livestock Judging",
+        "Intro to Animal Reproduction"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Interpersonal Communication",
+        "Intro to Public Speaking",
+        "Photojournalism I"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene III",
+        "Community Dental Health I",
+        "Dental Hygiene Theory I",
+        "Dental Hygiene Theory III"
+      ]
+    },
+    {
+      "prefix": "GPS",
+      "name": "Physical",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "carl-albert-state-college",
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "General Physical Science",
+        "General Physical Science Lab",
+        "General Physical Science w/La"
+      ]
+    },
+    {
+      "prefix": "IET",
+      "name": "IET",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "AC/DC Electrical Systems",
+        "Blueprint Reading",
+        "Electric Relay & Comp Control",
+        "IET Internship I",
+        "IET Internship II"
+      ]
+    },
+    {
+      "prefix": "OCTA",
+      "name": "OCTA",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Applied Anatomy for OTAs",
+        "Clinical Conditions",
+        "Current Trends in Occupational Therapy",
+        "Developmental Disabilty Theory",
+        "Fieldwork I-A"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography II",
+        "Acoustical Physics and Instrumentation I",
+        "Introduction to Diagnostic Medical Sonography",
+        "OB/Gyn Sonography II",
+        "Sonography Clinical Pract III"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "ENGT",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Technology Internship",
+        "Industrial Safety",
+        "Industry Print Reading with GD&amp;T",
+        "Introduction to Fabrication Lab",
+        "Manufacturing Maintenance"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Science",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "redlands-community-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Physical Science With Lab",
+        "The Nature of Science"
+      ]
+    },
+    {
+      "prefix": "SPC",
+      "name": "Speech",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Speech"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "Business",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Bus Communications",
+        "Business Internship",
+        "Business Statistics",
+        "Intro to Business"
+      ]
+    },
+    {
+      "prefix": "CSEC",
+      "name": "CSEC",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "A+",
+        "CompTIA Certification Preparation",
+        "Cryptography",
+        "Digital Forensics",
+        "Network+"
+      ]
+    },
+    {
+      "prefix": "ELET",
+      "name": "ELET",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Amplifiers I",
+        "DC Circuit Analysis",
+        "Digital Circuits",
+        "Hydraulics and Pneumatics",
+        "Industrial Robotics"
+      ]
+    },
+    {
+      "prefix": "HHPE",
+      "name": "HHPE",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Applied Anatomy and Kinesiology",
+        "First Aid",
+        "Foundations of Physical Education",
+        "Principles in Health Education and Health Promotion",
+        "Professional Careers in Nutritional Sciences"
+      ]
+    },
+    {
+      "prefix": "VETT",
+      "name": "Veterinary",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Calculations for Veterinary Nurses",
+        "Laboratory, Wild and Exotic Animal Nursing",
+        "Parasitology",
+        "Practicum: Animal Clinics and Nursing",
+        "Principles of Animal Nursing"
+      ]
+    },
+    {
+      "prefix": "AGEQ",
+      "name": "Equine",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Basic Care & Training",
+        "Equine Advertising & Marketing",
+        "Equine Behavior & Handling",
+        "Equine Event&Rodeo Production",
+        "Equine Timed Event Performance"
+      ]
+    },
+    {
+      "prefix": "CHDV",
+      "name": "CHDV",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Child & Family In Society",
+        "Child Growth & Development",
+        "Children w/ Special Needs",
+        "Creative Experiences Young Chi",
+        "Guidance Of Young Children"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Computer Applications",
+        "Data Base Management Systems",
+        "Data Comm and Network",
+        "Desktop Publishing"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "DRFT",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "AutoCAD 2",
+        "Basic SolidWorks",
+        "CATIA Fundamentals",
+        "Commercial Drafting and Detailing",
+        "Engineering Drawing with CAD"
+      ]
+    },
+    {
+      "prefix": "FEMS",
+      "name": "Fire",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Building Construction for Fire Protection",
+        "Emergency Services Safety and Survival",
+        "Fire Prevention",
+        "Fire Protection Hydraulics and Water Supply",
+        "Legal Aspects of Emergency Services"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Earth",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "General Geology (Physical)"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I",
+        "Elementary Japanese II",
+        "Intermediate Japanese Grammar and Conversation",
+        "Intermediate Japanese I",
+        "International Work and/or Study Seminar"
+      ]
+    },
+    {
+      "prefix": "ORI",
+      "name": "Freshman",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Freshman Orientation"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "Practicum",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "murray-state-college",
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Movement II",
+        "Clinical Practicum II",
+        "Clinical Practicum III",
+        "Pathology for the PTA",
+        "Practicum I"
+      ]
+    },
+    {
+      "prefix": "RELG",
+      "name": "RELG",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Christian New Testament",
+        "Christian Old Testament",
+        "Introduction to Religious Studies",
+        "Religion and Society",
+        "Religions of the World: The Eastern Tradition"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Financial Acct",
+        "Fundamentals of Managerial Acc",
+        "Introduction to Accounting"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "oklahoma-city-community-college",
+        "redlands-community-college",
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy With Lab",
+        "General Astronomy",
+        "HONORS General Astronomy"
+      ]
+    },
+    {
+      "prefix": "COSC",
+      "name": "Microcomputer",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Microcomputer Application"
+      ]
+    },
+    {
+      "prefix": "CRIJ",
+      "name": "CRIJ",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Community Relations",
+        "Criminal Law I",
+        "Human Relations",
+        "Intro to Corrections",
+        "Intro to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "EMSP",
+      "name": "Paramedic",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician",
+        "Paramedic Theory and Application I",
+        "Paramedic Theory and Application III",
+        "Principles of Paramedic I",
+        "Principles of Paramedic III"
+      ]
+    },
+    {
+      "prefix": "OTAT",
+      "name": "Fieldwork",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Elder Care",
+        "Fieldwork I-B",
+        "Fieldwork II-A",
+        "Fieldwork II-B",
+        "Hlthcare Sys & OCC Ther Mgmt"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "Science",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "General Physical Science"
+      ]
+    },
+    {
+      "prefix": "PSCI",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Gen Physical Science",
+        "Gen Physical Science Lab"
+      ]
+    },
+    {
+      "prefix": "PTAT",
+      "name": "Clinical",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Clinical Practice II",
+        "Clinical Practice III",
+        "Clinical Procedures w/ Lab",
+        "Neurology & Rehab w/ Lab"
+      ]
+    },
+    {
+      "prefix": "RC",
+      "name": "RC",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Basic Rt Procedures",
+        "Diagnostics & Outpatient Svs",
+        "Ped and Neo Resp Care",
+        "Rt Pathology and Pharmacology"
+      ]
+    },
+    {
+      "prefix": "SRGT",
+      "name": "Surgical",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Introduction to Surgical Technology",
+        "Perioperative Patient Care",
+        "Principles of Surgical Asepsis"
+      ]
+    },
+    {
+      "prefix": "BISC",
+      "name": "Biology",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Biological Concepts",
+        "Biology With Lab",
+        "Principles of Biology With Lab"
+      ]
+    },
+    {
+      "prefix": "HCAD",
+      "name": "Healthcare",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Financial Matters in Healthcare",
+        "Overview of Healthcare",
+        "Principles of Healthcare Management",
+        "Technology in Healthcare"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Care&Prevention Of Athltc Inju",
+        "Community Health",
+        "First Aid/Responding to emerge",
+        "Health of the School Child",
+        "Personal Health"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "(L,N)Principle of Horticulture",
+        "Beginning Floral Design Lab",
+        "Herbaceous Plant Materials"
+      ]
+    },
+    {
+      "prefix": "MIC",
+      "name": "Microbiology",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Microbiology"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "Science",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Ag Product Marketing & Sales",
+        "Introduction to Ag Economics",
+        "Introduction to Animal Science",
+        "Introduction to Plant Science",
+        "Topics in Agriculture"
+      ]
+    },
+    {
+      "prefix": "ANS",
+      "name": "Livestock",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Adv Livestock Judge Eval I",
+        "Adv Livestock Show Team I",
+        "Equine Enterprise Mgmt",
+        "Equine Training Methods",
+        "Intro Livestock Judging Eval I"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "General Chemistry I",
+        "General Chemistry II"
+      ]
+    },
+    {
+      "prefix": "CMSC",
+      "name": "Computer",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Business Applications Software",
+        "Computer Science Concepts I",
+        "Computer Science Concepts II",
+        "Prin Info Security & Ethics"
+      ]
+    },
+    {
+      "prefix": "CVTC",
+      "name": "Cardiovascular",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Cardiovascular Anatomy and Physiology",
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Introduction to Cardiovascular Technology",
+        "Invasive Procedures I"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Emergencies",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Medical Emergencies",
+        "Paramedic Internship",
+        "Trauma Emergencies"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "Legal",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Civil Procedure I",
+        "Contract Law",
+        "Intro to Legal Systems",
+        "Introduction to Legal Research and Writing",
+        "Legal Studies Capstone"
+      ]
+    },
+    {
+      "prefix": "MCOM",
+      "name": "MCOM",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Electronic Communication",
+        "HONORS TCC Connection I",
+        "Introduction to Broadcasting",
+        "Introduction to Media Studies",
+        "Mass Communication Internship I"
+      ]
+    },
+    {
+      "prefix": "OHS",
+      "name": "OHS",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Ergonomics and Human Factors",
+        "Intro to Hazardous Mat & Wast",
+        "Introduction To Fire Science",
+        "Introduction To Health & Saf",
+        "OSHA:Construction Indus & Saf"
+      ]
+    },
+    {
+      "prefix": "DGMT",
+      "name": "Graphic",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Digital Imaging And Printing",
+        "Digital Media Production",
+        "Graphic Design I",
+        "Graphic Design Internship I",
+        "Social Media Strat & Campaign"
+      ]
+    },
+    {
+      "prefix": "FCSE",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Intro To Nutrition"
+      ]
+    },
+    {
+      "prefix": "QCTT",
+      "name": "Quality",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Inspection Principles",
+        "Introduction to Quality",
+        "Non-Destructive Testing",
+        "Statistical Process Control, Quality, Costs and Audits"
+      ]
+    },
+    {
+      "prefix": "RELI",
+      "name": "Testament",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "connors-state-college",
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Intro Old Testament",
+        "New Testament Survey",
+        "Old Testament Survey"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Stats",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Elementary Statistics",
+        "Elementary Stats Co-Req Lab"
+      ]
+    },
+    {
+      "prefix": "AGTE",
+      "name": "Drone",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Coding and Robotics I",
+        "Drone Photo & Video",
+        "Drone Technology I",
+        "Drone Technology II"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation"
+      ]
+    },
+    {
+      "prefix": "CJPS",
+      "name": "Criminal",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Criminal Law I",
+        "Criminal Procedures",
+        "Intro To Criminal Justice",
+        "Juvenile Justice & Delinquency"
+      ]
+    },
+    {
+      "prefix": "DCP",
+      "name": "Film",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "American Cinema",
+        "Film Production & Business"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "EST",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Env Compliance Documentation",
+        "Env Sciences Internship II",
+        "Intro Environmental Science",
+        "Intro To Soil Science"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Elementary French II",
+        "French International Seminar and/or Field Studies"
+      ]
+    },
+    {
+      "prefix": "MOA",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Medical Law, Liability & Ethic",
+        "Medical Office Procedures I",
+        "Medical Terminology I"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "carl-albert-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Music Appreciation"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "Music",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Music Appreciation"
+      ]
+    },
+    {
+      "prefix": "NREM",
+      "name": "NREM",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "(L,N)Intro To Natural History",
+        "Introduction to Archery",
+        "Introduction to NREM",
+        "Shotgun Safety & Shooting Spor"
+      ]
+    },
+    {
+      "prefix": "SLPA",
+      "name": "School",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Instruct Prcdrs in Comm Disord",
+        "School Issues for the SLPA"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "murray-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Spanish I",
+        "Beginning Spanish II"
+      ]
+    },
+    {
+      "prefix": "VA",
+      "name": "Veterinary",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Veterinary Assistant I"
+      ]
+    },
+    {
+      "prefix": "ZOOL",
+      "name": "Anatomy",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy With Lab",
+        "Physiology With Lab"
+      ]
+    },
+    {
+      "prefix": "AGEC",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "connors-state-college",
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Ag Economics",
+        "Intro To Agriculture Economics"
+      ]
+    },
+    {
+      "prefix": "BC",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Business Communications"
+      ]
+    },
+    {
+      "prefix": "FV",
+      "name": "Film",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Film & Video Production I",
+        "Film & Video Production II",
+        "Film and Video Editing"
+      ]
+    },
+    {
+      "prefix": "INED",
+      "name": "Interpreting",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Interpreting I",
+        "Introduction to Interpreting",
+        "Introduction to Interpreting Ethics"
+      ]
+    },
+    {
+      "prefix": "LART",
+      "name": "Liberal",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "western-oklahoma-state-college"
+      ],
+      "sample_titles": [
+        "Liberal Arts Capstone"
+      ]
+    },
+    {
+      "prefix": "NAMS",
+      "name": "Native",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Native American Cultures",
+        "Native American Spiritualities (H)"
+      ]
+    },
+    {
+      "prefix": "NUT",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "General Physics I"
+      ]
+    },
+    {
+      "prefix": "RLED",
+      "name": "Testament",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "New Testament",
+        "Old Testament",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "AGL",
+      "name": "Leadership",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Leadership",
+        "Persnl Leadership Development"
+      ]
+    },
+    {
+      "prefix": "AGRN",
+      "name": "Plant",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Plant Science",
+        "Range and Pasture Management"
+      ]
+    },
+    {
+      "prefix": "AGSU",
+      "name": "Agroecsustain",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Appl Sustainability Capstone",
+        "Intro Agroec/Sustain"
+      ]
+    },
+    {
+      "prefix": "ANES",
+      "name": "Anesthesia",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Anesthesia Tech Practicum"
+      ]
+    },
+    {
+      "prefix": "CAT",
+      "name": "Computeraided",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Computer-Aided Design"
+      ]
+    },
+    {
+      "prefix": "COED",
+      "name": "Supervised",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Supervised Work Experience"
+      ]
+    },
+    {
+      "prefix": "CTED",
+      "name": "Cted",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Classroom & Lab Mgt in CTED",
+        "Techniques for Teaching CTED"
+      ]
+    },
+    {
+      "prefix": "DATA",
+      "name": "Data",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Data Analytics Skills",
+        "Introduction to Data Analytics"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Foundations of Teaching"
+      ]
+    },
+    {
+      "prefix": "FDSC",
+      "name": "Food",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "connors-state-college",
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Food Science",
+        "The Meat We Eat"
+      ]
+    },
+    {
+      "prefix": "HITC",
+      "name": "Coding",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Coding Capstone",
+        "HIT Professional Review"
+      ]
+    },
+    {
+      "prefix": "HP",
+      "name": "Program",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Honors Program Seminar"
+      ]
+    },
+    {
+      "prefix": "HRES",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "tulsa-community-college"
+      ],
+      "sample_titles": [
+        "Employee Law",
+        "Principles of Human Resources"
+      ]
+    },
+    {
+      "prefix": "LEIS",
+      "name": "Total",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Total Wellness"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oklahoma-city-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "AGEN",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Intro to Engineering in Agri"
+      ]
+    },
+    {
+      "prefix": "AGLE",
+      "name": "Agri",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Agri Leaders in Society"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "Range",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Principles of Range Management"
+      ]
+    },
+    {
+      "prefix": "AGRM",
+      "name": "Show",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Show And Sale Cattle Prep"
+      ]
+    },
+    {
+      "prefix": "AGRO",
+      "name": "Plant",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "connors-state-college"
+      ],
+      "sample_titles": [
+        "Intro To Plant & Soil Systems"
+      ]
+    },
+    {
+      "prefix": "CHA",
+      "name": "Chickasaw",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Chickasaw Humanities I"
+      ]
+    },
+    {
+      "prefix": "CON",
+      "name": "Construction",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Conservation of Nat Resources"
+      ]
+    },
+    {
+      "prefix": "COSU",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "College Success"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "Entrepreneurship",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurship & Innovation"
+      ]
+    },
+    {
+      "prefix": "ESPT",
+      "name": "Esports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Esports"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "Film",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Film"
+      ]
+    },
+    {
+      "prefix": "GEG",
+      "name": "World",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "HOR",
+      "name": "Prin",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Prin of Horticultural Science"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "Writing For Mass Media"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Casc",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "carl-albert-state-college"
+      ],
+      "sample_titles": [
+        "CASC Leadership I"
+      ]
+    },
+    {
+      "prefix": "MICR",
+      "name": "Microbiology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Microbiology With Lab"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "Marketing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Marketing"
+      ]
+    },
+    {
+      "prefix": "NASC",
+      "name": "Experiential",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "redlands-community-college"
+      ],
+      "sample_titles": [
+        "Experiential Appl Sci Research"
+      ]
+    },
+    {
+      "prefix": "SLP",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Foundations of Speech-Language"
+      ]
+    },
+    {
+      "prefix": "TH",
+      "name": "Oral",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Oral Interpretation"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "Unmanned",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "murray-state-college"
+      ],
+      "sample_titles": [
+        "Intro to Unmanned Systems"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/or/subject-vocab.json
+++ b/data/or/subject-vocab.json
@@ -1,0 +1,4582 @@
+{
+  "state": "or",
+  "generated_at": "2026-06-06T15:41:40.635Z",
+  "subjects": [
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 47,
+      "section_count": 790,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Algebra: Intermediate",
+        "Algebraic Literacy",
+        "Applied Differential Equations",
+        "Applied Math for Technicians **NC",
+        "Applied Technical Mathematics"
+      ]
+    },
+    {
+      "prefix": "WR",
+      "name": "WR",
+      "course_count": 31,
+      "section_count": 759,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Academic Support for Writing",
+        "Adv Creative Writing-Publ",
+        "Composition I",
+        "Composition II",
+        "Composition II-Honors"
+      ]
+    },
+    {
+      "prefix": "BI",
+      "name": "Biology",
+      "course_count": 25,
+      "section_count": 550,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Biology for Health Sciences",
+        "Cell Biology for Health Occupations",
+        "Cell Systems: Introduction to Genetics",
+        "Co-op Ed: Biology",
+        "Ecosystems: Evolution and Diversity"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 99,
+      "section_count": 549,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "2-D Animation: Basics",
+        "3-D Animation: Basics",
+        "3D Design: Construct + Recycle",
+        "ADVANCED PAINTING",
+        "Alternative Photography Processes"
+      ]
+    },
+    {
+      "prefix": "BA",
+      "name": "BA",
+      "course_count": 78,
+      "section_count": 536,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Directed Project",
+        "Accounting Fundamentals",
+        "Advanced Excel and Data Visualization",
+        "Advanced Payroll",
+        "Applied Accounting Capstone"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 63,
+      "section_count": 523,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Adv Flux Core Arc Weld Procss",
+        "Adv Gas Tngstn Arc Weld Procss",
+        "Adv Shielded Metal Arc Welding",
+        "ADVANCED FAB TECHNIQUES",
+        "Advanced Gas Metal Arc Welding"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 29,
+      "section_count": 355,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Abnormal Psychology II",
+        "Animal Behavior",
+        "Careers in Psychology",
+        "Coop Wk Exp: Psychology **NC"
+      ]
+    },
+    {
+      "prefix": "AV",
+      "name": "AV",
+      "course_count": 90,
+      "section_count": 308,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADV INSTRUMENT PILOT GROUND-AIRPLAN",
+        "Advanced Aircraft Systems",
+        "Advanced Helicopter Operations",
+        "Aerodynamics",
+        "Airframe Return to Service"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 21,
+      "section_count": 306,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "ARGUMENT &amp; CRITICAL DISCOURSE",
+        "Business and Professional Communication",
+        "Communicating Love",
+        "Communication, Gender and Culture",
+        "Conflict and Communication"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 98,
+      "section_count": 285,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED OPERATING SYSTEMS",
+        "Advanced Unix/Linux",
+        "AutoCAD 1",
+        "AutoCAD 2",
+        "AutoDESK Civil 3D"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 89,
+      "section_count": 279,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Archery",
+        "At-Home Fitness Adv",
+        "Ballroom Dance, Adv",
+        "Ballroom Dance, Beg",
+        "Ballroom Dance, Int"
+      ]
+    },
+    {
+      "prefix": "MUP",
+      "name": "Section",
+      "course_count": 59,
+      "section_count": 267,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED BASS (Section with Low-cost Course Materials)",
+        "APPLIED CELLO (Section with No-cost Course Materials)",
+        "Applied Cello Lessons",
+        "APPLIED CLARINET (Section with Low-cost Course Materials)",
+        "Applied Clarinet Lessons"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 73,
+      "section_count": 253,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Audio Engineering 3",
+        "AUDIO ENGINEERING I",
+        "AUDIO ENGINEERING III",
+        "AURAL SKILLS III",
+        "AURAL SKILLS VI"
+      ]
+    },
+    {
+      "prefix": "CH",
+      "name": "Chemistry",
+      "course_count": 43,
+      "section_count": 233,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "CHEM FOR ENG MAJORS II LAB",
+        "CHEMISTRY ENGINEER APPL LAB I",
+        "Chemistry Essentials",
+        "Chemistry for Engineering Majors 1",
+        "CHEMISTRY FOR ENGINEERS MAJORS"
+      ]
+    },
+    {
+      "prefix": "AVS",
+      "name": "Flight",
+      "course_count": 37,
+      "section_count": 231,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Systems & Structures I: Airframe",
+        "Aircraft Systems: Powerplant **NC",
+        "Applied Aerodynamics **NC",
+        "Aviation Fundamentals **NC",
+        "Aviation Law & Regulations **NC"
+      ]
+    },
+    {
+      "prefix": "MP",
+      "name": "Individual",
+      "course_count": 40,
+      "section_count": 215,
+      "colleges": [
+        "columbia-gorge-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "INDIV. LESSONS: TUBA/EUPHONIUM",
+        "INDIVIDUAL LESSON: BASSOON",
+        "INDIVIDUAL LESSON: CELLO",
+        "INDIVIDUAL LESSON: CLARINET",
+        "INDIVIDUAL LESSON: DBL BASS"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 52,
+      "section_count": 193,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Mobile Application Development",
+        "Advanced Programming: C#",
+        "Advanced Windows: Server Management",
+        "Artificial Intelligence Programming 1",
+        "Beginning Mobile Application Development"
+      ]
+    },
+    {
+      "prefix": "9.9",
+      "name": "9.9",
+      "course_count": 105,
+      "section_count": 169,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ACTIVIDADES MULTICULTURALES",
+        "ACULTURACI&Oacute;N, EXPERIENCIA LAT.",
+        "ADHD 201",
+        "ADULTS MUST FEEL SAFE TO LEARN",
+        "ADULTS WANT TO LEARN"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 26,
+      "section_count": 163,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Anat & Phys I Lab",
+        "Anat & Phys II Lab",
+        "Anat & Phys III Lab",
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology II"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "ED",
+      "course_count": 47,
+      "section_count": 137,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Adolescent Learning and Development",
+        "Anti-Bias Curric in Education",
+        "Children&#39;s Lit &amp; Curriculum",
+        "Children&#39;s Lit/Diverse Clsroom",
+        "CIVIL RIGHTS & MULTICULTURAL ISSUES IN EDUCATIONAL SETTINGS"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 29,
+      "section_count": 135,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Business Communication **LC",
+        "Computer Accounting Applications **NC",
+        "Consumer Behavior **NC",
+        "Coop Wk Exp: Accounting **NC",
+        "Customer Service Fundamentals **NC"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "HPE",
+      "course_count": 18,
+      "section_count": 122,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Anatomical Kinesiology",
+        "BEGINNING WEIGHT TRAINING (Section with No-cost Course Materials)",
+        "Exercise Physiology",
+        "Exercise Testing and Prescription",
+        "FIRST AID & CPR"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "History",
+      "course_count": 22,
+      "section_count": 119,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "CWE HISTORY",
+        "HISTORY OF MEXICO",
+        "History of the United States",
+        "HISTORY OF THE UNITED STATES 1914 TO PRESENT",
+        "History of WesternCivilization: Ancient to Medieval"
+      ]
+    },
+    {
+      "prefix": "GS",
+      "name": "Science",
+      "course_count": 11,
+      "section_count": 115,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Chemistry & Cell Biology",
+        "CWE PHYSICAL SCIENCE",
+        "Earth Science: Earth Revealed",
+        "Gen Sci: Earth Systems Science",
+        "General Science: Astronomy"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 33,
+      "section_count": 110,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Africa, Asia, South America",
+        "AFRICAN AMERICAN LITERATURE",
+        "BRITISH LITERATURE: EARLY",
+        "Children&#39;s Literature",
+        "Eng Lit: Victorian/Post-col"
+      ]
+    },
+    {
+      "prefix": "HE",
+      "name": "Health",
+      "course_count": 26,
+      "section_count": 110,
+      "colleges": [
+        "chemeketa-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "ADULT/INFANT FIRST AID CPR/AED",
+        "CHILD HEALTH, NUTRITION, SAFETY",
+        "COMMUNITY BIRTH DOULA",
+        "CWE HEALTH",
+        "DISEASE DETECTIVES"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 40,
+      "section_count": 109,
+      "colleges": [
+        "chemeketa-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Administration of Child Care Programs",
+        "Anti-Bias Curriculum",
+        "Applying Early Childhood Curriculum",
+        "Assessment & Evaluation",
+        "Child Nutrition/Health/Safety"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 45,
+      "section_count": 107,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ACCIDENT INVESTIGATION/TRAFFIC LAWS",
+        "CJ Personal Defense, Adv.",
+        "CJ Personal Defense, Beg.",
+        "COMMUNITY RELATIONS",
+        "CONCEPTS OF ENFORCEMENT SERVICES"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "Theory",
+      "course_count": 24,
+      "section_count": 106,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Barbering Clinic II",
+        "Barbering Theory",
+        "Barbering Theory Lab",
+        "Cosmetology Science",
+        "Esthetics Clinic II"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 14,
+      "section_count": 102,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Sociology",
+        "Death/Dying: Socio/Cltrl Prsp",
+        "Deviance, Power, and Prisons",
+        "HUMAN SEXUALITY",
+        "INTRO TO ENVIRONMENT &amp; SOCIETY"
+      ]
+    },
+    {
+      "prefix": "APR",
+      "name": "APR",
+      "course_count": 41,
+      "section_count": 97,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED PLC TROUBLESHOOTING",
+        "COMM SYSTEMS &amp; NETWORKS",
+        "DRIVE SYSTEMS",
+        "ELEC GENERATOR/MOTORS/CONTROL",
+        "ELECTRIC MOTORS"
+      ]
+    },
+    {
+      "prefix": "WRI",
+      "name": "Writing",
+      "course_count": 13,
+      "section_count": 93,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Co-Requisite Writing **NC",
+        "Composition I **NC",
+        "Composition II **LC",
+        "Corequisite for WRI 121Z",
+        "Creative Writing - Fiction Workshop **LC"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "Nursing",
+      "course_count": 42,
+      "section_count": 91,
+      "colleges": [
+        "clatsop-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Advocacy through Healthcare Policy",
+        "Chronic Illness 2 and End-of-Life",
+        "Chronic Illness 2 and End-of-Life - Clinical Lab",
+        "Clinical Pharmacology 1",
+        "Clinical Pharmacology 2"
+      ]
+    },
+    {
+      "prefix": "DRF",
+      "name": "DRF",
+      "course_count": 33,
+      "section_count": 87,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "3-D Modeling with Inventor",
+        "Architectural Design",
+        "Architectural Drafting 1",
+        "Architectural Plans",
+        "BIM Modeling"
+      ]
+    },
+    {
+      "prefix": "PH",
+      "name": "Physics",
+      "course_count": 23,
+      "section_count": 84,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Applied Physics",
+        "Astronomy: Galaxies",
+        "Astronomy: Solar System",
+        "CWE PHYSICS",
+        "DESCRIPTIVE ASTRONOMY"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "EMT",
+      "course_count": 26,
+      "section_count": 79,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "klamath-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Advanced Emergency Medical Technician Part 1",
+        "Advanced Emergency Medical Technician Part 2",
+        "Capstone Internship",
+        "Cooperative Work Experience"
+      ]
+    },
+    {
+      "prefix": "BT",
+      "name": "BT",
+      "course_count": 25,
+      "section_count": 77,
+      "colleges": [
+        "chemeketa-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Admin Capstone Projects",
+        "Business English 1",
+        "Business Proofreading and Editing",
+        "CLOUD BASED ACCOUNTING SYSTEMS",
+        "Co-op Ed: Business Seminar"
+      ]
+    },
+    {
+      "prefix": "ANS",
+      "name": "ANS",
+      "course_count": 40,
+      "section_count": 76,
+      "colleges": [
+        "linn-benton-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED HALTER TRAINING",
+        "ADVANCED HORSE TRAINING",
+        "ADVANCED HORSESHOEING",
+        "APPLIED ANIMAL NUTRITION",
+        "APPLIED SHEEP PRODUCTION"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 20,
+      "section_count": 75,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED PIPE WELDING",
+        "BASIC WELDING I",
+        "BASIC WELDING II",
+        "FLUX CORED ARC WELDING",
+        "GAS METAL ARC WELDING"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 15,
+      "section_count": 72,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Anthropology of Native North America",
+        "Archaeology Of Oregon",
+        "Biological Anthropology",
+        "Chicanx Culture and Identity",
+        "Cultural Anthropology"
+      ]
+    },
+    {
+      "prefix": "CAS",
+      "name": "CAS",
+      "course_count": 13,
+      "section_count": 72,
+      "colleges": [
+        "columbia-gorge-community-college",
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Business Applications **NC",
+        "Advanced Business Applications Lab **NC",
+        "BEGINNING DATABASES",
+        "Beginning Keyboarding **NC",
+        "BEGINNING PHOTOSHOP"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Philosophy",
+      "course_count": 18,
+      "section_count": 72,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Biomedical Ethics",
+        "Critical Thinking",
+        "Critical Thinking **NC",
+        "Critical Thinking &amp; Logic",
+        "Critical Thinking-Honors"
+      ]
+    },
+    {
+      "prefix": "EC",
+      "name": "EC",
+      "course_count": 3,
+      "section_count": 70,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "PRINCIPLES OF ECONOMICS: INTRODUCTION, INSTITUTIONS & PHILOSOPHIES",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "FRP",
+      "name": "Fire",
+      "course_count": 31,
+      "section_count": 64,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Build Construct Fire Protect",
+        "Building Construction for Fire Protection",
+        "Cooperative Work Experience",
+        "Emergency Services",
+        "Emergency Services Rescue"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 32,
+      "section_count": 64,
+      "colleges": [
+        "central-oregon-community-college",
+        "klamath-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Advanced Medical Coding Lab",
+        "Co-op Ed: Health Information Management",
+        "Coding Classifications III",
+        "Coop Wk Exp: HIM Prof Prac Exp I **NC"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 9,
+      "section_count": 62,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ANALYSIS/GEOMETRY/PRECALCULUS",
+        "BEGINNING ALGEBRA I",
+        "CALCULUS I",
+        "CALCULUS II",
+        "INTERMEDIATE ALGEBRA I"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 22,
+      "section_count": 60,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "3D Dynamics",
+        "Co-op Ed: Engineering",
+        "COMPUTATIONAL METHODS FOR ENGR",
+        "DESIGN THINK AND PROBLEM SOLVE",
+        "DIGITAL LOGIC DESIGN"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "MA",
+      "course_count": 19,
+      "section_count": 60,
+      "colleges": [
+        "central-oregon-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADMIN PRACTICUM",
+        "Applic of Prof Med Assist",
+        "Body Structure and Function I",
+        "Clinical Assistant 3",
+        "CLINICAL PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 39,
+      "section_count": 60,
+      "colleges": [
+        "central-oregon-community-college",
+        "columbia-gorge-community-college",
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Additive Manufacturing I",
+        "Automated Cutting",
+        "Blueprint Reading",
+        "BLUEPRINT READING",
+        "CAM Lathe I"
+      ]
+    },
+    {
+      "prefix": "PEAT",
+      "name": "Skills",
+      "course_count": 40,
+      "section_count": 60,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Baseball - Men&#39;s Cond. 1",
+        "Baseball - Men&#39;s Cond. 2",
+        "Baseball - Men&#39;s Skills 1",
+        "Baseball - Men&#39;s Skills 2",
+        "Basketball - Men&#39;s Cond. 1"
+      ]
+    },
+    {
+      "prefix": "INED",
+      "name": "INED",
+      "course_count": 15,
+      "section_count": 59,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CONTROL SYSTEMS",
+        "BASIC HYDRAULICS",
+        "BASIC PNEUMATICS",
+        "CAD I 2D DRAWING",
+        "CONTROL SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "MAS",
+      "course_count": 32,
+      "section_count": 58,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "100 Ton Master Training",
+        "200 Ton Master Training",
+        "Able Seafarer Training",
+        "Applied Rigging Technology",
+        "Celestial Navigation"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 21,
+      "section_count": 57,
+      "colleges": [
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Paramedic Internship P1",
+        "Co-op Ed: Paramedic Internship P2",
+        "Crisis Intervention",
+        "Electrocardiography I",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "HHP",
+      "name": "HHP",
+      "course_count": 13,
+      "section_count": 57,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "AHA BLS Provider CPR",
+        "Exercise Physiology",
+        "Exercise Testing &amp;Prescription",
+        "First Aid &amp; BLS Provider CPR",
+        "Fitness/First Aid"
+      ]
+    },
+    {
+      "prefix": "HHPA",
+      "name": "HHPA",
+      "course_count": 27,
+      "section_count": 56,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Backpacking",
+        "Barre Body",
+        "Basketball",
+        "Beginning Mountain Biking",
+        "Beginning Rock Climbing"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 31,
+      "section_count": 54,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "klamath-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED MEDICAL-SURGICAL CARE",
+        "ADVANCES MED-SURG PRACTICE",
+        "Basic EKG",
+        "Belonging in Nursing",
+        "Care in Urgent &amp; Comm Settings"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 9,
+      "section_count": 52,
+      "colleges": [
+        "central-oregon-community-college",
+        "clatsop-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "1st Year Spanish II",
+        "First Year Spanish III",
+        "First-year Spanish I",
+        "First-year Spanish II",
+        "First-year Spanish III"
+      ]
+    },
+    {
+      "prefix": "NATR",
+      "name": "NATR",
+      "course_count": 23,
+      "section_count": 51,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED BOTANY",
+        "ENVIRONMENT & SOCIETY",
+        "FIELD METHODS IN NATURAL RESOURCES",
+        "GLOBAL POSITIONING SYSTEMS (GPS)",
+        "INTRO TO FIRE EFFECTS"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Statistics",
+      "course_count": 4,
+      "section_count": 51,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Statistics I",
+        "INTRO TO STATS FOR ENGINEERS",
+        "N/A",
+        "Probability and Statistics 2"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 33,
+      "section_count": 48,
+      "colleges": [
+        "central-oregon-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADV STEERING/SUSPENSION/BRAKES",
+        "ADVANCED ENGINE PERFORMANCE",
+        "ASE Test Prep I",
+        "ASE Test Prep II",
+        "Auto Controller Systems I"
+      ]
+    },
+    {
+      "prefix": "G",
+      "name": "G",
+      "course_count": 17,
+      "section_count": 48,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Cascade Volcanoes",
+        "Catastrophic Earth",
+        "Co-op Ed: Environmental Science",
+        "Co-op Ed: Geology",
+        "Earth Materials and Plate Tectonics"
+      ]
+    },
+    {
+      "prefix": "BH",
+      "name": "BH",
+      "course_count": 29,
+      "section_count": 47,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Addictn Pharmacology/Physiolgy",
+        "ASAM and Addiction Treatment",
+        "Assessment Treatment Planning",
+        "Behavioral Health &amp; Early Lear",
+        "BH Student Success"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 47,
+      "colleges": [
+        "chemeketa-community-college",
+        "klamath-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Geological Hazards of PNW",
+        "Geology: Evolution of Earth",
+        "Geology: Rocks &amp; Minerals",
+        "Geology: Surface/Env Geology",
+        "Human Cultural Geography I **NC"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 26,
+      "section_count": 46,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "BILINGUAL EDUCATION",
+        "CHILD DEVELOPMENT I",
+        "CHILD DEVELOPMENT II",
+        "CHILD NUTRITION, HEALTH AND SAFETY",
+        "CHILDREN OF INCARCERATED PARENTS"
+      ]
+    },
+    {
+      "prefix": "HP",
+      "name": "HP",
+      "course_count": 6,
+      "section_count": 45,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Health Office Procedures",
+        "Human Body Systems 1",
+        "Human Body Systems 2",
+        "Introduction to Pharmacology",
+        "Legal and Ethical Aspects of Healthcare"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 18,
+      "section_count": 44,
+      "colleges": [
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Interviewing and Counseling",
+        "Best Practices in Human Services: Interventions",
+        "Case Management",
+        "Co-op Ed: Behavioral Health",
+        "Cognitive-Behavioral Strategies"
+      ]
+    },
+    {
+      "prefix": "MUL",
+      "name": "Design",
+      "course_count": 23,
+      "section_count": 44,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "3D Animation 2",
+        "Audio Production",
+        "Business Practices for Media Arts",
+        "Co-op Ed: Graphic Design",
+        "Co-op Ed: Multimedia"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "PS",
+      "course_count": 13,
+      "section_count": 44,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "linn-benton-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Political Science",
+        "Co-op Ed: Pre Law",
+        "Environmental Politics",
+        "Environmental Politics-Honors",
+        "INTRO INTERNATIONAL RELATIONS"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "Agriculture",
+      "course_count": 7,
+      "section_count": 43,
+      "colleges": [
+        "linn-benton-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "AGRICULTURE CO-OP WK EXP",
+        "AGRICULTURE SEMINAR:AG",
+        "COMPUTERS IN AGRICULTURE",
+        "CURRENT ISSUES IN AGRICULTURE (Section with Low-cost Course Materials)",
+        "CWE AGRICULTURE"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "CA",
+      "course_count": 19,
+      "section_count": 43,
+      "colleges": [
+        "chemeketa-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Adv Keyboard &amp; Doc Prod",
+        "Advanced Baking and Pastry",
+        "Advanced Cooking Theories 3",
+        "Beginning Baking and Pastry",
+        "Beginning Computing"
+      ]
+    },
+    {
+      "prefix": "FN",
+      "name": "Nutrition",
+      "course_count": 4,
+      "section_count": 43,
+      "colleges": [
+        "central-oregon-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Family Food and Nutrition",
+        "Human Nutrition",
+        "Personal Nutrition",
+        "Sports Nutrition"
+      ]
+    },
+    {
+      "prefix": "MT3.",
+      "name": "MT3.",
+      "course_count": 24,
+      "section_count": 43,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED PLC TROUBLESHOOTING",
+        "BEARINGS &amp; LUBE SYSTEMS",
+        "CAD FOR FACTORY AUTOMATION",
+        "CAPSTONE PROJECT &amp; ASSESSMENT",
+        "CAPSTONE PROJECT I"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "Dental",
+      "course_count": 23,
+      "section_count": 42,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Anesthesia/Analgesia for Dental Hygiene Therapy",
+        "Clinical Dental Hygiene 1",
+        "Clinical Dental Hygiene 1 Lab",
+        "Clinical Dental Hygiene 3 Clinic Lab",
+        "Clinical Dental Hygiene 3:Lecture/seminar"
+      ]
+    },
+    {
+      "prefix": "HM",
+      "name": "HM",
+      "course_count": 13,
+      "section_count": 42,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Career Success and eFolio",
+        "Certification Seminar",
+        "Dining Room Operations",
+        "Health Professional Develop",
+        "Health Record Content"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 11,
+      "section_count": 42,
+      "colleges": [
+        "chemeketa-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CWE SPANISH",
+        "First Year Spanish 1",
+        "First Year Spanish, Term 1",
+        "First Year Spanish, Term 2",
+        "First Year Spanish, Term 3"
+      ]
+    },
+    {
+      "prefix": "CJA",
+      "name": "Criminal",
+      "course_count": 20,
+      "section_count": 41,
+      "colleges": [
+        "klamath-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Civil Liability & Ethics in Criminal Justice",
+        "Coop Wk Exp: Criminal Justice **NC",
+        "Crime Scene Investigation",
+        "Crime Scene Investigation Writing Lab",
+        "Criminal Law"
+      ]
+    },
+    {
+      "prefix": "CGS",
+      "name": "CGS",
+      "course_count": 3,
+      "section_count": 39,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration & Planning **NC",
+        "College Survival & Success **LC",
+        "Scholarship Applications and Financial Literacy Seminar"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 15,
+      "section_count": 38,
+      "colleges": [
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading 1",
+        "Blueprint Reading 2",
+        "Building Construction",
+        "Building Construction A",
+        "Building Construction Surveying"
+      ]
+    },
+    {
+      "prefix": "TA",
+      "name": "Acting",
+      "course_count": 15,
+      "section_count": 38,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Acting 2",
+        "Acting 3",
+        "Acting for the Camera",
+        "Acting for the Camera 2",
+        "Acting I"
+      ]
+    },
+    {
+      "prefix": "HDFS",
+      "name": "HDFS",
+      "course_count": 12,
+      "section_count": 37,
+      "colleges": [
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Child Development",
+        "CONTEMPORARY FAMILIES IN U.S.",
+        "CWE CHILDHOOD DEVELOPMENT",
+        "Desarrollo del Ni&ntilde;o",
+        "EMOTIONAL WELL-BEING: TOOLS"
+      ]
+    },
+    {
+      "prefix": "HSER",
+      "name": "HSER",
+      "course_count": 13,
+      "section_count": 35,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADDICTION STUDIES COOP WK EXP (Section with No-cost Course Materials)",
+        "ADDICTIONS PHARMACOLOGY",
+        "ALCOHOL/DRUGS & FAMILY",
+        "CASE MANAGEMENT- CAPSTONE",
+        "COUNSELING TECHNIQUES I"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 9,
+      "section_count": 34,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "GENERAL BIOLOGY & LAB",
+        "GENERAL BIOLOGY WITH LAB",
+        "HUMAN ANATOMY & PHYSIOLOGY",
+        "HUMAN ANATOMY & PHYSIOLOGY & LAB",
+        "HUMAN ANATOMY-HUMAN DISSECTION"
+      ]
+    },
+    {
+      "prefix": "MMT",
+      "name": "MMT",
+      "course_count": 13,
+      "section_count": 34,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Video Editing",
+        "Advanced Video Editing Lab",
+        "Audio for Production",
+        "Audio for Production Lab",
+        "Community Project-Based Learning"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 20,
+      "section_count": 34,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Applied Kinesiology 2",
+        "Applied Kinesiology 2 Lab",
+        "Co-op Ed: First Clin. Exp",
+        "Co-op Ed: Physical Therapist Assistant - Second Clinical Experience",
+        "Co-op Ed: Physical Therapist Assistant - Third Clinical Experience"
+      ]
+    },
+    {
+      "prefix": "COOP",
+      "name": "Coop",
+      "course_count": 6,
+      "section_count": 33,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Florence",
+        "Co-op Ed: Internship Seminar",
+        "Co-op Ed: Service Learning",
+        "Co-op Ed: Service Learning-Honors",
+        "Cooperative Education: Pharmacy Tech"
+      ]
+    },
+    {
+      "prefix": "DA",
+      "name": "Dental",
+      "course_count": 19,
+      "section_count": 33,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Experiences",
+        "Basic Dental Assisting",
+        "Chairside Procedures 1",
+        "Co-op Ed: Dental Assisting",
+        "Co-op Ed: Dental Assisting Seminar"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 6,
+      "section_count": 32,
+      "colleges": [
+        "clatsop-community-college",
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Intercultural Communications",
+        "Interpersonal Communication",
+        "Persuasive Speech",
+        "Public Speaking **NC",
+        "Small Group Discussion"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 22,
+      "section_count": 30,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Careers in Wildland Fire",
+        "CWE Fire Science",
+        "Fire Behavior &amp; Combustion",
+        "Fire Bhvr &amp; Bld Const.",
+        "Fire Codes and Ordinances"
+      ]
+    },
+    {
+      "prefix": "HD",
+      "name": "HD",
+      "course_count": 10,
+      "section_count": 30,
+      "colleges": [
+        "central-oregon-community-college",
+        "clatsop-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CAREER EXPLORATION",
+        "CAREER LIFE PLANNING",
+        "Career Planning",
+        "College Success",
+        "Effect. Job Search Strategies"
+      ]
+    },
+    {
+      "prefix": "XMUP",
+      "name": "Lessons",
+      "course_count": 15,
+      "section_count": 30,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Applied Cello Lessons",
+        "Applied Drum Set Lessons",
+        "Applied Electric Bass Lessons",
+        "Applied Guitar Lessons",
+        "Applied Harp Lessons"
+      ]
+    },
+    {
+      "prefix": "DA5.",
+      "name": "Dental",
+      "course_count": 15,
+      "section_count": 29,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "BASIC SCIENCE FOR DENTISTRY",
+        "DENTAL ANATOMY &amp; HISTOLOGY",
+        "DENTAL MATERIALS I",
+        "DENTAL OFFICE EMERGENCIES",
+        "DENTAL OFFICE RECORDS"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 14,
+      "section_count": 29,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Control Robotics Power System",
+        "Digital Circuit Applications",
+        "Electronic Circuit Analysis",
+        "Electronic Concepts 1",
+        "Electronic Concepts 3"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 4,
+      "section_count": 28,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Environmental Science Lab",
+        "Forest Ecology",
+        "Forest Ecology Lab"
+      ]
+    },
+    {
+      "prefix": "LMT",
+      "name": "Massage",
+      "course_count": 17,
+      "section_count": 28,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Aromatherapy Fundamentals",
+        "Community Outreach",
+        "Eastern Theory &amp; Practice",
+        "Foot Reflexology",
+        "Hydrotherapy"
+      ]
+    },
+    {
+      "prefix": "AP",
+      "name": "AP",
+      "course_count": 22,
+      "section_count": 27,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Accident Investigations",
+        "Aerodynamics &#39;Pilot&#39;",
+        "Aircraft Systems &amp; Structures 1",
+        "Aircraft Systems &amp; Structures 2",
+        "Airman Certification Standards and Maneuvers"
+      ]
+    },
+    {
+      "prefix": "DEN",
+      "name": "Dental",
+      "course_count": 9,
+      "section_count": 27,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Dental Anatomy",
+        "Dental Assisting Practicum 2",
+        "Dental Materials 1",
+        "Dental Office Emergency Mgmt",
+        "Dental Radiology 2"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 8,
+      "section_count": 26,
+      "colleges": [
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language 1",
+        "American Sign Language 2",
+        "American Sign Language 3",
+        "American Sign Language 4",
+        "American Sign Language 6"
+      ]
+    },
+    {
+      "prefix": "FOR",
+      "name": "FOR",
+      "course_count": 20,
+      "section_count": 26,
+      "colleges": [
+        "central-oregon-community-college",
+        "oregon-coast-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Aerial Photo",
+        "Co-op Work Experience Forestry",
+        "Conservation of Natural Res",
+        "Dendrology",
+        "Field Dendrology"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 14,
+      "section_count": 26,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ArcGIS",
+        "Co-op Work Experience GIS",
+        "GEOGRAPHIC INFO SYSTEMS (GIS) I",
+        "GIS Capstone",
+        "Human Geography: Culture"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 14,
+      "section_count": 25,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Business Analytics",
+        "Co-op Ed: Applied Business Management",
+        "Cross-Cultural Management",
+        "Digital Marketing",
+        "Financial Management"
+      ]
+    },
+    {
+      "prefix": "AIT",
+      "name": "Artificial",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Artificial Intelligence",
+        "Introduction to Artificial Intelligence Lab"
+      ]
+    },
+    {
+      "prefix": "HPRD",
+      "name": "Rough",
+      "course_count": 7,
+      "section_count": 24,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "EQUINE WORK EXPERIENCE",
+        "ROUGH STOCK I",
+        "ROUGH STOCK II",
+        "ROUGH STOCK III",
+        "TIMED EVENTS I"
+      ]
+    },
+    {
+      "prefix": "MDA",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology for Health Science Professional I **NC",
+        "Anatomy & Physiology for Health Science Professional II **NC",
+        "Medical Terminology I",
+        "Medical Terminology II"
+      ]
+    },
+    {
+      "prefix": "VMW",
+      "name": "VMW",
+      "course_count": 17,
+      "section_count": 24,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Fall Vineyard Practices",
+        "General Viticulture",
+        "Independent Study",
+        "Introduction to Winemaking",
+        "Math &amp; Spreadsheets for Vines"
+      ]
+    },
+    {
+      "prefix": "ES",
+      "name": "ES",
+      "course_count": 8,
+      "section_count": 23,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Chicanx Culture and Identity",
+        "Contemporary Racial &amp; Ethnic Issues",
+        "Crisis Intervention",
+        "Historical Racial &amp; Ethnic Issues",
+        "Indigenous Tribes of Oregon"
+      ]
+    },
+    {
+      "prefix": "TEX",
+      "name": "Coop",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Coop Wk Exp: Cosmetology Seminar **NC",
+        "Coop Wk Exp: Seminar **NC"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 3,
+      "section_count": 22,
+      "colleges": [
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Gardening and Sustainable Food Systems",
+        "GREENHOUSE MANAGEMENT",
+        "INTRO TO PLANT GROWTH"
+      ]
+    },
+    {
+      "prefix": "NFM",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 22,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "OA",
+      "name": "Office",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DOCUMENT PRODUCTION",
+        "BUSINESS EDITING",
+        "OFFICE APPLICATIONS COOP WK EXP (Section with No-cost Course Materials)",
+        "OFFICE MANAGEMENT",
+        "OFFICE PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "PED",
+      "course_count": 6,
+      "section_count": 22,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Ballroom Dance I **NC",
+        "Beginning Fitness & Walking **NC",
+        "Beginning Weight Training **NC",
+        "Fitness and Conditioning for FirstResponders **NC",
+        "Intermediate Weight Training **NC"
+      ]
+    },
+    {
+      "prefix": "PFW",
+      "name": "Pipe",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED PIPE FITTING",
+        "ADVANCED PIPE PROCESS &amp; PREP",
+        "ALTERNATIVE JOINING METHODS",
+        "INTRO TO PIPE PROCESSING &amp; PRE",
+        "INTRODUCTION TO PIPE FITTING"
+      ]
+    },
+    {
+      "prefix": "UAS",
+      "name": "UAS",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "columbia-gorge-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Sensor",
+        "Advanced Sensor Lab",
+        "Capstone Project",
+        "Co-op Ed: Unmanned Aerial Systems",
+        "Fixed Wing Lab"
+      ]
+    },
+    {
+      "prefix": "WE1.",
+      "name": "WE1.",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CWE AUTO TECHNOLOGY",
+        "CWE CONSTRUCTION &amp; FORESTRY EQ",
+        "CWE FIRE SCIENCE",
+        "CWE FOR CADD",
+        "CWE HEAVY EQUIPMENT/DIESEL"
+      ]
+    },
+    {
+      "prefix": "CG",
+      "name": "CG",
+      "course_count": 9,
+      "section_count": 21,
+      "colleges": [
+        "chemeketa-community-college",
+        "columbia-gorge-community-college",
+        "lane-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Career and Life Planning",
+        "Career/Life Development",
+        "Career/Life Planning",
+        "College Survival and Success",
+        "COLLEGE SURVIVAL AND SUCCESS: PERSONAL RESPONSIBILITY"
+      ]
+    },
+    {
+      "prefix": "DSL",
+      "name": "DSL",
+      "course_count": 9,
+      "section_count": 21,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Engine Diagnostic",
+        "Advanced Hydraulics",
+        "Cooperative Work Experience",
+        "Electrical and Electronics",
+        "Engine Diagnostics and Repair"
+      ]
+    },
+    {
+      "prefix": "GSCI",
+      "name": "Physical",
+      "course_count": 5,
+      "section_count": 21,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "MEDICAL TERMINOLOGY I (Section with Low-cost Course Materials)",
+        "MEDICAL TERMINOLOGY II (Section with Low-cost Course Materials)",
+        "PHYSICAL SCIENCE GEOLOGY & LAB",
+        "PHYSICAL SCIENCE METEOROLOGY",
+        "PHYSICAL SCIENCE PHYSICS & LAB"
+      ]
+    },
+    {
+      "prefix": "HOR",
+      "name": "HOR",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Bees and Other Pollinators",
+        "Cooperative Work Experience",
+        "Fall Horticulture Practicum",
+        "Fall Plant Identification",
+        "Int Pest Mgt: Insects/Diseases"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "NDT",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED RADIOGRAPHY",
+        "CWE NONDESTRUCTIVE TEST &amp; EVAL",
+        "INDEPENDENT STUDY: NDT SEMINAR",
+        "INTRO PHASE ARRAY ULTRASONIC",
+        "INTRO TO NONDESTRUCTIVE TEST"
+      ]
+    },
+    {
+      "prefix": "VC",
+      "name": "VC",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Animation &amp; Motion Graphics 1",
+        "Business of Graphic Arts",
+        "Cooperative Work Experience",
+        "Design Studio",
+        "File Prep"
+      ]
+    },
+    {
+      "prefix": "WS",
+      "name": "Women",
+      "course_count": 5,
+      "section_count": 21,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "DISNEY: GENDER, RACE, EMPIRE",
+        "GLOBAL WOMEN",
+        "INTRO WOMEN, GENDER, SEXUALITY",
+        "Introduction to Women&#39;s Studies",
+        "Women of the World"
+      ]
+    },
+    {
+      "prefix": "XPE",
+      "name": "Fitness",
+      "course_count": 6,
+      "section_count": 21,
+      "colleges": [
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Community Dance Class 2",
+        "Community Fitness",
+        "Group Fitness",
+        "Hatha Yoga",
+        "Staff Fitness"
+      ]
+    },
+    {
+      "prefix": "ADS",
+      "name": "Addiction",
+      "course_count": 7,
+      "section_count": 20,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Basic Counseling & Addiction",
+        "Coop Wk Exp: Addictions **NC",
+        "Drug Use & Addiction",
+        "Ethical & Professional Issues **LC",
+        "Group Counseling & Addiction"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Classroom Management",
+        "Computers in Education",
+        "Computers in Education Lab",
+        "Coop Wk Exp: Education **NC",
+        "Instructional Strategies in Language Arts & Reading"
+      ]
+    },
+    {
+      "prefix": "VT",
+      "name": "VT",
+      "course_count": 15,
+      "section_count": 20,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Adv Small Animal Nursing",
+        "Anesthesiology &amp; Surg Tech",
+        "Animal Hosp &amp; Office Proc",
+        "Clinical Practicum I",
+        "Clinical Practicum II"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "AH",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "central-oregon-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CPR: AHA BLS &amp; First Aid",
+        "Cultural Responsiveness in HS",
+        "Math for Health Sciences",
+        "Medical Terminology",
+        "Phlebotomy"
+      ]
+    },
+    {
+      "prefix": "ARH",
+      "name": "History",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Ancient Art History",
+        "Art History 1: The Ancient World",
+        "Art History 3: The Modern World",
+        "Design &amp; Illustration History",
+        "History of Design Arts"
+      ]
+    },
+    {
+      "prefix": "GEG",
+      "name": "Geography",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Exploring Geography",
+        "Geography of Oregon",
+        "Geography of US &amp; Canada",
+        "Physical Geography"
+      ]
+    },
+    {
+      "prefix": "MLD",
+      "name": "Leadership",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Applied Leadership 1",
+        "Applied Leadership 2",
+        "Applied Leadership Capstone",
+        "Applied Leadership Capstone:BH",
+        "Innovate Develop Entrepreneur"
+      ]
+    },
+    {
+      "prefix": "NSG",
+      "name": "Nursing",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Nursing Practice (application)",
+        "Foundations of Nursing Practice (didactic)",
+        "Health & Illness Concepts I (application)",
+        "Health & Illness Concepts I (didactic)",
+        "Health & Illness Concepts II (application) - LPN"
+      ]
+    },
+    {
+      "prefix": "XELL",
+      "name": "Integrated",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "chemeketa-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "ESOL Program Fee",
+        "Integrated Skill A1 132 hours",
+        "Integrated Skill A2 132 hours",
+        "Integrated Skills A2 44 hours",
+        "Integrated Skills B1 132 Hours"
+      ]
+    },
+    {
+      "prefix": "CRS",
+      "name": "CRS",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CODING I",
+        "CODING III",
+        "CPC/CMA TEST TAKING STRATEGIES",
+        "GENERAL MEDICAL TERMINOLOGY",
+        "MED LAW &amp; ETHICS FOR CODERS"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Applied Math for Culinary Arts",
+        "Culinary Arts Capstone",
+        "Culinary Foundations I",
+        "Culinary Foundations III",
+        "Culinary Industry Internship"
+      ]
+    },
+    {
+      "prefix": "HDEV",
+      "name": "Freshman",
+      "course_count": 2,
+      "section_count": 18,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "FRESHMAN ORIENTATION (Section with No-cost Course Materials)",
+        "RESIDENCE LIFE LEADERSHIP"
+      ]
+    },
+    {
+      "prefix": "SLP",
+      "name": "SLP",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Augmentative/Alternative Comm",
+        "Clinical Doc/Materials Mgmt",
+        "Communication Disorders",
+        "Intervention Strategies - SLPA",
+        "Intro to Language Development"
+      ]
+    },
+    {
+      "prefix": "XDEI",
+      "name": "Cultural",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Becoming Anti-Racist",
+        "Cultural Call to Action",
+        "Cultural Self-Discovery",
+        "Diversity to Inclusion",
+        "Equitable Practices"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "lane-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Principles of Macroeconomics",
+        "PRINCIPLES OF MACROECONOMICS (Section with No-cost Course Materials)",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "GED",
+      "name": "GED",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ALGEBRA",
+        "COMPUTER BASICS I",
+        "GED PREP IN SPANISH",
+        "GED PREP: SOCIAL STUDY/SCIENCE",
+        "LANGUAGE ARTS"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Mechanical",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Basic Engineering Materials",
+        "CAD for Mechanical Design – Solid Modeling",
+        "CAD for Mechanical Design (Fusion)",
+        "CAD for Mechanical Design (Fusion)Lab",
+        "CAD for Mechanical Design I"
+      ]
+    },
+    {
+      "prefix": "PHE",
+      "name": "Health",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker",
+        "Health Literacy and Promotion",
+        "Health Psychology",
+        "Human Sexuality",
+        "Intro Human &amp; Planetary Health"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Gen Chem I Lab",
+        "Gen Chem II Lab",
+        "General Chemistry I",
+        "General Chemistry I Laboratory",
+        "General Chemistry II"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Macroeconomics **NC",
+        "Principles of Microeconomics **NC"
+      ]
+    },
+    {
+      "prefix": "EL",
+      "name": "Effective",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking for Essay Writing",
+        "Effective College Reading",
+        "Effective Digital and Online Learning",
+        "Effective Learning"
+      ]
+    },
+    {
+      "prefix": "HDF",
+      "name": "HDF",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Child Abuse and Neglect",
+        "Experiences Young Children",
+        "Family Relationships",
+        "Intro to Effective Parenting",
+        "Intro Wrkng w/Infants/Toddlers"
+      ]
+    },
+    {
+      "prefix": "MTOL",
+      "name": "Machining",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "BASIC PRINT READING: METALS",
+        "CNC I: MILL",
+        "CNC IV: MACHINING STRATEGIES",
+        "INSPECTION I",
+        "INTRO TO MANUAL MACHINING"
+      ]
+    },
+    {
+      "prefix": "XCDL",
+      "name": "XCDL",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "CDL Review Course Truck",
+        "CDL Review-15",
+        "CDL Review-3 Farm Endorsement",
+        "CDL-Farm Endorsement to CDL",
+        "ELDT Hazmat"
+      ]
+    },
+    {
+      "prefix": "AM",
+      "name": "AM",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions/ Transaxles",
+        "Automotive Basics and Maintenance",
+        "Brakes",
+        "Co-op Ed: Automotive",
+        "Electrical and Electronic Systems"
+      ]
+    },
+    {
+      "prefix": "EG4.",
+      "name": "EG4.",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED FUSION 360",
+        "ARCHITECTURAL DESIGN II",
+        "AUTOCAD",
+        "CAPSTONE PROJECT",
+        "CIVIL DRAFTING II"
+      ]
+    },
+    {
+      "prefix": "FA",
+      "name": "Understand",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Concepts of Visual Literacy",
+        "Film Genres: Horror",
+        "Introduction to Film",
+        "Understand Movies: Directors",
+        "Understand Movies: Film Styles"
+      ]
+    },
+    {
+      "prefix": "FLS",
+      "name": "FLS",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Applied Exercise Physiology 1",
+        "Career Preparation",
+        "Co-op Ed: Fitness",
+        "Coaching Healthy Eating",
+        "Coop Ed: Healthy Aging"
+      ]
+    },
+    {
+      "prefix": "AA",
+      "name": "Design",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CWE GRAPHICS",
+        "DIGITAL IMAGE PROCESSES III",
+        "GRAPHIC DESIGN I",
+        "GRAPHIC DESIGN III",
+        "PORTFOLIO &amp; PROFESSIONAL PRAC"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Elec Control Fundamentals",
+        "Electrical Fundamentals 1",
+        "Graphics and 3-D Modeling",
+        "Intro to Statistics/Engineers",
+        "Statics"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "chemeketa-community-college",
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "COLLEGE PLANNING AND SURVIVAL SKILLS",
+        "Creating College Success"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "klamath-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Coop Wk Exp: Geographic Information Systems **NC",
+        "Digital Earth",
+        "GIS 1",
+        "GIS 2"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "HISTORY OF WESTERN CIVILIZATIONS",
+        "SPECIAL STUDIES 1ST YEAR LATIN",
+        "U.S. HISTORY",
+        "U.S. HISTORY (Section with No-cost Course Materials)"
+      ]
+    },
+    {
+      "prefix": "HTM",
+      "name": "HTM",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Catering and Banquets",
+        "Customer Service",
+        "Foods &amp; Bevs: Gastronomy",
+        "Hospitality Industry",
+        "Hospitality IT Systems"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Physics I **NC",
+        "Fundamentals of Physics I Lab **NC",
+        "Gen Physics I Lab",
+        "Gen Physics II Lab",
+        "Gen Physics III Lab"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "HUMAN SEXUALITY",
+        "INTRO TO HUMAN DEVELOPMENT I",
+        "INTRO TO HUMAN DEVELOPMENT II",
+        "PSYCHOLOGY OF HUMAN RELATIONS",
+        "SEASONS OF LIFE"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surgical",
+      "course_count": 13,
+      "section_count": 14,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Operating Room Clinical I **NC",
+        "Operating Room Clinical II",
+        "Operating Room Seminar I **NC",
+        "Operating Room Seminar II",
+        "Preparing for Board Certification I **NC"
+      ]
+    },
+    {
+      "prefix": "AREC",
+      "name": "Agriculture",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "linn-benton-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "AGRICULTURE ACCOUNTING (Section with No-cost Course Materials)",
+        "FARM BUSINESS MANAGEMENT",
+        "GLOBAL AGRICULTURAL MARKETS",
+        "MANAGEMENT IN AGRICULTURE",
+        "MARKETING IN AGRICULTURE"
+      ]
+    },
+    {
+      "prefix": "CA8.",
+      "name": "CA8.",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "BANQUETS &amp; BUFFETS B",
+        "BANQUETS &amp; BUFFETS D",
+        "BANQUETS &amp; BUFFETS E",
+        "CHOCOLATE, CONFEC, FROZEN DESS",
+        "CREATING THE MENU"
+      ]
+    },
+    {
+      "prefix": "CMA",
+      "name": "CMA",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADMIN OFFICE FOR MED ASSISTANT",
+        "CLINICAL PRACTICUM",
+        "COMM FOR THE MEDICAL ASSISTANT",
+        "HUMAN RELATIONS FOR MED ASSIST",
+        "LAW &amp; ETHICS FOR THE MA"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "central-oregon-community-college",
+        "clatsop-community-college",
+        "lane-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Culture &amp; Literature Of Africa",
+        "HUM:ROMANTIC ERA-CONT SOCIETY",
+        "HUMANITIES:PREHISTORY-MID AGES",
+        "Intro to Humanities II",
+        "Medical and Health Humanities"
+      ]
+    },
+    {
+      "prefix": "MA3.",
+      "name": "MA3.",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CNC TECHNOLOGY III",
+        "CNC: SPECIAL PROJECTS",
+        "MANUFACTURING PROCESSES I",
+        "MANUFACTURING PROCESSES II",
+        "MANUFACTURING PROCESSES III"
+      ]
+    },
+    {
+      "prefix": "OL",
+      "name": "OL",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Alpine Climbing",
+        "Avalanche Level I and Rescue",
+        "Intro to Outdoor Leadership",
+        "OL Technical Skills",
+        "Outdoor Living Skills"
+      ]
+    },
+    {
+      "prefix": "PHM",
+      "name": "Pharmacy",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Pharmacology 1",
+        "Pharmacology 3",
+        "Pharmacology I",
+        "Pharmacy Basics",
+        "Pharmacy Calculations"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Comparative Religion",
+        "Middle Eastern Religions",
+        "Religion in U.S. Culture",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "klamath-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "First Year Spanish I **NC",
+        "First Year Spanish II **NC",
+        "First Year Spanish III **NC",
+        "First Year Spanish-First Term"
+      ]
+    },
+    {
+      "prefix": "BAK",
+      "name": "BAK",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Artisan Breads",
+        "Baking &amp; Pastry Foundations I",
+        "Baking Industry Internship",
+        "Baking Pastry Foundations III",
+        "Classical French Pastries"
+      ]
+    },
+    {
+      "prefix": "BLD",
+      "name": "BLD",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "chemeketa-community-college",
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Building Codes 2",
+        "Building Inspection Lab",
+        "Historc Preservation Practicum",
+        "Historic Preservation I",
+        "Hpr Directed Project"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "GENERAL CHEMISTRY & LAB",
+        "ORGANIC CHEMISTRY",
+        "SURVEY OF CHEMISTRY (HEALTH)",
+        "SURVEY OF CHEMISTRY (HEALTH) & LAB"
+      ]
+    },
+    {
+      "prefix": "CHN",
+      "name": "Chinese",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "2nd Yr Mandarin Chinese I",
+        "2nd Yr Mandarin Chinese III",
+        "Chinese Culture Through Film",
+        "Mandarin Chinese I",
+        "Mandarin Chinese III"
+      ]
+    },
+    {
+      "prefix": "ELA",
+      "name": "Community",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED COMMUNITY FOR ELA",
+        "ELA ADVANCED FAST TRACK",
+        "ELA INTERMEDIATE FAST TRACK",
+        "INT COMMUNITY FOR ELA"
+      ]
+    },
+    {
+      "prefix": "GE",
+      "name": "Engineering",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Computations",
+        "Engineering Orientation"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO SOCIAL WORK",
+        "SOCIAL WELFARE SYSTEM & POLICY",
+        "SOCIAL WORK COOP WK EXP"
+      ]
+    },
+    {
+      "prefix": "STA",
+      "name": "Statistics",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Statistics I"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy of the Solar System",
+        "Astronomy: The Stars",
+        "Cosmology and the Large-Scale Structure of the Universe",
+        "Introductory Astronomy"
+      ]
+    },
+    {
+      "prefix": "ATH",
+      "name": "Anthropology",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "chemeketa-community-college",
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Cultural Anthropology",
+        "INTRODUCTION TO ARCHAEOLOGY & PREHISTORY",
+        "INTRODUCTION TO ETHNOGRAPHY",
+        "INTRODUCTION TO PHYSICAL ANTHROPOLOGY"
+      ]
+    },
+    {
+      "prefix": "ERO",
+      "name": "Emergency",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Crisis Intervention",
+        "Emergency Vehicle Operator (EVOC)",
+        "Hazardous Materials Awareness and Operations",
+        "Intro to Emergency Response andOperations",
+        "Rescue Practices"
+      ]
+    },
+    {
+      "prefix": "FR",
+      "name": "French",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "central-oregon-community-college",
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "2nd Year French I",
+        "2nd Year French III",
+        "First Year French, Term 1",
+        "First Year French, Term 2",
+        "First-Year French"
+      ]
+    },
+    {
+      "prefix": "J",
+      "name": "Publications",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "central-oregon-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Journalism",
+        "Multimedia Journalism",
+        "News Reporting and Writing I",
+        "Publications Lab I",
+        "Publications Lab III"
+      ]
+    },
+    {
+      "prefix": "AS",
+      "name": "Foundations",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of the Air Force Part I",
+        "Foundations of the Air Force Part III",
+        "Leadership Laboratory",
+        "The Evolution of Air and Space Power 1991-2025"
+      ]
+    },
+    {
+      "prefix": "CAM",
+      "name": "CAM",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Adv CAD/CAM Integrations",
+        "Advanced Manual Integration",
+        "Benchwork &amp; Manual Fundmntls",
+        "Cooperative Work Experience",
+        "Intro to Lean Manufacturing"
+      ]
+    },
+    {
+      "prefix": "CNC",
+      "name": "Machining",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Machining Projects",
+        "Advanced CNC Machining: Skill Proofing",
+        "Basic CNC Machining Projects",
+        "Co-op Ed: CNC and Manufacturing",
+        "Introduction to 3D Modeling for Machinists"
+      ]
+    },
+    {
+      "prefix": "DS",
+      "name": "Diesel",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Diesel",
+        "Diesel and Auxiliary Fuel Systems",
+        "Diesel Engines and Engine Overhaul",
+        "Heavy Equipment Chassis and Power Trains",
+        "Heavy Equipment Hydraulics"
+      ]
+    },
+    {
+      "prefix": "ETHN",
+      "name": "Ethnic",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ETHNIC STUDIES"
+      ]
+    },
+    {
+      "prefix": "FNUT",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "NUTRITION (Section with Low-cost Course Materials)"
+      ]
+    },
+    {
+      "prefix": "XASE",
+      "name": "XASE",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Adult Secondary Education",
+        "GED Language Arts",
+        "GED Math",
+        "GED Science & Social Studies"
+      ]
+    },
+    {
+      "prefix": "ABF",
+      "name": "ABF",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Business Finance",
+        "Communication for Leaders",
+        "Principle Practice Sustain",
+        "Psychology of Leadership",
+        "Writing and Research"
+      ]
+    },
+    {
+      "prefix": "CSS",
+      "name": "CSS",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "linn-benton-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "FORAGE PRODUCTION",
+        "INTRO TO NOXIOUS WEEDS (Section with No-cost Course Materials)",
+        "PESTICIDE SAFETY AND USE",
+        "PRINCIPLES OF CROP SCIENCE",
+        "SOIL NUTRIENTS & FERTILIZER"
+      ]
+    },
+    {
+      "prefix": "D",
+      "name": "Dance",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Ballet 1",
+        "Ballet 2",
+        "Ballet 3",
+        "Dance Basics",
+        "Dance Improvisation"
+      ]
+    },
+    {
+      "prefix": "DST",
+      "name": "Diesel",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity",
+        "Diesel Electrical/Electronic Systems",
+        "Diesel HVAC Systems",
+        "Diesel Industry Skills Training",
+        "Engine Theory & Service - Diesel"
+      ]
+    },
+    {
+      "prefix": "JN",
+      "name": "Journalism",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CWE JOURNALISM",
+        "DESIGN &amp; PRODUCTION LAB",
+        "FEATURE WRITING",
+        "JOURNALISM LAB",
+        "MEDIA AND SOCIETY"
+      ]
+    },
+    {
+      "prefix": "PBT",
+      "name": "Phlebotomy",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED PHLEBOTOMY SKILLS",
+        "ANATOMY/PHYSIOLOGY PHLEBOTOMY",
+        "JOB SUCCESS &amp; PROF PHLEBOTOMY",
+        "LAB OPERATIONS IN PHLEBOTOMY",
+        "PBT COMM &amp; DOCUMENTATION"
+      ]
+    },
+    {
+      "prefix": "XWR",
+      "name": "Writing",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Writing Center",
+        "Writing Center On-Line",
+        "Writing Refresh"
+      ]
+    },
+    {
+      "prefix": "CLA",
+      "name": "Chicanolatino",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Intro Chicano/Latino Studies 1",
+        "Intro Chicano/Latino Studies 2",
+        "Intro Chicano/Latino Studies 3"
+      ]
+    },
+    {
+      "prefix": "ENSC",
+      "name": "Environment",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Aquatic Environment",
+        "Atmospheric Environment and Climate Change",
+        "Terrestrial Environment"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Violent",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "PHYSICAL GEOLOGY & LAB",
+        "VIOLENT EARTH"
+      ]
+    },
+    {
+      "prefix": "HEA",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "klamath-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "First Aid & Industrial Safety",
+        "NURSING & ALLIED HEALTH SEMINAR",
+        "Nursing Assistant Clinical",
+        "Nursing Assistant I"
+      ]
+    },
+    {
+      "prefix": "MED",
+      "name": "Assisting",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Med Assisting Clinic Practice",
+        "Med Assisting Practicum",
+        "Med Assisting Seminar",
+        "Med Assisting, Basic Procedure",
+        "Medical Asst Adv Proced"
+      ]
+    },
+    {
+      "prefix": "MREC",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "MEDICAL BILLING I",
+        "MEDICAL BILLING II",
+        "MEDICAL OFFICE PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "XMTH",
+      "name": "Jumpstart",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Jump Start MTH070",
+        "Jump-Start MTH095",
+        "Jump-Start MTH111",
+        "Math Refresh",
+        "Numerical Reasoning"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Technician",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "klamath-community-college",
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "AG MACHINE MAINTENANCE & INSPECTION",
+        "Entry Level Technician 1 **NC",
+        "Entry Level Technician 2",
+        "Lube Technician 1",
+        "Lube Technician 2 **NC"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "Livestock",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED LIVESTOCK SELECTION",
+        "EQUINE BUSINESS MANAGEMENT",
+        "HORSE BREEDING MANAGEMENT LAB",
+        "LIVESTOCK EVENTS PRACTICUM",
+        "LIVESTOCK SELECTION TECHNIQUES"
+      ]
+    },
+    {
+      "prefix": "AUM",
+      "name": "Auto",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Auto Heating and Air Condition",
+        "Auto Machine Shop Engine Assem",
+        "Auto Machine Shop-Upper Engine",
+        "Cooperative Work Experience"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Adv Steering Suspension Brakes",
+        "Electrical/Electronics II",
+        "Engine Diagnosis and Service",
+        "Engine Fundamentals & Repair",
+        "Engine Performance I"
+      ]
+    },
+    {
+      "prefix": "CW",
+      "name": "Chinuk",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Chinuk Wawa"
+      ]
+    },
+    {
+      "prefix": "ENVI",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "ENVIRONMENTAL SCIENCE & LAB"
+      ]
+    },
+    {
+      "prefix": "HVE",
+      "name": "HVE",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ELECTRICAL &amp; ELECTRONIC SYSTEM",
+        "EMPLOYABILITY SKILLS",
+        "FUNDAMENTAL SHOP SKILLS",
+        "MOBILE AC &amp; COMFORT SYSTEMS",
+        "MOBILE HYDRAULICS"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "GENERAL HUMAN NUTRITION"
+      ]
+    },
+    {
+      "prefix": "RC",
+      "name": "RC",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiopulmonary Diagnostics and Monitoring",
+        "Advanced Cardiopulmonary Diagnostics and Monitoring Lab",
+        "Clinical Patient Assessment",
+        "Introduction to Mechanical Ventilation",
+        "Respiratory Care Clinical Practice 1"
+      ]
+    },
+    {
+      "prefix": "SLD",
+      "name": "Leadership",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Chicano/Latino Leadership 1: Quien Soy? Quienes",
+        "Personal Mentoring",
+        "Post-Racial America: Challenges and Opportunities",
+        "Student Leadership"
+      ]
+    },
+    {
+      "prefix": "XMED",
+      "name": "Medical",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "MA Advanced Procedures",
+        "MA Basic Procedures",
+        "MA Clinical Practice 2",
+        "MA: Clinical Practice 1",
+        "Medical Assisting Practicum"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "Basics",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ABE COMPUTER BASICS I",
+        "ABE MATH BASICS",
+        "COLLEGE &amp; CAREER READINESS"
+      ]
+    },
+    {
+      "prefix": "AQS",
+      "name": "Aquarium",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Aquarium Science Internship",
+        "Biology of Captive Fishes",
+        "Introduction to Aquarium Science",
+        "Life Support Systems Design and Operation",
+        "Research Husbandry"
+      ]
+    },
+    {
+      "prefix": "FLM",
+      "name": "Filmmaking",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Audio Production/Sound Design",
+        "Documentary Filmmaking",
+        "Independent Filmmaking"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "Year",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "central-oregon-community-college",
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "1st Year Italian III",
+        "2nd Year Italian I",
+        "2nd Year Italian III",
+        "Applied Technology Projects",
+        "Industrial Safety"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "chemeketa-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "First Year Japanese, Term 1",
+        "First Year Japanese, Term 3",
+        "Japanese Culture",
+        "Second Year Japanese, Term 1",
+        "Second Year Japanese, Term 3"
+      ]
+    },
+    {
+      "prefix": "LIB",
+      "name": "Finding",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "central-oregon-community-college",
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Finding Information",
+        "Library Research Skills"
+      ]
+    },
+    {
+      "prefix": "WE",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CWE SEMINAR",
+        "CWE: CAREER EXPLORATION"
+      ]
+    },
+    {
+      "prefix": "XRE",
+      "name": "Cert",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Property Manager Cert Prep",
+        "Real Estate Broker Cert. Prep."
+      ]
+    },
+    {
+      "prefix": "CRWR",
+      "name": "Creative",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Creative Writing: Poetry-Honors",
+        "Introduction to Creative Writing: Fiction",
+        "Introduction to Creative Writing: Nonfiction",
+        "Introduction to Creative Writing: Poetry"
+      ]
+    },
+    {
+      "prefix": "IN4.",
+      "name": "Tech",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "TECH WRITING FOR CTE AUTO/DIES"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "MT",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Robotics",
+        "Microelectronic/Solar Cell Mfg",
+        "Pneumatic/Hydraulic Fundaments"
+      ]
+    },
+    {
+      "prefix": "R",
+      "name": "Religions",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "RELIGIONS OF EASTERN WORLD",
+        "RELIGIONS OF WESTERN WORLD"
+      ]
+    },
+    {
+      "prefix": "SOIL",
+      "name": "Soil",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "chemeketa-community-college",
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Soil Science"
+      ]
+    },
+    {
+      "prefix": "DSGN",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Capstone Project: UX/UI",
+        "Intro to Product Design",
+        "UX Design Principles",
+        "UX Research Methodologies"
+      ]
+    },
+    {
+      "prefix": "EV",
+      "name": "EV",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ADV CONTROL NETWORK DIAGNOSIS",
+        "EV PROPULSION SYSTEMS",
+        "SYSTEM ARCHITECTURE &amp; SAFETY",
+        "UNDERSTAND ADV DRIVER ASSIST"
+      ]
+    },
+    {
+      "prefix": "FE",
+      "name": "FE",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Career Jump Start",
+        "Cooperative Work Experience",
+        "Interviewing for Success",
+        "Resumes &amp; Job Search Correspon"
+      ]
+    },
+    {
+      "prefix": "FW",
+      "name": "FW",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "central-oregon-community-college",
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Hunting in Modern Society",
+        "PRIN OF WILDLIFE CONSERVATION",
+        "Survey of Northwest Birds"
+      ]
+    },
+    {
+      "prefix": "GSC",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Phy Sci Astr Lab **NC",
+        "Physical Science (Astronomy) **NC"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "NURSING ASSISTANT"
+      ]
+    },
+    {
+      "prefix": "OST",
+      "name": "Coop",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Occupational Skills"
+      ]
+    },
+    {
+      "prefix": "POSC",
+      "name": "American",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "AMERICAN GOVERNMENT",
+        "AMERICAN GOVERNMENT (Section with Low-cost Course Materials)"
+      ]
+    },
+    {
+      "prefix": "SUS",
+      "name": "SUS",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Environmental Science",
+        "Sustainable Food and Ag",
+        "Work Experience Sustainability"
+      ]
+    },
+    {
+      "prefix": "ANES",
+      "name": "Anesthesia",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Anes Tech Cert Exam Prep",
+        "Anesthesia Clinic Practicum 3A",
+        "Anesthesia Clinic Practicum 3B"
+      ]
+    },
+    {
+      "prefix": "CINE",
+      "name": "Film",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Film History 1-The Silent Era to Early Sound",
+        "Film History 3-1960s-the present"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "Year",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "2nd Year German I",
+        "2nd Year German II",
+        "2nd Year German III"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "International",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CWE INTERNATIONAL STUDIES"
+      ]
+    },
+    {
+      "prefix": "LING",
+      "name": "Linguistics",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Linguistics"
+      ]
+    },
+    {
+      "prefix": "MIC",
+      "name": "Integrated",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Integrated Software"
+      ]
+    },
+    {
+      "prefix": "NC",
+      "name": "Portfolio",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "CPL PORTFOLIO ASSESSMENT"
+      ]
+    },
+    {
+      "prefix": "NCMA",
+      "name": "NCMA",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Body Structure and Function I",
+        "Clinical Procedures I",
+        "MTWR"
+      ]
+    },
+    {
+      "prefix": "PHLB",
+      "name": "Phlebotomy",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "PHLEBOTOMY"
+      ]
+    },
+    {
+      "prefix": "SP",
+      "name": "Small",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "SMALL GROUP DISCUSSION"
+      ]
+    },
+    {
+      "prefix": "XAGR",
+      "name": "XAGR",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Landscaping Groundskeeping",
+        "Ornamental/Turf Herbicide Trng",
+        "Private App License Training"
+      ]
+    },
+    {
+      "prefix": "9.2",
+      "name": "Preparando",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "PREPARANDO MI NEGOCIO PARA"
+      ]
+    },
+    {
+      "prefix": "CAT",
+      "name": "Prin",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "BASIC PRIN COMPUTED TOMOGRAPHY"
+      ]
+    },
+    {
+      "prefix": "CVL",
+      "name": "Civil",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Civil Survey"
+      ]
+    },
+    {
+      "prefix": "DATA",
+      "name": "Data",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "central-oregon-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Data Science"
+      ]
+    },
+    {
+      "prefix": "DRFT",
+      "name": "Drafting",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "GENERAL DRAFTING & SKETCHING WELDER"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "Electrical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "ELECTRICAL CIRCUIT ANALYSIS 1"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Business Ownership"
+      ]
+    },
+    {
+      "prefix": "EXSI",
+      "name": "Exercise",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "INTERNSHIP: EXERCISE SCIENCE",
+        "INTRO TO ATHLETIC INJURIES"
+      ]
+    },
+    {
+      "prefix": "FWR",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "NATURAL RESOURCES SEMINAR"
+      ]
+    },
+    {
+      "prefix": "FYS",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "First Year Seminar"
+      ]
+    },
+    {
+      "prefix": "HEC",
+      "name": "Child",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "CHILD DEVELOPMENT"
+      ]
+    },
+    {
+      "prefix": "HPHY",
+      "name": "Methods",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Research Methods in Biology and Human Physiology"
+      ]
+    },
+    {
+      "prefix": "LA",
+      "name": "Foundational",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Foundational Language Skills"
+      ]
+    },
+    {
+      "prefix": "MG",
+      "name": "Data",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Data Analytics for Leaders"
+      ]
+    },
+    {
+      "prefix": "PLP",
+      "name": "Prior",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Prior Lrng Portfolio"
+      ]
+    },
+    {
+      "prefix": "WGS",
+      "name": "Womens",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Gender & Beauty Ideals",
+        "Intro to Women's Studies"
+      ]
+    },
+    {
+      "prefix": "XAPR",
+      "name": "Certificationtest",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college",
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Certification/Test Preparation",
+        "PACT"
+      ]
+    },
+    {
+      "prefix": "XCA",
+      "name": "Degree",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Degree Works Training"
+      ]
+    },
+    {
+      "prefix": "XEGR",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Study Lab"
+      ]
+    },
+    {
+      "prefix": "XES",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Health Care Provider CPR"
+      ]
+    },
+    {
+      "prefix": "XFA",
+      "name": "Culture",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Culture Through Films"
+      ]
+    },
+    {
+      "prefix": "XVEL",
+      "name": "Support",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "IET Academic Support",
+        "IET-Academic Support"
+      ]
+    },
+    {
+      "prefix": "XVMW",
+      "name": "Math",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Math &amp; Excel for Vineyards",
+        "Vineyard Pest Management"
+      ]
+    },
+    {
+      "prefix": "0.7",
+      "name": "Life",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "Life Skills Enrollment"
+      ]
+    },
+    {
+      "prefix": "AET",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "INDUSTRIAL SAFETY & MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "History",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "History Pacific NW Architect"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "Botany",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "clatsop-community-college"
+      ],
+      "sample_titles": [
+        "Botany"
+      ]
+    },
+    {
+      "prefix": "CEM",
+      "name": "Surveying",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "SURVEYING"
+      ]
+    },
+    {
+      "prefix": "DI",
+      "name": "Procextremities",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "RAD PROC-EXTREMITIES &amp; SPINE"
+      ]
+    },
+    {
+      "prefix": "ESR",
+      "name": "Environ",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "ENVIRON SCIENCE:CHEM PERSPECT"
+      ]
+    },
+    {
+      "prefix": "IDS",
+      "name": "Coop",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Ed: Sustainability Coordinator"
+      ]
+    },
+    {
+      "prefix": "NMC",
+      "name": "Media",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "NEW MEDIA AND CULTURE"
+      ]
+    },
+    {
+      "prefix": "NR",
+      "name": "Natual",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Natual Resources"
+      ]
+    },
+    {
+      "prefix": "OS",
+      "name": "Records",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "RECORDS AND INFORMATION MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "treasure-valley-community-college"
+      ],
+      "sample_titles": [
+        "PHILOSOPHICAL PROBLEMS"
+      ]
+    },
+    {
+      "prefix": "SAF",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "INDUSTRIAL SAFETY AND OSHA 10"
+      ]
+    },
+    {
+      "prefix": "SS1.",
+      "name": "Roadrunner",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "ROADRUNNER CONNECTIONS"
+      ]
+    },
+    {
+      "prefix": "ST",
+      "name": "Surgical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "linn-benton-community-college"
+      ],
+      "sample_titles": [
+        "SURGICAL TECH THEORY IV"
+      ]
+    },
+    {
+      "prefix": "WFS",
+      "name": "Wildland",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "klamath-community-college"
+      ],
+      "sample_titles": [
+        "Wildland Firefighter 2 **NC"
+      ]
+    },
+    {
+      "prefix": "WT",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "columbia-gorge-community-college"
+      ],
+      "sample_titles": [
+        "SOCIAL MEDIA MARKETING"
+      ]
+    },
+    {
+      "prefix": "XACT",
+      "name": "Abeged",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "ABE/GED Orientation"
+      ]
+    },
+    {
+      "prefix": "XAUM",
+      "name": "Automotive",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Ldrsp Institute"
+      ]
+    },
+    {
+      "prefix": "XCH",
+      "name": "XCH",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oregon-coast-community-college"
+      ],
+      "sample_titles": [
+        "N/A"
+      ]
+    },
+    {
+      "prefix": "XEMS",
+      "name": "Emergency",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lane-community-college"
+      ],
+      "sample_titles": [
+        "EMT - Emergency Medical Tech"
+      ]
+    },
+    {
+      "prefix": "XFRP",
+      "name": "Fire",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chemeketa-community-college"
+      ],
+      "sample_titles": [
+        "Fire Suppression Selection"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/sd/subject-vocab.json
+++ b/data/sd/subject-vocab.json
@@ -1,0 +1,1411 @@
+{
+  "state": "sd",
+  "generated_at": "2026-06-06T15:41:40.644Z",
+  "subjects": [
+    {
+      "prefix": "BAD",
+      "name": "BAD",
+      "course_count": 13,
+      "section_count": 76,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Applied Business Math (CBAVC)",
+        "Business Communication (ON)",
+        "Grant Writing",
+        "Introduction to Business (CBAVC)",
+        "Leadership"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 8,
+      "section_count": 71,
+      "colleges": [
+        "oglala-lakota-college",
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Communication in the Workplace",
+        "Composition",
+        "Composition I (CBAVC)",
+        "Composition II (CBAVC)",
+        "Global Issues"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 15,
+      "section_count": 60,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Law I",
+        "Business/Marketing Internship",
+        "Capstone in Business Studies",
+        "Customer Service"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 14,
+      "section_count": 51,
+      "colleges": [
+        "oglala-lakota-college",
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Accounting Information Systems (ON)",
+        "Accounting Spreadsheet Applications",
+        "Auditing",
+        "Cost Accounting",
+        "Income Tax I"
+      ]
+    },
+    {
+      "prefix": "LAK",
+      "name": "Lakota",
+      "course_count": 8,
+      "section_count": 48,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Internship in Lakota Studies",
+        "Lakota Grammar",
+        "Lakota Language Assessment",
+        "Lakota Language I",
+        "Lakota Language II (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "SOWK",
+      "course_count": 7,
+      "section_count": 46,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "HBSE I",
+        "Introduction to Research",
+        "Methods I",
+        "Methods III",
+        "Practicum I"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 6,
+      "section_count": 42,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Biology I",
+        "Biology I Lab",
+        "Human Biology",
+        "Human Physiology",
+        "Mammalogy"
+      ]
+    },
+    {
+      "prefix": "CHW",
+      "name": "CHW",
+      "course_count": 7,
+      "section_count": 37,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Advocacy, Medical Law, and Ethical",
+        "Care Coordination and System Naviga",
+        "Community Health Workers Role",
+        "First Aid Basic for Care in the Com",
+        "Health Promotion and Coaching"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 5,
+      "section_count": 36,
+      "colleges": [
+        "oglala-lakota-college",
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Chemistry I (RBAVC)",
+        "Chemistry I Lab (RBAVC)",
+        "Chemistry Survey",
+        "Chemistry Survey Lab",
+        "Organic Chemistry 1"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 6,
+      "section_count": 34,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Basic Math II (CBAVC)",
+        "Calculus 1",
+        "College Algebra (CBAVC)",
+        "Elementary Algebra (CBAVC)",
+        "Intermediate Algebra (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "LSOC",
+      "name": "Lakota",
+      "course_count": 3,
+      "section_count": 26,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "American Indian Women",
+        "Lakota Culture",
+        "Lakota Thought & Philosophy"
+      ]
+    },
+    {
+      "prefix": "CD",
+      "name": "Child Development",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Ethical & Legal Issues for CDP",
+        "Family Counsel. & Chem. Depend.",
+        "Introduction to Alcoholism",
+        "Native Am. Substance Abuse"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 1,
+      "section_count": 22,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "General Psychology (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "Theory",
+      "course_count": 18,
+      "section_count": 20,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions Lab",
+        "Automatic Transmissions Theory",
+        "Automotive Welding Lab",
+        "Brake Lab",
+        "Brake Theory"
+      ]
+    },
+    {
+      "prefix": "LHIST",
+      "name": "Lakota",
+      "course_count": 4,
+      "section_count": 20,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Lakota History I",
+        "Lakota History II",
+        "Sem. In Contemporary Indian Hist."
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 2,
+      "section_count": 20,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Introduction to Literature (CBAVC)",
+        "Minority Literature"
+      ]
+    },
+    {
+      "prefix": "MIS",
+      "name": "Inform",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Applied Inform. Processing (RBAVC)"
+      ]
+    },
+    {
+      "prefix": "SPCM",
+      "name": "Speech",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Speech Communications (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "BHT",
+      "name": "BHT",
+      "course_count": 18,
+      "section_count": 19,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Behavioral Health in Adult and Agin",
+        "Behavioral Health in Diverse Social",
+        "Case Management, Assessment, and Cl",
+        "Child, Adolescent, and Family Syste",
+        "Clinical Experience I"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "CET",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "CAD II-Civil 3D",
+        "CAD III-Roadway Corridors",
+        "Construction Materials Testing",
+        "Intro to Civil Eng & Technical Prof",
+        "JumpStart"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Application Development",
+        "C# Programming",
+        "Data Analysis",
+        "Dynamic Website Development",
+        "eBusiness"
+      ]
+    },
+    {
+      "prefix": "CVS",
+      "name": "Sonography",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Cardiac Sonography II",
+        "Cardiac Sonography III",
+        "Cardiac Sonography Lab II",
+        "Cardiac Sonography Lab III",
+        "Cardiovascular Sonography Clinic II"
+      ]
+    },
+    {
+      "prefix": "ECH",
+      "name": "ECH",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Curriculum for Self-Awareness",
+        "Early Learning & Develop. (CBAVC)",
+        "Family Literacy",
+        "Introduction to Early Childhood Ed.",
+        "Materials & Techniques I (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "HC",
+      "name": "HC",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Anatomy/Physiology",
+        "Applied Anatomy/Physiology Lab",
+        "Certified Nursing Assistant (CNA)",
+        "JumpStart",
+        "Medical Language"
+      ]
+    },
+    {
+      "prefix": "LART",
+      "name": "Lakota",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Indian Art History",
+        "Lakota Artifact & Regalia Reprod.",
+        "Traditional Lakota Arts I",
+        "Traditional Lakota Arts II"
+      ]
+    },
+    {
+      "prefix": "AAR",
+      "name": "Acad",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Acad Advise Registration Programmin"
+      ]
+    },
+    {
+      "prefix": "CVI",
+      "name": "Invasive",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Asepsis & Cardiac Cath Related Surg",
+        "Electrophysiology",
+        "Emergency Cardiac Care Lab",
+        "Inv Diagn Proc II Lab",
+        "Inv Diagn Proc Lab"
+      ]
+    },
+    {
+      "prefix": "AB",
+      "name": "Auto",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Body Electrical AC",
+        "Auto Body Lab",
+        "Auto Body Welding",
+        "Auto Refinish Lab",
+        "Auto Refinish Lab II"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "IT",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Application Software TNT",
+        "Command Line",
+        "Introduction to Networks",
+        "Network Analysis",
+        "Network Protocols"
+      ]
+    },
+    {
+      "prefix": "LAKM",
+      "name": "Mgmt",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Community Action Project",
+        "Financial Mgmt. Administration",
+        "Lak. Env. Mgmt. & Protection (CBAVC)",
+        "Lak. Found. For Ldrship & Mgmt (CASD)",
+        "Lakota Ldrship. & Comm.Skills"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Fundamentals for Nursing Lab B",
+        "Holistic Adult Nursing II Lab A",
+        "Pharm. For Nursing III",
+        "Pharmacology for Nursing I",
+        "Professional & Transcultural Nsg."
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "ACT",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Architectural Drawing I",
+        "Architectural Drawing II",
+        "BIM Capstone",
+        "Commercial Construction Techniques",
+        "Construction Estimating"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Computers"
+      ]
+    },
+    {
+      "prefix": "CAR",
+      "name": "Onsite",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Carpentry Theory II",
+        "On-Site Construction I",
+        "On-Site Construction II",
+        "On-Site Construction III",
+        "On-Site Construction IV"
+      ]
+    },
+    {
+      "prefix": "LLAW",
+      "name": "LLAW",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Civil Law and Procedures",
+        "Contract Law",
+        "Family Law"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Drawing I"
+      ]
+    },
+    {
+      "prefix": "BD",
+      "name": "Build",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Build Dakota Scholarship Student",
+        "Build Dakota Success"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "ED",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Child & Adolescent Development",
+        "Children's Literature",
+        "Educational Psychology",
+        "Foundations of Education"
+      ]
+    },
+    {
+      "prefix": "LLIT",
+      "name": "Literature",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "American Indian Literature",
+        "Contemporary Indian Literature",
+        "Lakota Oral Literature"
+      ]
+    },
+    {
+      "prefix": "OED",
+      "name": "OED",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Computer Basics",
+        "Concepts of DB Mang.",
+        "Dictation & Transcription",
+        "Word Processing I"
+      ]
+    },
+    {
+      "prefix": "DEN",
+      "name": "Dental",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Experience II",
+        "Dental Radiography Lab",
+        "Dental Radiology"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "Computer",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "CAD Special Topics",
+        "Computer Assisted Design I",
+        "Computer Assisted Design II",
+        "Computer Assisted Design III/Arch"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Sonography III",
+        "OB/Gyn Sonography I",
+        "OB/Gyn Sonography I Lab"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Principles of Macroeconomics"
+      ]
+    },
+    {
+      "prefix": "EDECH",
+      "name": "Methods",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Methods of Tchg ECH/Elem Math",
+        "Methods of Teaching ECH/Elem Sci",
+        "Methods of Teaching Reading"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "Electrical",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Electrical Blue Prints",
+        "Electrical Fundamentals I",
+        "Electrical Fundamentals II"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Introduction to CADD",
+        "Introduction to Engineering I",
+        "Introduction to Engineering II"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "LSCI",
+      "name": "Lakota",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Lakota & the Environment",
+        "Traditional Plants, Foods,& Herbs"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "American Government"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Integrated",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Integrated Sci.for Elem Tchrs I"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "Ethics",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Ethics in the Worksplace"
+      ]
+    },
+    {
+      "prefix": "CV",
+      "name": "Ultrasound",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Cardiovascular Physiology & Patholo",
+        "Ultrasound Physics"
+      ]
+    },
+    {
+      "prefix": "LDCM",
+      "name": "Organizational",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Leadership Communications",
+        "Organizational Ldrshp. & Vision"
+      ]
+    },
+    {
+      "prefix": "LMUS",
+      "name": "Lakota",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Lakota Music Composition"
+      ]
+    },
+    {
+      "prefix": "LPN",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Nursing Clinical",
+        "Medical Surgical Nursing II",
+        "Pharmacology for the LPN"
+      ]
+    },
+    {
+      "prefix": "LPOL",
+      "name": "Indian",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Indian Law",
+        "Lakota Tribal Laws,Treaties&Gov't"
+      ]
+    },
+    {
+      "prefix": "NSCI",
+      "name": "Methods",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Integrated Environmental Science",
+        "Research Methods"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Sociology"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Statistics",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Statistics for Social Science"
+      ]
+    },
+    {
+      "prefix": "CMST",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Foundations of Communication"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Evolution"
+      ]
+    },
+    {
+      "prefix": "CMT",
+      "name": "Construction",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Construction Basics",
+        "Construction Basics Lab"
+      ]
+    },
+    {
+      "prefix": "EDLK",
+      "name": "Student",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Seminar for Student Teaching"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician Lab",
+        "Emergency Medical Technician-Basic"
+      ]
+    },
+    {
+      "prefix": "ENS",
+      "name": "Science",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Science for Educators & More (F2F)"
+      ]
+    },
+    {
+      "prefix": "EXED",
+      "name": "Diagnostic",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Diagnostic Teaching (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "GART",
+      "name": "Photoshop",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Photoshop"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Introduction to GIS"
+      ]
+    },
+    {
+      "prefix": "HISA",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "American History I"
+      ]
+    },
+    {
+      "prefix": "HT",
+      "name": "Horticulture",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Horticulture Science",
+        "Horticulture Science Lab"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "HV",
+      "name": "Hvacr",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Intro to HVACR"
+      ]
+    },
+    {
+      "prefix": "LMEA",
+      "name": "School",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "School Law (CASD)"
+      ]
+    },
+    {
+      "prefix": "LPOLS",
+      "name": "Tribal",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Tribal Laws, Treaties, & Gov't"
+      ]
+    },
+    {
+      "prefix": "LPSY",
+      "name": "Native",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Native American Psychology"
+      ]
+    },
+    {
+      "prefix": "LSOCM",
+      "name": "Culture",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Lak. Culture Resource Mgmt."
+      ]
+    },
+    {
+      "prefix": "OMATH",
+      "name": "Occupational",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Occupational Math"
+      ]
+    },
+    {
+      "prefix": "PLMB",
+      "name": "Plumbing",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Plumbing Fundamentals"
+      ]
+    },
+    {
+      "prefix": "SCED",
+      "name": "Reading",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Reading in the Content Area (CBAVC)"
+      ]
+    },
+    {
+      "prefix": "TMATH",
+      "name": "Construction",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oglala-lakota-college"
+      ],
+      "sample_titles": [
+        "Construction Trades Math"
+      ]
+    },
+    {
+      "prefix": "AGBUS150",
+      "name": "Crop",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Crop Science"
+      ]
+    },
+    {
+      "prefix": "AGBUS170",
+      "name": "Animal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Animal Science"
+      ]
+    },
+    {
+      "prefix": "AGBUS230",
+      "name": "Agriculture",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Agriculture Marketing"
+      ]
+    },
+    {
+      "prefix": "AGBUS240",
+      "name": "Agriculture",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Agriculture Lending"
+      ]
+    },
+    {
+      "prefix": "AGBUS250",
+      "name": "Princ",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Princ Farm&Ranch Mngmnt"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "American Sign Language"
+      ]
+    },
+    {
+      "prefix": "CODE",
+      "name": "Review",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "CPC Review"
+      ]
+    },
+    {
+      "prefix": "DT",
+      "name": "Print",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Print Reading for Construction"
+      ]
+    },
+    {
+      "prefix": "ECHL",
+      "name": "Family",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Family Relations"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Health Information Service"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southeast-technical-college"
+      ],
+      "sample_titles": [
+        "Human Resource Management"
+      ]
+    }
+  ],
+  "program_titles": [
+    ".The SCC CORE - General Education Requirements",
+    "Academic Transfer, A.A.",
+    "Academic Transfer, A.S.",
+    "Academic Transfer, Electives List",
+    "Accounting, A.A.",
+    "Adult & Juvenile Services and Corrections, A.A.S.",
+    "Agricultural Teacher Education, A.A.S.",
+    "Agriculture Management & Production, A.A.S.",
+    "Alcohol & Drug Counseling Certificate",
+    "Artificial Intelligence for Professionals, Certificate",
+    "Associate Degree Nursing, A.A.S.",
+    "Associate Degree Nursing, A.A.S. (LPN-ADN Option)",
+    "Associate of Health Sciences",
+    "Auto Collision Repair Technology, A.A.S.",
+    "Automotive Technology and Light Repair Certificate",
+    "Automotive Technology Diploma",
+    "Automotive Technology, A.A.S.",
+    "AVD Low Voltage Technician Diploma",
+    "Baking/Pastry Diploma",
+    "Baking/Pastry, A.A.S.",
+    "Biotechnology Certificate",
+    "Biotechnology Diploma",
+    "Biotechnology, A.S.",
+    "Bookkeeping Certificate",
+    "Bookkeeping Diploma",
+    "Building Construction Technology Certificate",
+    "Building Construction Technology, A.A.S.",
+    "Business Certificate",
+    "Business Diploma",
+    "Business, A.A.",
+    "Business, A.A.S.",
+    "Client Relations Certificate",
+    "Computer Information Technology, Applications Development Diploma",
+    "Computer Information Technology, Applications Development, A.A.S.",
+    "Computer Information Technology, Computer Support Diploma",
+    "Computer Information Technology, Computer Support, A.A.S.",
+    "Computer Information Technology, Cybersecurity, A.A.S.",
+    "Computer Information Technology, General Technician Certificate",
+    "Computer Information Technology, Network Management Diploma",
+    "Computer Information Technology, Network Management, A.A.S.",
+    "Concrete Construction Technician Certificate",
+    "Concrete Construction Technician Diploma",
+    "Concrete Construction Technician, A.A.S.",
+    "Criminal Justice, A.A.",
+    "Criminal Justice, A.A.S.",
+    "Culinary Arts, A.A.S.",
+    "Culinary Arts, Diploma",
+    "Culinary Communications, A.A.S",
+    "Culinary Communications, Diploma",
+    "Culinary/Hospitality Certificate",
+    "Data Science, A.S.",
+    "Dental Assistant (with Expanded Duties), A.A.S.",
+    "Dental Assistant Diploma",
+    "Design & Drafting Technology Certificate - Designing Software",
+    "Design & Drafting Technology Certificate - Intro to Design Software",
+    "Design & Drafting Technology Certificate - Residential Design",
+    "Design & Drafting Technology, Architectural Design, A.A.S.",
+    "Design & Drafting Technology, Computer Aided Design Drafting, A.A.S.",
+    "Diesel Technology-Truck Diploma",
+    "Diesel Technology-Truck Maintenance & Light Repair Certificate",
+    "Diesel Technology-Truck, A.A.S.",
+    "Diesel-Ag Equipment Service Tech Diploma",
+    "Diesel-Ag Equipment Service Tech Maintenance & Light Repair Certificate",
+    "Diesel-Ag Equipment Service Tech, A.A.S.",
+    "Dietary Manager Certificate",
+    "Early Childhood Education - Certificate",
+    "Early Childhood Education Certificate - In Home Care Provider",
+    "Early Childhood Education Certificate - Infant/Toddler",
+    "Early Childhood Education Certificate - Preschool",
+    "Early Childhood Education Diploma",
+    "Early Childhood Education, A.A.",
+    "Early Childhood Education, A.A.S.",
+    "Electrical & Electromechanical Technology, Automation & Robotics Certificate",
+    "Electrical & Electromechanical Technology, Automation & Robotics, A.A.S.",
+    "Electrical & Electromechanical Technology, Electrical Technician Certificate",
+    "Electrical & Electromechanical Technology, Electrical Technician, A.A.S.",
+    "Electrical & Electromechanical Technology, Electromechanical Industrial Maintenance Technician Certificate",
+    "Electrical & Electromechanical Technology, Electromechanical Industrial Maintenance Technician, A.A.S.",
+    "Electrician Construction Apprenticeship - LEJATC Certificate",
+    "Electrician Construction Apprenticeship - LEJATC Option",
+    "Electronic Systems Technology Technician Diploma",
+    "Electronic Systems Technology, AVD and Low Voltage Systems Certificate",
+    "Electronic Systems Technology, AVD and Low Voltage Systems, A.A.S.",
+    "Electronic Systems Technology, Electronic System Technician Certificate",
+    "Electronic Systems Technology, Electronic Systems Technician, A.A.S.",
+    "Energy Generation Operations Certificate",
+    "Energy Generation Operations Diploma",
+    "Energy Generation Operations, A.A.S.",
+    "Entrepreneurship Certificate",
+    "Event-Venue Operations Management Certificate",
+    "Ford Automotive Student Service Educational Training, A.A.S.",
+    "Fundamentals of Agriculture Certificate",
+    "General Motors Automotive Service Educational Program, A.A.S.",
+    "Geographic Information Systems Technician Certificate",
+    "Geographic Information Systems Technician Diploma",
+    "Geographic Information Systems Technician, A.A.S.",
+    "Global Studies Certificate",
+    "Graphic Design Media Arts, A.A.S.",
+    "Healthcare Management, A.A.S.",
+    "Healthcare Services Certificate",
+    "Heating, Ventilation, Air Conditioning & Refrigeration Technology Diploma",
+    "Heating, Ventilation, Air Conditioning & Refrigeration Technology, A.A.S.",
+    "Horticulture & Turfgrass Management, A.A.S.",
+    "Hospitality Management, A.A.S.",
+    "Hospitality Management, Diploma",
+    "Human Services, A.A.S.",
+    "Integrated Technologies, A.A.S.",
+    "John Deere Construction & Forestry Equipment Tech, A.A.S.",
+    "John Deere Tech, A.A.S.",
+    "Land Surveying/GIS/Civil Engineering Technology, A.A.S.",
+    "Law Enforcement & Homeland Security, A.A.S.",
+    "Livestock Management & Production, A.A.S.",
+    "Long Term Care Administration Certificate",
+    "Long Term Care Administration, A.A.S.",
+    "Manufacturing Engineering Technology Certificate",
+    "Manufacturing Engineering Technology Diploma",
+    "Manufacturing Engineering Technology, A.A.S.",
+    "Medical Assisting Diploma",
+    "Medical Laboratory Technology, A.A.S.",
+    "Microsoft Office Specialist (MOS) Preparation Certificate",
+    "Nondestructive Testing Technology, A.A.S.",
+    "Occupational Therapy Assistant, A.A.S.",
+    "Office Professional Certificate",
+    "Office Professional Diploma",
+    "Office Professional, A.A.S.",
+    "Operations and Service Management, A.A.S.",
+    "Paramedic Diploma",
+    "Paramedic, A.A.S.",
+    "Peer Support Certificate",
+    "Pharmacy Technician Diploma",
+    "Physical Therapist Assistant, A.A.S.",
+    "Plumbing Technology, Diploma",
+    "Plumbing, Heating, and Air Conditioning Technology, A.A.S",
+    "Polysomnographic (Sleep) Technology Certificate",
+    "Powersports Technology Diploma",
+    "Powersports Technology, A.A.S.",
+    "Practical Nursing Diploma",
+    "Precision Agriculture Certificate",
+    "Precision Agriculture Diploma",
+    "Precision Machining and Automation General Machinist Certificate",
+    "Precision Machining and Automation Technology Diploma",
+    "Precision Machining and Automation Technology, Advanced CNC & Automation, A.A.S.",
+    "Precision Machining and Automation Technology, Tool Maker Mold and Die, A.A.S.",
+    "Professional Truck Driver Training Certificate",
+    "Psychology, A.A.",
+    "Radiologic Technology, A.A.S.",
+    "Respiratory Care, A.A.S.",
+    "Surgical First Assist Certificate",
+    "Surgical Technology, A.A.S.",
+    "Technical Skills Instructor, A.O.S.",
+    "Utility Lineworker, A.A.S.",
+    "Water Quality and Wastewater Treatment Operations Certificate",
+    "Welding Technology Certificate",
+    "Welding Technology Diploma",
+    "Welding Technology, A.A.S."
+  ]
+}

--- a/data/tx/subject-vocab.json
+++ b/data/tx/subject-vocab.json
@@ -1,0 +1,8780 @@
+{
+  "state": "tx",
+  "generated_at": "2026-06-06T15:41:40.868Z",
+  "subjects": [
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 72,
+      "section_count": 8238,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adult Education Math",
+        "Basic Mathematics",
+        "Basic Mathematics & Contemporary Mathematics",
+        "Basic Mathematics & Introduction to Statistics",
+        "Beginning Algebra"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 31,
+      "section_count": 6787,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "&lt;b&gt;HNR;&lt;/b&gt;Composition II",
+        "Acad Cooperative - English",
+        "American Literature",
+        "American Literature I: Precolonial through the Romantic Period",
+        "Base NCBO English"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 56,
+      "section_count": 5667,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Acad Coop Biol Sci/Life Sciences",
+        "Academic Cooperative - Bio/Life Sci",
+        "ANATOMY & PHYS",
+        "Anatomy & Physiology I Lab",
+        "Anatomy & Physiology II Lab"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 12,
+      "section_count": 3762,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative",
+        "African American History II",
+        "African-American History I",
+        "History of World Civilizations I",
+        "Mexican American History I (to the United States-Mexico War Era)"
+      ]
+    },
+    {
+      "prefix": "GOVT",
+      "name": "GOVT",
+      "course_count": 6,
+      "section_count": 3223,
+      "colleges": [
+        "amarillo-college",
+        "blinn-college-district",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative",
+        "Federal and Texas Constitutions",
+        "Federal Government (Federal Constitution &amp; Topics) (070)",
+        "Introduction to Political Science",
+        "Mexican-American and Latinx Politics"
+      ]
+    },
+    {
+      "prefix": "MUAP",
+      "name": "MUAP",
+      "course_count": 332,
+      "section_count": 2691,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Applied Baritone/Euphonium",
+        "Applied Conducting",
+        "Applied French Horn",
+        "Applied Music Brass",
+        "Applied Music Composition"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 15,
+      "section_count": 2689,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Academic Cooperative",
+        "Adolescent Psychology I",
+        "Biological Psychology",
+        "Child Psychology"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 23,
+      "section_count": 2269,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative",
+        "Art Appreciation (050/090)",
+        "Art History I (Prehistoric to the 14th century)",
+        "Art History II (14th century to the present)",
+        "Art Metals I"
+      ]
+    },
+    {
+      "prefix": "SPCH",
+      "name": "Communication",
+      "course_count": 7,
+      "section_count": 2209,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative-Comm",
+        "Discussion and Small Group",
+        "Honors - Business and Professional Communication",
+        "Interpersonal Communication (010/090)",
+        "Introduction to Speech Communication (010/090)"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 6,
+      "section_count": 2049,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Education Lab",
+        "FYS - Learning Framework",
+        "Introduction to Special Populations",
+        "Introduction to the Teaching Profession",
+        "Learning Framework: 1st Year Experience"
+      ]
+    },
+    {
+      "prefix": "WLDG",
+      "name": "Welding",
+      "course_count": 69,
+      "section_count": 1983,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "south-texas-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "ADVANCE PIPE WE",
+        "Advanced Flux Cored Arc Welding",
+        "ADVANCED FLUX CORED ARC WELDING",
+        "Advanced Gas Metal Arc Welding",
+        "Advanced Gas Metal Arc Welding (GMAW)"
+      ]
+    },
+    {
+      "prefix": "RNSG",
+      "name": "Nursing",
+      "course_count": 104,
+      "section_count": 1889,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "blinn-college-district",
+        "cisco-college",
+        "clarendon-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adapt to the Role of Prof Nurse",
+        "Adaptation to Role of Professional Nurse",
+        "Advanced Concepts of Adult Health",
+        "Care of Childbearing Family",
+        "Care of Children and Families"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 28,
+      "section_count": 1696,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "GEN CHEMISTRY I",
+        "General Chemistry for Engineering Majors",
+        "General Chemistry I (lecture)",
+        "General Chemistry I Lab",
+        "General Chemistry I Laboratory"
+      ]
+    },
+    {
+      "prefix": "KINE",
+      "name": "KINE",
+      "course_count": 105,
+      "section_count": 1385,
+      "colleges": [
+        "blinn-college-district",
+        "cisco-college",
+        "coastal-bend-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "mclennan-community-college",
+        "navarro-college",
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adaptive Personalized Fitness",
+        "Adaptive Physical Education",
+        "Adv Jogging/Walking/Fitness",
+        "Advanced Co-Ed Weight Training",
+        "Aerobics II"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 8,
+      "section_count": 1348,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "History of Religions I",
+        "History of Religions II",
+        "Introduction to Ethics (040)",
+        "Introduction to Formal Logic",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 3,
+      "section_count": 1330,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Principles of Macroeconomics (080/090)",
+        "Principles of Microeconomics Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 31,
+      "section_count": 1324,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative",
+        "Advanced Ear Training and Sight Singing II",
+        "American Mus-Hist Rock & Roll",
+        "Class Piano Level I",
+        "Class Piano Level II"
+      ]
+    },
+    {
+      "prefix": "VNSG",
+      "name": "VNSG",
+      "course_count": 77,
+      "section_count": 1065,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "A&P for Allied Health",
+        "Advanced Nursing Skills",
+        "Anatomy and Physiology for Allied Health",
+        "Applied Nursing Skills",
+        "APPLIED NURSING SKILLS I"
+      ]
+    },
+    {
+      "prefix": "CSME",
+      "name": "CSME",
+      "course_count": 68,
+      "section_count": 1046,
+      "colleges": [
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "panola-college",
+        "south-plains-college",
+        "texarkana-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "ADV. COSMETOLOGY APPLI & REL THEORY",
+        "Advanced Cosmetology Applications &",
+        "Advanced Cosmetology Techniques",
+        "ADVANCED COSMETOLOGY TECHNIQUES",
+        "Advanced Hair Cutting and Related Theory"
+      ]
+    },
+    {
+      "prefix": "INRW",
+      "name": "Integrated",
+      "course_count": 24,
+      "section_count": 1003,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Adult Education Reading/Writi",
+        "Ascender: INRW Special Topics",
+        "Base Integ Read &amp; Write (DM1)",
+        "Base NCBO Int Rd &amp; Writ (DM1)",
+        "INRW CoReq to ENGL 1301"
+      ]
+    },
+    {
+      "prefix": "CRIJ",
+      "name": "CRIJ",
+      "course_count": 15,
+      "section_count": 989,
+      "colleges": [
+        "amarillo-college",
+        "blinn-college-district",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Community Resources in Corrections",
+        "Correctional Systems and Practices- 10 Week Summer Session",
+        "Court Systems and Practices CAPSTONE",
+        "Crime in America",
+        "Criminal Investigations"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 8,
+      "section_count": 977,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Criminology",
+        "Drug Use and Abuse",
+        "Human Sexuality",
+        "Introduction to Sociology (080/090)",
+        "Marriage and the Family"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 37,
+      "section_count": 927,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "COLL PHYSICS I",
+        "COLL PHYSICS II",
+        "College Physics I",
+        "College Physics I (Lec/Lab)",
+        "College Physics I Laboratory"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 4,
+      "section_count": 902,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Principles of Financial Accounting",
+        "Principles of Managerial Accounting"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "Business",
+      "course_count": 5,
+      "section_count": 895,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Business Law I",
+        "Business Principles",
+        "Business Report Writing & Corresp",
+        "Business Statistics",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "HUMA",
+      "course_count": 7,
+      "section_count": 888,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "American Minority Studies",
+        "Fine Arts Appreciation",
+        "INTRO TO THE HUMANITIES; HUMAN RIGH",
+        "Introduction to Mexican-American Studies",
+        "Introduction to the Humanities II"
+      ]
+    },
+    {
+      "prefix": "BMGT",
+      "name": "Management",
+      "course_count": 39,
+      "section_count": 815,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Communication in Management/PS Applications",
+        "Business Ethics",
+        "Communications in Management",
+        "Cooperation Education - Business Administration and Management, General",
+        "Cooperative - Education Ind Tech"
+      ]
+    },
+    {
+      "prefix": "COSC",
+      "name": "Programming",
+      "course_count": 12,
+      "section_count": 803,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "\"C\" Programming",
+        "C Programming",
+        "Computer Organization",
+        "Introduction to Computer Programming (C++)",
+        "Introduction to Computing"
+      ]
+    },
+    {
+      "prefix": "DRAM",
+      "name": "DRAM",
+      "course_count": 19,
+      "section_count": 796,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative in Theatre",
+        "Acting I",
+        "Acting II",
+        "Film Appreciation (050)",
+        "History of the Theater I"
+      ]
+    },
+    {
+      "prefix": "EMSP",
+      "name": "EMSP",
+      "course_count": 70,
+      "section_count": 727,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "blinn-college-district",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Assessment Based Management",
+        "Cardiology",
+        "Clin-Emergency Medical Tech",
+        "Clinical - Emergency Medical Technology/Technician"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 7,
+      "section_count": 707,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "BEG SPANISH II",
+        "Beginning Conversational Spanish I",
+        "Beginning Spanish I with Lab",
+        "Elementary Spanish II",
+        "Intermediate Spanish I (040)"
+      ]
+    },
+    {
+      "prefix": "AUMT",
+      "name": "Automotive",
+      "course_count": 54,
+      "section_count": 669,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced EV/Hybrid Light Vehicle Diagnosis and Repair",
+        "Auto Comp & Fuel Systems",
+        "Auto Eng Perf Analysis Theory I",
+        "Auto Eng Perf Analysis Theory II",
+        "Auto Eng Removal & Install"
+      ]
+    },
+    {
+      "prefix": "BCIS",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 651,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Business Computer Applications",
+        "Business Computer Applications (090)"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "GEOL",
+      "course_count": 21,
+      "section_count": 607,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative",
+        "Earth Science II for Non-Majors",
+        "Earth Sciences for Non-Science Majors I",
+        "Earth Sciences for Non-Science Majors I Laboratory",
+        "Earth Sciences for Non-Science Majors II"
+      ]
+    },
+    {
+      "prefix": "MUEN",
+      "name": "Ensemble",
+      "course_count": 67,
+      "section_count": 551,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "A Cappella Choir (Freshman)",
+        "A Cappella Choir (sophomore)",
+        "Advanced Mariachi Ensemble",
+        "Chamber (Small) Vocal Ensemble",
+        "Chamber Ensemble"
+      ]
+    },
+    {
+      "prefix": "ITSY",
+      "name": "Security",
+      "course_count": 34,
+      "section_count": 509,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "blinn-college-district",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Applied Ethical Hacking and Penetration Testing",
+        "COMP/INFO SEC P",
+        "Computer System Forensics",
+        "COOP ED COMP & INFO SYS SEC",
+        "Cyber-Psychology and the Effects of Emerging Technology"
+      ]
+    },
+    {
+      "prefix": "ITSC",
+      "name": "ITSC",
+      "course_count": 32,
+      "section_count": 508,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Linux",
+        "App Software Problem Solving",
+        "APPL PROBLEM SO",
+        "COOP EDUC: COMPUTER & INFO SCIENCES",
+        "Integrated Software App III"
+      ]
+    },
+    {
+      "prefix": "HITT",
+      "name": "HITT",
+      "course_count": 45,
+      "section_count": 493,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "ADV BILLING/REI",
+        "Advanced Medical Coding",
+        "Ambulatory Coding",
+        "Clin-Health Info Med Records",
+        "Clinical"
+      ]
+    },
+    {
+      "prefix": "ITNW",
+      "name": "ITNW",
+      "course_count": 38,
+      "section_count": 466,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "blinn-college-district",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Cloud Concepts",
+        "Amazon Cloud Computing Architecture (AWS)",
+        "Amazon Cloud Developer (AWS)",
+        "Amazon Cloud Foundations (AWS)",
+        "Application Development for the Cloud"
+      ]
+    },
+    {
+      "prefix": "ACNT",
+      "name": "Accounting",
+      "course_count": 48,
+      "section_count": 456,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Accounting",
+        "Accounting and Business Ethics",
+        "Accounting Capstone",
+        "Accounting Data Analytics",
+        "Accounting Ethics"
+      ]
+    },
+    {
+      "prefix": "HPRS",
+      "name": "Health",
+      "course_count": 30,
+      "section_count": 406,
+      "colleges": [
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Basic Health Profession Skills",
+        "BASIC HLTH PROF",
+        "Central Sterile Processing I",
+        "Central Sterile Processing II",
+        "Central Sterile Processing III"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 13,
+      "section_count": 397,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Chem Engnrg Thermodynamics I",
+        "Computer Programming for Engineering Applications through Zoom",
+        "Electrical Circuits I (Lecture +Lab)",
+        "Electrical Circuits I Lab",
+        "Electrical Circuits I Lecture"
+      ]
+    },
+    {
+      "prefix": "RADR",
+      "name": "RADR",
+      "course_count": 51,
+      "section_count": 397,
+      "colleges": [
+        "amarillo-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Imaging",
+        "Advanced Radiographic Procedures",
+        "Basic Radiographic Procedures",
+        "Clinical - Radiologic Technology/Science",
+        "Clinical - Radiologic Technology/Science - Radiographer"
+      ]
+    },
+    {
+      "prefix": "HART",
+      "name": "HART",
+      "course_count": 49,
+      "section_count": 389,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "south-texas-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Advanced A/C Controls",
+        "Advanced Electricity for HVAC",
+        "Air Conditioning & Refrig Codes",
+        "Air Conditioning and Troubleshooting",
+        "Air Conditioning Control Princ"
+      ]
+    },
+    {
+      "prefix": "PTAC",
+      "name": "Process",
+      "course_count": 21,
+      "section_count": 386,
+      "colleges": [
+        "alvin-community-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "odessa-college",
+        "palo-alto-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Industrial Economics",
+        "Industrial Processes",
+        "Int-Process Technology",
+        "INTERN-PRO TEC2",
+        "Internship - Process Technology/Technician"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "Esol",
+      "course_count": 43,
+      "section_count": 375,
+      "colleges": [
+        "clarendon-college",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "odessa-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Composition for Foreign Speakers",
+        "Advanced Conversation for Foreign Speakers",
+        "Advanced Grammar for Foreign Speakers",
+        "Advanced Intermediate Composition for Foreign Speakers",
+        "Advanced Intermediate Conversation/Foreign Speakers"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 18,
+      "section_count": 374,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Audio/Radio Production",
+        "Editing & Layout-Desktop Publishing",
+        "Film Appreciation: Doc & Media",
+        "Introduction to Advertising",
+        "Introduction to Electronic Media"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 70,
+      "section_count": 363,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "college-of-the-mainland",
+        "frank-phillips-college",
+        "howard-college",
+        "kilgore-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "paris-junior-college",
+        "texarkana-college",
+        "vernon-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Advanced Baseball",
+        "Advanced Fast-Pitch Softball",
+        "Advanced Rodeo",
+        "Baseball I",
+        "Baseball II"
+      ]
+    },
+    {
+      "prefix": "MRKG",
+      "name": "Marketing",
+      "course_count": 24,
+      "section_count": 362,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advertising and Sales Promotion",
+        "Co-op Business Marketing Mgmt I",
+        "Customer Relationship Management",
+        "Digital Marketing Law, Ethics, and Crisis Management",
+        "e-Commerce Marketing"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 36,
+      "section_count": 355,
+      "colleges": [
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "navarro-college",
+        "odessa-college",
+        "san-antonio-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Capstone Project",
+        "Community & Public Health",
+        "Community and Public Health",
+        "Community and Public Health Clinical",
+        "Community Nursing Clinical (Capstone)"
+      ]
+    },
+    {
+      "prefix": "FIRS",
+      "name": "Firefighter",
+      "course_count": 18,
+      "section_count": 352,
+      "colleges": [
+        "amarillo-college",
+        "blinn-college-district",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Continuing Education for Firefighters",
+        "Firefighter Agility &amp; Fitness",
+        "Firefighter Agility and Fitness Preparation",
+        "Firefighter Certification I",
+        "Firefighter Certification II"
+      ]
+    },
+    {
+      "prefix": "ELPT",
+      "name": "Electrical",
+      "course_count": 41,
+      "section_count": 343,
+      "colleges": [
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "frank-phillips-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "texarkana-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "AC/DC Drives",
+        "ADVANCED ELECTR",
+        "Basic Electrical Theory",
+        "Commercial Wiring",
+        "Cooperative Education - Electrical and Power Transmission Installation/Installer General"
+      ]
+    },
+    {
+      "prefix": "ITSE",
+      "name": "Programming",
+      "course_count": 45,
+      "section_count": 320,
+      "colleges": [
+        "amarillo-college",
+        "blinn-college-district",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "vernon-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "ADV COMP PROGRA",
+        "Advanced C++ Programming",
+        "Advanced Database Programming",
+        "Advanced Object-Oriented Programming",
+        "Assembly Language Programming"
+      ]
+    },
+    {
+      "prefix": "AERM",
+      "name": "AERM",
+      "course_count": 51,
+      "section_count": 299,
+      "colleges": [
+        "amarillo-college",
+        "del-mar-college",
+        "howard-college",
+        "north-central-texas-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Aircraft Composites",
+        "Aircraft Electrical Systems",
+        "Aircraft Power Plant Inspection",
+        "Aircraft Powerplant Electric",
+        "Aircraft Powerplant Electrical"
+      ]
+    },
+    {
+      "prefix": "MDCA",
+      "name": "Medical",
+      "course_count": 33,
+      "section_count": 299,
+      "colleges": [
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Anatomy and Physiology for Medical Assistants",
+        "Anatomy/Physiology Medical Assts",
+        "Clinical - Med/Clinic Assist",
+        "Clinical - Medical Assistant"
+      ]
+    },
+    {
+      "prefix": "RSPT",
+      "name": "Care",
+      "course_count": 59,
+      "section_count": 298,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Advanced Cardiopulmonary A & P",
+        "Advanced Cardiopulmonary Anatomy and Physiology",
+        "Applied Physics/Respiratory C",
+        "Basic Dysrhythmia Interpretati"
+      ]
+    },
+    {
+      "prefix": "DEMR",
+      "name": "DEMR",
+      "course_count": 48,
+      "section_count": 294,
+      "colleges": [
+        "amarillo-college",
+        "coastal-bend-college",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "navarro-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Advanced Brake Systems",
+        "Advanced Diesel Tune-up and Troubleshooting",
+        "Advanced Diesel Tune-Up and Troubleshooting",
+        "Advanced Electrical Systems",
+        "Advanced Electronics Controls"
+      ]
+    },
+    {
+      "prefix": "CDEC",
+      "name": "Child",
+      "course_count": 55,
+      "section_count": 292,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adm Program for Children",
+        "Admin of Programs for Child II",
+        "Administration of Programs",
+        "Administration of Programs for Children I",
+        "CHILD ABUSE AND NEGLECT"
+      ]
+    },
+    {
+      "prefix": "ITCC",
+      "name": "Ccna",
+      "course_count": 11,
+      "section_count": 273,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "CCNA 1: Introduction to Networks",
+        "CCNA 2: Switching, Routing, and Wireless Essentials",
+        "CCNA 2: Switching, Routing, and Wireless Essentials (SRWE)",
+        "CCNA 3: Enterprise Networking, Security &amp; Automation",
+        "CCNA 3: Enterprise Networking, Security, and Automation"
+      ]
+    },
+    {
+      "prefix": "CHEF",
+      "name": "CHEF",
+      "course_count": 28,
+      "section_count": 265,
+      "colleges": [
+        "alvin-community-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "A la Carte Cooking",
+        "A La Carte Cooking",
+        "Advanced Food Preparation",
+        "American Regional Cuisine",
+        "Basic Food Preparation"
+      ]
+    },
+    {
+      "prefix": "CNBT",
+      "name": "Construction",
+      "course_count": 39,
+      "section_count": 262,
+      "colleges": [
+        "amarillo-college",
+        "clarendon-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "odessa-college",
+        "paris-junior-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Basic Construction Safety",
+        "Building and Contracting",
+        "Building Codes and Inspections",
+        "COMMERCIAL/INDUSTRIAL BLUEPRINT READING",
+        "Computer-Aided Construction Scheduling"
+      ]
+    },
+    {
+      "prefix": "ARTC",
+      "name": "ARTC",
+      "course_count": 33,
+      "section_count": 250,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Art Direction I",
+        "Art Direction II",
+        "Basic Graphic Design",
+        "Basic Illustration",
+        "Computer Illustration"
+      ]
+    },
+    {
+      "prefix": "DFTG",
+      "name": "Drafting",
+      "course_count": 39,
+      "section_count": 239,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "clarendon-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer-Aided Drafting",
+        "Advanced Pipe Drafting",
+        "Advanced Technologies In Architectural Design And Drafting",
+        "Advanced Technologies in Mechanical Design and Drafting",
+        "Architectural Drafting - Commercial"
+      ]
+    },
+    {
+      "prefix": "MLAB",
+      "name": "MLAB",
+      "course_count": 42,
+      "section_count": 232,
+      "colleges": [
+        "amarillo-college",
+        "del-mar-college",
+        "houston-community-college",
+        "mclennan-community-college",
+        "navarro-college",
+        "northeast-texas-community-college",
+        "panola-college",
+        "st-philips-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adv Topics/Medical Lab Tech",
+        "Advanced Topics",
+        "Clin-Clinical/Medical Lab Technicia",
+        "Clinical - Clinical/Medical Laboratory Technician",
+        "Clinical - Clinical/Medical Laboratory Technician IV"
+      ]
+    },
+    {
+      "prefix": "INTC",
+      "name": "Instrumentation",
+      "course_count": 37,
+      "section_count": 230,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "st-philips-college",
+        "texarkana-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "AC/DC Motor Control",
+        "AC/DC Motor Controls",
+        "Analog Cont II",
+        "Analytical Instrumentation",
+        "Application of Industrial Automatic"
+      ]
+    },
+    {
+      "prefix": "HRPO",
+      "name": "Human",
+      "course_count": 11,
+      "section_count": 229,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Benefits and Compensation",
+        "Co-op - Human Resources Mgmt",
+        "Employee Relations",
+        "Employment Practices",
+        "Human Relations"
+      ]
+    },
+    {
+      "prefix": "LGLA",
+      "name": "LGLA",
+      "course_count": 40,
+      "section_count": 227,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "mclennan-community-college",
+        "navarro-college",
+        "odessa-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Administrative Law",
+        "Advanced Civil Litigation",
+        "Advanced Legal Document Preparation",
+        "Business Organizations",
+        "Certified Paralegal Exam Review"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 6,
+      "section_count": 225,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "frank-phillips-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Cultural Anthropology",
+        "Intro to Anthropology",
+        "Introduction to Archaeology",
+        "Physical Anthropology",
+        "Physical Anthropology Lab"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 6,
+      "section_count": 225,
+      "colleges": [
+        "college-of-the-mainland",
+        "houston-community-college",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Introduction to Stars and Galaxies",
+        "Solar System (030)",
+        "Solar System Laboratory",
+        "Solar System Lecture",
+        "Stars & Galaxies- Lec + Lab"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 19,
+      "section_count": 224,
+      "colleges": [
+        "cisco-college",
+        "clarendon-college",
+        "collin-county-community-college-district",
+        "frank-phillips-college",
+        "howard-college",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Agronomy (lab)",
+        "Agronomy (lecture & lab)",
+        "Computers in Agriculture",
+        "Fundamentals of Agronomy",
+        "Horticulture (lab)"
+      ]
+    },
+    {
+      "prefix": "SDEV",
+      "name": "Success",
+      "course_count": 3,
+      "section_count": 223,
+      "colleges": [
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "st-philips-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Foundations for College Learning",
+        "Strategies for Success",
+        "Student Success Course: Learning Frameworks"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 3,
+      "section_count": 217,
+      "colleges": [
+        "amarillo-college",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Human Geography",
+        "Physical Geography",
+        "World Regional Geography (080/090)"
+      ]
+    },
+    {
+      "prefix": "POFT",
+      "name": "POFT",
+      "course_count": 36,
+      "section_count": 214,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adm Office Procedures I",
+        "Admin Project Solutions",
+        "Administrative Office Procedures I",
+        "Administrative Office Procedures II",
+        "Administrative Project Solutions"
+      ]
+    },
+    {
+      "prefix": "ENVR",
+      "name": "Environmental",
+      "course_count": 7,
+      "section_count": 208,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "kilgore-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "san-antonio-college",
+        "temple-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Environmental Science I (030)",
+        "Environmental Science I (lab)",
+        "Environmental Science I (Lecture)",
+        "Environmental Science II (lab)",
+        "Environmental Science II Lecture"
+      ]
+    },
+    {
+      "prefix": "PTHA",
+      "name": "PTHA",
+      "course_count": 40,
+      "section_count": 205,
+      "colleges": [
+        "amarillo-college",
+        "blinn-college-district",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Basic Patient Care Skills",
+        "Biophysical Agents",
+        "Clin-Phys Therapist Assist II",
+        "Clin-Phys Therapist Assist III",
+        "Clinical - Phy Therapist Asst"
+      ]
+    },
+    {
+      "prefix": "LIBR",
+      "name": "LIBR",
+      "course_count": 2,
+      "section_count": 202,
+      "colleges": [
+        "northeast-lakeview-college"
+      ],
+      "sample_titles": [
+        "Honors - Research 102",
+        "Research 101"
+      ]
+    },
+    {
+      "prefix": "NCBM",
+      "name": "Math",
+      "course_count": 22,
+      "section_count": 189,
+      "colleges": [
+        "clarendon-college",
+        "coastal-bend-college",
+        "collin-county-community-college-district",
+        "howard-college",
+        "kilgore-college",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "panola-college",
+        "paris-junior-college",
+        "southwest-college-for-the-deaf"
+      ],
+      "sample_titles": [
+        "BASE Math 1",
+        "College Math Readiness",
+        "Developmental Math",
+        "DEVELOPMENTAL MATHEMATICS",
+        "DEVELOPMNTL MAT"
+      ]
+    },
+    {
+      "prefix": "MRTS",
+      "name": "MRTS",
+      "course_count": 17,
+      "section_count": 185,
+      "colleges": [
+        "northeast-texas-community-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Contemporary Funeral Service Practices",
+        "Crematory Operations",
+        "Funeral Service Arts Board Preparat",
+        "Funeral Service Internship Orientation",
+        "Funeral Service Science Board Prep"
+      ]
+    },
+    {
+      "prefix": "BUSG",
+      "name": "Business",
+      "course_count": 16,
+      "section_count": 178,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Business Law and Contracts",
+        "BUSINESS LEADERSHIP APPLICATION",
+        "COOP-BUS/COMM",
+        "Cooperative Education Business General",
+        "Cooperative Education I"
+      ]
+    },
+    {
+      "prefix": "MUSP",
+      "name": "MUSP",
+      "course_count": 37,
+      "section_count": 178,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "lamar-state-college-port-arthur",
+        "mclennan-community-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "AACM: Bass Guitar",
+        "AACM: Commercial Guitar",
+        "AACM: Percussion",
+        "AACM: Piano",
+        "AACM: Voice"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 15,
+      "section_count": 175,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northwest-vista-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "tarrant-county-college-district",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Ballroom I",
+        "Beginning Ballet",
+        "Beginning Jazz Dance",
+        "Beginning Modern Dance",
+        "Dance Appreciation"
+      ]
+    },
+    {
+      "prefix": "ESLA",
+      "name": "ESLA",
+      "course_count": 16,
+      "section_count": 173,
+      "colleges": [
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Grammar 1",
+        "Grammar 3",
+        "Grammar 4",
+        "Grammar II",
+        "Reading 1"
+      ]
+    },
+    {
+      "prefix": "IMED",
+      "name": "IMED",
+      "course_count": 18,
+      "section_count": 172,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "panola-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education - IMED",
+        "Cooperative Education-Web Page",
+        "Digital Media Programming",
+        "Interactive Digital Media I",
+        "Interactive Digital Media II"
+      ]
+    },
+    {
+      "prefix": "DAAC",
+      "name": "Counseling",
+      "course_count": 26,
+      "section_count": 165,
+      "colleges": [
+        "alvin-community-college",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "odessa-college",
+        "san-antonio-college",
+        "tarrant-county-college-district",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Addicted Family Intervention",
+        "Assessment of Substance-Related and Addictive Disorders",
+        "Basic Counseling Skills",
+        "Clin: Sub Abuse/Addiction Coun",
+        "Clinical - Substance Abuse/Addiction Counseling"
+      ]
+    },
+    {
+      "prefix": "SRGT",
+      "name": "Surgical",
+      "course_count": 39,
+      "section_count": 164,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Basic Skills of Surgical Technology",
+        "Clin - Surgical Technology",
+        "Clinical",
+        "Clinical - Advanced SRGT",
+        "Clinical - Surgical Technology II"
+      ]
+    },
+    {
+      "prefix": "OTHA",
+      "name": "Occupational",
+      "course_count": 32,
+      "section_count": 158,
+      "colleges": [
+        "amarillo-college",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "panola-college",
+        "st-philips-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Clin: Occupational Therapy Ast",
+        "Clin: Occupational Therpy Asst",
+        "Clinical - Occupational Therapist Assistant",
+        "Clinical II -Level I Fieldwork",
+        "Clinical III- OTA"
+      ]
+    },
+    {
+      "prefix": "CJLE",
+      "name": "CJLE",
+      "course_count": 30,
+      "section_count": 157,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "odessa-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "temple-college"
+      ],
+      "sample_titles": [
+        "Advanced Firearms",
+        "Basic Firearms",
+        "Basic Peace Officer I",
+        "Basic Peace Officer II",
+        "Basic Peace Officer III"
+      ]
+    },
+    {
+      "prefix": "VTHT",
+      "name": "Veterinary",
+      "course_count": 33,
+      "section_count": 153,
+      "colleges": [
+        "collin-county-community-college-district",
+        "howard-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "palo-alto-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Anesthesia and Surgical Assistance",
+        "Canine and Feline Care and Husbandry",
+        "Canine and Feline Clinical Management",
+        "Clinical - Veterinary/Animal Health Technology/Technician and Veterinary Assistant",
+        "Cooperative Education I - Veterinary/Animal Health Technology/Technician and Veterinary Assistant"
+      ]
+    },
+    {
+      "prefix": "ABDR",
+      "name": "Repair",
+      "course_count": 39,
+      "section_count": 148,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "laredo-college",
+        "northeast-texas-community-college",
+        "south-plains-college",
+        "st-philips-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Adv. Collision Repair Welding",
+        "Advanced Auto Body Welding",
+        "Advanced Driver Assistance Systems",
+        "Advanced Refinishing (Capstone)",
+        "Auto Body Mechanical and Electrical Service"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "Architectural",
+      "course_count": 15,
+      "section_count": 147,
+      "colleges": [
+        "del-mar-college",
+        "san-antonio-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Architectural Computer Graphics",
+        "Architectural Design I",
+        "Architectural Design II",
+        "Architectural Design III",
+        "Architectural Design IV"
+      ]
+    },
+    {
+      "prefix": "ARTV",
+      "name": "Animation",
+      "course_count": 14,
+      "section_count": 144,
+      "colleges": [
+        "amarillo-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northwest-vista-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "2D Animation I",
+        "3-D Animation I",
+        "3-D Animation II",
+        "3-D Modeling and Rendering I",
+        "3-D Modeling and Rendering II"
+      ]
+    },
+    {
+      "prefix": "DMSO",
+      "name": "DMSO",
+      "course_count": 41,
+      "section_count": 141,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "paris-junior-college",
+        "st-philips-college",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Abdominopelvic Sonography",
+        "Advance Ultra Rev",
+        "Advanced Obstetrics Sonography",
+        "Advanced Sonography Practices",
+        "Advanced Ultrasound and Review"
+      ]
+    },
+    {
+      "prefix": "FIRT",
+      "name": "Fire",
+      "course_count": 37,
+      "section_count": 141,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "navarro-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Building Codes and Construction",
+        "Building Construction in the Fire Service",
+        "Co-op Education - Fire Protection",
+        "Fire Administratiion I",
+        "Fire Administration II"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "Barber",
+      "course_count": 17,
+      "section_count": 137,
+      "colleges": [
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "frank-phillips-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "north-central-texas-college",
+        "odessa-college",
+        "south-plains-college",
+        "texarkana-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Barber Styling I",
+        "Advanced Barber Styling II",
+        "Barber Law and Shop Management I",
+        "Barber Law and Shop Management II",
+        "Barber Styling I"
+      ]
+    },
+    {
+      "prefix": "LMGT",
+      "name": "Logistics",
+      "course_count": 19,
+      "section_count": 137,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "northeast-lakeview-college",
+        "northeast-texas-community-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "south-texas-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Contemporary Logistics Issues",
+        "Domestic and International Transportation Management",
+        "Economics of Transportation and Distribution",
+        "Import/Export CCS",
+        "International Logistics Management"
+      ]
+    },
+    {
+      "prefix": "MCHN",
+      "name": "MCHN",
+      "course_count": 38,
+      "section_count": 137,
+      "colleges": [
+        "amarillo-college",
+        "clarendon-college",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "palo-alto-college",
+        "south-plains-college",
+        "south-texas-college",
+        "st-philips-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Machining",
+        "Advanced Computer-Aided Manufacturing (CAM)",
+        "Advanced Machining I",
+        "Advanced Machining II",
+        "Basic Lathe"
+      ]
+    },
+    {
+      "prefix": "OSHT",
+      "name": "OSHT",
+      "course_count": 19,
+      "section_count": 137,
+      "colleges": [
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "south-texas-college",
+        "st-philips-college",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Accident Prev, Inspect, Invest",
+        "Construction Site Safety and Health",
+        "Cooperative Education - Occupational Safety and Health Technology/Technician",
+        "ENERGY INDUST S",
+        "ENERGY INDUSTRIAL SAFETY"
+      ]
+    },
+    {
+      "prefix": "TECA",
+      "name": "Child",
+      "course_count": 4,
+      "section_count": 136,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Child Growth and Development",
+        "Families, School, and Community",
+        "INTRODUCTION TO EARLY CHILDHOOD ED",
+        "Wellness of the Young Child"
+      ]
+    },
+    {
+      "prefix": "SLNG",
+      "name": "SLNG",
+      "course_count": 40,
+      "section_count": 134,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "san-antonio-college",
+        "southwest-college-for-the-deaf",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Techniques for Deaf Support Specialist/ Service Providers",
+        "Amer Sign Lang (ASL) III",
+        "American Sign Lang (ASL) V",
+        "American Sign Language (ASL)V",
+        "Conversational ASL"
+      ]
+    },
+    {
+      "prefix": "CETT",
+      "name": "CETT",
+      "course_count": 22,
+      "section_count": 132,
+      "colleges": [
+        "alvin-community-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "odessa-college",
+        "palo-alto-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "temple-college",
+        "texarkana-college",
+        "victoria-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "AC Circuits",
+        "DC Circuits",
+        "DC-AC Circuits",
+        "Digital Applications",
+        "Digital Fundamentals"
+      ]
+    },
+    {
+      "prefix": "PHRA",
+      "name": "Pharmacy",
+      "course_count": 32,
+      "section_count": 130,
+      "colleges": [
+        "alvin-community-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northwest-vista-college",
+        "san-antonio-college",
+        "texarkana-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Clin-Pharm Technician/Assist",
+        "Clinical - Pharmacy Technician/Assistant",
+        "Clinical II - Pharmacy Tech",
+        "Clinical Institution II",
+        "Clinical-Pharmacy Techn/Assist"
+      ]
+    },
+    {
+      "prefix": "CRTR",
+      "name": "CRTR",
+      "course_count": 26,
+      "section_count": 128,
+      "colleges": [
+        "del-mar-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Accelerated Machine Shorthand",
+        "Advanced Machine Shorthand",
+        "Captioning Technology I",
+        "Cooperative Education - Court Reporting/Court Reporter",
+        "Court Reporter Certification Preparation"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 27,
+      "section_count": 124,
+      "colleges": [
+        "amarillo-college",
+        "blinn-college-district",
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "tarrant-county-college-district",
+        "temple-college"
+      ],
+      "sample_titles": [
+        "Clinical - Dental Hygiene",
+        "Clinical - Dental Hygiene/Hygi",
+        "Clinical II - Dental Hygienist",
+        "Clinical-Dental Hygienist II",
+        "Clinical-Dental Hygienist III"
+      ]
+    },
+    {
+      "prefix": "GAME",
+      "name": "Game",
+      "course_count": 27,
+      "section_count": 124,
+      "colleges": [
+        "amarillo-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northwest-vista-college",
+        "south-plains-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Art for 2D Games",
+        "Artificial Intelligence Programming I",
+        "Character Sculpting",
+        "Design and Creation of Games",
+        "Game & Simulation Programming II"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 45,
+      "section_count": 124,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-state-college-port-arthur",
+        "mclennan-community-college",
+        "northwest-vista-college",
+        "south-plains-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Acoustics",
+        "Audio Electronics",
+        "Audio Engineering I",
+        "Audio Engineering II",
+        "Audio Engineering III"
+      ]
+    },
+    {
+      "prefix": "ITSW",
+      "name": "ITSW",
+      "course_count": 11,
+      "section_count": 123,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "northwest-vista-college",
+        "odessa-college",
+        "panola-college",
+        "paris-junior-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Database",
+        "Advanced Spreadsheets",
+        "INTRO WORD PROC",
+        "Introduction to Database",
+        "Introduction to Database-Access"
+      ]
+    },
+    {
+      "prefix": "NURA",
+      "name": "Nurse",
+      "course_count": 13,
+      "section_count": 116,
+      "colleges": [
+        "amarillo-college",
+        "clarendon-college",
+        "collin-county-community-college-district",
+        "howard-college",
+        "lamar-state-college-port-arthur",
+        "northeast-texas-community-college",
+        "paris-junior-college",
+        "south-texas-college",
+        "st-philips-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Body Systems",
+        "Clinical - Nurse Assist/Aid",
+        "CLINICAL &ndash; Nursing Assistant / Aide and Patient Care Assistant/Aide",
+        "CLINICAL NURSE",
+        "Clinical Nursing Assistant/Aide and Patient Assistant/Aide"
+      ]
+    },
+    {
+      "prefix": "RELE",
+      "name": "Real",
+      "course_count": 25,
+      "section_count": 111,
+      "colleges": [
+        "cisco-college",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "mclennan-community-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Contract Forms and Addenda",
+        "Contract Forms and Addenda - 26542 - RELE 1200 - 001",
+        "Cooperative Education - Real Estate - 35198 - RELE 2380 - 001",
+        "Fundamentals of Environmental Issues",
+        "Law of Agency"
+      ]
+    },
+    {
+      "prefix": "CVOP",
+      "name": "Skills",
+      "course_count": 9,
+      "section_count": 110,
+      "colleges": [
+        "amarillo-college",
+        "lamar-institute-of-technology",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Advanced Driving Skills I",
+        "Advanced Driving Skills II",
+        "Comm Drv License Writ Skills",
+        "Commercial DL Driving Skills",
+        "Commercial DL Written Skills"
+      ]
+    },
+    {
+      "prefix": "SOCW",
+      "name": "Social",
+      "course_count": 3,
+      "section_count": 108,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Academic Cooperative - Social Work",
+        "Introduction to Social Work",
+        "Social Welfare: Legislation, Programs, and Services."
+      ]
+    },
+    {
+      "prefix": "INMT",
+      "name": "INMT",
+      "course_count": 13,
+      "section_count": 104,
+      "colleges": [
+        "amarillo-college",
+        "clarendon-college",
+        "coastal-bend-college",
+        "del-mar-college",
+        "houston-community-college",
+        "howard-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "navarro-college",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "south-plains-college",
+        "st-philips-college",
+        "temple-college",
+        "texarkana-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Computer Aided Design/Computer Aided Manufacturing",
+        "COMPUTER AIDED DESIGN/MANUFACTURING",
+        "COMPUTER INTEGRATED MANUFACTURING",
+        "Computer Numerical Controls",
+        "Cooperative Ed-Manufacturing Tech"
+      ]
+    },
+    {
+      "prefix": "POFI",
+      "name": "POFI",
+      "course_count": 13,
+      "section_count": 103,
+      "colleges": [
+        "amarillo-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "navarro-college",
+        "odessa-college",
+        "palo-alto-college",
+        "panola-college",
+        "san-antonio-college",
+        "south-plains-college",
+        "south-texas-college",
+        "southwest-college-for-the-deaf",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Advanced Word Processing",
+        "Computer Applications I",
+        "Computer Applications II",
+        "Databases",
+        "DESKTOP PUBLISH"
+      ]
+    },
+    {
+      "prefix": "DSAE",
+      "name": "DSAE",
+      "course_count": 27,
+      "section_count": 102,
+      "colleges": [
+        "alvin-community-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "st-philips-college",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adv Cardiac Sonography and Rev",
+        "Advanced Cardiac Sonography",
+        "Advanced Echocardiography Lab",
+        "Cardiac Sonography Patho II",
+        "Cardiac Sonography Pathophysiology I"
+      ]
+    },
+    {
+      "prefix": "FLMC",
+      "name": "Film",
+      "course_count": 20,
+      "section_count": 99,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "northwest-vista-college",
+        "san-antonio-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Advan. Film and Video Editing",
+        "Advanced Film and Video Editing",
+        "Audio Post Production",
+        "Cinematography",
+        "Cooperative Education: Film and Video Production"
+      ]
+    },
+    {
+      "prefix": "PSTR",
+      "name": "PSTR",
+      "course_count": 18,
+      "section_count": 99,
+      "colleges": [
+        "college-of-the-mainland",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Advanced Pastry Shop",
+        "Bakery Operations and Management",
+        "Baking for Special Dietary Needs",
+        "Breads and Rolls",
+        "Cake Baking and Production"
+      ]
+    },
+    {
+      "prefix": "ORGL",
+      "name": "Leadership",
+      "course_count": 6,
+      "section_count": 91,
+      "colleges": [
+        "palo-alto-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Behavior, Ethics, Leadership I",
+        "Conflict & Negotiation",
+        "Data Driven Decis. Making",
+        "Ethics & Leadership II",
+        "Issues in Organizational Leadership"
+      ]
+    },
+    {
+      "prefix": "PLAB",
+      "name": "PLAB",
+      "course_count": 12,
+      "section_count": 88,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "howard-college",
+        "lamar-state-college-port-arthur",
+        "mclennan-community-college",
+        "panola-college",
+        "south-texas-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Clinical",
+        "Clinical - Phlebotomy/Phlebotomist",
+        "Clinical-Phlebotomy/Phlebot.",
+        "Clinical-Phlebotomy/Phlebotom",
+        "CLN:Phleb/Phleboto-ITA 26-C003"
+      ]
+    },
+    {
+      "prefix": "CJSA",
+      "name": "CJSA",
+      "course_count": 27,
+      "section_count": 87,
+      "colleges": [
+        "coastal-bend-college",
+        "college-of-the-mainland",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "mclennan-community-college",
+        "navarro-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "CONTEMPORARY ISSUES IN CRIMINAL JUS",
+        "Coop Ed Criminal Justice",
+        "Court Systems & Practices",
+        "Crime - America",
+        "Criminal Investigation"
+      ]
+    },
+    {
+      "prefix": "HAMG",
+      "name": "Hospitality",
+      "course_count": 19,
+      "section_count": 86,
+      "colleges": [
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Computers in Hospitality",
+        "Convention and Group Management and Services",
+        "Coop Hosp Admin. Management",
+        "Front Office Management",
+        "Guest Room Management"
+      ]
+    },
+    {
+      "prefix": "SGNL",
+      "name": "American",
+      "course_count": 6,
+      "section_count": 83,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "san-antonio-college",
+        "southwest-college-for-the-deaf",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "American Sign Language I:Beg I",
+        "Beg. American Sign Language II",
+        "Beginning American Sign Language I (ASL 1)",
+        "Beginning American Sign Language II (ASL 2)",
+        "Intermediate American Sign Language I (ASL 3)"
+      ]
+    },
+    {
+      "prefix": "RSTO",
+      "name": "Management",
+      "course_count": 13,
+      "section_count": 82,
+      "colleges": [
+        "college-of-the-mainland",
+        "del-mar-college",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Beverage Management",
+        "Catering",
+        "Dining Room Service",
+        "Food Service Management",
+        "Hospitality Supervision"
+      ]
+    },
+    {
+      "prefix": "STSC",
+      "name": "Success",
+      "course_count": 2,
+      "section_count": 81,
+      "colleges": [
+        "del-mar-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Student Success",
+        "Transition to College Success"
+      ]
+    },
+    {
+      "prefix": "PFPB",
+      "name": "Plumbing",
+      "course_count": 24,
+      "section_count": 79,
+      "colleges": [
+        "del-mar-college",
+        "frank-phillips-college",
+        "lamar-institute-of-technology",
+        "north-central-texas-college",
+        "st-philips-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Advanced Pipe Practices",
+        "Advanced Pipefitting Standards, Specs & Installation",
+        "Backflow Prevention",
+        "Basic Blueprint Reading for Plumbers",
+        "BASIC HVAC FOR PLUMBING/PIPEFITTING"
+      ]
+    },
+    {
+      "prefix": "RBTC",
+      "name": "RBTC",
+      "course_count": 13,
+      "section_count": 75,
+      "colleges": [
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "palo-alto-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Electromechanical Devices",
+        "Programmable Logic Controllers",
+        "Robot Application",
+        "Robot Application, Set-up & Testing",
+        "Robot Interfacing"
+      ]
+    },
+    {
+      "prefix": "DNTA",
+      "name": "Dental",
+      "course_count": 25,
+      "section_count": 72,
+      "colleges": [
+        "del-mar-college",
+        "houston-community-college",
+        "san-antonio-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Adv Dental Assisting Appl",
+        "Advanced Dental Assisting Applications",
+        "Advanced Dental Radiology",
+        "Advanced Dental Science",
+        "Chairside Assisting"
+      ]
+    },
+    {
+      "prefix": "OLRN",
+      "name": "Orientation",
+      "course_count": 1,
+      "section_count": 70,
+      "colleges": [
+        "northeast-lakeview-college",
+        "northwest-vista-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Orientation to Online Learning"
+      ]
+    },
+    {
+      "prefix": "MUSB",
+      "name": "Music",
+      "course_count": 15,
+      "section_count": 66,
+      "colleges": [
+        "del-mar-college",
+        "houston-community-college",
+        "mclennan-community-college",
+        "san-antonio-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Audio Production for the Music Business",
+        "Commercial Music Project",
+        "Concert Promotion and Venue Management",
+        "Cooperative Education - Music, Management",
+        "Intrnshp-Music Bus. Mgmt & Mer"
+      ]
+    },
+    {
+      "prefix": "PSYT",
+      "name": "Psychology",
+      "course_count": 7,
+      "section_count": 64,
+      "colleges": [
+        "mclennan-community-college",
+        "northeast-texas-community-college",
+        "san-antonio-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Counseling Theories",
+        "Death and Dying",
+        "Interviewing and Communication Skills",
+        "Prin Behavior Mgt/Modificaton"
+      ]
+    },
+    {
+      "prefix": "CPMT",
+      "name": "Computer",
+      "course_count": 15,
+      "section_count": 63,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "palo-alto-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Networking",
+        "Compti It Fundamentals (itf+)",
+        "Computer Integration",
+        "Computer Networking Technology",
+        "Computer System Peripherals"
+      ]
+    },
+    {
+      "prefix": "TMGT",
+      "name": "TMGT",
+      "course_count": 15,
+      "section_count": 63,
+      "colleges": [
+        "del-mar-college",
+        "lone-star-college-system",
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Accounting for Managers",
+        "Comm and Conflict Resolution",
+        "Ethics & Corporate Social Resp",
+        "Finance for Managers",
+        "Human Resources Management and Labor Law"
+      ]
+    },
+    {
+      "prefix": "KIDS",
+      "name": "Camp",
+      "course_count": 35,
+      "section_count": 60,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "A.I. Designers & Developers",
+        "Amazing Art",
+        "Art of Hand Lettering",
+        "Beginning Robotics Camp",
+        "C.P.R. for T(w)eens"
+      ]
+    },
+    {
+      "prefix": "ELMT",
+      "name": "ELMT",
+      "course_count": 13,
+      "section_count": 59,
+      "colleges": [
+        "amarillo-college",
+        "clarendon-college",
+        "del-mar-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "odessa-college",
+        "palo-alto-college",
+        "paris-junior-college",
+        "south-plains-college",
+        "st-philips-college",
+        "temple-college",
+        "texarkana-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Advanced Programmable Logic Control",
+        "Basic Fluid Power",
+        "ELECTR TBLSHOOT",
+        "Electromechanical Systems",
+        "Industrial Electronics"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 4,
+      "section_count": 59,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "northwest-vista-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "st-philips-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Elementary French II",
+        "Intermediate French I",
+        "Intermediate French II"
+      ]
+    },
+    {
+      "prefix": "SCWK",
+      "name": "Social",
+      "course_count": 11,
+      "section_count": 55,
+      "colleges": [
+        "del-mar-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "san-antonio-college",
+        "tarrant-county-college-district",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Abnormal Behavior",
+        "Assessment and Case Management",
+        "Ethics for Social Service Professionals",
+        "Group Work Intervention",
+        "Human Behavior and the Social Environment"
+      ]
+    },
+    {
+      "prefix": "RTVB",
+      "name": "Production",
+      "course_count": 21,
+      "section_count": 54,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "san-antonio-college",
+        "south-plains-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Audio Production II",
+        "Audio/Radio Experience I",
+        "Audio/Radio Production I",
+        "Audio/Radio Production II",
+        "Audio/Radio Production II Lab"
+      ]
+    },
+    {
+      "prefix": "HALT",
+      "name": "HALT",
+      "course_count": 25,
+      "section_count": 53,
+      "colleges": [
+        "collin-county-community-college-district",
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "palo-alto-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Arboriculture",
+        "COOPERATIVE EDUCATION",
+        "Garden Center Management",
+        "Greenhouse Management",
+        "Herbaceous Plants"
+      ]
+    },
+    {
+      "prefix": "CTEC",
+      "name": "CTEC",
+      "course_count": 13,
+      "section_count": 51,
+      "colleges": [
+        "alvin-community-college",
+        "college-of-the-mainland",
+        "del-mar-college",
+        "lamar-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Appl Instrumental Analysis II",
+        "Applied Instrumental Analy I",
+        "Applied Petrochemical Tech",
+        "Chemical Calculations I",
+        "Chemical Calculations II"
+      ]
+    },
+    {
+      "prefix": "IBUS",
+      "name": "International",
+      "course_count": 13,
+      "section_count": 51,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "laredo-college",
+        "san-antonio-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education - International Business/Trade/Commerce",
+        "Global Supply Chain Management",
+        "Import Customs Regulations",
+        "Intercultural Management",
+        "International Banking and Finance"
+      ]
+    },
+    {
+      "prefix": "SCIT",
+      "name": "SCIT",
+      "course_count": 13,
+      "section_count": 51,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "northeast-texas-community-college",
+        "panola-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Applied Analytical Chemistry I",
+        "Applied General Chemistry I",
+        "Applied General Chemistry II",
+        "Applied Human A&P I",
+        "Applied Organic Chemistry I"
+      ]
+    },
+    {
+      "prefix": "UNIV",
+      "name": "UNIV",
+      "course_count": 8,
+      "section_count": 51,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "21st Digital Citizn & Info Lit",
+        "Fndn Creativity & Innovation",
+        "Leadership Principles",
+        "Managerial Operations",
+        "Professional Ethics"
+      ]
+    },
+    {
+      "prefix": "IRW",
+      "name": "Integrated",
+      "course_count": 2,
+      "section_count": 47,
+      "colleges": [
+        "coastal-bend-college",
+        "college-of-the-mainland"
+      ],
+      "sample_titles": [
+        "Adv Integrated Read/Writing",
+        "Integrated Reading & Writing I"
+      ]
+    },
+    {
+      "prefix": "FITT",
+      "name": "Exercise",
+      "course_count": 15,
+      "section_count": 46,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "northwest-vista-college",
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education Health and Physical Education, General",
+        "Exercise Science",
+        "Fitness &amp; Exercise Testing",
+        "Fitness Event Planning &amp; Promotion",
+        "Fitness Industry Operations &amp; Technology"
+      ]
+    },
+    {
+      "prefix": "NETC",
+      "name": "Cloud",
+      "course_count": 10,
+      "section_count": 43,
+      "colleges": [
+        "northwest-vista-college"
+      ],
+      "sample_titles": [
+        "Advanced AI and Machine Learning in Cloud Environments",
+        "Big Data Analy on Cloud Infra",
+        "Cloud Datacenter Operations I",
+        "Cloud Datacenter Operations II",
+        "Cloud Engineering and Datacenter Compliance"
+      ]
+    },
+    {
+      "prefix": "EPCT",
+      "name": "EPCT",
+      "course_count": 11,
+      "section_count": 42,
+      "colleges": [
+        "college-of-the-mainland",
+        "del-mar-college",
+        "lamar-institute-of-technology",
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Adv Environmental Inst Ana",
+        "Contingency Planning",
+        "Dept of Transport (DOT) Reg",
+        "Environ Regulation Interp/App",
+        "Environ Sampling/Analysis"
+      ]
+    },
+    {
+      "prefix": "CTMT",
+      "name": "Tomography",
+      "course_count": 8,
+      "section_count": 40,
+      "colleges": [
+        "coastal-bend-college",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "st-philips-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Clinical - Radiologic Technology/Science - Radiographer",
+        "Clinical - Radiologic Technology/Science - Radiographer Active",
+        "Clinical Radiologic/Science Radiographer",
+        "Clinical-Radiologic Tech/Serv",
+        "Comp Tomography (CT) Review"
+      ]
+    },
+    {
+      "prefix": "EECT",
+      "name": "EECT",
+      "course_count": 8,
+      "section_count": 40,
+      "colleges": [
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "north-central-texas-college",
+        "palo-alto-college",
+        "st-philips-college",
+        "victoria-college"
+      ],
+      "sample_titles": [
+        "Communications Circuits",
+        "Convergent Technologies",
+        "Electronic Soldering",
+        "Introduction To Telecommunications",
+        "Practicum(or Field Experience)-Electrical Electronic &amp; Communications Engineering Technology/Tech"
+      ]
+    },
+    {
+      "prefix": "OPMG",
+      "name": "Manager",
+      "course_count": 2,
+      "section_count": 39,
+      "colleges": [
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Manager. Rapport &amp; Document.",
+        "Technology in Enterprise Management"
+      ]
+    },
+    {
+      "prefix": "TECM",
+      "name": "Technical",
+      "course_count": 6,
+      "section_count": 39,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "coastal-bend-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "kilgore-college",
+        "north-central-texas-college",
+        "south-plains-college",
+        "st-philips-college",
+        "tarrant-county-college-district",
+        "temple-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Industrial Mathematics",
+        "Special Topics in Applied Math",
+        "Technical Algebra and Trigonometry",
+        "Technical Calculations",
+        "Technical Math Applications"
+      ]
+    },
+    {
+      "prefix": "TMTH",
+      "name": "Algebra",
+      "course_count": 6,
+      "section_count": 39,
+      "colleges": [
+        "lamar-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Adv Developmental Math (CM3)",
+        "Adv Intermediate Algebra (CM1)",
+        "BASE NCBO (Algebra) (DM10)",
+        "BASE NCBO (Mathematics) (DM1)",
+        "Developmental Math (DM1)"
+      ]
+    },
+    {
+      "prefix": "AIRP",
+      "name": "Flight",
+      "course_count": 25,
+      "section_count": 38,
+      "colleges": [
+        "howard-college",
+        "lone-star-college-system",
+        "north-central-texas-college",
+        "south-plains-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Air Navigation",
+        "Air Navigation",
+        "Aircraft Systems",
+        "Aviation Safety",
+        "Cert Flight Instr - Flight"
+      ]
+    },
+    {
+      "prefix": "BIOM",
+      "name": "BIOM",
+      "course_count": 19,
+      "section_count": 38,
+      "colleges": [
+        "houston-community-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Advanced Imaging Systems",
+        "Applied Biomedical Equipment Technology Applied Biomedical Equipment Technology Appl",
+        "Biomed Clinical Instrument",
+        "Biomedical Clinical Instrumentation",
+        "Diagnostic Ultrasound Imaging System"
+      ]
+    },
+    {
+      "prefix": "EDEL",
+      "name": "Methods",
+      "course_count": 6,
+      "section_count": 38,
+      "colleges": [
+        "odessa-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Elementary Geometry",
+        "Methods of Teaching Elem Math",
+        "Methods of Teaching Elem Sci",
+        "Methods of Teaching Soc Stud",
+        "Student Tchng/Clinical Appr I"
+      ]
+    },
+    {
+      "prefix": "CHLT",
+      "name": "Community",
+      "course_count": 8,
+      "section_count": 37,
+      "colleges": [
+        "houston-community-college",
+        "howard-college",
+        "northwest-vista-college",
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Clinical &ndash; Community Health Services/Liaison/Counseling",
+        "Community Health Advocacy",
+        "Community Health Field Methods",
+        "Community Nutrition",
+        "Introduction to Community Health"
+      ]
+    },
+    {
+      "prefix": "DSVT",
+      "name": "Vascular",
+      "course_count": 14,
+      "section_count": 37,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "lone-star-college-system",
+        "st-philips-college",
+        "temple-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adv Non-Invasive Vas Tech Lab",
+        "Adv Vascular Sonography Review",
+        "Advanced Vascular Technology",
+        "Cerebral Vascular Evaluation",
+        "Clinical - DMST Vasc Tech III"
+      ]
+    },
+    {
+      "prefix": "HECO",
+      "name": "Nutrition",
+      "course_count": 2,
+      "section_count": 36,
+      "colleges": [
+        "alvin-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "south-plains-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Nutrition and Diet Therapy",
+        "Science of Nutrition"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 34,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lone-star-college-system",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese I-Fundamentals Of Japanese",
+        "Elementary Japanese II",
+        "Intermediate Japanese I",
+        "Intermediate Japanese II"
+      ]
+    },
+    {
+      "prefix": "PHTC",
+      "name": "Photography",
+      "course_count": 15,
+      "section_count": 34,
+      "colleges": [
+        "amarillo-college",
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "odessa-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Architectural Photography",
+        "Color Photography I",
+        "Color Photography II",
+        "Cooperative Education - Commercial Photography",
+        "Expressive Photography"
+      ]
+    },
+    {
+      "prefix": "VTHTL",
+      "name": "Clinical",
+      "course_count": 10,
+      "section_count": 34,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Anesthesia & Surgical Assist",
+        "Clinical Pathology I",
+        "Equine Clinical Mgmt Lab",
+        "Intro to Veterinary Tech",
+        "Lab Animal Clinical Mgmt."
+      ]
+    },
+    {
+      "prefix": "CVTT",
+      "name": "Cardiovascular",
+      "course_count": 12,
+      "section_count": 32,
+      "colleges": [
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiovascular Instrumentation",
+        "Cardiac Catheterization I",
+        "Cardiac Catheterization II",
+        "Cardiovascular Anatomy and Physiology",
+        "Cardiovascular Pathophysiology"
+      ]
+    },
+    {
+      "prefix": "GISC",
+      "name": "GISC",
+      "course_count": 19,
+      "section_count": 32,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Advanced Problems in Geographic Information Systems (GIS)",
+        "Applying AI to GIS Field Proj",
+        "Cartography & Geography in Geographical Information Systems",
+        "Concpt & Careers in GIS",
+        "Cooperative Education in Cartography"
+      ]
+    },
+    {
+      "prefix": "ITAI",
+      "name": "ITAI",
+      "course_count": 11,
+      "section_count": 32,
+      "colleges": [
+        "blinn-college-district",
+        "houston-community-college",
+        "lone-star-college-system",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "A.I. 5/6G Communications & ORAN Networks",
+        "A.I. Controls for Robotics",
+        "A.I. Policies, Procedures, & Governance",
+        "Artificial Intelligence (A.I.) History, Theory, and Platforms",
+        "Cloud Configurations & Resources for A.I."
+      ]
+    },
+    {
+      "prefix": "DORI",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 31,
+      "colleges": [
+        "lamar-institute-of-technology"
+      ],
+      "sample_titles": [
+        "College Success Skills"
+      ]
+    },
+    {
+      "prefix": "EMAP",
+      "name": "Emergency",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Capstone in Emergency Management",
+        "Dev Volun Resources/Decis Maki",
+        "Disaster Exercise Design/Eval",
+        "Disaster Recovery",
+        "Disaster Response and Recovery"
+      ]
+    },
+    {
+      "prefix": "EDTP",
+      "name": "Pops",
+      "course_count": 6,
+      "section_count": 30,
+      "colleges": [
+        "lone-star-college-system",
+        "odessa-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Adv Mthd for Tchg Spec Pops",
+        "Behavior Mgmt in Spec Pops",
+        "Dsgn Assess for Gen & Sp Pops",
+        "Edu Prgrm & Serv for Spec Pops",
+        "Foundations of Inclusion and Differentiation for Special Populations"
+      ]
+    },
+    {
+      "prefix": "FDNS",
+      "name": "FDNS",
+      "course_count": 6,
+      "section_count": 30,
+      "colleges": [
+        "laredo-college",
+        "st-philips-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Child Nutrition and Programs",
+        "Introduction to Dietetics",
+        "Introduction to Foods",
+        "Nutrition",
+        "Practicum - Clinical Dietetics"
+      ]
+    },
+    {
+      "prefix": "HMSY",
+      "name": "Homeland",
+      "course_count": 7,
+      "section_count": 30,
+      "colleges": [
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "odessa-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Critical Infrastructure Protection",
+        "Homeland Security Emergency Communications Management",
+        "Homeland Security Emergency Contingency Planning",
+        "Homeland Security Intelligence Operations",
+        "Introduction to Homeland Security"
+      ]
+    },
+    {
+      "prefix": "IEIR",
+      "name": "Industrial",
+      "course_count": 5,
+      "section_count": 30,
+      "colleges": [
+        "amarillo-college",
+        "cisco-college",
+        "coastal-bend-college",
+        "lone-star-college-system",
+        "odessa-college",
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Alt Circuit Industrial Apps",
+        "Industrial Equipment Maintenance",
+        "Intro Direct Current Circuits",
+        "Motor Controls"
+      ]
+    },
+    {
+      "prefix": "POFM",
+      "name": "Medical",
+      "course_count": 11,
+      "section_count": 29,
+      "colleges": [
+        "houston-community-college",
+        "kilgore-college",
+        "lamar-state-college-port-arthur",
+        "odessa-college",
+        "palo-alto-college",
+        "temple-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Intermediate Medical Coding",
+        "Internship-Med Admin Assistant",
+        "Internship-Medical Administrative/Executive Assistant/ and Medical Secretary",
+        "MEDICAL ADMIN S",
+        "Medical Administrative Support"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Leadership",
+      "course_count": 12,
+      "section_count": 28,
+      "colleges": [
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Air Force Today I",
+        "EVOL/USAF AIR & SPACE POWER",
+        "Heritage and Values I",
+        "Heritage and Values II",
+        "Leadership Foundation II"
+      ]
+    },
+    {
+      "prefix": "BNKG",
+      "name": "Financial",
+      "course_count": 12,
+      "section_count": 28,
+      "colleges": [
+        "amarillo-college",
+        "houston-community-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Analyzing Financial Statements",
+        "Commercial Lending",
+        "Consumer Lending",
+        "Coop. Ed.-Banking and Financial Support Services",
+        "Cooperative Work Experience II"
+      ]
+    },
+    {
+      "prefix": "DEBA",
+      "name": "Base",
+      "course_count": 1,
+      "section_count": 28,
+      "colleges": [
+        "del-mar-college"
+      ],
+      "sample_titles": [
+        "Base NCBO"
+      ]
+    },
+    {
+      "prefix": "NMTT",
+      "name": "Nuclear",
+      "course_count": 14,
+      "section_count": 28,
+      "colleges": [
+        "amarillo-college",
+        "houston-community-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Pet/Fusion Tech",
+        "Introduction to Nuclear Medicine",
+        "Nuclear Med Instrumentation",
+        "Nuclear Medicine Methodol II",
+        "Nuclear Medicine Methodology I"
+      ]
+    },
+    {
+      "prefix": "JLRY",
+      "name": "JLRY",
+      "course_count": 16,
+      "section_count": 27,
+      "colleges": [
+        "paris-junior-college"
+      ],
+      "sample_titles": [
+        "CASTING I",
+        "CASTING II",
+        "JEWELRY TECH IV",
+        "JLRY REP/FAB II",
+        "JLRY REPR/FAB I"
+      ]
+    },
+    {
+      "prefix": "PTRT",
+      "name": "Petroleum",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "houston-community-college",
+        "kilgore-college",
+        "lone-star-college-system",
+        "panola-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "ENER MATH/COMP",
+        "NAT GAS PROCESS",
+        "NATURAL GAS PRO",
+        "Overview of Petroleum Industry",
+        "Petrol. Safety & Env. Hazards"
+      ]
+    },
+    {
+      "prefix": "BASM",
+      "name": "Base",
+      "course_count": 1,
+      "section_count": 26,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Base Beginning Algebra"
+      ]
+    },
+    {
+      "prefix": "CMSW",
+      "name": "CMSW",
+      "course_count": 9,
+      "section_count": 26,
+      "colleges": [
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Assessment & Service Delivery",
+        "Behavior Modification with Cognitive Disorder",
+        "Family Intervention Strategies",
+        "Life Coaching Ethics",
+        "Practicum-Clinical & Medical Social Work"
+      ]
+    },
+    {
+      "prefix": "EDEC",
+      "name": "EDEC",
+      "course_count": 7,
+      "section_count": 26,
+      "colleges": [
+        "odessa-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Child and Adolescent Guidance",
+        "Dev in a Cross-Cultural Persp",
+        "Devlpmnt Drng Erly Chldhood",
+        "Prenatal and Inf. Development",
+        "Sup Exp W/ Infants & Toddlers"
+      ]
+    },
+    {
+      "prefix": "NCBI",
+      "name": "Intgr",
+      "course_count": 4,
+      "section_count": 26,
+      "colleges": [
+        "howard-college",
+        "panola-college",
+        "paris-junior-college",
+        "southwest-college-for-the-deaf"
+      ],
+      "sample_titles": [
+        "BASE NCBO integrated Reading/Writing",
+        "INTGR READ/WRIT",
+        "NCB INT READ WR"
+      ]
+    },
+    {
+      "prefix": "ARET",
+      "name": "ARET",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Adv. Engineering Programming",
+        "Advanced Engineering Design",
+        "Automation Systems",
+        "E-Pneum. & Hydr Cntrl Circt.",
+        "Manufacturing Processes"
+      ]
+    },
+    {
+      "prefix": "HYDR",
+      "name": "Hydraulics",
+      "course_count": 5,
+      "section_count": 24,
+      "colleges": [
+        "kilgore-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system",
+        "northeast-texas-community-college",
+        "south-plains-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Basic Hydraulics",
+        "Fluid Power System Design",
+        "Hydraulics and Pneumatics",
+        "Rigging and Conveying Systems"
+      ]
+    },
+    {
+      "prefix": "INEW",
+      "name": "Programming",
+      "course_count": 6,
+      "section_count": 24,
+      "colleges": [
+        "amarillo-college",
+        "lamar-institute-of-technology",
+        "navarro-college",
+        "northwest-vista-college",
+        "palo-alto-college",
+        "san-antonio-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Advanced Java Programming",
+        "Advanced Web Programming",
+        "Comprehensive Software Project: Coding, Testing, and Implementation",
+        "Comprehensive Software Project: Planning and Design",
+        "Object Oriented Design"
+      ]
+    },
+    {
+      "prefix": "ENER",
+      "name": "Energy",
+      "course_count": 5,
+      "section_count": 23,
+      "colleges": [
+        "amarillo-college",
+        "lone-star-college-system",
+        "panola-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Basic Mech Skills for Energy",
+        "Employee Success in Energy Industry",
+        "EMPLOYMENT SUCC",
+        "INTRO ENERGY IN",
+        "SCADA and Networking"
+      ]
+    },
+    {
+      "prefix": "FSHD",
+      "name": "FSHD",
+      "course_count": 13,
+      "section_count": 23,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Bustier Construction",
+        "Custom Patterns",
+        "Design Construction Techniques",
+        "Draping",
+        "Fashion Collection Design"
+      ]
+    },
+    {
+      "prefix": "ITMT",
+      "name": "ITMT",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "alvin-community-college",
+        "amarillo-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Administering a Windows Server Operating System",
+        "Administering an Advanced Server Infrastructure",
+        "Azure Administrator",
+        "Azure Data Fundamentals",
+        "Config Adv Wind Serv Op Sys"
+      ]
+    },
+    {
+      "prefix": "MRIT",
+      "name": "Clinical",
+      "course_count": 8,
+      "section_count": 23,
+      "colleges": [
+        "coastal-bend-college",
+        "lone-star-college-system",
+        "st-philips-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Clinical - Radiologic Technology/Science - Radiographer",
+        "Clinical III-Radiologic Tech",
+        "Magnetic Resonance Equipment and Methodology",
+        "MRI - Registry Review",
+        "MRI Physics"
+      ]
+    },
+    {
+      "prefix": "PMGT",
+      "name": "Integration",
+      "course_count": 1,
+      "section_count": 23,
+      "colleges": [
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Integration, Scope and Quality Management"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "del-mar-college",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Basic Reading & Comprehension",
+        "Basic Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "DSAI",
+      "name": "Data",
+      "course_count": 5,
+      "section_count": 22,
+      "colleges": [
+        "northeast-lakeview-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Advanced Data Science and Analytics",
+        "Applications of Machine Learning",
+        "Computing Foundations for Data Science and Artificial Intelligence",
+        "Introduction to Data Science and Artificial Intelligence",
+        "Mathematical Foundations of Data Science and Artificial Intelligence"
+      ]
+    },
+    {
+      "prefix": "SRVY",
+      "name": "Surveying",
+      "course_count": 12,
+      "section_count": 22,
+      "colleges": [
+        "laredo-college",
+        "lone-star-college-system",
+        "northeast-lakeview-college"
+      ],
+      "sample_titles": [
+        "Capstone Exam Prep",
+        "Computer Aided Mapping",
+        "Cooperative Education - Survey Technology/ Surveying",
+        "Global Positioning System Techniques for Surveying and Mapping",
+        "Introduction to Geographic Information Systems"
+      ]
+    },
+    {
+      "prefix": "CJCR",
+      "name": "Correction",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "odessa-college",
+        "south-texas-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Basic Jail Course",
+        "Correction Officer I",
+        "Correction Officer II",
+        "Inservice Correction Officers",
+        "Legal Aspects of Corrections"
+      ]
+    },
+    {
+      "prefix": "HLAB",
+      "name": "HLAB",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "houston-community-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Clinical - Histologic Technology/Histotechnologist I",
+        "Clinical - Histologic Technology/Histotechnologist II",
+        "Clinical - Histologic Technology/Histotechnologist III",
+        "Clinical Histologic Technology I",
+        "Clinical Histologic Technology II"
+      ]
+    },
+    {
+      "prefix": "HONRH",
+      "name": "HONRH",
+      "course_count": 7,
+      "section_count": 21,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Honors College Academic Service Learning",
+        "Honors College Leadership Seminar",
+        "Honors Portfolio",
+        "Honors Research Methods",
+        "Honors Writing Seminar"
+      ]
+    },
+    {
+      "prefix": "PBAD",
+      "name": "Public",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Budgeting in the Public Sector",
+        "Ethics in the Public Sector",
+        "Governmental Agencies",
+        "Human Resource Management in the Public Sector",
+        "Legal Aspects of Public Management"
+      ]
+    },
+    {
+      "prefix": "EMSPL",
+      "name": "EMSPL",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "temple-college"
+      ],
+      "sample_titles": [
+        "Assessment Based Management",
+        "Emergency Medical Technician",
+        "Emergency Pharmacology",
+        "EMS Operations",
+        "EMSP-1356 Lab"
+      ]
+    },
+    {
+      "prefix": "INDS",
+      "name": "Interior",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Basic Elements of Design",
+        "Computer-Aided Drafting for Interior Designers",
+        "Fundamentals of Interior Design",
+        "Fundamentals of Space Planning",
+        "History of Interiors"
+      ]
+    },
+    {
+      "prefix": "LTCA",
+      "name": "LTCA",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "mclennan-community-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Clinical-Hosp/Health Fac Adm",
+        "Fin. Mgt. in L.T.C. Facilities",
+        "Internship-Hosp/Health Fac Adm",
+        "Intro to Long-Term Care Adm.",
+        "Long Term Care Law"
+      ]
+    },
+    {
+      "prefix": "MILS",
+      "name": "Leadership",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Basic Leadership I",
+        "Basic Leadership II",
+        "Basic Leadership Lab I",
+        "Basic Leadership Lab II",
+        "Introduction to Leadership I"
+      ]
+    },
+    {
+      "prefix": "NCIE",
+      "name": "Ncieenglish",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "navarro-college"
+      ],
+      "sample_titles": [
+        "NCIE-English"
+      ]
+    },
+    {
+      "prefix": "ORGD",
+      "name": "Organizational",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Organizational Development"
+      ]
+    },
+    {
+      "prefix": "CYBR",
+      "name": "CYBR",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Network Topologies and Protocols",
+        "Cyber Crime",
+        "Cyber Defense Operations",
+        "Cyber Privacy",
+        "Digital and Device Forensics"
+      ]
+    },
+    {
+      "prefix": "IFWA",
+      "name": "Nutrition",
+      "course_count": 4,
+      "section_count": 19,
+      "colleges": [
+        "college-of-the-mainland",
+        "del-mar-college",
+        "northeast-texas-community-college",
+        "odessa-college",
+        "south-plains-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Meat Identifying & Processing",
+        "Nutrition and Menu Planning",
+        "Nutrition for Food Service Pro",
+        "Quantity Procedures"
+      ]
+    },
+    {
+      "prefix": "PMHS",
+      "name": "Serv",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "mclennan-community-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Pract-Psych MntlHlthSrvsTech",
+        "Pract-Psychiat/M H Serv Tech",
+        "Practicum (or Field Experience) - Psychiatric/Mental Health Services Technician",
+        "Practicum (or Field Experience) Psychiatric/Mental Health Services Technician",
+        "Sp Top in Psych/Mtl Hlth Serv"
+      ]
+    },
+    {
+      "prefix": "ITDF",
+      "name": "Digital",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "amarillo-college",
+        "laredo-college",
+        "palo-alto-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Digital Forensics Analysis",
+        "Digital Forensics Collection",
+        "Digital Forensics Tools",
+        "Intro to Digital Forensics",
+        "Introduction to Digital Forensics"
+      ]
+    },
+    {
+      "prefix": "OPTS",
+      "name": "OPTS",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "st-philips-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Contact Lenses",
+        "Advanced Ophthalmic Techniques",
+        "Advanced Opthalmic Techniques",
+        "Anatomy and Physiology for Eye Care Technology",
+        "Basic Contact Lenses"
+      ]
+    },
+    {
+      "prefix": "PRDV",
+      "name": "PRDV",
+      "course_count": 3,
+      "section_count": 18,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "CPR Skills Check",
+        "DWI Education Program",
+        "EMS CEU Training:"
+      ]
+    },
+    {
+      "prefix": "BITC",
+      "name": "BITC",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "collin-county-community-college-district",
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Bioinformatics",
+        "Biotechnology Laboratory Instrumentation",
+        "Biotechnology Laboratory Methods and Techniques",
+        "Internship - Biology Technician/Biotechnology Laboratory Technician",
+        "Molecular Biology Techniques"
+      ]
+    },
+    {
+      "prefix": "COMG",
+      "name": "Topicscommunications",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "del-mar-college"
+      ],
+      "sample_titles": [
+        "Special Topics/Communications"
+      ]
+    },
+    {
+      "prefix": "EDLL",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "lone-star-college-system",
+        "odessa-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Foundations in Reading Instruction: The Science of Teaching Reading",
+        "Language Literacy Acquisition"
+      ]
+    },
+    {
+      "prefix": "MACS",
+      "name": "Support",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "howard-college",
+        "southwest-college-for-the-deaf"
+      ],
+      "sample_titles": [
+        "Algebra Support 3",
+        "Algebra Support I",
+        "Business Math Support 3",
+        "Contemporary Math Support 2",
+        "Contemporary Math Support I"
+      ]
+    },
+    {
+      "prefix": "MHSM",
+      "name": "Management",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Financial Management for Healthcare",
+        "Health Care Law and Ethics",
+        "Healthcare Information Technology",
+        "Healthcare Operations Management",
+        "Healthcare Quality and Risk Management"
+      ]
+    },
+    {
+      "prefix": "ENGA",
+      "name": "Composition",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "palo-alto-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Composition and Grammar",
+        "Reading and Vocabulary"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Workforce",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "texarkana-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Workforce Dev Crit Thinking",
+        "Workforce Development with Critical"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 3,
+      "section_count": 16,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Business Planning for Entrepre",
+        "Entrepreneurial App of Bus Law",
+        "Foundations Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "RADRL",
+      "name": "Tech",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Intermed Rad Procedures Lab",
+        "Rad Tech Lab"
+      ]
+    },
+    {
+      "prefix": "CRPT",
+      "name": "Systems",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "amarillo-college",
+        "del-mar-college",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "CoOp - Carpentry",
+        "Floor Systems",
+        "Interior Finish Systems",
+        "Introduction to Carpentry",
+        "Roof Systems"
+      ]
+    },
+    {
+      "prefix": "DMTH",
+      "name": "Algebra",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "lamar-state-college-port-arthur"
+      ],
+      "sample_titles": [
+        "Beginning Algebra",
+        "Beginning Algebra Support Course",
+        "Foundations of College Algebra",
+        "Foundations of Mathematics for Business and Social Sciences",
+        "Foundations of Quantitative Reasoning"
+      ]
+    },
+    {
+      "prefix": "QCTC",
+      "name": "Quality",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "del-mar-college",
+        "houston-community-college",
+        "lone-star-college-system",
+        "mclennan-community-college",
+        "north-central-texas-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Qc Tech: Lean Six Sigma",
+        "Quality Assurance",
+        "QUALITY CONTROL",
+        "Standards",
+        "Testing and Inspection Systems"
+      ]
+    },
+    {
+      "prefix": "AGAH",
+      "name": "Ranch",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "clarendon-college",
+        "northeast-texas-community-college",
+        "panola-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "2ND YEAR ACADEMIC RANCH AND FEEDLOT OPERATIONS PATH",
+        "ACADEMIC RANCH AND FEEDLOT OPERATIONS PATH",
+        "ANIMAL REPRODUCTION",
+        "Beef Cattle Production",
+        "BEEF CATTLE PRODUCTION"
+      ]
+    },
+    {
+      "prefix": "ARCE",
+      "name": "Structural",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "del-mar-college",
+        "houston-community-college",
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "laredo-college",
+        "lone-star-college-system",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Architectural Illustration",
+        "Architectural Materials and Methods of Construction",
+        "Code Spec,Contract Documents",
+        "Structural Drafting",
+        "Structural Steel Detailing"
+      ]
+    },
+    {
+      "prefix": "IRWS",
+      "name": "Integ",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "paris-junior-college"
+      ],
+      "sample_titles": [
+        "INTEG READ/WRIT"
+      ]
+    },
+    {
+      "prefix": "NDTE",
+      "name": "Ultrasonics",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "del-mar-college",
+        "kilgore-college",
+        "lone-star-college-system",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Ultrasonics",
+        "Electromagnetic Testing",
+        "Intermediate Ultrasonics",
+        "Introduction to Ultrasonics",
+        "Liq Penetrant/Magnetic Testing"
+      ]
+    },
+    {
+      "prefix": "PSGT",
+      "name": "PSGT",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "alvin-community-college",
+        "collin-county-community-college-district",
+        "lone-star-college-system",
+        "temple-college"
+      ],
+      "sample_titles": [
+        "AAS Clinical I-Polysomnography",
+        "Aas Clinical II",
+        "Clinical II - Polysomnography",
+        "Neuroanatomy & Physiology",
+        "Polysomnography II"
+      ]
+    },
+    {
+      "prefix": "AGEQ",
+      "name": "Equine",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "north-central-texas-college",
+        "northeast-texas-community-college",
+        "vernon-college",
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "ADVANCED RANCH HORSE RIDING",
+        "ADVANCED REINING",
+        "Equine Behavior & Training",
+        "EQUINE ENTERPRISE MANAGEMENT",
+        "EQUINE SCIENCE I"
+      ]
+    },
+    {
+      "prefix": "AGMG",
+      "name": "AGMG",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "clarendon-college",
+        "northeast-texas-community-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "AGRICULTURAL RECORDS MANAGEMENT",
+        "Coop Ed-Ag Bus/Mgt",
+        "Internship-Ag Bus & Mgmt, General",
+        "Introduction To Agribusiness",
+        "Practicum-Farm & Ranch Manage"
+      ]
+    },
+    {
+      "prefix": "DATN",
+      "name": "Data",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "lamar-institute-of-technology",
+        "lamar-state-college-port-arthur",
+        "lone-star-college-system",
+        "north-central-texas-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DATA VISUALIZATION",
+        "Analytical Tools and Methods",
+        "Cloud Computing for Data Analytics",
+        "Introduction to Data Visualization &amp; Analytics"
+      ]
+    },
+    {
+      "prefix": "ENCS",
+      "name": "English",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "howard-college",
+        "southwest-college-for-the-deaf"
+      ],
+      "sample_titles": [
+        "English College Support I",
+        "English College Support III"
+      ]
+    },
+    {
+      "prefix": "FYIS",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 13,
+      "colleges": [
+        "frank-phillips-college"
+      ],
+      "sample_titles": [
+        "First Year Institute Seminar"
+      ]
+    },
+    {
+      "prefix": "ITCA",
+      "name": "Cybersecurity",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Cybersecurity Fundamentals",
+        "Fundamentals of Disaster Recovery and Business Continuity"
+      ]
+    },
+    {
+      "prefix": "PERS",
+      "name": "Membership",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Couples Fitness Membership",
+        "Family Gym Membership",
+        "Individual Fitness Membership",
+        "Pickleball for Beginners",
+        "Senior Membership 60+"
+      ]
+    },
+    {
+      "prefix": "ARAB",
+      "name": "Arabic",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "collin-county-community-college-district",
+        "houston-community-college",
+        "lone-star-college-system",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Beginning Arabic II",
+        "Elementary Arabic I",
+        "Intermediate Arabic I",
+        "Intermediate Arabic II"
+      ]
+    },
+    {
+      "prefix": "CEC",
+      "name": "CEC",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking for Standardized Tests",
+        "Dental Assistant Registration Course and Exam",
+        "Dental Assistant Registration Retest",
+        "Green Thumb Gardening Workshop",
+        "HESI A2 and TEAS Preparatory Course: Anatomy and Physiology"
+      ]
+    },
+    {
+      "prefix": "EDIT",
+      "name": "Instructional",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "lone-star-college-system",
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Instructional Technology"
+      ]
+    },
+    {
+      "prefix": "NCTC",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "north-central-texas-college"
+      ],
+      "sample_titles": [
+        "FIRST YEAR EXPERIENCE COURSE"
+      ]
+    },
+    {
+      "prefix": "AGCR",
+      "name": "AGCR",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "clarendon-college",
+        "collin-county-community-college-district",
+        "northeast-texas-community-college",
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Entomology",
+        "Forage and Pasture Management",
+        "Internship - Crop Production",
+        "Intro to Sustainable Ag",
+        "Introduction to Sustainable Agriculture"
+      ]
+    },
+    {
+      "prefix": "CISC",
+      "name": "CISC",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Computer Technology & Impact",
+        "Database & Data Management",
+        "Machine Learning",
+        "Management Information Sys",
+        "Offensive Security"
+      ]
+    },
+    {
+      "prefix": "DVMA",
+      "name": "Dmat",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "cisco-college"
+      ],
+      "sample_titles": [
+        "DMAT0314 01 & MATH1314 01 PAIRED",
+        "DMAT0332 E2 & MATH1332 E2 PAIRED",
+        "DMAT0342 01 & MATH1342 01 PAIRED"
+      ]
+    },
+    {
+      "prefix": "ETWR",
+      "name": "Stsocial",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "amarillo-college",
+        "houston-community-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Introduction to Technical Writing",
+        "ST-Social Media Tools"
+      ]
+    },
+    {
+      "prefix": "LNWK",
+      "name": "Line",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "lamar-institute-of-technology",
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Climbing Skills",
+        "Distribution Line Construction",
+        "Distribution Operations",
+        "Orientation Line Skill Fundam",
+        "Overhead Line Construction I"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "navarro-college"
+      ],
+      "sample_titles": [
+        "Intro Algebra"
+      ]
+    },
+    {
+      "prefix": "DSPE",
+      "name": "Pedi",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "alvin-community-college"
+      ],
+      "sample_titles": [
+        "Adv Pedi Cardi Sonography Rev",
+        "Advanced Pedi Echo Lab",
+        "Advanced Pedi Echocardiography",
+        "Clinical - DMST Pedi Echo III",
+        "Intro to Pedi Echo Techniques"
+      ]
+    },
+    {
+      "prefix": "DVEN",
+      "name": "Derw",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "cisco-college"
+      ],
+      "sample_titles": [
+        "DERW0303 05 & ENGL1301 05 PAIRED"
+      ]
+    },
+    {
+      "prefix": "FDST",
+      "name": "FDST",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Analysis of Must and Wine",
+        "Grape and Wine Chemistry",
+        "Grapevine Biology",
+        "Principles of Enology II",
+        "Principles of Viticulture II"
+      ]
+    },
+    {
+      "prefix": "HRGY",
+      "name": "Horl",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "paris-junior-college"
+      ],
+      "sample_titles": [
+        "ADV HORL SYS I",
+        "ADV HORL SYS II",
+        "ADV HORL SYSIII",
+        "HOROLOGY I",
+        "HOROLOGY II"
+      ]
+    },
+    {
+      "prefix": "NUPC",
+      "name": "Patient",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "northeast-texas-community-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Clinical - Patient Care Assistant",
+        "Patient Care Technician"
+      ]
+    },
+    {
+      "prefix": "OLIE",
+      "name": "OLIE",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Effective Communication",
+        "History of Integration & Advocacy",
+        "Networking & Customer Service"
+      ]
+    },
+    {
+      "prefix": "WIND",
+      "name": "Wind",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "south-plains-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Intro to Wind Energy",
+        "Wind Power Delivery Systems",
+        "Wind Turbine Trblshting/Repair"
+      ]
+    },
+    {
+      "prefix": "DMSOL",
+      "name": "Sonography",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "temple-college"
+      ],
+      "sample_titles": [
+        "Sonographic Sectional Anatomy",
+        "Sonography of Abdominopelvic",
+        "Sonography of Obstetrics"
+      ]
+    },
+    {
+      "prefix": "METL",
+      "name": "Corrosion",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "del-mar-college",
+        "kilgore-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "COR OPER QUAL",
+        "CORROSION OP 2",
+        "INTRO CORROSION",
+        "Introduction to Metallurgy",
+        "PRACTICUM"
+      ]
+    },
+    {
+      "prefix": "OHSM",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Critical Incident Management",
+        "Emergency Management & Conting",
+        "Industrial Hygiene",
+        "Interactions of Hzds Mtrls",
+        "Legal Aspects of Health & Saf"
+      ]
+    },
+    {
+      "prefix": "SMARTE",
+      "name": "Smart",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "amarillo-college"
+      ],
+      "sample_titles": [
+        "Smart Start - English/Reading"
+      ]
+    },
+    {
+      "prefix": "SMARTM",
+      "name": "Smart",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "amarillo-college"
+      ],
+      "sample_titles": [
+        "Smart Start Math"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "Program",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "temple-college"
+      ],
+      "sample_titles": [
+        "AEL Program Math",
+        "AEL Program Reading"
+      ]
+    },
+    {
+      "prefix": "EEIR",
+      "name": "National",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "National Electrical Code"
+      ]
+    },
+    {
+      "prefix": "ENDT",
+      "name": "ENDT",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "alvin-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Ndt Procedures",
+        "Applied Elect/Instrumentation",
+        "Clinical III - Endt",
+        "Electroencephalography"
+      ]
+    },
+    {
+      "prefix": "FSHN",
+      "name": "Fashion",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Pattern Drafting",
+        "Fashion Buying",
+        "Fashion Promotion",
+        "Fashion Retailing",
+        "Textiles"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Elementary German I",
+        "Elementary German II"
+      ]
+    },
+    {
+      "prefix": "HUWC",
+      "name": "Practicum",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Practicum Health Unit Coord"
+      ]
+    },
+    {
+      "prefix": "INCR",
+      "name": "Physics",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "coastal-bend-college",
+        "lamar-institute-of-technology",
+        "laredo-college",
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Measurement and Process Cntrl",
+        "Microprocessor Systems Maintenance",
+        "Physics of Instrumentation"
+      ]
+    },
+    {
+      "prefix": "RSPTL",
+      "name": "Mechanical",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Mechanical Ventilation Lab",
+        "Respiratory Care Procedures I"
+      ]
+    },
+    {
+      "prefix": "CBFM",
+      "name": "Maintenance",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "del-mar-college",
+        "northeast-texas-community-college"
+      ],
+      "sample_titles": [
+        "Building Maintenance I",
+        "Industrial Scaffold & Rigging",
+        "Mechanical Maintenance"
+      ]
+    },
+    {
+      "prefix": "DIRW",
+      "name": "Readwrite",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "weatherford-college"
+      ],
+      "sample_titles": [
+        "Int Read/Write Lvl II"
+      ]
+    },
+    {
+      "prefix": "FINA",
+      "name": "Entrepreneurial",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurial Finance"
+      ]
+    },
+    {
+      "prefix": "ITAL",
+      "name": "Italian",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Elementary Italian I",
+        "Elementary Italian II"
+      ]
+    },
+    {
+      "prefix": "MSCI",
+      "name": "Leadership",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Applied Leadership and Management II",
+        "Fundamentals of Leadership and Management I",
+        "Fundamentals of Leadership and Management II"
+      ]
+    },
+    {
+      "prefix": "NCBE",
+      "name": "Ncbe",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "NCBE Writing Intervention"
+      ]
+    },
+    {
+      "prefix": "WMGT",
+      "name": "Mgmt",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "panola-college"
+      ],
+      "sample_titles": [
+        "MGMT & BIO WHIT"
+      ]
+    },
+    {
+      "prefix": "CSAMX",
+      "name": "Csamath",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "college-of-the-mainland"
+      ],
+      "sample_titles": [
+        "CSA-Math"
+      ]
+    },
+    {
+      "prefix": "CSATX",
+      "name": "Csaela",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "college-of-the-mainland"
+      ],
+      "sample_titles": [
+        "CSA-ELA"
+      ]
+    },
+    {
+      "prefix": "DHYGL",
+      "name": "Dental",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "temple-college"
+      ],
+      "sample_titles": [
+        "Dental Radiology (lab)",
+        "Preclinic Dental Hygiene"
+      ]
+    },
+    {
+      "prefix": "ECRD",
+      "name": "Electrocardiography",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "howard-college",
+        "lamar-state-college-port-arthur",
+        "south-texas-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Electrocardiography"
+      ]
+    },
+    {
+      "prefix": "ENTC",
+      "name": "Statics",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Statics",
+        "Strength of Materials"
+      ]
+    },
+    {
+      "prefix": "FMKT",
+      "name": "Floral",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "north-central-texas-college",
+        "palo-alto-college"
+      ],
+      "sample_titles": [
+        "Advanced Floral Design",
+        "FLORAL DESIGN",
+        "Flower Shop Management"
+      ]
+    },
+    {
+      "prefix": "OLIA",
+      "name": "OLIA",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Self-Awareness & Personal Change",
+        "Stress in the Workplace I",
+        "Wellness Lifestyle I"
+      ]
+    },
+    {
+      "prefix": "PTHAL",
+      "name": "PTHAL",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Biophysical Agents",
+        "Laboratory",
+        "Therapeutic Exercise Lab"
+      ]
+    },
+    {
+      "prefix": "SPNL",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Health Care Spanish"
+      ]
+    },
+    {
+      "prefix": "ANES",
+      "name": "Anesthesia",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "houston-community-college",
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Anesthesia Tech Clinic Exp I",
+        "Anesthesia Technology Clinical Experience II",
+        "Anesthesia Technology Fundamentals II",
+        "Introduction of Anesthesia Technology",
+        "Principles of Anesthesia Technology"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Chinese",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "houston-community-college",
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Beginning Chinese I",
+        "Elementary Chinese II",
+        "Intermediate Chinese II"
+      ]
+    },
+    {
+      "prefix": "CSFA",
+      "name": "Surgical",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "Fundamentals and Surgical Safety",
+        "Lab: Suturing, Knot Tying, Hemostasis, and Wound Healing",
+        "Surgical Procedures"
+      ]
+    },
+    {
+      "prefix": "DENG",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "lamar-state-college-port-arthur"
+      ],
+      "sample_titles": [
+        "Foundations of Composition",
+        "Integrated Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "IRAW",
+      "name": "Integrated",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "clarendon-college"
+      ],
+      "sample_titles": [
+        "INTEGRATED READING AND WRITING DEVELOPMENTAL LEVEL 2",
+        "INTEGRATED READING AND WRITING DEVELOPMENTAL LEVEL 3",
+        "INTEGRATED READING AND WRITING I"
+      ]
+    },
+    {
+      "prefix": "MLSC",
+      "name": "Military",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Military Leadership Development I",
+        "Military leadership I",
+        "Ranger Challenge Training"
+      ]
+    },
+    {
+      "prefix": "DLBT",
+      "name": "Dental",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "southwest-college-for-the-deaf"
+      ],
+      "sample_titles": [
+        "Dental Anatomy & Tooth Morph.",
+        "Dental Ceramic Technique I",
+        "Dental Materials",
+        "Fixed Restorative Techniques I"
+      ]
+    },
+    {
+      "prefix": "OLWF",
+      "name": "Campus",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Campus RAMP II",
+        "Internship - Occupational & Life Skills Internship I (Community Internship I)"
+      ]
+    },
+    {
+      "prefix": "POFL",
+      "name": "Legal",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "odessa-college"
+      ],
+      "sample_titles": [
+        "Legal Document Processing"
+      ]
+    },
+    {
+      "prefix": "RELG",
+      "name": "Testament",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "amarillo-college"
+      ],
+      "sample_titles": [
+        "Romans",
+        "The New Testament"
+      ]
+    },
+    {
+      "prefix": "BUSA",
+      "name": "Investments",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "san-antonio-college"
+      ],
+      "sample_titles": [
+        "Investments and Securities"
+      ]
+    },
+    {
+      "prefix": "CNSE",
+      "name": "Equipment",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lamar-institute-of-technology",
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Earth Moving Equipment Operations",
+        "Equipment Operation"
+      ]
+    },
+    {
+      "prefix": "ESLC",
+      "name": "Listeningspeaking",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "ESL Listening/Speaking Transitioning",
+        "ESL Listening/Speaking, Advanced",
+        "ESL Listening/Speaking, Intermediate"
+      ]
+    },
+    {
+      "prefix": "ESLG",
+      "name": "Grammar",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "ESL Grammar Advanced",
+        "ESL Grammar Intermediate",
+        "ESL Grammar Transitioning"
+      ]
+    },
+    {
+      "prefix": "ESLR",
+      "name": "Reading",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "ESL Reading Advanced",
+        "ESL Reading Intermediate",
+        "ESL Reading Transitioning"
+      ]
+    },
+    {
+      "prefix": "ESLW",
+      "name": "Writing",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "ESL Writing Advanced",
+        "ESL Writing Intermediate",
+        "ESL Writing Transitioning"
+      ]
+    },
+    {
+      "prefix": "ESLX",
+      "name": "ESLX",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "collin-county-community-college-district"
+      ],
+      "sample_titles": [
+        "ESL Pronunciation",
+        "ESL Vocabulary and Idioms",
+        "Test-Taking and Study Skills for Non-Native English Speakers"
+      ]
+    },
+    {
+      "prefix": "GERS",
+      "name": "Gerontology",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "mclennan-community-college",
+        "paris-junior-college"
+      ],
+      "sample_titles": [
+        "Introduction to Gerontology"
+      ]
+    },
+    {
+      "prefix": "HEMR",
+      "name": "Natural",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "del-mar-college",
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Natural Gas Compression",
+        "Tracks and Undercarriages"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "Horticulture",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "amarillo-college",
+        "north-central-texas-college"
+      ],
+      "sample_titles": [
+        "Horticulture"
+      ]
+    },
+    {
+      "prefix": "NCBW",
+      "name": "Based",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "coastal-bend-college"
+      ],
+      "sample_titles": [
+        "Non Course Based I.R.W. II"
+      ]
+    },
+    {
+      "prefix": "ORIE",
+      "name": "Dream",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "howard-college"
+      ],
+      "sample_titles": [
+        "Dream Week"
+      ]
+    },
+    {
+      "prefix": "PMTH",
+      "name": "Prenursing",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "frank-phillips-college"
+      ],
+      "sample_titles": [
+        "Pre-Nursing Math"
+      ]
+    },
+    {
+      "prefix": "SMRT",
+      "name": "Smart",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Alarm System Fundamentals",
+        "Smart Building Fundamentals"
+      ]
+    },
+    {
+      "prefix": "AFSC",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Evolution of Air Power I",
+        "Foundations of the USAF I"
+      ]
+    },
+    {
+      "prefix": "AGME",
+      "name": "Harvesting",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "navarro-college",
+        "north-central-texas-college"
+      ],
+      "sample_titles": [
+        "FARM AND RANCH SHOP SKILLS",
+        "Harvesting Equipment"
+      ]
+    },
+    {
+      "prefix": "CLAB",
+      "name": "Collaboration",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northwest-vista-college"
+      ],
+      "sample_titles": [
+        "Collaboration"
+      ]
+    },
+    {
+      "prefix": "COLS",
+      "name": "Success",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "kilgore-college"
+      ],
+      "sample_titles": [
+        "SUCCESS STRAT"
+      ]
+    },
+    {
+      "prefix": "ELTN",
+      "name": "Electrical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Electrical Troubleshooting"
+      ]
+    },
+    {
+      "prefix": "ENDO",
+      "name": "Team",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Aseptic Technique",
+        "The Art of Team Work & Professional Skills"
+      ]
+    },
+    {
+      "prefix": "FCEL",
+      "name": "Fuel",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "st-philips-college"
+      ],
+      "sample_titles": [
+        "Introduction to Fuel Cell Technology"
+      ]
+    },
+    {
+      "prefix": "GLBIS",
+      "name": "Global",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Global Scholars Portfolio",
+        "Intro to International Studies"
+      ]
+    },
+    {
+      "prefix": "GRPH",
+      "name": "Vector",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mclennan-community-college"
+      ],
+      "sample_titles": [
+        "Vector Graphic for Production"
+      ]
+    },
+    {
+      "prefix": "HYDC",
+      "name": "Hydrogen",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lamar-state-college-port-arthur"
+      ],
+      "sample_titles": [
+        "Introduction to Hydrogen, Ammonia &amp; CO Production"
+      ]
+    },
+    {
+      "prefix": "LNGM",
+      "name": "Liquefied",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lamar-state-college-port-arthur"
+      ],
+      "sample_titles": [
+        "Introduction to Liquefied Natural Gas Manufacturing",
+        "Liquefied Natural Gas Hazards and Safety Practices"
+      ]
+    },
+    {
+      "prefix": "MAIR",
+      "name": "Refrigerators",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "laredo-college"
+      ],
+      "sample_titles": [
+        "Refrigerators, Freezers, Window Air Conditioners"
+      ]
+    },
+    {
+      "prefix": "MRMT",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Medical Transcription I"
+      ]
+    },
+    {
+      "prefix": "NCBT",
+      "name": "Integr",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "coastal-bend-college"
+      ],
+      "sample_titles": [
+        "Integr Reading & Tech Writing"
+      ]
+    },
+    {
+      "prefix": "NUCP",
+      "name": "Radiation",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lone-star-college-system"
+      ],
+      "sample_titles": [
+        "Radiation Protection I"
+      ]
+    },
+    {
+      "prefix": "ORIN",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "College 101: Student Orientation"
+      ]
+    },
+    {
+      "prefix": "RBPT",
+      "name": "Onsite",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "laredo-college"
+      ],
+      "sample_titles": [
+        "Onsite Power Generation and Renewable Energy"
+      ]
+    },
+    {
+      "prefix": "SLPS",
+      "name": "Security",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Security of Computers/Data"
+      ]
+    },
+    {
+      "prefix": "ACRW",
+      "name": "Academic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Academic Reading And Writing"
+      ]
+    },
+    {
+      "prefix": "AEL",
+      "name": "AEL",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "navarro-college"
+      ],
+      "sample_titles": [
+        "AEL"
+      ]
+    },
+    {
+      "prefix": "AVNC",
+      "name": "Aviation",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Aviation Elec Systems Install"
+      ]
+    },
+    {
+      "prefix": "DE02",
+      "name": "Ncbo",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "del-mar-college"
+      ],
+      "sample_titles": [
+        "NCBO Developmental Reading"
+      ]
+    },
+    {
+      "prefix": "DITA",
+      "name": "Dietary",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Dietary Manager I"
+      ]
+    },
+    {
+      "prefix": "DMAT",
+      "name": "Developmental",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cisco-college"
+      ],
+      "sample_titles": [
+        "Developmental STEM Algebra"
+      ]
+    },
+    {
+      "prefix": "DSAEL",
+      "name": "Cardiac",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "temple-college"
+      ],
+      "sample_titles": [
+        "Intro to Cardiac Sonagraphy"
+      ]
+    },
+    {
+      "prefix": "GREE",
+      "name": "Greek",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "amarillo-college"
+      ],
+      "sample_titles": [
+        "Greek I"
+      ]
+    },
+    {
+      "prefix": "GUAS",
+      "name": "Fund",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "del-mar-college"
+      ],
+      "sample_titles": [
+        "Fund of Unmanned Air Sys"
+      ]
+    },
+    {
+      "prefix": "INSR",
+      "name": "Essentials",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Essentials of Risk Management"
+      ]
+    },
+    {
+      "prefix": "ITDS",
+      "name": "Data",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Data Visualization"
+      ]
+    },
+    {
+      "prefix": "ITXR",
+      "name": "Virtual",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Virtual Reality"
+      ]
+    },
+    {
+      "prefix": "KORE",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Korean I"
+      ]
+    },
+    {
+      "prefix": "LBRA",
+      "name": "Practicum",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Practicum Library Technology"
+      ]
+    },
+    {
+      "prefix": "LNWC",
+      "name": "Regulators",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-plains-college"
+      ],
+      "sample_titles": [
+        "Regulators, Reclosers, & Caps"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "Automated",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northeast-texas-community-college"
+      ],
+      "sample_titles": [
+        "Introduction Automated Manufacturin"
+      ]
+    },
+    {
+      "prefix": "MSSG",
+      "name": "Massage",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Internship - Massage Therapy"
+      ]
+    },
+    {
+      "prefix": "NAUT",
+      "name": "Ships",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Ships and Shipping"
+      ]
+    },
+    {
+      "prefix": "NCLEX",
+      "name": "Nclex",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "amarillo-college"
+      ],
+      "sample_titles": [
+        "NCLEX Student Group"
+      ]
+    },
+    {
+      "prefix": "PLTC",
+      "name": "Composite",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Composite Bonding"
+      ]
+    },
+    {
+      "prefix": "PORT",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Portuguese I"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "Technology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "amarillo-college"
+      ],
+      "sample_titles": [
+        "Technology Research"
+      ]
+    },
+    {
+      "prefix": "RRBC",
+      "name": "Remote",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-vista-college"
+      ],
+      "sample_titles": [
+        "Remote Ready Boot Camp"
+      ]
+    },
+    {
+      "prefix": "TRAI",
+      "name": "Theory",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of the Theory & Practice of Translation & Interpretation"
+      ]
+    },
+    {
+      "prefix": "TRLA",
+      "name": "Quality",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "houston-community-college"
+      ],
+      "sample_titles": [
+        "Quality Management and Project Management in Localization"
+      ]
+    },
+    {
+      "prefix": "TRVM",
+      "name": "Convnmeet",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "del-mar-college"
+      ],
+      "sample_titles": [
+        "Intro to Convn/Meet Mgmt"
+      ]
+    },
+    {
+      "prefix": "TXCS",
+      "name": "Texas",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tarrant-county-college-district"
+      ],
+      "sample_titles": [
+        "Texas Course Sharing"
+      ]
+    },
+    {
+      "prefix": "WFAP",
+      "name": "Academic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "texarkana-college"
+      ],
+      "sample_titles": [
+        "Academic Prep"
+      ]
+    },
+    {
+      "prefix": "WKNF",
+      "name": "Edgo",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "vernon-college"
+      ],
+      "sample_titles": [
+        "Ed2Go:"
+      ]
+    }
+  ],
+  "program_titles": [
+    "21st Century Police Administration, Level 2 Certificate",
+    "AA Psychology",
+    "AAS in Emergency Medical Services",
+    "AAS Small Business Management",
+    "AAS Surgical Technology",
+    "AAS-Criminal Justice Technology",
+    "Accounting A.A.S.",
+    "Accounting Assistant I",
+    "Accounting Assistant II",
+    "Accounting Assistant III",
+    "Accounting Certificate",
+    "Accounting Information Management, AAS",
+    "Accounting Technology Certificate - Level I",
+    "Accounting, A.A.S.",
+    "Accounting, AAS",
+    "Accounting, Area of Study - General Studies Electives",
+    "Accounting, C1",
+    "Administrative Assistant Specialist Certificate - Level I",
+    "Administrative Support Specialist, Level 1 Certificate",
+    "Adult Echocardiography Certificate",
+    "Advanced Biotechnology, Level 2 Certificate",
+    "Advanced Manufacturing - Assistant Certificate",
+    "Advanced Manufacturing - Automation Controls Technician",
+    "Advanced Manufacturing - Heating, Ventilation and Air Conditioning Assistant",
+    "Advanced Manufacturing - Heating, Ventilation and Air Conditioning Technician",
+    "Advanced Manufacturing - Industrial Maintenance Technician",
+    "Advanced Manufacturing - Instrumentation and Electronics Assistant",
+    "Advanced Manufacturing - Instrumentation and Electronics Technician",
+    "Advanced Manufacturing - Renewable Energy Technician",
+    "Advanced Manufacturing (A.A.S.) - Automation Controls",
+    "Advanced Manufacturing (A.A.S.) - Heating, Ventilation and Air Conditioning",
+    "Advanced Manufacturing (A.A.S.) - Industrial Maintenance",
+    "Advanced Manufacturing (A.A.S.) - Instrumentation and Electronics",
+    "Advanced Manufacturing (A.A.S.) - Renewable Energy",
+    "Advanced Manufacturing Fundamental Skills Certificate",
+    "Advanced Welding, Level 1 Certificate",
+    "Advertising/Public Relations",
+    "After School Provider",
+    "Agribusiness A.A.S.",
+    "Agricultural Business Award",
+    "Agricultural Business, AS",
+    "Agriculture, Area of Study - General Studies Electives",
+    "Agriculture, AS",
+    "Air Force and Army ROTC, Area of Study - General Studies Electives",
+    "Allied Health - Dental Assisting - Specialization, A.A.S.",
+    "Allied Health - Endoscopy-Specialization, A.A.S.",
+    "Allied Health - Medical Assistant - Specialization, A.A.S.",
+    "Allied Health - Pharmacy Technician - Specialization, A.A.S.",
+    "Allied Health - Vocational Nursing - Specialization, A.A.S.",
+    "American Sign Language, Area of Study - General Studies Electives",
+    "Anesthesia Technologist, A.A.S.",
+    "Anesthesia Technology, AAS",
+    "Animation & Game Art, AAS",
+    "Animation & Game Art, Level 1 Certificate",
+    "Anthropology, A.A.",
+    "Anthropology, AA",
+    "Anthropology, Area of Study - General Studies Electives",
+    "Application Development, A.A.S.",
+    "Applied Agricultural Engineering Pathway",
+    "Architectural CAD Operator",
+    "Architectural Paraprofessional",
+    "Architectural Technology",
+    "Architectural Technology, AAS",
+    "Architecture, AA",
+    "Art - Graphic Design (A.A.S.)",
+    "Art - Graphic Design Certificate",
+    "Art (A.S.)",
+    "Art, A.A.",
+    "Art, Area of Study - General Studies Electives",
+    "Artificial Intelligence & Robotics, B.A.T.",
+    "Artificial Intelligence, A.A.S.",
+    "Arts, AA",
+    "AS Psychology",
+    "AS-Health Sciences / Nursing",
+    "ASL Studies, Level 2 Certificate",
+    "Associate Degree Nursing — LVN to ADN Transition A.A.S.",
+    "Associate Degree Nursing A.A.S.",
+    "Associate Degree Nursing, Generic Nursing Track, A.A.S.",
+    "Associate Degree Nursing, LVN Transition Track, A.A.S.",
+    "Associate in Science, A.S.",
+    "Associate of Applied Science in Licensed Vocational Nursing - Transition",
+    "Associate of Applied Science in Paramedic to RN – Transition",
+    "Associate of Arts Degree",
+    "Associate of Arts General Studies, Suggested Transfer Guide for Drama",
+    "Associate of Arts General Studies, Suggested Transfer Guide for English",
+    "Associate of Arts General Studies, Suggested Transfer Guide for History",
+    "Associate of Arts General Studies, Suggested Transfer Guide for Music/Music Education",
+    "Associate of Arts General Studies, Suggested Transfer Guide for Psychology",
+    "Associate of Arts General Studies, Suggested Transfer Guide for Sociology",
+    "Associate of Arts General Studies, Suggested Transfer Guide for Spanish",
+    "Associate of Arts General Studies, Suggested Transfer Guide for Speech",
+    "Associate of Arts in Communication Studies",
+    "Associate of Arts in Criminal Justice",
+    "Associate of Arts in Music",
+    "Associate of Arts in Teaching (A.A.T.) 7 - 12, EC - 12 Other than Special Education",
+    "Associate of Arts in Teaching (A.A.T.) EC - 6, EC - 12 Special Education",
+    "Associate of Arts in Teaching Leading to Initial Texas Teacher Certification 4-8, EC-12 Special Education^",
+    "Associate of Arts in Teaching Leading to Initial Texas Teacher Certification 8-12, EC-12 Other Than Special Education^",
+    "Associate of Arts in Teaching Leading to Initial Texas Teacher Certification EC-6^",
+    "Associate of Arts in Teaching: Early Childhood through Grade 6",
+    "Associate of Science",
+    "Associate of Science Degree",
+    "Associate of Science General Studies, Suggested Transfer Guide for Accounting",
+    "Associate of Science General Studies, Suggested Transfer Guide for Agriculture",
+    "Associate of Science General Studies, Suggested Transfer Guide for Athletic Training",
+    "Associate of Science General Studies, Suggested Transfer Guide for Biology",
+    "Associate of Science General Studies, Suggested Transfer Guide for Business Administration",
+    "Associate of Science General Studies, Suggested Transfer Guide for Chemistry",
+    "Associate of Science General Studies, Suggested Transfer Guide for Computer Science",
+    "Associate of Science General Studies, Suggested Transfer Guide for Criminal Justice",
+    "Associate of Science General Studies, Suggested Transfer Guide for Economics",
+    "Associate of Science General Studies, Suggested Transfer Guide for Government",
+    "Associate of Science General Studies, Suggested Transfer Guide for Kinesiology/Physical Education",
+    "Associate of Science General Studies, Suggested Transfer Guide for Mathematics",
+    "Associate of Science General Studies, Suggested Transfer Guide for Physics",
+    "Associate of Science General Studies, Suggested Transfer Guide for Pre-Baccalaureate Nursing",
+    "Associate of Science General Studies, Suggested Transfer Guide for Pre-Med/Pre-Dentistry",
+    "Associate of Science General Studies, Suggested Transfer Guide for Pre-Pharmacy",
+    "Associate of Science General Studies, Suggested Transfer Guide for Pre-Veterinary Medicine",
+    "Associate of Science Health Sciences-Nursing",
+    "Associate of Science in Education",
+    "Associate of Science in Engineering",
+    "Audio Engineering A.A.S.",
+    "Audio Engineering Certificate",
+    "Audio Engineering Live Sound Track, Level 1 Certificate",
+    "Audio Engineering Studio Track, Level 1 Certificate",
+    "Audio Recording Technology, A.A.S.",
+    "Audio Recording Technology, C1",
+    "Audio Technologist, OSA",
+    "Autobody/Collision Repair Technician, C1",
+    "AutoCAD & 3-D Software",
+    "AutoCAD, OSA",
+    "Automotive Collision Repair, AAS",
+    "Automotive Collision Technology (A.A.S)",
+    "Automotive Collision Technology Advanced Certificate",
+    "Automotive Collision Technology Basic Certificate",
+    "Automotive Collision Technology Intermediate Certificate",
+    "Automotive Enhanced Skills Certificate",
+    "Automotive Level 1 Certificate",
+    "Automotive Level 2 Certificate",
+    "Automotive Metal Repair",
+    "Automotive Refinishing",
+    "Automotive Service Technician (AST) - Level 2 Certificate",
+    "Automotive Service Technology, AAS",
+    "Automotive Service Technology: Toyota Technician Education Network, AAS",
+    "Automotive Technician, C1",
+    "Automotive Technology - Advanced Automotive Certificate",
+    "Automotive Technology - Certificate (TDCJ), CERT1",
+    "Automotive Technology - Honda PACT Track, AAS",
+    "Automotive Technology - Intermediate Automotive Certificate",
+    "Automotive Technology - Maintenance & Light Repair, C1",
+    "Automotive Technology - Technician, A.A.S.",
+    "Automotive Technology - Toyota T-Ten Track, AAS",
+    "Automotive Technology (A.A.S.)",
+    "Automotive Technology A.A.S.",
+    "Automotive Technology Certificate TDCJ",
+    "Automotive Technology, A.A.S",
+    "Automotive Technology, A.A.S.",
+    "Automotive Technology, AAS",
+    "Automotive Technology, Level 1 Certificate",
+    "Automotive/Diesel Technology Basic Certificate",
+    "Aviation Maintenance Technology - Aerospace Manufacturing (A.A.S.)",
+    "Aviation Maintenance Technology - Aerospace Manufacturing Certificate",
+    "Aviation Maintenance Technology - Airframe Mechanic Certificate",
+    "Aviation Maintenance Technology - Powerplant Mechanic Certificate",
+    "Aviation Maintenance Technology (A.A.S.)",
+    "Aviation Maintenance Technology-Airframe",
+    "Aviation Maintenance Technology-Powerplant",
+    "Aviation Maintenance Technology: Airframe, AAS",
+    "Aviation Maintenance Technology: Powerplant, AAS",
+    "Bachelor of Applied Arts and Science in Computer Science",
+    "Bachelor of Applied Arts and Science in Organizational Leadership",
+    "Bachelor of Applied Arts and Sciences in Early Childhood Education and Teaching",
+    "Bachelor of Applied Technology in Medical and Health Services Management",
+    "Bachelor of Science in Nursing (RN-to-BSN)",
+    "Baker, C1",
+    "Baking and Pastry",
+    "Banking and Financial Services, AAS",
+    "Banking, Level 1 Certificate",
+    "Banking/Finance, A.A.S.",
+    "Barber",
+    "Barber, Level 1 Certificate",
+    "Basic CAD Technician",
+    "Basic Editing, OSA",
+    "Basic Fire Fighting",
+    "Basic Firefighter Certification",
+    "Basic Firefighter, C1",
+    "Basic Firefighter, Level 1 Certificate",
+    "Basic Geographic Information Systems (GIS) Skills",
+    "Basic Manufacturing / Machining, C1: Deactivated Fall 2023",
+    "Basic Peace Officer",
+    "Basic Peace Officer Academy - Level 1",
+    "Basic Peace Officer Certification",
+    "Basic Peace Officer Course",
+    "Basic Peace Officer Licensing, C1",
+    "Basic Welding Certificate Level I - Level 1",
+    "Basic Welding, Level 1 Certificate",
+    "Beverage Management I",
+    "Beverage Management II",
+    "BIOL Program Change: Additional Restricted Elective Option",
+    "Biological Science, A.S.",
+    "Biology (A.S.)",
+    "Biology Majors & Pre‐Medical Programs, A.S.",
+    "Biology, Area of Study - General Studies Electives",
+    "Biology, AS",
+    "Biology, Health Sciences Professions, A.S.",
+    "Biomedical Equipment Technology, AAS",
+    "Biotechnology (A.S.)",
+    "Biotechnology Laboratory Sciences",
+    "Biotechnology Laboratory Sciences Advanced Technical Certificate - Level 2",
+    "Biotechnology Laboratory Sciences Certificate - Level 2",
+    "Biotechnology Laboratory Sciences, AAS",
+    "Biotechnology, Level 1 Certificate",
+    "BITC AAS Program Change",
+    "BITC Program Change - AAS add course option",
+    "BITC Program Change Cert 2",
+    "BITC Program Change: Add Cert1",
+    "BITC Program Change: Add OSA",
+    "BITC Program Change: Additional Course Options in Degree and Certificates",
+    "BITC Program Change: Decrease Hours Cert2",
+    "BITC Program Changes: Update degree/certificate plans",
+    "Building Technology",
+    "Business Administration (A.S.)",
+    "Business Administration & Management Field of Study (Transfer Curriculum)",
+    "Business Administration A.A.S.",
+    "Business Administration and Management, AAS",
+    "Business Administration and Management, Bachelor’s",
+    "Business Administration Certificate",
+    "Business Administration Field of Study",
+    "Business Administration, A.S.",
+    "Business Administration: Accounting Assistant, AAS",
+    "Business Administration: Business, AAS",
+    "Business Administration: Entrepreneurship & Small Business Management, AAS",
+    "Business Administration: Fashion Merchandising, AAS",
+    "Business Administration: Management, AAS",
+    "Business Administration: Marketing, AAS",
+    "Business Field of Study, AA",
+    "Business Field of Study, Certificate",
+    "Business Foundation Certificate",
+    "Business I",
+    "Business II",
+    "Business Management",
+    "Business Management - Advanced Management & Leadership (TDCJ), Cert1",
+    "Business Management - Advanced Management & Leadership, CERT1",
+    "Business Management - Applied Business Management (TDCJ), CERT2",
+    "Business Management - Applied Business Management, CERT2",
+    "Business Management - Business Management, AAS",
+    "Business Management - Emerging Management & Leadership (TDCJ), CERT1",
+    "Business Management - Emerging Management & Leadership, CERT1",
+    "Business Management - Entrepreneurial Management (TDCJ), OSA",
+    "Business Management - Entrepreneurial Management, OSA",
+    "Business Management - Entrepreneurship, C1",
+    "Business Management - Fundamentals of Business Management (TDCJ), OSA",
+    "Business Management - Fundamentals of Business Management, OSA",
+    "Business Management - General Business, A.A.S.",
+    "Business Management - Insurance Specialist/Associate, C1",
+    "Business Management - Nonprofit Management & Leadership (TDCJ), OSA",
+    "Business Management - Nonprofit Management & Leadership, OSA",
+    "Business Management - Practical Management Skills (TDCJ), OSA",
+    "Business Management - Practical Management Skills, OSA",
+    "Business Management - Strategic Business Management (TDCJ), OSA",
+    "Business Management - Strategic Business Management, OSA",
+    "Business Management (TDCJ), A.A.S.",
+    "Business Management, A.A.S.",
+    "Business Management, Level 1 Certificate",
+    "Business Management, OSA",
+    "Business Office Support Systems, AAS",
+    "Business Technology - General Office Administration, A.A.S.",
+    "Business Technology - Human Resources/PeopleSoft Specialization - C1",
+    "Business Technology (A.A.S.)",
+    "Business Technology Banking & Finance Certificate",
+    "Business Technology Foundations Certificate",
+    "Business Technology Professional Certificate",
+    "Business Technology Systems Certificate",
+    "Business, A.A.",
+    "Business, Area of Study - General Studies Electives",
+    "Business, AS",
+    "Cardiac Electrophysiology",
+    "Cardiovascular Sonography A.A.S.",
+    "Carpentry AAS",
+    "Carpentry Certificate Level I",
+    "Carpentry Certificate Level II",
+    "Catering/Private Chef",
+    "Central Sterile Processing, Level 1 Certificate",
+    "Certified Instructional Designer",
+    "Certified Instructor",
+    "Certified Medication Aide",
+    "Certified Medication Aide Refresher",
+    "Certified Nurse Aide, (C.N.A.)",
+    "Certified Training Manager",
+    "Certified Veterinary Assistant",
+    "CHANGE rubric/prefix from PHED to KINE",
+    "Chemical Dependency Counselor, C1",
+    "Chemistry (A.S.)",
+    "Chemistry, A.S.",
+    "Chemistry, Area of Study - General Studies Electives",
+    "Chemistry, AS",
+    "Child Care Administration",
+    "Child Care Administration, OSA",
+    "Child Care Provider/Assistant Certificate",
+    "Child Care Worker Certificate",
+    "Child Care Worker Certificate - Level 1",
+    "Child Development - Administration, C1",
+    "Child Development / Early Childhood Administration Certificate, CERT1",
+    "Child Development / Early Childhood Certificate, CERT1",
+    "Child Development Associate (CDA) Training, Level 1 Certificate",
+    "Child Development Associate (CDA) Training, OSA",
+    "Child Development Name Change",
+    "Child Development, A.A.S.",
+    "Child Development, AAS",
+    "Child Development/Early Childhood - CDEC Administrator Certificate",
+    "Child Development/Early Childhood - CDEC Provider Certificate",
+    "Child Development/Early Childhood (A.A.S.)",
+    "Childhood Development A.A.",
+    "CIS - Applied Systems & Design Certificate",
+    "CIS - Computer Information Systems (A.A.S.)",
+    "CIS - Computer Networking/Cybersecurity (A.A.S.)",
+    "CIS - Cybersecurity Technician Certificate",
+    "CIS - Digital Forensics Technician Certificate",
+    "CIS - Game Design Certificate",
+    "CIS - IT Foundations Certificate",
+    "CIS - Network Technician Certificate",
+    "CIS - Software Development Certificate",
+    "CIS - Software Foundations Certificate",
+    "CIS - Web Development Foundations Certificate",
+    "Cisco Support",
+    "CISSP Information Systems Cybersecurity Professional, Level 1 Certificate",
+    "Civil Technology",
+    "Clinical Medical Assistant",
+    "Clinical Operations Management",
+    "Cloud Computing",
+    "Cloud Computing - Cloud Infrastructure Technician, Level 1 Certificate",
+    "Cloud Computing - Infrastructure, AAS",
+    "Cloud Computing - Infrastructure, Level 1 Certificate",
+    "CNC Machinist Technology",
+    "Collision Metal Technician, Level 1 Certificate",
+    "Collision Paint Technician, Level 1 Certificate",
+    "Collision Technology, AAS",
+    "Collision Technology, Level 2 Certificate",
+    "Combination Pipe Welding, C1",
+    "Commercial Music, AAS",
+    "Commercial Photography Specialist, Level 2 Certificate",
+    "Commercial Photography, AAS",
+    "Commercial Pilot",
+    "Commercial Sample Maker, C1",
+    "Communication Design - Graphic Design Track, AAS",
+    "Communication Design - User Experience Design Track, AAS",
+    "Communication Field of Study, AA",
+    "Communication Field of Study, Certificate",
+    "Communication Studies, AA",
+    "Communication Studies, Field of Study AA",
+    "Communication, Area of Study - General Studies Electives",
+    "Communications - A.S.",
+    "Communications, A.A.",
+    "Computed Tomography Certificate Program",
+    "Computer and Information Sciences, A.A.S.",
+    "Computer and Information Sciences, Level 1 Certificate",
+    "Computer Applications Assistant, Level 1 Certificate",
+    "Computer Applications Specialist, Level 2 Certificate",
+    "Computer Applications, OSA",
+    "Computer Graphics",
+    "Computer Information Systems, A.A.",
+    "Computer Information Technology, OSA",
+    "Computer Networking - Infrastructure Track (Routing and Switching), AAS",
+    "Computer Networking - Integrated Systems Track, AAS",
+    "Computer Networking Advanced Server Tech. CERT1",
+    "Computer Networking Certificate, CERT2",
+    "Computer Networking Cloud and Client-based Systems, OSA",
+    "Computer Networking Cloud Computing, OSA",
+    "Computer Networking Fundamentals, OSA",
+    "Computer Networking Introductory Tech Certificate, CERT1",
+    "Computer Networking Network Server Support, OSA",
+    "Computer Networking Troubleshooting, OSA",
+    "Computer Networking, A.A.S.",
+    "Computer Numerical Controls (CNC), A.A.S.",
+    "Computer Science",
+    "Computer Science, A.S.",
+    "Computer Science, Area of Study - General Studies Electives",
+    "Computer Science, AS",
+    "Computer Support Specialist, Level 2 Certificate",
+    "Computer Systems - Computer Support Track, AAS",
+    "Computer Systems - Information Systems Track, AAS",
+    "Computer Systems Networking - Information Technology Core, C1",
+    "Computer Systems Networking, A.A.S",
+    "Computer-Aided Drafting and Design Technology: Building/Civil Technology, AAS",
+    "Computer-Aided Drafting and Design Technology: Manufacturing Technology, AAS",
+    "Computer-Aided Drafting and Design, AAS",
+    "Computer-Aided Drafting and Design, Level 1 Certificate",
+    "Computer-Aided Drafting and Design, Level 2 Certificate",
+    "Construction Inspection Technician",
+    "Construction Management",
+    "Construction Management Technology",
+    "Construction Management Technology - General, A.A.S.",
+    "Construction Management Technology, AAS",
+    "Construction Management Technology, C1",
+    "Construction Management, AAS",
+    "Construction Management, BAS",
+    "Construction Management, OSA",
+    "Construction Manager, Level 2 Certificate",
+    "Construction Safety",
+    "Construction Safety and Management, Level 2 Certificate",
+    "Construction Safety Management, Level 1 Certificate",
+    "Construction Safety, AAS",
+    "Construction Safety, Level 1 Certificate",
+    "Construction Science, AS",
+    "Construction Technology - Electrical and Management, Level 2 Certificate",
+    "Construction Technology - Electrical Management, Level 1 Certificate",
+    "Construction Technology - Electrical, AAS",
+    "Construction Technology - Electrical, Level 1 Certificate",
+    "Construction Technology - Plumbing and Management, Level 2 Certificate",
+    "Construction Technology - Plumbing Management, Level 1 Certificate",
+    "Construction Technology - Plumbing, AAS",
+    "Construction Technology - Plumbing, Level 1 Certificate",
+    "Construction Technology Advanced Carpentry Certificate",
+    "Construction Technology Advanced Certificate",
+    "Construction Technology Basic Certificate",
+    "Construction Technology Carpentry (A.A.S.)",
+    "Construction Technology General (A.A.S.)",
+    "Construction Technology Intermediate Carpentry Certificate",
+    "Construction Technology Intermediate Certificate",
+    "Controlled Environment Agriculture, Level 1 Certificate",
+    "Core Curriculum",
+    "Core Curriculum Requirements",
+    "Corrections Certificate - Level 1",
+    "Cosmetology - Advanced Hair Techniques, Level 2 Certificate",
+    "Cosmetology - Barber Track, AAS",
+    "Cosmetology - Barber, Level 2 Certificate",
+    "Cosmetology - Cosmetology, Level 1 Certificate",
+    "Cosmetology - General Track, AAS",
+    "Cosmetology A.A.S.",
+    "Cosmetology Certificate",
+    "Cosmetology Instructor",
+    "Cosmetology Instructor, A.A.S.: Deactivated Fall 2023",
+    "Cosmetology Instructor, C1: Deactivated Fall 2023",
+    "Cosmetology Instructor, Level 1 Certificate",
+    "Cosmetology Operator, A.A.S.",
+    "Cosmetology Operator, Level 1 Certificate",
+    "Criminal Justice",
+    "Criminal Justice - Law Enforcement & Police Administration, A.A.S.",
+    "Criminal Justice - Law Enforcement, A.A.S.",
+    "Criminal Justice - Police Officer Licensing Certificate, CERT1",
+    "Criminal Justice (A.S.)",
+    "Criminal Justice A.A.",
+    "Criminal Justice A.A.S. (Law Enforcement)",
+    "Criminal Justice and Policing",
+    "Criminal Justice Field of Study",
+    "Criminal Justice Field of Study, AA",
+    "Criminal Justice Field of Study, Certificate",
+    "Criminal Justice Law Enforcement (A.A.S.)",
+    "Criminal Justice Law Enforcement Certificate",
+    "Criminal Justice Technology, AAS",
+    "Criminal Justice-Correctional Officer, OSA",
+    "Criminal Justice-Corrections Practitioner, Cert1",
+    "Criminal Justice-Corrections Professional, Cert2",
+    "Criminal Justice-Corrections, A.A.S.",
+    "Criminal Justice-Foundational Proficiency, OSA",
+    "Criminal Justice-Professional Policing, Cert2",
+    "Criminal Justice, A.A.",
+    "Criminal Justice, AA",
+    "Criminal Justice, AAS",
+    "Criminal Justice, Area of Study - General Studies Electives",
+    "Criminal Justice, Field of Study AA",
+    "Criminal Justice, OSA",
+    "Criminal Justice, Professional Policing, OSA",
+    "Culinary Arts (TDCJ), A.A.S.",
+    "Culinary Arts Baking (TDCJ), OSA",
+    "Culinary Arts Baking, OSA",
+    "Culinary Arts Certificate (TDCJ), CERT2",
+    "Culinary Arts Certificate Advanced (TDCJ), CERT1",
+    "Culinary Arts Certificate Advanced, CERT1",
+    "Culinary Arts Certificate Introduction (TDCJ), CERT1",
+    "Culinary Arts Certificate Introduction, CERT1",
+    "Culinary Arts Certificate, CERT2",
+    "Culinary Arts Fundamentals (TDCJ), OSA",
+    "Culinary Arts Fundamentals, OSA",
+    "Culinary Arts I",
+    "Culinary Arts, A.A.S.",
+    "Culinary Arts, AAS",
+    "Culinary Arts, Level 1 Certificate",
+    "Cybersecurity",
+    "Cybersecurity AAS",
+    "Cybersecurity Certificate Level 2",
+    "Cybersecurity Infrastructure Technician, Level 1 Certificate",
+    "Cybersecurity Level 1 Certificate",
+    "Cybersecurity Level 2 Certificate",
+    "Cybersecurity Option A.A.S.",
+    "Cybersecurity, A.A.S.",
+    "Cybersecurity, BAT",
+    "Cybersecurity, CERT2",
+    "Cybersecurity, Cyber AI, OSA",
+    "Cybersecurity, Cyber Analyst, Cert1",
+    "Cybersecurity, Cyber Defense Analyst, OSA",
+    "Cybersecurity, Digital Forensics, OSA",
+    "Cybersecurity, Network Security Technician, CERT1",
+    "Cybersecurity, Networking Principles, OSA",
+    "Cybersecurity, Systems and Security, OSA",
+    "Cybersecurity, Systems Programming and Security, OSA",
+    "Dance, A.A.",
+    "Dance, Area of Study - General Studies Electives",
+    "Data Management Applications for Healthcare, Level 2 Certificate",
+    "Data Science, A.A.S.",
+    "Database Concepts, OSA",
+    "Database Development Fundamentals, Level 1 Certificate",
+    "Database Development Professional, Level 2 Certificate",
+    "Database Development, AAS",
+    "Database Programming Certificate",
+    "Database Programming Foundations, OSA",
+    "Database Programming Option A.A.S.",
+    "Dental Assisting, C1",
+    "Dental Assisting, Level 1 Certificate",
+    "Dental Hygiene",
+    "Dental Hygiene (A.A.S.)",
+    "Dental Hygiene, A.A.S.",
+    "Dental Hygiene, AAS",
+    "Diagnostic Cardiovascular Sonography-Electrocardiography, OSA",
+    "Diagnostic Cardiovascular Sonography, Adult Echocardiography, A.A.S.",
+    "Diagnostic Cardiovascular Sonography, Pediatric Echocardiography, A.A.S.",
+    "Diagnostic Cardiovascular Sonography, Vascular Sonography, A.A.S.",
+    "Diagnostic Medical Sonography - Cardiac Track, AAS",
+    "Diagnostic Medical Sonography - General Track, AAS",
+    "Diagnostic Medical Sonography A.A.S.",
+    "Diagnostic Medical Sonography, A.A.S.",
+    "Diagnostic Medical Sonography, AAS",
+    "Diesel",
+    "Diesel Service Technician, C1",
+    "Diesel Technician",
+    "Dietary Manager",
+    "Digital Communication - General, C1",
+    "Digital Communication - Mobile Application, C1",
+    "Digital Communication, A.A.S.",
+    "Digital Communications",
+    "Digital Gaming & Simulation for Artists, A.A.S.",
+    "Digital Gaming & Simulation for Programmers, A.A.S.",
+    "Digital Marketing, C1",
+    "Digital Marketing, Level 1 Certificate",
+    "Drafting - Drafting Technician Certificate",
+    "Drafting (A.A.S.)",
+    "Drafting & Design Engineering Technology - General, C1",
+    "Drafting & Design Engineering Technology (TDCJ), A.A.S.",
+    "Drafting & Design Engineering Technology Cert. (TDCJ), CERT2",
+    "Drafting & Design Engineering Technology Cert., CERT2",
+    "Drafting & Design Engineering Technology Introductory Certificate (TDCJ), CERT1",
+    "Drafting & Design Engineering Technology Introductory Certificate, CERT1",
+    "Drafting & Design Engineering Technology, A.A.S.",
+    "Drafting and Design Engineering Advanced Certificate (TDCJ), CERT1",
+    "Drafting and Design Engineering Advanced Certificate, CERT1",
+    "Drafting and Design Engineering Technology Advanced Technical Drafter (TDCJ), OSA",
+    "Drafting and Design Engineering Technology Advanced Technical Drafter, OSA",
+    "Drafting and Design Engineering Technology CADD Operator (TDCJ), OSA",
+    "Drafting and Design Engineering Technology CADD Operator, OSA",
+    "Drafting and Design Engineering Technology Technical Drafter (TDCJ), OSA",
+    "Drafting and Design Engineering Technology Technical Drafter, OSA",
+    "Drama, A.A.",
+    "Dual Credit: Certificate in Early Learning Pathway",
+    "Early Childhood - Grade 3 (EC - 3) Field of Study, AAT",
+    "Early Childhood - Grade 6 Field of Study, AAT",
+    "Early Childhood Administrator, Level 1 Certificate",
+    "Early Childhood Administrator, OSA",
+    "Early Childhood Education A.A.S.",
+    "Early Childhood Education AAS Degree",
+    "Early Childhood Educator (0-8 years), AAS",
+    "Early Childhood Educator (0-8 Years), Level 2 Certificate",
+    "Early Childhood, OSA",
+    "Economics, Area of Study - General Studies Electives",
+    "Economics, AS",
+    "Eddy Current Technician",
+    "Education (4-8 Core Subjects) Field of Study",
+    "Education (A.A.T.)",
+    "Education (EC-3 Core Subjects) Field of Study",
+    "Education (EC-6 Core Subjects) Field of Study",
+    "Education, Area of Study - General Studies Electives",
+    "Education, AS",
+    "Electrical",
+    "Electrical Line Technician, AAS",
+    "Electrical Technology - Residential, C1",
+    "Electrical Technology, A.A.S.",
+    "Electrical Technology, Commercial, C1",
+    "Electrician Helper",
+    "Electrocardiography Technician",
+    "Electromechanical Technology",
+    "Electronic Engineering Technology, AAS",
+    "Electronic Engineering Technology, Level 1 Certificate",
+    "Electronic Engineering Technology, Level 2 Certificate",
+    "Electronic Engineering Technology, OSA",
+    "Electronic Music Production, C1: Deactivated Fall 2023",
+    "Electronics Engineering Technology, Biomedical Electronics - Specialization, A.A.S.",
+    "Electronics Engineering Technology, Computer Engineering - Specialization, A.A.S.",
+    "Electronics Engineering Technology, Computer Servicing / Networks, C1",
+    "Electronics Technology",
+    "Electronics Technology: Advanced Energy Technician, AAS",
+    "Electronics Technology: Robotics and Automation, AAS",
+    "Emergency Medical Services",
+    "Emergency Medical Services - Advanced Technician, C1",
+    "Emergency Medical Services - Paramedic, C1",
+    "Emergency Medical Services Advanced Certificate, CERT1",
+    "Emergency Medical Services Paramedic Certificate, CERT1",
+    "Emergency Medical Services Professions (A.A.S.)",
+    "Emergency Medical Services Professions, AAS",
+    "Emergency Medical Services Professions, OSA",
+    "Emergency Medical Services, A.A.S.",
+    "Emergency Medical Services, AAS",
+    "Emergency Medical Services, Level 1 A-EMT Certificate",
+    "Emergency Medical Services, Level 2 Paramedic Certificate",
+    "Emergency Medical Technician",
+    "EMS Degree",
+    "EMSP Advanced Emergency Medical Technician (AEMT) Certificate",
+    "EMSP Paramedic Certificate",
+    "EMT Basic, OSA",
+    "Engine Analysis Technician",
+    "Engineering (A.S.)",
+    "Engineering A.S.",
+    "Engineering Computer Science (A.S.)",
+    "Engineering Science, A.S.",
+    "Engineering, Area of Study - General Studies Electives",
+    "Engineering, AS",
+    "English (A.A.)",
+    "English, A.A.",
+    "English, AA",
+    "English, Area of Study - General Studies Electives",
+    "Enhanced Robotics & Automation Skills Certificate",
+    "Entrepreneurship and Small Business Management I",
+    "Entrepreneurship and Small Business Management II",
+    "Entrepreneurship Certificate - FPC Bryan",
+    "Entrepreneurship Certificate - Level I",
+    "Entrepreneurship, Level 1 Certificate",
+    "Entry Level Collision Technician, OSA",
+    "Entry Welding Certification, Level 1 Certificate",
+    "Entry-Level Automotive Technician",
+    "Entry-Level HVAC, OSA",
+    "Entry-Level Network Support, OSA",
+    "Entry-Level Welding, OSA",
+    "Environmental Health and Safety Technician",
+    "Environmental Science (A.S.)",
+    "Environmental Science, Area of Study - General Studies Electives",
+    "Equine Production and Management A.A.S.",
+    "Equine Production and Management Certificate",
+    "ESC - Advanced Animation & Game Art Production - Level 3 Certificate",
+    "ESC - Advanced Culinary Arts, Level 3 Certificate",
+    "ESC - Advanced Pastry Arts, Level 3 Certificate",
+    "ESC - Interpreting in Medical Settings, Level 3 Certificate",
+    "ESC - Motion Graphics, Level 3 Certificate",
+    "ESC - Networking Systems Professional (CCNP), Level 3 Certificate",
+    "ESC - Toyota Collision Technician, Level 3 Certificate",
+    "Event Management, C1",
+    "Express Maintenance Technician (XMT), Level 1 Certificate",
+    "Facial Specialist, C1",
+    "Facilities Maintenance AAS",
+    "Facilities Maintenance Certificate Level I",
+    "Facilities Maintenance Certificate Level II",
+    "Farm and Ranch Management, A.A.S.",
+    "Farm and Ranch Management, Level 1 Certificate",
+    "Fashion Design - Digital Design, C1",
+    "Fashion Design, A.A.S.",
+    "Fashion Image Merchandising, C1",
+    "Fashion Management & Merchandising, A.A.S.",
+    "Fashion Merchandising I",
+    "Fashion Merchandising II",
+    "Fashion Sales Associate",
+    "Field of Study - ARTS Studio Track",
+    "Field of Study ART General Studies Track",
+    "Field of Study Drama (Drama and Dramatics/Theatre Arts General Track)",
+    "Film - Screenwriting Certificate",
+    "Film Industry: Light Commercial Construction",
+    "Filmmaking - General, A.A.S.",
+    "Filmmaking, C1",
+    "Financial Lending, C1",
+    "Financial Operations, C1",
+    "Financial Services, Level 1 Certificate",
+    "Fire & Arson Investigation, A.A.S.",
+    "Fire Academy",
+    "Fire Investigator",
+    "Fire Officer Candidate, OSA",
+    "Fire Officer, C1",
+    "Fire Officer, Level 1 Certificate",
+    "Fire Protection - Basic Firefighter Certificate",
+    "Fire Protection and Safety Technology/Technician A.A.S.",
+    "Fire Protection Technology (A.A.S.)",
+    "Fire Protection Technology, AAS",
+    "Fire Safety and Health, AAS",
+    "Fire Science, AAS",
+    "Fire Services Administration A.A.S.",
+    "Firefighter, A.A.S.",
+    "Food and Nutrition Coach",
+    "Foodservice Operations",
+    "Foreign Languages, Area of Study - General Studies Electives",
+    "Foundations of Hotel Operations, Level 1 Certificate",
+    "Foundations of Meetings and Event Management, Level 1 Certificate",
+    "Foundations of Restaurant Operations, Level 1 Certificate",
+    "General Education",
+    "General Service Technician",
+    "General Studies (A.S.)",
+    "General Studies (TDCJ), A.A.",
+    "General Studies, A.A.",
+    "General Studies, AA",
+    "General Studies, AS",
+    "Geographic Information Science - Technician, C1",
+    "Geographic Information Science, A.A.S.",
+    "Geographic Information Systems, AAS",
+    "Geography, Area of Study - General Studies Electives",
+    "Geology, A.S.",
+    "Geology, Area of Study - General Studies Electives",
+    "Geospatial Information Science (GIS), AAS",
+    "Geospatial Information Science (GIS), Level 1 Certificate",
+    "Geospatial Information Science (GIS), Level 2 Certificate",
+    "Golf and Sports Turf Management AAS",
+    "Golf Turf Maintenance Technician Certificate",
+    "Government, A.A.",
+    "Government/Political Science, Area of Study - General Studies Electives",
+    "Graphic Communication, AAS",
+    "Graphic Design Foundations, Level 1 Certificate",
+    "Graphic Design, Level 2 Certificate",
+    "Ground Technician",
+    "Health Information Management-Medical Coding Certificate, CERT2",
+    "Health Information Management, A.A.S.",
+    "Health Information Management, AAS",
+    "Health Information Management, Level 1 Certificate",
+    "Health Information Management, Level 2 Certificate",
+    "Health Information Systems, OSA",
+    "Health Information Technology - Analysis, C1",
+    "Health Information Technology - Analysis, C1 (Part-Time)",
+    "Health Information Technology, A.A.S.",
+    "Health Information Technology, A.A.S. (Part-Time)",
+    "Health Information Technology, AAS",
+    "Health Professions - Certified Nurse Aide (CNA) Track, AAS",
+    "Health Professions - Certified Nurse Aide (CNA) Track, ICLC",
+    "Health Professions - Certified Nurse Aide (CNA) Track, Level 1 Certificate",
+    "Health Professions - Electrocardiograph Technician (EKG) Track, AAS",
+    "Health Professions - Electrocardiograph Technician (EKG) Track, ICLC",
+    "Health Professions - Electrocardiograph Technician (EKG) Track, Level 1 Certificate",
+    "Health Professions - Patient Care Technician (PCT) Track, AAS",
+    "Health Professions - Patient Care Technician (PCT) Track, ICLC",
+    "Health Professions - Patient Care Technician (PCT) Track, Level 1 Certificate",
+    "Health Professions - Phlebotomy Technician (PHLEB) Track, AAS",
+    "Health Professions - Phlebotomy Technician (PHLEB) Track, ICLC",
+    "Health Professions - Phlebotomy Technician (PHLEB) Track, Level 1 Certificate",
+    "Health Science, A.S.",
+    "Healthcare Management Specialist I",
+    "Healthcare Management Specialist II",
+    "Healthcare Management, AAS",
+    "Healthcare Management, B.A.S.",
+    "Healthy Meal Planning",
+    "Heat, Ventilation, and Air Conditioning, A.A.S.",
+    "Heat, Ventilation, and Air Conditioning, Level 1 Certificate",
+    "Heating and Air Conditioning",
+    "Heating, Air Conditioning & Refrigeration, A.A.S.",
+    "Heating, Air Conditioning and Refrigeration Technology: Commercial HVAC/R Technician, AAS",
+    "Heating, Air Conditioning and Refrigeration Technology: Residential HVAC/R Technician, AAS",
+    "Heavy Line Technician",
+    "Heavy Vehicle & Industrial Technology-Heavy Equipment - Specialization, A.A.S.",
+    "Heavy Vehicle & Industrial Technology, A.A.S.",
+    "Help Desk Support, OSA",
+    "High School (Grades 8-12), AAT",
+    "Histologic Technician, A.A.S.",
+    "History Field of Study",
+    "History, A.A.",
+    "History, Area of Study - General Studies Electives",
+    "Histotechnology A.A.S.",
+    "Horticulture",
+    "Horticulture (A.S.)",
+    "Horticulture, AAS",
+    "Hospitality and Food Service Management - Hotel / Restaurant Management Track, AAS",
+    "Hospitality and Food Service Management - Meetings and Event Management Track, AAS",
+    "Hospitality and Foodservice Management, Level 2 Certificate",
+    "Hospitality Management, A.A.S.",
+    "Hospitality Management: Food Service Management, AAS",
+    "Hospitality Management: Hospitality/Travel and Tourism Management, AAS",
+    "Hospitality Management: Meeting and Event Planning/Convention and Group Management, AAS",
+    "Hospitality/Hotel Supervision",
+    "Hospitality/Travel & Tourism Supervision",
+    "Human Resources Management and Organizational Management, AAS",
+    "Human Resources Management, AAS",
+    "Human Resources Specialist I",
+    "Human Resources Specialist II",
+    "Human Resources, Level 1 Certificate",
+    "Human Service Provider A.A.S.",
+    "Human Service Technology, A.A.S.",
+    "HVAC (Heating, Ventilation, Air Conditioning), AAS",
+    "HVAC Commercial Servicing Certification, Level 2 Certificate",
+    "HVAC Installer",
+    "HVAC Residential Servicing Certification, Level 1 Certificate",
+    "HVAC Residential Technician I",
+    "HVAC Residential Technician II",
+    "HVAC/R Commercial Technician",
+    "Industrial Automation Systems Electrical/Energy Technology, Level 1 Certificate",
+    "Industrial Automation Systems, A.A.S.",
+    "Industrial Technician I",
+    "Industrial Technician II",
+    "Industrial Technician, AAS",
+    "Information Systems Certificate",
+    "Information Systems Cybersecurity, AAS",
+    "Information Systems Cybersecurity, Level 1 Certificate",
+    "Information Systems Option A.A.S.",
+    "Information Systems Specialist, Level 1 Certificate",
+    "Information Technology: Animation for Game and Simulation",
+    "Information Technology: Cisco Support",
+    "Information Technology: Cloud Computing I",
+    "Information Technology: Cloud Computing, AAS",
+    "Information Technology: Cybersecurity Specialist",
+    "Information Technology: Cybersecurity, AAS",
+    "Information Technology: Ethical Hacking",
+    "Information Technology: Game and Simulation Programming I",
+    "Information Technology: Game and Simulation Programming II",
+    "Information Technology: Game, Simulation, and Animation Design, AAS",
+    "Information Technology: Information Technology Support",
+    "Information Technology: Network Support",
+    "Information Technology: Network Support, AAS",
+    "Information Technology: Programming I",
+    "Information Technology: Programming II",
+    "Information Technology: Programming, AAS",
+    "Information Technology: Web Applications Programming I",
+    "Information Technology: Web Applications Programming II",
+    "Information Technology: Web Applications Programming, AAS",
+    "Infrastructure Track - Datacenter Technician, Level 1 Certificate",
+    "Infrastructure Track - Infrastructure Administrator, Level 2 Certificate",
+    "Infrastructure Track - Infrastructure Technician (CCNA), Level 1 Certificate",
+    "Instrumentation & Controls Engineering Technology, A.A.S.",
+    "Insurance Industry, Level 1 Certificate",
+    "Insurance Management, AAS",
+    "Integrated Systems Track - Network Automation, Level 1 Certificate",
+    "Integrated Systems Track - Windows Administrator, Level 1 Certificate",
+    "Integrated Technology, A.A.S.",
+    "Integrated Technology, CERT2",
+    "Integrated Technology, Cloud Computing, OSA",
+    "Integrated Technology, Cloud- and Client-based Systems, OSA",
+    "Integrated Technology, Data Analytics, OSA",
+    "Integrated Technology, Integrated Programming, OSA",
+    "Integrated Technology, IT Project Management, OSA",
+    "Integrated Technology, Networking Fundamentals, OSA",
+    "Integrated Technology, Networking Tech, CERT1",
+    "Integrated Technology, Robotic Programming, OSA",
+    "Integrated Technology, Systems Security, OSA",
+    "Integrated Technology, Systems Tech, CERT1",
+    "Interdisciplinary Studies, A.A.",
+    "Interior Design, A.A.S.",
+    "Interior Design, AAS",
+    "Interior Design, Level 1 Certificate",
+    "Interior Design, Level 2 Certificate",
+    "Interior Design, OSA",
+    "International Business, A.A.S.: Deactivated Fall 2023",
+    "Interpreter Training Program (ITP), AAS",
+    "IT Support Assistant, Level 1 Certificate",
+    "Kinesiology, Area of Study - General Studies Electives",
+    "Kritser Diesel - Advanced Certificate",
+    "Kritser Diesel - Basic Certificate",
+    "Kritser Diesel - Diesel Transportation Technician (A.A.S.)",
+    "Kritser Diesel - Intermediate Certificate",
+    "Kritser Diesel (A.A.S.)",
+    "Law Enforcement, Public Administration, and Supervision, AAS",
+    "Legal Assistant, A.A.S.",
+    "Legal Studies (A.A.S.)",
+    "Legal Studies/Paralegal Professional Certificate",
+    "Library Technician",
+    "Library Technician, AAS",
+    "Licensed Vocational Nursing, Level 2 Certificate, Fall 2019 Start Date",
+    "Licensed Vocational Nursing, Level 2 Certificate, Fall 2020 Start Date",
+    "Licensed Vocational Nursing, Level 2 Certificate, Spring 2020 Start Date",
+    "Licensed Vocational Nursing, Level 2 Certificate, Spring 2021 Start Date",
+    "Line Technician",
+    "Liquid Penetrant / Magnetic Particle Technician",
+    "Live Event Technology, A.A.S.",
+    "Live Event Technology, Audio Production, OSA",
+    "Live Event Technology, CERT1",
+    "Live Event Technology, CERT2",
+    "Live Event Technology, Engineering Solutions, OSA",
+    "Logistics & Global Supply Chain Management, A.A.S.",
+    "Logistics and Supply Chain Management, AAS",
+    "Logistics Training - Truck Driving",
+    "Logistics, Advanced Enterprise Resource Planning, OSA",
+    "Logistics, Advanced Logistics Management, OSA",
+    "Logistics, Basic Logistics Management, OSA",
+    "Logistics, Basic Materials and Warehouse Management, OSA",
+    "Logistics, Level 1 Certificate",
+    "Logistics, Materials and Supply Chain Certificate, CERT1",
+    "Logistics, Materials and Supply Chain Certificate, CERT2",
+    "Logistics, Materials, and Supply Chain Management, A.A.S.",
+    "Long Term Care Administration",
+    "LVN to RN Bridge Program, AAS",
+    "LVN Transition to Professional Nursing Practice, A.A.S.",
+    "Machining Fundamentals Certificate",
+    "Machining Technology (A.A.S.)",
+    "Machining Technology Advanced Certificate",
+    "Machining Technology, A.A.S.: Deactivated Fall 2023",
+    "Machining, Level 1 Certificate",
+    "Maintenance & Light Repair Technician (MLR) - Level 1 Certificate",
+    "Mammography Certificate Program",
+    "Management - Business Management (A.A.S.)",
+    "Management - Business Management Advanced Certificate",
+    "Management - Business Management Basic Certificate",
+    "Management - Business Management Intermediate Certificate",
+    "Management - Business Management Marketable Skills Certificate",
+    "Management I",
+    "Management II",
+    "Manufacturing Engineering Technology, A.A.S.",
+    "Manufacturing Technology",
+    "Marketing",
+    "Marketing - General, A.A.S.",
+    "Marketing, AAS",
+    "Marketing, Advertising and Sales, A.A.S.",
+    "Marketing, Advertising and Sales, Advanced Cert1",
+    "Marketing, Advertising and Sales, Advanced Marketing OSA",
+    "Marketing, Advertising and Sales, Cert2",
+    "Marketing, Advertising and Sales, Customer Service OSA",
+    "Marketing, Advertising and Sales, Digital Marketing OSA",
+    "Marketing, Advertising and Sales, Introduction Cert1",
+    "Marketing, Advertising and Sales, Sales and Retail OSA",
+    "Mass Communication A.A.",
+    "Mass Media (A.A.S.)",
+    "Mass Media (A.S.)",
+    "Mass Media Advanced Certificate",
+    "Mass Media Online Marketing Certificate",
+    "Mass Media Production Certificate",
+    "Mass Media Recording Arts Certificate",
+    "Massage Therapy",
+    "Mathematics (A.S.)",
+    "Mathematics, A.S.",
+    "Mathematics, Area of Study - General Studies Electives",
+    "Mechatronics Technology",
+    "Medical Assistant",
+    "Medical Assisting (MA), AAS",
+    "Medical Assisting (MA), Level 1 Certificate",
+    "Medical Assisting, Level 1 Certificate",
+    "Medical Coder",
+    "Medical Coding and Billing, Level 1 Certificate",
+    "Medical Laboratory Technician, A.A.S.",
+    "Medical Laboratory Technician, AAS",
+    "Medical Laboratory Technology (A.A.S.)",
+    "Medical Laboratory Technology A.A.S.",
+    "Medical Office Support, Level 1 Certificate",
+    "Medical Scribe, OSA",
+    "Medical Technology",
+    "Medicine",
+    "Meeting & Event Planning/Convention & Group Management",
+    "Meetings and Event Management, Level 2 Certificate",
+    "Mental Health & Addiction Counseling, Co-Occurring Basic Skills, OSA",
+    "Mental Health and Addiction Counseling (TDCJ), A.A.S.",
+    "Mental Health and Addiction Counseling Certificate (TDCJ), CERT2",
+    "Mental Health and Addiction Counseling Certificate, CERT2",
+    "Mental Health and Addiction Counseling Enhanced Skills, CERT3",
+    "Mental Health and Addiction Counseling, A.A.S.",
+    "Mental Health and Addiction Counseling, Co-Occurring Basic Skills, OSA",
+    "Mental Health and Addiction Counseling, Counseling Recovery Technician Certificate (TDCJ), CERT1",
+    "Mental Health and Addiction Counseling, Counseling Recovery Technician Certificate, CERT1",
+    "Mental Health and Human Services, AAS",
+    "Mental Health Substance Abuse Counseling, AAS",
+    "Middle Grades (Grades 4-8) Field of Study, AAT",
+    "Multidisciplinary Studies, A.A.",
+    "Music - Instrumental Concentration, A.A.",
+    "Music - Musical Theatre Concentration, A.A.",
+    "Music - Voice Concentration, A.A.",
+    "Music (A.S.)",
+    "Music Business - Administration - Specialization, A.A.S",
+    "Music Business, Level 2 Certificate",
+    "Music Field of Study",
+    "Music, A.A.",
+    "Music, Area of Study - General Studies Electives",
+    "Networking Technology",
+    "Neurodiagnostic Technology Advanced Technical Certificate, ATC",
+    "Neurodiagnostic Technology, A.A.S",
+    "Nondestructive Inspection, Testing and Evaluation, AAS",
+    "Nondestructive Testing Technician",
+    "Nuclear Medicine (A.A.S.)",
+    "Nuclear Medicine Technology, A.A.S.",
+    "Nursing - Associate Degree Nursing (ADN) (A.A.S.)",
+    "Nursing - Vocational Nursing Certificate",
+    "Nursing (ADN), A.A.S.",
+    "Nursing (RN), AAS",
+    "Nursing (RN), BSN",
+    "Nursing Assistant Certificate, CERT1",
+    "Nursing Field of Study",
+    "Nursing Transition (LVN-to-ADN), A.A.S.",
+    "Nutrition and Dietetics, AAS",
+    "Nutrition Specialist I",
+    "Occupational Safety and Environmental Technology, AAS",
+    "Occupational Therapy Assistant",
+    "Occupational Therapy Assistant (A.A.S.)",
+    "Occupational Therapy Assistant, A.A.S.",
+    "Occupational Therapy Assistant, A.A.S. (Part-Time)",
+    "Paralegal / Legal Assistant, AAS",
+    "Paralegal Basic Skills, OSA",
+    "Paralegal Certificate, General Practice, CERT2",
+    "Paralegal General, Level 2 Certificate",
+    "Paralegal Studies",
+    "Paralegal Studies, AAS",
+    "Paralegal, A.A.S.",
+    "Paralegal, Apprenticeship Cert1",
+    "Paralegal, Criminal Law, Cert2",
+    "Paralegal, Family Law Cert2",
+    "Paramedic Certificate",
+    "Paramedic Program",
+    "Paramedic, Level 1 Certificate",
+    "Paramedicine",
+    "Pastry Arts, A.A.S.",
+    "Pastry Arts, AAS",
+    "Pastry Arts, Level 1 Certificate",
+    "Petroleum Engineering Technology, A.A.S.",
+    "Pharmacy Technician - Advanced, Level 2 Certificate",
+    "Pharmacy Technician Certificate, CERT1",
+    "Pharmacy Technician Certificate, CERT2",
+    "Pharmacy Technician, A.A.S.",
+    "Pharmacy Technician, Level 1 Certificate",
+    "Philosophy, Area of Study - General Studies Electives",
+    "Phlebotomy Technology",
+    "Photographic Retouching",
+    "Photography (A.A.S.)",
+    "Photography (A.S.)",
+    "Photography Certificate",
+    "Photography, Area of Study - General Studies Electives",
+    "Physical Science, A.S.",
+    "Physical Therapist Assistant",
+    "Physical Therapist Assistant (A.A.S.)",
+    "Physical Therapist Assistant, A.A.S.",
+    "Physical Therapist Assistant, A.A.S. (Part-Time)",
+    "Physical Therapist Assistant, AAS",
+    "Physics (A.S.)",
+    "Physics, A.S.",
+    "Physics, Area of Study - General Studies Electives",
+    "Piano Performance",
+    "Plant Health Specialist",
+    "Political Science Field of Study, AA",
+    "Polysomnographic Technology, AAS",
+    "Polysomnographic Technology, Level 1 Certificate",
+    "Polysomnography - Sleep Medicine, A.A.S.",
+    "Pre-Nursing (A.S.)",
+    "Preschool Child Care Provider",
+    "Process Technology Certificate, CERT1",
+    "Process Technology Certificate, CERT2",
+    "Process Technology, A.A.S.",
+    "Production Specialist, Level 1 Certificate",
+    "Professional Nursing Practice, A.A.S.",
+    "Professional Pilot, AAS",
+    "Psychology (A.S.)",
+    "Psychology Field of Study",
+    "Psychology Field of Study, AA",
+    "Psychology Field of Study, Certificate",
+    "Psychology, A.A.",
+    "Psychology, A.S.",
+    "Psychology, Area of Study - General Studies Electives",
+    "Public Relations",
+    "Purchasing, Level 1 Certificate",
+    "Radio & TV Broadcasting AAS",
+    "Radio/Audio Production",
+    "Radiographic Inspector",
+    "Radiography (A.A.S.)",
+    "Radiography Technician",
+    "Radiography, A.A.S.",
+    "Radiologic Technology",
+    "Real Estate - General, A.A.S.",
+    "Real Estate Management, AAS",
+    "Real Estate Sales Agent, Level 1 Certificate",
+    "Recreation Management, Level 1 Certificate",
+    "Registered Dental Assistant",
+    "Rehabilitation Aide, OSA",
+    "Religion (A.A.)",
+    "Renewable Energy Technology",
+    "Residential or Commercial Construction Management, Level 1 Certificate",
+    "Respiratory Care (A.A.S.)",
+    "Respiratory Care A.A.S.",
+    "Respiratory Care, A.A.S.",
+    "Respiratory Care, AAS",
+    "Respiratory Therapist, A.A.S.",
+    "Retail Management",
+    "Robotics & Automation AAS",
+    "Robotics & Automation Level 1 Certificate",
+    "Robotics & Automation Level 2 Certificate",
+    "Robotics and Automation Technology, AAS",
+    "Robotics and Automation Technology, Level 1 Certificate",
+    "Robotics and Automation Technology, Level 2 Certificate",
+    "Sales and Marketing, Level 1 Certificate",
+    "School Marshal",
+    "Security Management",
+    "Sign Language - Interpreting Transliteration Technology, A.A.S.",
+    "Small Business Associate",
+    "Smart Building Technology, A.A.S.",
+    "Social Science (A.S.)",
+    "Social Work",
+    "Social Work Field of Study",
+    "Social Work, Area of Study - General Studies Electives",
+    "Sociology Field of Study",
+    "Sociology Field of Study, AA",
+    "Sociology Field of Study, Certificate",
+    "Sociology, A.A.",
+    "Sociology, Area of Study - General Studies Electives",
+    "Software Application Specialist, Level 1 Certificate",
+    "Software Development Fundamentals, Level 1 Certificate",
+    "Software Development Programming, Level 2 Certificate",
+    "Software Development, AAS",
+    "Software Development, BAT",
+    "Sonography (A.A.S.)",
+    "Special Educator (0-8 Years), OSA",
+    "Sport and Recreation Management, AAS",
+    "Sport and Recreation Management, Level 2 Certificate",
+    "Sport Management, Level 1 Certificate",
+    "Sports & Human Performance, A.A.",
+    "Sports Turf Technician Certificate",
+    "Studio Art, A.A.",
+    "Studio Production, Level 1 Certificate",
+    "Substance Abuse Counseling",
+    "Substance Abuse Counseling Certificate",
+    "Supply Chain Management, AAS",
+    "Surface Water Operator",
+    "Surgical Assisting, Advanced Technical Certificate",
+    "Surgical Technology (A.A.S.)",
+    "Surgical Technology, A.A.S.",
+    "Surgical Technology, AAS",
+    "Surgical Technology, Level 2 Certificate",
+    "Sustainable Agriculture, Level 1 Certificate",
+    "Systems Track - Systems Administrator, Level 2 Certificate",
+    "Tarrant County College Educator Preparation Program",
+    "Teaching, A.A.T.",
+    "Teaching, EC through grade 6, A.A.",
+    "Teaching, Grades 7-12, A.A.",
+    "Theatre (A.S.)",
+    "Theatre/Drama, Area of Study - General Studies Electives",
+    "Toyota General Service Technician",
+    "Toyota Service Technician",
+    "Translation & Interpretation, A.A.S.",
+    "Transportation Management",
+    "Truck Driving",
+    "TV/Video Production/Film",
+    "Ultrasound Technician",
+    "Urban Sustainable Agriculture, AAS",
+    "User Experience Design Foundations, Level 1 Certificate",
+    "User Experience Design, Level 2 Certificate",
+    "Vascular Certificate Coursework",
+    "Veterinary Technology A.A.S.",
+    "Veterinary Technology, AAS",
+    "Video Production, AAS",
+    "Video Production, Level 1 Certificate",
+    "Vocational Nursing Certificate",
+    "Vocational Nursing Certificate - Evening Program",
+    "Vocational Nursing Certificate, CERT2",
+    "Vocational Nursing Certified Nursing Assistant, OSA",
+    "Vocational Nursing Medication Aide, OSA",
+    "Vocational Nursing, Level 2 Certificate",
+    "Warehouse Management",
+    "Wastewater Operator",
+    "Water Operator",
+    "Water Resources Technician",
+    "Web Development Certificate",
+    "Web Development Foundations, OSA",
+    "Web Development Fundamentals, Level 1 Certificate",
+    "Web Development Option A.A.S.",
+    "Welding Enhanced Skills Certificate",
+    "Welding Fabrication Certification, Level 1 Certificate",
+    "Welding Fundamentals Certificate",
+    "Welding Intermediate Layout and Pipe Welding (TDCJ), OSA",
+    "Welding Level 1 Certificate",
+    "Welding Level 2 Certificate",
+    "Welding Shielded Metal Arc Welding, OSA TDCJ",
+    "Welding Technology (A.A.S.)",
+    "Welding Technology A.A.S",
+    "Welding Technology Advanced Certificate",
+    "Welding Technology Certificate, CERT1",
+    "Welding Technology Certificate, CERT2",
+    "Welding Technology Certification, Level 2 Certificate",
+    "Welding Technology Intermediate Certificate",
+    "Welding Technology, A.A.S.",
+    "Welding Technology, AAS TDCJ",
+    "Welding Technology, Cert1 TDCJ",
+    "Welding Technology, Cert2 TDCJ",
+    "Welding, A.A.S.",
+    "Welding, AAS",
+    "Welding, Intermediate Layout and Pipe Welding, OSA",
+    "Welding, Intro to Gas Tungsten Arc Welding & Shield Metal Arc Welding Pipe, OSA",
+    "Welding, Intro to Gas Tungsten Arc Welding and Shield Metal Arc Welding Pipe, OSA TDCJ",
+    "Welding, Safety and Multiple Processes, OSA",
+    "Welding, Safety and Multiple Processes, OSA TDCJ",
+    "Welding, Shielded Metal Arc Welding, OSA",
+    "Wind Energy",
+    "World Languages, A.A."
+  ]
+}

--- a/data/ut/subject-vocab.json
+++ b/data/ut/subject-vocab.json
@@ -1,0 +1,2588 @@
+{
+  "state": "ut",
+  "generated_at": "2026-06-06T15:41:40.895Z",
+  "subjects": [
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 202,
+      "section_count": 776,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "A Cappella Choir I",
+        "A Cappella Choir II",
+        "A Cappella Choir III",
+        "A Cappella Choir IV",
+        "Advanced Audio Production"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 35,
+      "section_count": 644,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "A Brief Course in Calculus",
+        "Algebraic Reasoning w/ Modeling MA",
+        "Alternative Route to Statistics for Secondary Math Teaching",
+        "Applied Statistics - (Richfield)",
+        "AR Calc. Secondary Teacher"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 43,
+      "section_count": 582,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "American Literature I HU",
+        "Children&#39;s Literature HU",
+        "Contemporary World Literature (HU)",
+        "Contemporary World Literature HU",
+        "Critical Introduction to Literature (HU)"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 41,
+      "section_count": 506,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Human Donor Dissection",
+        "Beginning Human Donor Dissection",
+        "Biological/Health Sciences Internship I",
+        "Biology I Lab LB - (Richfield)",
+        "Biology I LS - (Richfield)"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 65,
+      "section_count": 382,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "2D Surface",
+        "3D Animation &amp; Rigging",
+        "3D Design",
+        "3D Modeling &amp; Sculpting",
+        "4D Time"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 22,
+      "section_count": 283,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Chemistry of Color PS",
+        "Elementary Bioorganic Chem",
+        "Elementary Chemistry Lab LB - (Richfield)",
+        "Elementary Chemistry PS - (Richfield)",
+        "Forensic Science Lab LB"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 25,
+      "section_count": 262,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Analysis of Argument (CM)",
+        "Argumentation (WC)",
+        "Communication CO-OP/Internship",
+        "Communication Internship I",
+        "Conflict Mgmt &amp; Divers.(SS)"
+      ]
+    },
+    {
+      "prefix": "TEWT",
+      "name": "Welding",
+      "course_count": 27,
+      "section_count": 205,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Blueprint Read for Welders-AM",
+        "Flux Cored Arc Welding (FCAW) I",
+        "Flux Cored Arc Welding (FCAW) II",
+        "Flux Cored Arc Welding I-AM",
+        "Flux Cored Arc Welding II-AM"
+      ]
+    },
+    {
+      "prefix": "TESL",
+      "name": "Level",
+      "course_count": 28,
+      "section_count": 184,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Building ESL &amp; Academic Skills",
+        "Community Outreach",
+        "Foundation Listening and Speaking",
+        "Foundation Reading and Writing",
+        "International Partners"
+      ]
+    },
+    {
+      "prefix": "TEIT",
+      "name": "TEIT",
+      "course_count": 25,
+      "section_count": 179,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "A+ Core I",
+        "A+ Core II",
+        "Career &amp; Workplace Relations",
+        "Certification Test Prep I",
+        "Certification Test Prep II"
+      ]
+    },
+    {
+      "prefix": "TEAM",
+      "name": "TEAM",
+      "course_count": 29,
+      "section_count": 163,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Applied System Diagnostics",
+        "Electric Motor Control Systems",
+        "Electrical Systems",
+        "Essential Skills and Safety",
+        "HMI Programming"
+      ]
+    },
+    {
+      "prefix": "TEMA",
+      "name": "Nephi",
+      "course_count": 17,
+      "section_count": 150,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Anatomy &amp; Physiology - (Nephi Learning Center)",
+        "Assisting with Medical Specialties I",
+        "Assisting with Medical Specialties II",
+        "Clinical Procedures - (Nephi Learning Center)",
+        "Health &amp; Wellness - (Nephi Learning Center)"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 12,
+      "section_count": 149,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Behavioral Science Analytics &amp; Evaluation",
+        "Brain and Behavior",
+        "Educational Psychology",
+        "Experiential &amp; Recreational Therapeutic Practices"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 24,
+      "section_count": 143,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Applied Business Calculus",
+        "Business Careers Seminar",
+        "Business Communications(CM)",
+        "Business Computer Proficiency",
+        "Business Internships I"
+      ]
+    },
+    {
+      "prefix": "TECS",
+      "name": "Tech",
+      "course_count": 17,
+      "section_count": 135,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Adv Training and Skills - (HS Tech Ed - Kanab)",
+        "Adv. Cosmetology/Barbering Lab - (HS Tech Ed - Kanab)",
+        "Barbering Basics - (HS Tech Ed - Kanab)",
+        "Cosmetology/Barber Inter Theory - (HS Tech Ed - Kanab)",
+        "Cosmetology/Barbering Clinical I - (HS Tech Ed - Kanab)"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 20,
+      "section_count": 128,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Anatomy of a Homicide",
+        "Careers in Criminal Justice, Law, and Society",
+        "Criminal Investigations",
+        "Criminal Justice Cooperative Education",
+        "Criminal Justice Internship I"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 44,
+      "section_count": 122,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Adult Medical Nursing Care",
+        "Adult Medical Surgical Nursing Care Lab",
+        "Advanced Medical Surgical Nursing",
+        "Advanced Medical Surgical Nursing Clinical",
+        "Advanced Medical Surgical Nursing Lab"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 10,
+      "section_count": 121,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "American Hist (AI)-in Spanish",
+        "Americanization: Ethnicity, Power and Privilege (HU)",
+        "Ancient World Civilization SS",
+        "Asian History: Traditions",
+        "Colonial Latin American History"
+      ]
+    },
+    {
+      "prefix": "TEAC",
+      "name": "TEAC",
+      "course_count": 21,
+      "section_count": 119,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Air Cond &amp; Refrig Controls",
+        "Air Distribution Systems",
+        "Basic Installation Skills",
+        "Basic Refrigeration Systems",
+        "Capstone Project"
+      ]
+    },
+    {
+      "prefix": "TEMT",
+      "name": "Gunnison",
+      "course_count": 16,
+      "section_count": 109,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Print Reading - (ACT Gunnison)",
+        "CNC Lathe Basic Operation",
+        "CNC Lathe Concepts - (ACT Gunnison)",
+        "CNC Lathe Programming - (ACT Gunnison)",
+        "CNC Mill Basic Operation"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 16,
+      "section_count": 103,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Algorithms &amp; Data Structures",
+        "Computer Organization and Architecture",
+        "Data Wrangling",
+        "Digital Circuits",
+        "Discrete Structures"
+      ]
+    },
+    {
+      "prefix": "TEET",
+      "name": "Electronics",
+      "course_count": 15,
+      "section_count": 100,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "AC Electronics",
+        "Analog Electronics",
+        "Basic Electronics Fundamentals",
+        "Certified Electronics Technician",
+        "DC Electronics"
+      ]
+    },
+    {
+      "prefix": "TEMC",
+      "name": "TEMC",
+      "course_count": 13,
+      "section_count": 100,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Business Grammar",
+        "Business Writing",
+        "Coding Certification Exam Prep",
+        "Coding I",
+        "Coding II"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 11,
+      "section_count": 98,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Community-Engaged Public Health: Introduction to the Social Determinants of Health",
+        "Ethical, Social, and Legal Issues in Health Care (HR)",
+        "Form and Functions of the Human Body I",
+        "Health and Diseases: Introduction to Epidemiology",
+        "Healthcare Systems and Public Policy"
+      ]
+    },
+    {
+      "prefix": "CSIS",
+      "name": "CSIS",
+      "course_count": 23,
+      "section_count": 95,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced JavaScript and JSP",
+        "Advanced Spreadsheet Applications",
+        "Android Application Development",
+        "Apps and Applets: an Introduction to Programming",
+        "Business Computer Proficiency - Spreadsheets and Databases"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 19,
+      "section_count": 94,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Astronomy Research: Double Stars Measurements",
+        "Astronomy: Stars and Galaxies PS",
+        "College Physics I",
+        "College Physics II",
+        "College Physics Lab I"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 13,
+      "section_count": 90,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Cloud-Based Accounting Systems",
+        "Current Topics in Accounting",
+        "Federal Income Tax",
+        "Financial Accounting - (Richfield)",
+        "Financial Accounting I"
+      ]
+    },
+    {
+      "prefix": "HLAC",
+      "name": "HLAC",
+      "course_count": 31,
+      "section_count": 88,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Basketball I",
+        "Body Strength and Tone",
+        "Cardio Fitness",
+        "Cheer Squad I",
+        "CorePilatesBarre- Reformer"
+      ]
+    },
+    {
+      "prefix": "CMGT",
+      "name": "Construction",
+      "course_count": 23,
+      "section_count": 87,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Acoustic Guitar Construction",
+        "Birth of a Flute (AR)",
+        "Building Codes &amp; Inspections",
+        "Building Construction I",
+        "Building Construction II"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 53,
+      "section_count": 86,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Swimming",
+        "Archery I",
+        "Archery II",
+        "Badgerettes Dance Team",
+        "Basketball Fundamentals"
+      ]
+    },
+    {
+      "prefix": "FHS",
+      "name": "FHS",
+      "course_count": 12,
+      "section_count": 83,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Adolescent Growth &amp; Dev.",
+        "Child Development: Birth-Eight",
+        "Child Guidance",
+        "Child Guidance - Lab",
+        "Couple and Family Relationships (SS)"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 7,
+      "section_count": 83,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "American Heritage AI",
+        "Internship",
+        "Introduction to Comparative Politics (SS)",
+        "Introduction to International Politics (SS)",
+        "Introduction to U.S. Government &amp; Politics (AI)"
+      ]
+    },
+    {
+      "prefix": "NRSG",
+      "name": "Nursing",
+      "course_count": 23,
+      "section_count": 78,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Nursing",
+        "Health Assessment",
+        "Introduction to Clinical Judgement",
+        "LPN NCLEX Prep",
+        "LPN NCLEX Prep Clinical"
+      ]
+    },
+    {
+      "prefix": "TECM",
+      "name": "Gunnison",
+      "course_count": 11,
+      "section_count": 77,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Adv Composite Fabrication - (ACT Gunnison)",
+        "Autoclave Processing - (ACT Gunnison)",
+        "Basic Composite Fabrication - (ACT Gunnison)",
+        "Blueprint Reading - (ACT Gunnison)",
+        "CNC Composite Processes - (ACT Gunnison)"
+      ]
+    },
+    {
+      "prefix": "FASH",
+      "name": "FASH",
+      "course_count": 30,
+      "section_count": 75,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "20th Century Fashion",
+        "Advanced Sewing",
+        "Alterations",
+        "Apparel Analysis",
+        "Beginning Sewing"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 75,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to the Humanities (HU)"
+      ]
+    },
+    {
+      "prefix": "FLM",
+      "name": "Film",
+      "course_count": 20,
+      "section_count": 72,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Acting for Film",
+        "Advanced Video Editing And Postproduction",
+        "Beginning Film Production",
+        "Cinematography",
+        "Commercial Film Production"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 29,
+      "section_count": 70,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Analog Circuits",
+        "Analog Circuits Laboratory",
+        "Applied Ethics for Professionals",
+        "Applied Probability &amp; Statistics for Engineers",
+        "Digital Circuits"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 69,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Economic History of the United States (AI)",
+        "Economics as a Social Science (SS)",
+        "Intro to Microeconomics SS - (Richfield)",
+        "Labor Economics",
+        "Principles of Macroeconomics (SS)"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "SW",
+      "course_count": 16,
+      "section_count": 68,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Behavioral Science Analytics &amp; Evaluation",
+        "Case Management and Mental Health",
+        "Crisis Intervention",
+        "Diverse Populations",
+        "Ethics and the Social Work Professional"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 15,
+      "section_count": 67,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "ARL-Creating a Learning Environment",
+        "ARL-Instruction,Technology, Assessment, &amp; Planning",
+        "ARL-Intro to SPED",
+        "ARL-Literacy Strategies in the Content Area",
+        "ARL-Teaching Diverse Populations"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 4,
+      "section_count": 65,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Financial Mathematics (QS)",
+        "Financial Services Capstone",
+        "Introduction to Investments",
+        "Personal Finance (SS)"
+      ]
+    },
+    {
+      "prefix": "CHEF",
+      "name": "CHEF",
+      "course_count": 23,
+      "section_count": 64,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Baking I - Introduction to Baking",
+        "Baking I Lab",
+        "Baking II - Artisan Breads &amp; Pastries",
+        "Baking III - Classic European Tortes &amp; Restaurant Desserts",
+        "Catering Management"
+      ]
+    },
+    {
+      "prefix": "INTD",
+      "name": "Design",
+      "course_count": 24,
+      "section_count": 61,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Rendering",
+        "Advanced Kitchen &amp; Bath Design",
+        "Applying Feng Shui in Interior Design",
+        "Basic CAD for Interior Design",
+        "Business Practices of Interior Design"
+      ]
+    },
+    {
+      "prefix": "HFST",
+      "name": "HFST",
+      "course_count": 20,
+      "section_count": 60,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Courtship and Marriage",
+        "Creative Experiences for Children",
+        "Family Relations SS",
+        "Foundations of Nutrition LS - (Richfield)",
+        "Guidance of Young Children"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 4,
+      "section_count": 58,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Dietetics and Nutrition Science",
+        "Nutrition for the Life Cycle",
+        "Scientific Foundations of Human Nutrition (LS)",
+        "Special Topics in Nutrition/Dietetics"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 8,
+      "section_count": 56,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Business Management Cooperative Education",
+        "Business Statistics",
+        "Distribution Systems",
+        "Entrepreneurship",
+        "Human Resource Management"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 12,
+      "section_count": 53,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Archaeology Internship",
+        "Fundamentals of Archaeology",
+        "Historical Archaeology (SS)",
+        "Human Origins: Evolution and Diversity (LS)",
+        "Introduction to Anthropology SS"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 26,
+      "section_count": 53,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Amer Social Dance I - Women",
+        "Ballet II",
+        "Ballet III",
+        "Ballroom Technique I - Women",
+        "Choreography Practicum"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 11,
+      "section_count": 53,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advertising &amp; Promotions",
+        "Business Presentations",
+        "Consumerism",
+        "Customer Service (HR)",
+        "Digital Marketing"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 6,
+      "section_count": 53,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Doing Sociology: Introduction to Social Research",
+        "Gender &amp; U.S. Society (SS)",
+        "Intro to Sociology SS - (Richfield)",
+        "Marriage and Family",
+        "Modern Social Problems SS"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 14,
+      "section_count": 52,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Biogeography PS",
+        "Cartography",
+        "Earth&#39;s Environments (PS)",
+        "Exploring World Geography SS - (Richfield)",
+        "Fundamentals of Drones"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 30,
+      "section_count": 49,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Acting for Musical Theatre",
+        "Acting I: Basic Acting (AR)",
+        "Acting II - Scene Study for Stage and Screen",
+        "Basic Scenic Design",
+        "Costume Construction"
+      ]
+    },
+    {
+      "prefix": "TECD",
+      "name": "Commercial",
+      "course_count": 1,
+      "section_count": 48,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Commercial Driver&#39;s License Class A - (Delta Training Site)"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 9,
+      "section_count": 46,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Ethics &amp; Bus. Leadership HU - (Richfield)",
+        "Ethics and Values in the Contemporary World (HU)",
+        "Intercollegiate Ethics Bowl",
+        "Introduction to Environmental Ethics (HU)",
+        "Introduction to Philosophy (HU)"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 13,
+      "section_count": 43,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Dinosaurs &amp; Other Life of the Past PS",
+        "Drone Operations and Safety Certification",
+        "Fundamentals GPS/GIS Navig. - (Richfield)",
+        "Geology Field Studies I",
+        "Geology of the National Parks PS"
+      ]
+    },
+    {
+      "prefix": "EDDT",
+      "name": "EDDT",
+      "course_count": 11,
+      "section_count": 42,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "3D Modeling",
+        "Advanced AutoCAD",
+        "CNC Programming and CNC Machining Theory and Lab",
+        "Electronics Drafting",
+        "Engineering Graphics &ndash; Introduction, Principles &amp; Applications using 3D CAD Software"
+      ]
+    },
+    {
+      "prefix": "GNST",
+      "name": "GNST",
+      "course_count": 10,
+      "section_count": 41,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "College Success Skills",
+        "Dealing with Life",
+        "Designing Your Career",
+        "Fundamentals of Residence Life",
+        "Intercultural Experience Abroad I"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "EXSC",
+      "course_count": 23,
+      "section_count": 39,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Certification Exam Preparation",
+        "Designing Training Programs",
+        "Evaluation and Assessment of Fitness",
+        "Exercise Physiology",
+        "Exercise Science Internship I"
+      ]
+    },
+    {
+      "prefix": "TEEL",
+      "name": "Electrical",
+      "course_count": 5,
+      "section_count": 39,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Electrical Apprenticeship IA - (Nephi)",
+        "Electrical Apprenticeship IIA - (Nephi)",
+        "Electrical Apprenticeship IIIA - (Delta)",
+        "Electrician Apprentice IB",
+        "Electrician Apprentice IVA"
+      ]
+    },
+    {
+      "prefix": "RADS",
+      "name": "RADS",
+      "course_count": 13,
+      "section_count": 36,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Patient Care",
+        "Clinical Education I",
+        "Clinical Education III",
+        "Clinical Education IV",
+        "Intro to Radiologic Technology"
+      ]
+    },
+    {
+      "prefix": "TEAU",
+      "name": "TEAU",
+      "course_count": 15,
+      "section_count": 36,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions",
+        "Automotive Safety and Basics",
+        "Brakes",
+        "Electrical I",
+        "Electrical II"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 9,
+      "section_count": 35,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Welding and Fabrication",
+        "Advanced Welding and Fabrication Lab",
+        "Automated Welding and Fabrication",
+        "Automated Welding and Fabrication Lab",
+        "Fundamentals of Welding"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Yoga",
+      "course_count": 13,
+      "section_count": 34,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Aid and Safety",
+        "Fitness Motiv./Behav Response",
+        "Intro Group Fitness Instructor",
+        "Intro to Yoga Teacher Training",
+        "Know Greater Heroes I"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 18,
+      "section_count": 34,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Application of Functional Anatomy in Physical Therapy",
+        "Clinical Internship I",
+        "Clinical Internship II",
+        "Clinical Internship III",
+        "Implementation of Patient Care Skills in Physical Therapy"
+      ]
+    },
+    {
+      "prefix": "LS",
+      "name": "LS",
+      "course_count": 16,
+      "section_count": 33,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Bankruptcy and Collections",
+        "Computer Essentials for Paralegals",
+        "Contracts",
+        "Criminal Law and Procedure",
+        "Ethics"
+      ]
+    },
+    {
+      "prefix": "BTEC",
+      "name": "Biotechnology",
+      "course_count": 7,
+      "section_count": 31,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Applied Molecular Biology",
+        "Biomolecular Separation and Analysis",
+        "Biotechnology Experience",
+        "Cell Culture",
+        "Engineering Life: Fundamentals of Biotechnology (LS)"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "Architectural",
+      "course_count": 11,
+      "section_count": 30,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Architectural Design Workshop",
+        "Architectural Design Studio I",
+        "Architectural Rendering FA",
+        "Architecture Workshop",
+        "Basic Architectural Communication I"
+      ]
+    },
+    {
+      "prefix": "TECL",
+      "name": "Healthcare",
+      "course_count": 4,
+      "section_count": 28,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Admin Healthcare Procedures",
+        "Basic Healthcare Procedures",
+        "Clinical Lab Procedures I",
+        "Introduction to Healthcare"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 20,
+      "section_count": 27,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiopulmonary Pathophysiology",
+        "Application of Respiratory Therapy",
+        "Cardiopulmonary Structure and Function",
+        "Clinical Rotation II",
+        "Clinical Rotation III"
+      ]
+    },
+    {
+      "prefix": "AMTT",
+      "name": "Systems",
+      "course_count": 16,
+      "section_count": 24,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Aircraft Electronic Systems/Troubleshooting",
+        "Aircraft Electronic Systems",
+        "Aircraft Electronics Technician, NCATT Endorsements",
+        "Airframe Systems I - Sheet Metal &amp; Non-Metallic Structures",
+        "Airframe Systems II - Aircraft Systems"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 16,
+      "section_count": 24,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology for Occupational Therapy",
+        "Functional Anatomy",
+        "Functional Anatomy Supervised Instruction",
+        "Geriatrics",
+        "Introduction to Occupational Therapy"
+      ]
+    },
+    {
+      "prefix": "TEDT",
+      "name": "TEDT",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Basic Diesel",
+        "Basic Engine Performance",
+        "Brakes",
+        "Diesel Safety and Basics",
+        "Drivetrain"
+      ]
+    },
+    {
+      "prefix": "TEPL",
+      "name": "Plumbing",
+      "course_count": 5,
+      "section_count": 24,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Plumbing IA",
+        "Plumbing IB",
+        "Plumbing IIA",
+        "Plumbing IIIA",
+        "Plumbing IVA"
+      ]
+    },
+    {
+      "prefix": "ATMO",
+      "name": "Weather",
+      "course_count": 3,
+      "section_count": 23,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Climate Change (PS)",
+        "Mountain Weather &amp; Climate",
+        "Severe and Hazardous Weather (PS)"
+      ]
+    },
+    {
+      "prefix": "TENA",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 23,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant - (Millard High School/Post-High)"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surgical",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Surgical Procedures",
+        "Clinical Education I",
+        "Clinical Education II",
+        "Comprehensive Surgical Procedures",
+        "Introduction to Surgical Procedures I"
+      ]
+    },
+    {
+      "prefix": "ETHS",
+      "name": "ETHS",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "African Amer. Culture (SS)",
+        "Asian American Experiences (SS)",
+        "Chican* and Latin* Experiences (SS)",
+        "Introduction to Ethnic Studies (SS)",
+        "Muxeres Malcriadas: Chicana/x &amp; Latina/x Feminisms"
+      ]
+    },
+    {
+      "prefix": "MORT",
+      "name": "Embalming",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Embalming I",
+        "Embalming I Lab",
+        "Embalming II",
+        "Embalming II Lab",
+        "Funeral Service Psychology and Counseling"
+      ]
+    },
+    {
+      "prefix": "AGBS",
+      "name": "AGBS",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Agribusiness Foundations",
+        "Agriculture Computer Applications and Direct Marketing",
+        "Agriculture Internship I",
+        "Anatomy &amp; Physiology of Domestic Animals",
+        "Anatomy &amp; Physiology of Domestic Animals Lab"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "ASL",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "ASL Conversation II",
+        "ASL Fingerspelling &amp; Numbers",
+        "Beginning American Sign Language II (LN)",
+        "Beginning ASL I",
+        "Conversation I"
+      ]
+    },
+    {
+      "prefix": "CTEL",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Leadership &amp; Team Building (HR)"
+      ]
+    },
+    {
+      "prefix": "ENVS",
+      "name": "Environmental Science",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science (LS)",
+        "Environmental Science Lab"
+      ]
+    },
+    {
+      "prefix": "SLSS",
+      "name": "Become",
+      "course_count": 1,
+      "section_count": 17,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Become the Higher Learner"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Art History: Prehistory/Renaissance (HU)",
+        "Art History: Renaissance/Contemporary (HU)"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "Dental",
+      "course_count": 13,
+      "section_count": 14,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene III",
+        "Dental Anatomy",
+        "Dental Embryology/Histology",
+        "Dental Hygiene Theory I"
+      ]
+    },
+    {
+      "prefix": "SE",
+      "name": "SE",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Algorithms",
+        "Advanced Front-End Development",
+        "Back-End Web Development",
+        "Cloud Application Development",
+        "Database Systems"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Spanish",
+        "Second Semester Spanish (LN)",
+        "Third Semester Spanish"
+      ]
+    },
+    {
+      "prefix": "AR",
+      "name": "Refinishing",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Refinishing",
+        "Refinishing Skill Development"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Diverse Populations",
+        "Integrated Technology in Education",
+        "Intro to Artificial Intelligence in the Classroom",
+        "Intro to Education - (Richfield)"
+      ]
+    },
+    {
+      "prefix": "RELS",
+      "name": "RELS",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "America&#39;s RELS Landscape (HU)",
+        "Introduction to Buddhist Philosophy",
+        "World Religions (HU)"
+      ]
+    },
+    {
+      "prefix": "TEEM",
+      "name": "Emergency",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "salt-lake-community-college",
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Emergency Medical Technicians",
+        "AEMT - Advanced Emergency Medical Technician",
+        "Emergency Medical Technician"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Cybersecurity System Analyst",
+        "Introduction to Networks",
+        "Penetration Test Fundamentals",
+        "Scaling Networks in the Enterprise",
+        "Switching, Routing, and Wireless Essentials"
+      ]
+    },
+    {
+      "prefix": "FA",
+      "name": "Human",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Basic Metal Sculpting (AR)",
+        "Human Relations and Collaboration in the Performing Arts (HR)"
+      ]
+    },
+    {
+      "prefix": "MSE",
+      "name": "Microscopy",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Elements of Material Science",
+        "Fundamentals of Microscopy",
+        "Intro to Materials Sci. Engr.",
+        "Introduction to Materials Science and Engineering Lab",
+        "Introduction to Scanning Electron Microscopy"
+      ]
+    },
+    {
+      "prefix": "OLE",
+      "name": "Leadership",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Backcountry Trail Steward",
+        "Expedition Leadership",
+        "Introduction to Outdoor Leadership SS",
+        "Mountain Biking",
+        "Outdoor Leadership Business &amp; Careers"
+      ]
+    },
+    {
+      "prefix": "INTR",
+      "name": "Interpreting",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "ASL/English Interpreting III",
+        "Connections to Community I",
+        "Connections to Community III",
+        "Educational Interpreting",
+        "Ethics/Professional Standards"
+      ]
+    },
+    {
+      "prefix": "STEM",
+      "name": "Mathematics",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Mathematics and Technology (QS)",
+        "Spec Topics: STEM Bridge"
+      ]
+    },
+    {
+      "prefix": "TEPN",
+      "name": "Nursing",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Comprehensive Mental Health Nursing",
+        "Empowering Communities: The Role of LPNs in Public Health",
+        "Fundamentals of Nursing Practice",
+        "Geriatric Nursing: Enhancing Quality of Life",
+        "Introduction to Nursing Pharmacology"
+      ]
+    },
+    {
+      "prefix": "TEPT",
+      "name": "Pharmacy",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Pharm Tech Skills",
+        "Community Pharmacy Practice",
+        "Externship",
+        "Institutional Pharm Practice",
+        "Introduction to Pharmacy"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Automatic Transmission/Transaxle",
+        "Automotive Electrical/Electronic Systems III",
+        "Automotive Engine &amp; Emission Controls I",
+        "Automotive Engine &amp; Emission Controls II",
+        "Automotive Manual Drivetrain &amp; Axles"
+      ]
+    },
+    {
+      "prefix": "CM",
+      "name": "Construction",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "3D Architectural Modeling I",
+        "Architecture and Technical Drawing CAD",
+        "Building Science Fundamentals",
+        "Construction Codes and Zoning",
+        "Construction Internship I"
+      ]
+    },
+    {
+      "prefix": "DSTA",
+      "name": "DSTA",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Engine Diagnostics",
+        "Advanced Engine Performance",
+        "Diesel Systems Special Studies",
+        "Heavy Duty Repair CO-OP",
+        "Preventative Maintenance - Brakes"
+      ]
+    },
+    {
+      "prefix": "ELI",
+      "name": "Electricity",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Electricity I A",
+        "Math for the Trades (QS)"
+      ]
+    },
+    {
+      "prefix": "EE",
+      "name": "Electrical",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Engineering for Non-Majors",
+        "Fundamentals of Electrical Circuits II",
+        "Fundamentals of Engineering Electronics",
+        "Introduction to Electrical Circuits I",
+        "Introduction to Electrical Engineering and Lab Methods"
+      ]
+    },
+    {
+      "prefix": "MEEN",
+      "name": "Engineering",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Graphics &amp; Design Software",
+        "Introduction to Design in Engineering Systems",
+        "Introduction to Design in Engineering Systems Lab",
+        "Manufacturing Engineering &amp; Technology",
+        "Manufacturing Engineering &amp; Technology Lab"
+      ]
+    },
+    {
+      "prefix": "TENT",
+      "name": "Nail",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Techniques Class/Lab",
+        "Nail Technician Business Basics",
+        "Nail Technician I",
+        "Nail Technician II Clinical"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Semester",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Japanese",
+        "Second Semester Japanese (LN)",
+        "Third Semester Japanese"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "Radiography",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Codes and Procedures",
+        "Intro./Non-Destructive Testing",
+        "Radiation Safety",
+        "Radiography 1 Theory",
+        "Radiography I Lab"
+      ]
+    },
+    {
+      "prefix": "NR",
+      "name": "Natural",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Animal Identification",
+        "Intro to Natural Resources - (Richfield)",
+        "Natural Resource Internship",
+        "Pesticide Appl. Safety Cert. - (Richfield)",
+        "Wildland Plant Identification"
+      ]
+    },
+    {
+      "prefix": "OAPR",
+      "name": "Recreation",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Fall Outdoor Related Activity in Outdoor Adventure, Parks &amp; Recreation",
+        "Internship in Outdoor Adventure, Parks &amp; Recreation",
+        "Recreation Programming and Leadership",
+        "Ski Lift Maintenance Level 1",
+        "Social Psychology of Outdoor Adventure, Parks &amp; Recreation (SS)"
+      ]
+    },
+    {
+      "prefix": "TECO",
+      "name": "Carpentry",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Advanced Carpentry Concepts",
+        "Cabinet Making",
+        "Carpentry Concepts",
+        "Construction Print Reading",
+        "Introduction to Carpentry"
+      ]
+    },
+    {
+      "prefix": "AMFG",
+      "name": "Manufacturing",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Manufacturing Principles I",
+        "Automation &amp; Industrial Controls",
+        "First Year Advanced Manufacturing Apprenticeship Capstone",
+        "Orientation to Advanced Manufacturing",
+        "Second Year Advanced Manufacturing Apprenticeship Capstone"
+      ]
+    },
+    {
+      "prefix": "DST",
+      "name": "DST",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Engines &amp; Electronics",
+        "Basic Diesel",
+        "Drivetrains Gear Drives",
+        "H.D. Electrical Lighting",
+        "Specialty Training HDM"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "HVAC I A",
+        "HVAC IIA",
+        "HVAC IIIA",
+        "HVAC IVA",
+        "Math Basics for HVAC (QS)"
+      ]
+    },
+    {
+      "prefix": "IND",
+      "name": "Math",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Math for Industry (QS)",
+        "Math for Welders"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I - (Richfield)",
+        "Intermediate Spanish I",
+        "Undergraduate Tutoring"
+      ]
+    },
+    {
+      "prefix": "TEPH",
+      "name": "Phlebotomy",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy I",
+        "Phlebotomy II"
+      ]
+    },
+    {
+      "prefix": "AGTM",
+      "name": "Farm",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Agricultural Chemicals and Applications",
+        "Farm Machinery Maintenance, Management and Operation",
+        "Farm Safety",
+        "Forage and Grazing Management",
+        "Introduction to Plant Science"
+      ]
+    },
+    {
+      "prefix": "CEEN",
+      "name": "Civil",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Computational Methods",
+        "Computer-Aided Design for Civil Engineers",
+        "Engineering Economics and Management",
+        "Introduction To Civil And Environmental Engineering Design",
+        "Surveying For Civil Engineers"
+      ]
+    },
+    {
+      "prefix": "TEPM",
+      "name": "Power",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Power Equipment Engine Systems and Repair",
+        "Power Equipment Engine Fundamentals and Repair"
+      ]
+    },
+    {
+      "prefix": "VOC",
+      "name": "Cooperative",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Military",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "General Military Leadership Laboratory I",
+        "General Military Leadership Laboratory III",
+        "The Evolution of USAF Air &amp; Space Power I",
+        "The Foundations of the United States Air Force"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Chinese",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Elementary Chinese I",
+        "Elementary Chinese II",
+        "Undergraduate Tutoring"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "Circuits",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "AC and DC Circuits",
+        "Industrial Controls"
+      ]
+    },
+    {
+      "prefix": "FRN",
+      "name": "Semester",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester French",
+        "Third Semester French"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I",
+        "Undergraduate Tutoring"
+      ]
+    },
+    {
+      "prefix": "POR",
+      "name": "Portuguese",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Portuguese",
+        "Intermediate Portuguese I"
+      ]
+    },
+    {
+      "prefix": "TEDM",
+      "name": "Marketing",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Content Marketing &amp; Analytics",
+        "Email Marketing (formerly TEDM 1020)",
+        "Introduction to Marketing (formerly TEDM 1000)",
+        "Search Engine Optimization (formerly TEDM 1100)"
+      ]
+    },
+    {
+      "prefix": "CHI",
+      "name": "Semester",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Chinese",
+        "Second Semester Chinese (LN)",
+        "Third Semester Chinese"
+      ]
+    },
+    {
+      "prefix": "HON",
+      "name": "HON",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "American Identities (SS)",
+        "Honors Intermediate Writing (WC)",
+        "Intellectual Traditions: Human Experience Through Storytelling (HU)"
+      ]
+    },
+    {
+      "prefix": "INTL",
+      "name": "INTL",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Latin American Perspectives: Culture and Identity (HU)",
+        "Spc Tpc: Mexico Study Abroad",
+        "The Immigrant Experience through Literature and Film (HU)"
+      ]
+    },
+    {
+      "prefix": "LING",
+      "name": "Language",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Introduction to Language Systems HU",
+        "Language in Society HU"
+      ]
+    },
+    {
+      "prefix": "MLS",
+      "name": "MLS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to the Army and Critical Thinking",
+        "Leadership &amp; Decision Making",
+        "Military Physical Readiness"
+      ]
+    },
+    {
+      "prefix": "TEBL",
+      "name": "Bricklayer",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Bricklayer IA",
+        "Bricklayer IIA",
+        "Bricklayer IIIA"
+      ]
+    },
+    {
+      "prefix": "TELE",
+      "name": "Officer",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Law Enforcement Officer - LEO",
+        "Special Function Officer"
+      ]
+    },
+    {
+      "prefix": "TEMS",
+      "name": "TEMS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Beef Cutting I",
+        "Equipment",
+        "Introduction to Meat Services"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "Metallurgynonstructural",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Metallurgy/Nonstructural Parts",
+        "Non-structural Skill/Appl Dev"
+      ]
+    },
+    {
+      "prefix": "CHL",
+      "name": "Community",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Community and Public Health Issues",
+        "Healthcare Systems"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "Food",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Event Planning for Tourist Destinations",
+        "Food &amp; Beverage Management"
+      ]
+    },
+    {
+      "prefix": "ITL",
+      "name": "Italian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Italian",
+        "Intermediate Italian I"
+      ]
+    },
+    {
+      "prefix": "PLI",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Math for the Trades (QS)"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Introduction to Special Education"
+      ]
+    },
+    {
+      "prefix": "ARB",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Arabic I"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Applied Technical Math"
+      ]
+    },
+    {
+      "prefix": "CEGS",
+      "name": "Small",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "GS 10,000 Small Businesses"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Process",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals Of Process Engineering"
+      ]
+    },
+    {
+      "prefix": "DSD",
+      "name": "Taste",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "DSD: A Taste of Louisiana"
+      ]
+    },
+    {
+      "prefix": "HONR",
+      "name": "Intellectual",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Intellectual Traditions - (Honors)"
+      ]
+    },
+    {
+      "prefix": "KOR",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Korean"
+      ]
+    },
+    {
+      "prefix": "MCCT",
+      "name": "Product",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "Product Design Fundamentals - Rapid Prototyping via Additive Manufacturing"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Interdisciplinary",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "snow-college"
+      ],
+      "sample_titles": [
+        "Interdisciplinary Physical Science PS"
+      ]
+    },
+    {
+      "prefix": "RUS",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "salt-lake-community-college"
+      ],
+      "sample_titles": [
+        "First Semester Russian"
+      ]
+    }
+  ],
+  "program_titles": [
+    "Accounting (AS) — Certificate",
+    "Advanced Emergency Medical Technician (Certificate) — Certificate",
+    "Advanced Emergency Medical Technician: Technical Certificate",
+    "Advanced Manufacturing: AAS",
+    "Advanced Networking and Cybersecurity (Certificate) — Certificate",
+    "Aerospace/Aviation Technology Maintenance: AAS",
+    "Agribusiness (AAS) — Associate of Science",
+    "Agribusiness (AS) — Certificate",
+    "Agribusiness (Certificate) — Certificate",
+    "Aircraft Electronics: Academic Certificate",
+    "American Sign Language: AA",
+    "American Sign Language/English Interpreting: AAS",
+    "Apprenticeship Electrical Independent Technology: AAS",
+    "Apprenticeship Facilities Maintenance Technology: AAS",
+    "Apprenticeship Heating, Cooling & Refrigeration (HVAC): AAS",
+    "Apprenticeship Plumber Independent Technology: AAS",
+    "Architecture: AS",
+    "Art (AS) — Certificate",
+    "Automation Technology (Certificate) — Certificate",
+    "Automation Technology: Technical Certificate (SL Tech)",
+    "Automotive Collision Repair and Refinishing: AAS",
+    "Automotive Collision Repair: Academic Certificate",
+    "Automotive Refinishing: Academic Certificate",
+    "Automotive Technology (AAS) — Associate of Applied Science",
+    "Automotive Technology (Certificate) — Associate of Applied Science",
+    "Automotive Technology: Technical Certificate (SL Tech)",
+    "Basic Accounting (Certificate) — Certificate",
+    "Behavioral Health Technician: Academic Certificate",
+    "Behavioral Sciences (AS Meta-Major) — Certificate",
+    "Biology (AS) — Certificate",
+    "Biology: AS",
+    "Biotechnology: AS",
+    "Brick Mason: Technical Certificate (SL Tech)",
+    "Business (AS) — Certificate",
+    "Business (ASB) — Associate of Science",
+    "Business (Certificate) — Associate of Arts",
+    "Business and Music Technology (Certificate) — Associate of Arts",
+    "Business Management: AAS",
+    "Business Services (AS Meta-Major) — Certificate",
+    "Business: AA",
+    "Business: AS",
+    "Cabinetmaking and Furniture Construction: Academic Certificate",
+    "Carpentry Fundamentals (Certificate) — Certificate",
+    "Chemical Engineering (AS) — Certificate",
+    "Chemistry (AS) — Certificate",
+    "Chemistry: AS",
+    "Child Development (AS) — Certificate",
+    "Childcare Management (AAS) — Associate of Science",
+    "Civil and Environmental Engineering (AS) — Certificate",
+    "Clinical Laboratory Assistant: Technical Certificate (SL Tech)",
+    "CNC Machinist Technician: Technical Certificate (SL Tech)",
+    "Commercial Driver’s License-Class A: Technical Certificate (SL Tech)",
+    "Commercial Driver's License, Class A (Certificate) — Certificate",
+    "Commercial Music: AAS",
+    "Communication (AS and AA) — Certificate",
+    "Communication (Certificate) — Certificate",
+    "Communication and Rhetoric (AS Meta-Major) — Certificate",
+    "Communication Studies: AS",
+    "Community Health and Leadership: AS",
+    "Composites (Certificate) — Certificate",
+    "Computer Science (AS) — Certificate",
+    "Computer Science: AS",
+    "Computer Systems and Software (AS Meta-Major) — Certificate",
+    "Concrete Masonry Apprenticeship: Technical Certificate (SL Tech)",
+    "Construction Laborer: Technical Certificate (SL Tech)",
+    "Construction Management (AAS) — Associate of Science",
+    "Construction Management (AS) — Certificate",
+    "Construction Management and Sustainable Building: AAS",
+    "Construction Management: AS",
+    "Construction Technology (Certificate) — Certificate",
+    "Cosmetology (Certificate) — Certificate",
+    "Criminal Justice: AAS",
+    "Criminal Justice: AS",
+    "Criminal Justice/Corrections (AS) — Certificate",
+    "Culinary Arts: AAS",
+    "Cultural Resource Management: Academic Certificate",
+    "Dance (AS) — Certificate",
+    "Dental Hygiene: AAS",
+    "Diesel & Heavy Duty Mechanics Technology (AAS) — Associate of Science",
+    "Diesel Systems Technology: AAS",
+    "Diesel Technology (Certificate) — Certificate",
+    "Diesel Technology: Technical Certificate (SL Tech)",
+    "Digital Marketing and Analytics (Certificate) — Certificate",
+    "Early Childhood Education (AS) — Certificate",
+    "Earth and Environmental Science: AS",
+    "Economics (AS) — Certificate",
+    "Economics: AS",
+    "Education (AS) — Certificate",
+    "Education and Learning (AS Meta-Major) — Certificate",
+    "Education: AS",
+    "Electrical and Computer Engineering (AS) — Certificate",
+    "Electrical Apprenticeship (Certificate) — Certificate",
+    "Electrical Apprenticeship: Technical Certificate (SL Tech)",
+    "Electrical Engineering Essentials: Academic Certificate",
+    "Electronics Assembly Technology: Technical Certificate (SL Tech)",
+    "Electronics Technology: Technical Certificate (SL Tech)",
+    "Emergency Medical Technician (Certificate) — Certificate",
+    "Emergency Medical Technician: Technical Certificate",
+    "Engineering Design Manufacturing Technology: AAS",
+    "Engineering Design/Drafting Technology: AS",
+    "Engineering Drafting and Manufacturing Technology: Academic Certificate",
+    "Engineering: APE",
+    "English (AA) — Certificate",
+    "English Studies: AS",
+    "Entrepreneurship (Certificate) — Certificate",
+    "Equine Management (AAS) — Associate of Science",
+    "Equine Management (Certificate) — Certificate",
+    "Exercise Science (AS) — Certificate",
+    "Exercise Science / Kinesiology: AS",
+    "Family & Consumer Science Education (AS) — Certificate",
+    "Family and Human Development (AS) — Certificate",
+    "Family and Human Studies: Academic Certificate",
+    "Family and Human Studies: AS",
+    "Family Studies (Certificate) — Certificate",
+    "Farm and Ranch Management (AAS) — Associate of Science",
+    "Fashion Design and Development: AAS",
+    "Film Production Technician: AAS",
+    "Firefighter: Technical Certificate (SL Tech)",
+    "Fitness Technician: AAS",
+    "Game Design & Development: Academic Certificate",
+    "General Studies: AA",
+    "General Studies: AS",
+    "General Technology (AAS) — Associate of Science",
+    "Geographic Information Systems and Drones: AAS",
+    "Geographic Information Systems: Academic Certificate",
+    "Geography (AS) — Certificate",
+    "Geology (AS) — Certificate",
+    "Graphic Communications: Academic Certificate",
+    "Graphic Communications: AS",
+    "Health Professions (AS Meta-Major) — Certificate",
+    "History (AS) — Certificate",
+    "Hospitality Management: AS",
+    "Human Services (Certificate) — Certificate",
+    "Humanities (AA Meta-Major) — Certificate",
+    "Humanities: AA",
+    "Humanities: AS",
+    "HVACR Technician (Certificate) — Certificate",
+    "HVACR Technician: Technical Certificate (SL Tech)",
+    "Industrial Technology (AAS) — Certificate",
+    "Information Technology (Certificate) — Certificate",
+    "Information Technology: Technical Certificate (SL Tech)",
+    "Interior Design: AAS",
+    "International Studies: AA",
+    "Journalism & Digital Media: AS",
+    "Languages and Linguistics (AA Meta-Major) — Certificate",
+    "Law Enforcement Officer: Technical Certificate",
+    "Life Sciences (AS Meta-Major) — Certificate",
+    "Low Voltage Technician Apprenticeship: Technical Certificate (SL Tech)",
+    "Machining Technology (Certificate) — Certificate",
+    "Machining Technology: Technical Certificate (SL Tech)",
+    "Marketing (Certificate) — Associate of Arts",
+    "Master Automobile Service Technician: AAS",
+    "Mathematics (AS) — Certificate",
+    "Mathematics: AS",
+    "Mechanical and Industrial Engineering (AS) — Certificate",
+    "Medical Assisant (Certificate) — Certificate",
+    "Medical Assistant: Technical Certificate (SL Tech)",
+    "Medical Coding & Billing: Technical Certificate (SL Tech)",
+    "Micro-/Nanotechnology: Academic Certificate",
+    "MIDI: Academic Certificate",
+    "Mortuary Science: AAS",
+    "Music (AS) — Certificate",
+    "Music Recording Technology: Academic Certificate",
+    "Music: AS",
+    "Music: Commercial Music (BM) — Associate of Science",
+    "Nail Technician (Certificate) — Certificate",
+    "Natural Resources (AAS) — Associate of Applied Science",
+    "Natural Resources (AS) — Certificate",
+    "Natural Resources (Certificate) — Certificate",
+    "Networking and Cybersecurity (AAS) — Associate of Science",
+    "Networking and Cybersecurity (Certificate) — Certificate",
+    "Networking and Cybersecurity: Technical Certificate (SL Tech)",
+    "Non-Destructive Testing - Eddy Current: Academic Certificate",
+    "Non-Destructive Testing - Radiography: Academic Certificate",
+    "Non-Destructive Testing - Ultrasonics: Academic Certificate",
+    "Non-Destructive Testing: AAS",
+    "Nursing (ASN) — Associate of Science",
+    "Nursing Assistant (Certificate) — Certificate",
+    "Nursing Assistant: Technical Certificate (SL Tech)",
+    "Nursing: AAS",
+    "Nutrition (AS) — Certificate",
+    "Occupational Therapy Assistant: AAS",
+    "Outdoor Adventure Parks and Recreation: AS",
+    "Outdoor Entrepreneurship (Certificate) — Certificate",
+    "Outdoor Leadership (Certificate) — Certificate",
+    "Outdoor Leadership and Entrepreneurship (AS) — Certificate",
+    "Outdoor Technical Skills (Certificate) — Certificate",
+    "Paralegal Studies: AAS",
+    "Paraprofessional in Education (Certificate) — Certificate",
+    "Pharmacy Technician: Technical Certificate (SL Tech)",
+    "Philosophy (AA) — Certificate",
+    "Phlebotomy (Certificate) — Certificate",
+    "Photography Foundation: Academic Certificate",
+    "Physical Education Teaching (AS) — Certificate",
+    "Physical Science (AS Meta-Major) — Certificate",
+    "Physical Therapist Assistant: AAS",
+    "Physics (AS) — Certificate",
+    "Physics, Engineering, and Math (AS Meta-Major) — Certificate",
+    "Physics: AS",
+    "Plumbing Apprenticeship: Technical Certificate (SL Tech)",
+    "Political Science (AS) — Certificate",
+    "Political Science: AS",
+    "Power Equipment and Motorcycle Technology: Technical Certificate (SL Tech)",
+    "Practical Nursing: Technical Certificate (SL Tech)",
+    "Pre-Engineering (APE) — Associate of Science",
+    "Pre-Health Sciences: AS",
+    "Pre-Veterinary (AS) — Certificate",
+    "Precision Agriculture (AAS) — Certificate",
+    "Precision Agriculture (Certificate) — Certificate",
+    "Professional Sales: Academic Certificate",
+    "Psychology (AS) — Certificate",
+    "Psychology: AS",
+    "Radiologic Technology: AAS",
+    "Remote Aircraft Business (Certificate) — Certificate",
+    "Respiratory Therapy (AAS) — Associate of Applied Science",
+    "Respiratory Therapy: AAS",
+    "Robotics Technology: Technical Certificate (SL Tech)",
+    "Salon Business (AAS) — Associate of Science",
+    "Small Unmanned Aerial Systems: Academic Certificate",
+    "Social & Behavioral Sciences: AA",
+    "Social & Behavioral Sciences: AS",
+    "Social Sciences (AS Meta-Major) — Certificate",
+    "Social Work (AS) — Certificate",
+    "Social Work: AS",
+    "Sociology (AS) — Certificate",
+    "Software Engineering (AS) — Certificate",
+    "Software Engineering (BS) — Associate of Science",
+    "Spanish Language (AA) — Certificate",
+    "Special Function Officer: Technical Certificate",
+    "Statistics (AS) — Certificate",
+    "Strategic Communication (AS) — Certificate",
+    "Substance Use Disorder Counselor: Academic Certificate",
+    "Surgical Technology: AAS",
+    "Sustainable Building Construction: Academic Certificate",
+    "Teach/English as a Second Lang (AA) — Certificate",
+    "Teaching English as a Second Language (Certificate) — Certificate",
+    "Technical Theatre: Academic Certificate",
+    "Theater (AS) — Certificate",
+    "Theatre Arts: AS",
+    "Video or Radio Production: AAS",
+    "Visual and Performing Arts (AS Meta-Majors) — Certificate",
+    "Visual Art & Design - Animation: AS",
+    "Visual Art & Design - Fine Arts: AS",
+    "Visual Art & Design - Motion Graphics: Academic Certificate",
+    "Visual Art: AAS",
+    "Visual Studies (AFA) — Associate of Science",
+    "Web Graphic Design: Academic Certificate",
+    "Welding Fabrication & Inspection: AAS",
+    "Welding Technology (Certificate) — Certificate",
+    "Welding Technology: Technical Certificate (SL Tech)",
+    "Writing and Rhetoric (Certificate) — Certificate"
+  ]
+}

--- a/data/wa/subject-vocab.json
+++ b/data/wa/subject-vocab.json
@@ -1,0 +1,15827 @@
+{
+  "state": "wa",
+  "generated_at": "2026-06-06T15:41:41.093Z",
+  "subjects": [
+    {
+      "prefix": "BIOL&",
+      "name": "Human",
+      "course_count": 18,
+      "section_count": 3793,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Biol Science I: Majors Cellular",
+        "Biological Science II: Majors Animal",
+        "Biology for Non-majors with Lab",
+        "General Biology with Lab for Pre-Allied Health Students",
+        "Human A & P I"
+      ]
+    },
+    {
+      "prefix": "ENGL&",
+      "name": "Literature",
+      "course_count": 21,
+      "section_count": 3082,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Literature I: Haunted America",
+        "American Literature II: Landscapes, Migration, and Imaginary Homelands",
+        "American Literature III: Liberation Stories",
+        "British Literature I",
+        "British Literature II"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 160,
+      "section_count": 2773,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "19th Century Through Post-Modern Art History",
+        "3-Dimensional Design",
+        "3D Design Introduction to Sculpture",
+        "3D Digital Design 1:Intro to 3D Computer Aided Modeling",
+        "3D Digital Design 2: Advanced Modeling, Rendering and Presentation"
+      ]
+    },
+    {
+      "prefix": "MATH&",
+      "name": "Calculus",
+      "course_count": 16,
+      "section_count": 2538,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Business Calculus [M/S] [Q/SR]",
+        "Calculus I [M/S] [Q/SR]",
+        "Calculus II [M/S] [Q/SR]",
+        "Calculus III",
+        "Calculus III [M/S] [Q/SR]"
+      ]
+    },
+    {
+      "prefix": "CHEM&",
+      "name": "Chemistry",
+      "course_count": 27,
+      "section_count": 2326,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Chemical Concepts with Lab",
+        "Chemical Concepts: Your Intricate Environment",
+        "General Chemistry I W/ Lab [M/S]",
+        "General Chemistry I: Non-Lab",
+        "General Chemistry II W/ Lab [M/S]"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 124,
+      "section_count": 2023,
+      "colleges": [
+        "bates-technical-college",
+        "centralia-college",
+        "clark-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "olympic-college",
+        "peninsula-college",
+        "renton-technical-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Pipe Welding Lab",
+        "Adv Pipe Welding Lecture",
+        "Advanced Arc Welding",
+        "Advanced Arc Welding 2",
+        "Advanced Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 127,
+      "section_count": 1752,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Algebra Applications for Economics and Business",
+        "Algebra for Precalculus II",
+        "Algebra I Supported [RE]",
+        "Algebra II Supported [RE]",
+        "Algebraic Tools for Vocational Application [RE]"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 176,
+      "section_count": 1629,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Acute Health Concepts-Clinical Lab",
+        "Advanced Clinical Practicum",
+        "Advanced Concepts of Ethics & Policy in Healthcare",
+        "Advanced Med-Surg Across the Lifespan",
+        "Alterations in Health Care Needs Clinical"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 166,
+      "section_count": 1617,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chorus",
+        "Advanced Class Piano",
+        "Advanced Ear Training",
+        "Advanced Vocal Jazz",
+        "American Popular Music"
+      ]
+    },
+    {
+      "prefix": "CMST&",
+      "name": "Communication",
+      "course_count": 6,
+      "section_count": 1229,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Intercultural Communication: Diversity",
+        "Interpersonal Communication: Diversity",
+        "Introduction to Communication Studies [C]",
+        "Introduction to Media Studies: CD",
+        "Introduction to Public Speaking"
+      ]
+    },
+    {
+      "prefix": "PSYC&",
+      "name": "Psychology",
+      "course_count": 4,
+      "section_count": 1219,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "General Psychology (Diversity)",
+        "Human Sexuality: A Psychological Approach",
+        "Lifespan Developmental Psychology",
+        "Psychological Disorders [S/B]"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 139,
+      "section_count": 1136,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Academic Skills: Gaining Knowledge and Power",
+        "Accelerated Support for ENGL& 101 Success",
+        "Advanced Composition-Portfolio",
+        "Advanced Fiction Writing",
+        "Advanced Poetry Writing"
+      ]
+    },
+    {
+      "prefix": "ABE",
+      "name": "ABE",
+      "course_count": 80,
+      "section_count": 1037,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "centralia-college",
+        "highline-college",
+        "north-seattle-college",
+        "shoreline-community-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "ABE Digital Literacy I",
+        "ABE Educational Interview",
+        "ABE HS Washington State History and Civics",
+        "ABE Integrated Skills 5",
+        "ABE Integrated Skills 6"
+      ]
+    },
+    {
+      "prefix": "HIST&",
+      "name": "History",
+      "course_count": 19,
+      "section_count": 806,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "African American History: Out of Africa",
+        "History of U.S. IV",
+        "History of US I: Colonial America and the Early U.S.",
+        "History of US II: Nineteenth Century America",
+        "History of US III: The Recent American Past"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 126,
+      "section_count": 785,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "grays-harbor-college",
+        "highline-college",
+        "pierce-college-district",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Active Mindfulness",
+        "Active Weight Maintenance",
+        "Advanced Archery",
+        "Advanced Basketball Skills and Rules",
+        "Advanced Conditioning for Athletes I"
+      ]
+    },
+    {
+      "prefix": "ECED&",
+      "name": "ECED&",
+      "course_count": 13,
+      "section_count": 762,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Administration of Early Childhood Education",
+        "Child Care Basics",
+        "Curriculum Development in Early Childhood Education",
+        "ECE Practicum 1-Nurturing Relationships",
+        "Environments - Young Child: Learning Environments"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 171,
+      "section_count": 741,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Human Resource Management",
+        "Advanced Microsoft Excel [RE]",
+        "Advanced Project Management",
+        "Advertising",
+        "Applied Business Capstone"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 77,
+      "section_count": 727,
+      "colleges": [
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Gas Tungsten Arc Welding I (GTAW)",
+        "Advanced Gas Tungsten Arc Welding II",
+        "Advanced Pipe Welding",
+        "Advanced Weld Process",
+        "Alloy Fabrication"
+      ]
+    },
+    {
+      "prefix": "PHYS&",
+      "name": "Physics",
+      "course_count": 20,
+      "section_count": 704,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Engineering Phys Lab III",
+        "Engineering Physics - Electricity and Magnetism",
+        "Engineering Physics I",
+        "Engineering Physics I Laboratory",
+        "Engineering Physics I W/ Lab [M/S]"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 127,
+      "section_count": 583,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Active Directory [RE]",
+        "Advanced Data Structures",
+        "Advanced Object Oriented Programming [RE]",
+        "Agile Methodology & ePortfolio Planning",
+        "AI Prompting for Programming"
+      ]
+    },
+    {
+      "prefix": "BUS&",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 561,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Business Law and the Regulation of Business",
+        "Introduction to Business [S/B]"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 120,
+      "section_count": 558,
+      "colleges": [
+        "edmonds-college",
+        "highline-college",
+        "olympic-college",
+        "pierce-college-district",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "A+ Hardware Support",
+        "Advanced Data Recovery & Clean Room Operations",
+        "Advanced Linux/Unix",
+        "Advanced Systems",
+        "Advanced Windows Server"
+      ]
+    },
+    {
+      "prefix": "SOC&",
+      "name": "Sociology",
+      "course_count": 2,
+      "section_count": 535,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sociology (Diversity)",
+        "Social Problems: The Pursuit of Social Justice"
+      ]
+    },
+    {
+      "prefix": "POLS&",
+      "name": "POLS&",
+      "course_count": 6,
+      "section_count": 514,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Comparative Government (D) (SS)",
+        "International Relations [S/B]",
+        "Introduction to Law: United States",
+        "Introduction to Political Science",
+        "Introduction to Political Theory"
+      ]
+    },
+    {
+      "prefix": "ELA",
+      "name": "ELA",
+      "course_count": 66,
+      "section_count": 512,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "skagit-valley-college",
+        "tacoma-community-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Advanced ELA",
+        "Beginning ELA",
+        "Beginning Reading Improvement",
+        "Bridge I: Composition",
+        "Bridge II: Composition"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "Esol",
+      "course_count": 55,
+      "section_count": 489,
+      "colleges": [
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Academic ESOL composition and reading skills I",
+        "Academic ESOL composition and reading skills II",
+        "Academic reading skills",
+        "Advanced speaking and listening",
+        "English composition I"
+      ]
+    },
+    {
+      "prefix": "ACCT&",
+      "name": "Accounting",
+      "course_count": 3,
+      "section_count": 481,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Principles of Accounting I (AE)",
+        "Principles of Accounting II (AE)",
+        "Principles of Accounting III (AE)"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "IT",
+      "course_count": 105,
+      "section_count": 474,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "cascadia-college",
+        "everett-community-college",
+        "green-river-college",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "peninsula-college",
+        "renton-technical-college",
+        "tacoma-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "A+ Operating Systems",
+        "Administration of Networks",
+        "Advanced Managing & Maintaining The Pc",
+        "Advanced Networking and Network Security",
+        "Advanced Networking Technologies"
+      ]
+    },
+    {
+      "prefix": "NUTR&",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 430,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Introduction to Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "EDUC&",
+      "name": "EDUC&",
+      "course_count": 13,
+      "section_count": 423,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Child Development [S/B]",
+        "Child Development I: Birth to 8",
+        "Child, Family and Community Relationship",
+        "Diversity in Education (Pre K-12 Focus)",
+        "Exceptional Child (Introduction to Special Education)"
+      ]
+    },
+    {
+      "prefix": "ELL",
+      "name": "Level",
+      "course_count": 58,
+      "section_count": 412,
+      "colleges": [
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Academic Reading Skills",
+        "Educational Interview",
+        "Educational Interview III",
+        "ELL Community-Based Level 1",
+        "ELL Community-Based Level 2"
+      ]
+    },
+    {
+      "prefix": "SPAN&",
+      "name": "Spanish",
+      "course_count": 6,
+      "section_count": 405,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Spanish I: DIV",
+        "Spanish II: DIV",
+        "Spanish III: DIV",
+        "Spanish IV: DIV",
+        "Spanish V: DIV"
+      ]
+    },
+    {
+      "prefix": "ANTH&",
+      "name": "ANTH&",
+      "course_count": 18,
+      "section_count": 394,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Mosaic",
+        "Archaeology [S/B]",
+        "Bioanthropology w/Lab: CD",
+        "Biological Anthropology [M/S]",
+        "Cross-Cultural Medicine"
+      ]
+    },
+    {
+      "prefix": "ECON&",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 385,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Macro Economics [S/B]",
+        "Micro Economics [S/B]"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 115,
+      "section_count": 383,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "shoreline-community-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "10-Key",
+        "Accounting Applications and Analysis",
+        "Accounting Information Systems",
+        "Accounting Information Systems and Controls",
+        "Accounting Integration"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 35,
+      "section_count": 380,
+      "colleges": [
+        "bates-technical-college",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Air Balance and Duct Sizing",
+        "Basic Electricity, Magnetism",
+        "Basic First Aid and CPR",
+        "Basic Layout and Patterns",
+        "Basic Metalworking"
+      ]
+    },
+    {
+      "prefix": "COLL",
+      "name": "College",
+      "course_count": 8,
+      "section_count": 365,
+      "colleges": [
+        "bates-technical-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lower-columbia-college",
+        "olympic-college",
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "College & Career Success",
+        "College Essentials: Introduction to Clark",
+        "College Success for All",
+        "College Success Skills",
+        "Employment Portfolio Seminar"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 42,
+      "section_count": 350,
+      "colleges": [
+        "bates-technical-college",
+        "cascadia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "north-seattle-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Beginning Oral Communication Level 1",
+        "Beginning Written Communication Level 1",
+        "Community-Based Multilevel ESL",
+        "Educational Interviewing for ESL Students",
+        "English As A Second Language-Level 4A"
+      ]
+    },
+    {
+      "prefix": "ELCON",
+      "name": "ELCON",
+      "course_count": 35,
+      "section_count": 347,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Motor Controls",
+        "Advanced Projects I",
+        "Advanced Projects II",
+        "Advanced Projects III",
+        "Advanced Projects IV"
+      ]
+    },
+    {
+      "prefix": "CMST",
+      "name": "Communication",
+      "course_count": 75,
+      "section_count": 343,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Communication in Business & Technology",
+        "Advanced Public Speaking (H)",
+        "Advertising",
+        "Applied Professional Communication",
+        "Coaching and Mentoring Public Speakers"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 107,
+      "section_count": 326,
+      "colleges": [
+        "bellingham-technical-college",
+        "clark-college",
+        "grays-harbor-college",
+        "lake-washington-institute-of-technology",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "A.B.S. Brakers/Scanners",
+        "Advanced Applied Electrical",
+        "Advanced Automotive Brakes",
+        "Advanced Automotive Engine Performance",
+        "Advanced Automotive Steering and Suspension"
+      ]
+    },
+    {
+      "prefix": "MUSCA",
+      "name": "MUSCA",
+      "course_count": 96,
+      "section_count": 319,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Applied Instrument:Bass",
+        "Applied Instrument:Bassoon",
+        "Applied Instrument:Cello",
+        "Applied Instrument:Clarinet",
+        "Applied Instrument:Euphonium"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 94,
+      "section_count": 316,
+      "colleges": [
+        "bellingham-technical-college",
+        "clover-park-technical-college",
+        "grays-harbor-college",
+        "renton-technical-college",
+        "seattle-central-college",
+        "skagit-valley-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking and Pastry Lab",
+        "Advanced Breads & Pastry Theory",
+        "Advanced Culinary Methods: Meat and Seafood",
+        "Advanced Culinary Techniques",
+        "Advanced Food Service Management"
+      ]
+    },
+    {
+      "prefix": "AVP",
+      "name": "Pilot",
+      "course_count": 37,
+      "section_count": 296,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Airline Multi-Engine Crm (Crew Resource Management) I",
+        "Airline Multi-Engine Crm (Crew Resource Management) II",
+        "Certified Flight Instructor I",
+        "Certified Flight Instructor II",
+        "Certified Instrument Flight Instructor"
+      ]
+    },
+    {
+      "prefix": "ATECH",
+      "name": "ATECH",
+      "course_count": 18,
+      "section_count": 294,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Auto Work Experience",
+        "Automatic Transmission and Trans-axle",
+        "Automotive Leadership Skills 1",
+        "Automotive Leadership Skills 2",
+        "Automotive Leadership Skills 3"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 79,
+      "section_count": 292,
+      "colleges": [
+        "bellevue-college",
+        "cascadia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Laboratory Methods in Genomics",
+        "Anatomy & Physiology Prep Class",
+        "Basic Principles of Flow Cytometry",
+        "Basics of Bioinformatics",
+        "Behavioral Neuroscience"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Systems",
+      "course_count": 67,
+      "section_count": 286,
+      "colleges": [
+        "big-bend-community-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "everett-community-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Advanced Electricity",
+        "Advanced Hangar Operations & Maintenance",
+        "Advanced Rotor Systems Maintenance & Repair",
+        "Aircraft Drawings, Cleaning & Corrosion Control, Ground Operations & Servicing, and Fluid Lines & Fi",
+        "Aircraft Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "BTEC",
+      "name": "BTEC",
+      "course_count": 56,
+      "section_count": 282,
+      "colleges": [
+        "centralia-college",
+        "lower-columbia-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Data Analysis",
+        "Advanced Keyboarding & Microsoft Outlook",
+        "AI Support for Business Applications",
+        "Beginning Keyboarding & Computer Skills",
+        "Billing & Coding Exam Certification Preparation"
+      ]
+    },
+    {
+      "prefix": "ASTR&",
+      "name": "Astronomy",
+      "course_count": 4,
+      "section_count": 278,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lower-columbia-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Intro to Astronomy W/ Lab [M/S]",
+        "Stars, Galaxies and the Cosmos",
+        "Survey of Astronomy",
+        "The Solar System w/Lab"
+      ]
+    },
+    {
+      "prefix": "PHIL&",
+      "name": "Logic",
+      "course_count": 4,
+      "section_count": 271,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Critical Thinking",
+        "Introduction to Philosophy (H)",
+        "Introduction to Symbolic Logic (Symbolic Reasoning)",
+        "Traditional Logic"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 66,
+      "section_count": 263,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Work Experience",
+        "Crisis Intervention for Professionals",
+        "Evolutionary Psychology",
+        "Forensic Psychology",
+        "Fundamentals of Psychological Research [S/B]"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 60,
+      "section_count": 261,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Biomedical Ethics",
+        "Biomedical Ethics: Theory and Practice",
+        "Business Ethics Theory and Practice",
+        "Environmental Ethics",
+        "Environmental Ethics and Sustainability"
+      ]
+    },
+    {
+      "prefix": "CONST",
+      "name": "CONST",
+      "course_count": 79,
+      "section_count": 251,
+      "colleges": [
+        "clover-park-technical-college",
+        "edmonds-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Carpentry Design and Concepts",
+        "Advanced Technology for Construction I",
+        "Architectural Blueprint Reading I",
+        "AutoCAD for Construction",
+        "Basic Estimating"
+      ]
+    },
+    {
+      "prefix": "FIRES",
+      "name": "Fire",
+      "course_count": 25,
+      "section_count": 244,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Fire Service",
+        "Employment Preparation",
+        "Fire Hose and Appliances",
+        "Fire Service Applications I",
+        "Fire Service Applications II"
+      ]
+    },
+    {
+      "prefix": "MUSC&",
+      "name": "Music",
+      "course_count": 20,
+      "section_count": 242,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Ear Training 1",
+        "Ear Training 4",
+        "Ear Training 5",
+        "Ear Training 6",
+        "Ear Training II"
+      ]
+    },
+    {
+      "prefix": "BSTEC",
+      "name": "BSTEC",
+      "course_count": 46,
+      "section_count": 232,
+      "colleges": [
+        "cascadia-college",
+        "edmonds-college",
+        "highline-college",
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "10-Key Mastery",
+        "Advanced Excel Projects",
+        "Advanced Microsoft Office Projects",
+        "Advanced Word Projects",
+        "Bus Writing/Grammar for The Wkplce"
+      ]
+    },
+    {
+      "prefix": "ENVS&",
+      "name": "Environmental",
+      "course_count": 2,
+      "section_count": 227,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Environmental Science with Lab",
+        "Survey of Environmental Science: Sustaining Our Earth"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 84,
+      "section_count": 223,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "columbia-basin-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced ECE Curriculum Development",
+        "Advanced Language and Literacy Methods",
+        "Advanced Math Methods",
+        "Advanced Seminar [RE]",
+        "Art for Children"
+      ]
+    },
+    {
+      "prefix": "HAC",
+      "name": "HAC",
+      "course_count": 19,
+      "section_count": 221,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Controls & Troubleshooting",
+        "Advanced Motor Theory",
+        "Advanced Refrigeration",
+        "Basic Electricity",
+        "Basic Refrigeration I"
+      ]
+    },
+    {
+      "prefix": "GEOL&",
+      "name": "Geology",
+      "course_count": 5,
+      "section_count": 220,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Environmental Geology With Lab",
+        "Geology of The Pacific Northwest",
+        "Historical Geology: The Earth Through Time",
+        "Intro to Physical Geology W/ Lab [M/S]",
+        "Survey of Earth Science"
+      ]
+    },
+    {
+      "prefix": "DRMA",
+      "name": "DRMA",
+      "course_count": 78,
+      "section_count": 217,
+      "colleges": [
+        "bellevue-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "green-river-college",
+        "lower-columbia-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-falls-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Acting",
+        "Acting 1",
+        "Acting 2",
+        "Acting 3",
+        "Acting Contemporary Scene Study"
+      ]
+    },
+    {
+      "prefix": "TS",
+      "name": "TS",
+      "course_count": 32,
+      "section_count": 216,
+      "colleges": [
+        "everett-community-college",
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Adult Basic Math",
+        "Adult Basic Math Support",
+        "Basic Math Skills II",
+        "Essentials of Intermediate Algebra",
+        "Exploring STEM through Geometry"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 136,
+      "section_count": 215,
+      "colleges": [
+        "bellingham-technical-college",
+        "columbia-basin-college",
+        "lake-washington-institute-of-technology",
+        "peninsula-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Adv Dental Hygiene Theory & Practice Management",
+        "Advanced Dental Hygiene Clinical Practice VI",
+        "Advanced Dental Hygiene Clinical Practice VII",
+        "Advanced Dental Hygiene Practice II",
+        "Advanced Dental Hygiene Practice III"
+      ]
+    },
+    {
+      "prefix": "ENGR&",
+      "name": "Engineering",
+      "course_count": 14,
+      "section_count": 215,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "tacoma-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Construction Graphics",
+        "Dynamics",
+        "Electrical Circuits with Lab",
+        "Engineering Computations",
+        "Engineering Computer-Aided Design/VIsualization"
+      ]
+    },
+    {
+      "prefix": "MTX",
+      "name": "MTX",
+      "course_count": 25,
+      "section_count": 210,
+      "colleges": [
+        "clark-college",
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Advanced Fluid Power Systems",
+        "Advanced Programmable Logic Controllers",
+        "Basic Measurement Tools",
+        "Capstone/Final Project"
+      ]
+    },
+    {
+      "prefix": "AHE",
+      "name": "AHE",
+      "course_count": 59,
+      "section_count": 209,
+      "colleges": [
+        "bellevue-college",
+        "edmonds-college",
+        "north-seattle-college",
+        "seattle-central-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Insurance Billing",
+        "Advanced Outpatient Coding and Auditing",
+        "AHE Healthcare Provider: CPR",
+        "Anatomy & Physiology",
+        "Applied Pharmacology II"
+      ]
+    },
+    {
+      "prefix": "ART&",
+      "name": "Appreciation",
+      "course_count": 1,
+      "section_count": 208,
+      "colleges": [
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation: The World of Art"
+      ]
+    },
+    {
+      "prefix": "PAED",
+      "name": "Parent",
+      "course_count": 21,
+      "section_count": 205,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Parent Education Fall 1-2 Yr Old",
+        "Parent Education Fall 3-4 Year Old",
+        "Parent Education Fall 4-5 Year Old",
+        "Parent Education Fall Family",
+        "Parent Education Fall Pre-Kindergarten"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 68,
+      "section_count": 203,
+      "colleges": [
+        "bates-technical-college",
+        "bellingham-technical-college",
+        "clark-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "3D Computer Aided Design",
+        "Advanced Engineering Safety",
+        "Advanced Surveying",
+        "Applied Engineering Analysis for Manufacturing",
+        "Applied Hydraulics"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "HLTH",
+      "course_count": 46,
+      "section_count": 202,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "centralia-college",
+        "clark-college",
+        "edmonds-college",
+        "everett-community-college",
+        "lower-columbia-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Skills: Office Management",
+        "Administrative Skills: Practice Finance",
+        "Case Management II",
+        "Clinical Laboratory Skills",
+        "Clinical Skills - Ambulatory"
+      ]
+    },
+    {
+      "prefix": "ASL&",
+      "name": "American",
+      "course_count": 6,
+      "section_count": 198,
+      "colleges": [
+        "bellevue-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III:DIV",
+        "American Sign Language IV",
+        "American Sign Language V"
+      ]
+    },
+    {
+      "prefix": "CJ&",
+      "name": "CJ&",
+      "course_count": 6,
+      "section_count": 198,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "columbia-basin-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Criminal Law (AE)",
+        "Introduction to Corrections (AE)",
+        "Introduction to Criminal Justice in America",
+        "Introduction to Criminology",
+        "Introduction to Forensic Science (AE)"
+      ]
+    },
+    {
+      "prefix": "NATRS",
+      "name": "NATRS",
+      "course_count": 54,
+      "section_count": 196,
+      "colleges": [
+        "green-river-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Silviculture",
+        "Aerial Photos, GIS and Forest Navigation",
+        "Applications in Geographic Information Systems",
+        "Bio Invasions: Invasive Species Management",
+        "Capstone in Natural Resources Delivery"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 45,
+      "section_count": 195,
+      "colleges": [
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Cinema and Society",
+        "American Multicultural Arts Experience",
+        "American Popular Culture",
+        "Arts Magazine Publication II",
+        "Arts Magazine Publication III"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Medical",
+      "course_count": 60,
+      "section_count": 195,
+      "colleges": [
+        "big-bend-community-college",
+        "clark-college",
+        "columbia-basin-college",
+        "spokane-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Admin. Medical Assistant Office Procedures I [RE]",
+        "Admin. Medical Assistant Office Procedures II [RE]",
+        "Administrative Medical Assistant I",
+        "Administrative Medical Assistant II",
+        "Administrative Medical Assistant III"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 74,
+      "section_count": 192,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Diversity",
+        "Behavioral and Cultural Issues In Healthcare",
+        "Bodies in Society",
+        "Crime and Justice",
+        "Criminology and Delinquency"
+      ]
+    },
+    {
+      "prefix": "MEC",
+      "name": "MEC",
+      "course_count": 58,
+      "section_count": 189,
+      "colleges": [
+        "centralia-college",
+        "clover-park-technical-college",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Embedded Systems - Knowledge",
+        "Advanced Embedded Systems - Skill",
+        "Advanced Sensors and Actuators - Skill",
+        "AI and Data Analytics - Knowledge",
+        "AI and Data Analytics - Skill"
+      ]
+    },
+    {
+      "prefix": "BAK",
+      "name": "BAK",
+      "course_count": 27,
+      "section_count": 186,
+      "colleges": [
+        "renton-technical-college",
+        "seattle-central-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Artisan Bread II",
+        "Artisan Breads and Pastries",
+        "Bakery Lab II - Advanced Techniques & Leadership",
+        "Bakery Math",
+        "Baking for Special Diets"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Medical",
+      "course_count": 32,
+      "section_count": 185,
+      "colleges": [
+        "bates-technical-college",
+        "bellingham-technical-college",
+        "everett-community-college",
+        "pierce-college-district",
+        "skagit-valley-college",
+        "spokane-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrocardiography",
+        "Basic Electrocardiography",
+        "Contemporary Issues in Pre-Hospital Care",
+        "Emergency Medical Technician",
+        "Emergency Medical Technician I"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "AH",
+      "course_count": 17,
+      "section_count": 183,
+      "colleges": [
+        "clark-college",
+        "lower-columbia-college",
+        "tacoma-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Concepts of Anatomy and Physiology I",
+        "Basic Concepts of Anatomy and Physiology II",
+        "Bloodborne Pathogens in Healthcare Settings",
+        "Communication & Cultural Concepts In Health Care",
+        "First Aid/CPR/Blood-Borne Pathogen Training"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 19,
+      "section_count": 181,
+      "colleges": [
+        "edmonds-college",
+        "green-river-college",
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Advance Additive Manufacturing",
+        "Applied Hydraulics",
+        "Applied Materials for Manufacturing",
+        "Computer Integrated Manufacturing",
+        "Conventional and Computer Numerical Control (CNC) Machining Level 1"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 70,
+      "section_count": 181,
+      "colleges": [
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "olympic-college",
+        "spokane-falls-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Acute Care Lab",
+        "Advanced Physical Rehabilitation",
+        "Anatomy and Pathophysiology for The PTA I",
+        "Anatomy and Pathophysiology for The PTA II",
+        "Applied Anatomy"
+      ]
+    },
+    {
+      "prefix": "IE",
+      "name": "Level",
+      "course_count": 59,
+      "section_count": 176,
+      "colleges": [
+        "pierce-college-district",
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "IE Grammar IA (Beginning Literacy)",
+        "IE Grammar IB (Beginning Literacy)",
+        "IE Grammar IIA (Low Beginning)",
+        "IE Grammar IIB (Low Beginning)",
+        "IE Grammar IIIA (High Beginning)"
+      ]
+    },
+    {
+      "prefix": "MACH",
+      "name": "MACH",
+      "course_count": 67,
+      "section_count": 173,
+      "colleges": [
+        "bates-technical-college",
+        "bellingham-technical-college",
+        "lake-washington-institute-of-technology",
+        "spokane-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD/CAM for Machining",
+        "Advanced CNC Lathe Operation",
+        "Advanced CNC Machining",
+        "Advanced CNC Mill Operation",
+        "Advanced Print Reading"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 71,
+      "section_count": 166,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "columbia-basin-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "lower-columbia-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "shoreline-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Cooperative Field Experience-I",
+        "Adv Cooperative Field Experience-II",
+        "Adv Cooperative Field Experience-III",
+        "Adv Cooperative Field Experience-IV",
+        "Advanced Crime Analysis Techniques"
+      ]
+    },
+    {
+      "prefix": "MUSIC",
+      "name": "MUSIC",
+      "course_count": 43,
+      "section_count": 163,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Advanced Applied Jazz Piano",
+        "Advanced Applied Music Brass",
+        "Advanced Applied Music Guitar",
+        "Advanced Applied Music Percussion",
+        "Advanced Applied Music Piano"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 33,
+      "section_count": 158,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "green-river-college",
+        "highline-college",
+        "olympic-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Applied Strength of Materials for Manufacturing",
+        "Concepts of The Physical World",
+        "Discoveries In Physics",
+        "Engineering Physics I",
+        "Engineering Physics II"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 69,
+      "section_count": 157,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "centralia-college",
+        "columbia-basin-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Language and Literacy",
+        "Anti-Bias Education [RE]",
+        "Anti-Bias Education: DIV",
+        "Applications In EDUC I",
+        "Assessment"
+      ]
+    },
+    {
+      "prefix": "BTAC",
+      "name": "BTAC",
+      "course_count": 46,
+      "section_count": 156,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Advanced Excel",
+        "Advanced Keyboarding",
+        "Advanced Word",
+        "Beginning Keyboarding",
+        "Beginning Word"
+      ]
+    },
+    {
+      "prefix": "ENVS",
+      "name": "Environmental Science",
+      "course_count": 48,
+      "section_count": 155,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "columbia-basin-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "peninsula-college",
+        "seattle-central-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Applied Research in Geographic Information Systems",
+        "Applied Research in Hydrology",
+        "Applied Research in Water Quality",
+        "Applied Research in Water/Wastewater Operations",
+        "Applied Research in Watershed Restoration"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "Dental",
+      "course_count": 67,
+      "section_count": 151,
+      "colleges": [
+        "renton-technical-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Chairside Assisting",
+        "Advanced Chairside Assisting Lab",
+        "Advanced Dental Radiology",
+        "Advanced Dental Radiology Lab",
+        "Amalgam Restorations Lab"
+      ]
+    },
+    {
+      "prefix": "EM",
+      "name": "Emergency",
+      "course_count": 41,
+      "section_count": 150,
+      "colleges": [
+        "cascadia-college",
+        "edmonds-college",
+        "highline-college",
+        "peninsula-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "All Hazards Emergency Planning",
+        "Artificial Intelligence for Emergency Management",
+        "Basic Incident Command System/National Incident Mgmt System",
+        "Community Disaster Recovery & Resilience",
+        "Continuity Planning for Business and Government"
+      ]
+    },
+    {
+      "prefix": "CCS",
+      "name": "CCS",
+      "course_count": 6,
+      "section_count": 149,
+      "colleges": [
+        "edmonds-college",
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "AI in Academics and the Workplace",
+        "Career and College Success: Liberal Arts",
+        "Career Planning Seminar",
+        "Healthcare Professions Exploration",
+        "Pathways to Success"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Medical",
+      "course_count": 49,
+      "section_count": 148,
+      "colleges": [
+        "edmonds-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "olympic-college",
+        "renton-technical-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Medical Procedures",
+        "AHA Basic Life Support for Healthcare Providers and First Aid",
+        "Anatomy and Physiology I",
+        "Anatomy and Physiology II",
+        "Career and National Examination Preparation"
+      ]
+    },
+    {
+      "prefix": "TS-OD",
+      "name": "Open",
+      "course_count": 18,
+      "section_count": 148,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Academic Orientation and Planning for Open Doors",
+        "Language Arts & Literature Level 6 Open Doors-1",
+        "Language Arts and Lit Level 6 Open Doors-2",
+        "Language Arts and Literature Level 4 Open Doors",
+        "Language Arts and Literature Level 5 Open Doors"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "CAP",
+      "course_count": 47,
+      "section_count": 145,
+      "colleges": [
+        "bellingham-technical-college",
+        "clark-college",
+        "south-puget-sound-community-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Applied Math In Context",
+        "Basic Expository Writing",
+        "Basic Math",
+        "CAP Health & Fitness"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "Film",
+      "course_count": 53,
+      "section_count": 144,
+      "colleges": [
+        "big-bend-community-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "olympic-college",
+        "peninsula-college",
+        "shoreline-community-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Acting for the Camera I",
+        "Acting for the Camera II",
+        "Acting for the Camera III",
+        "Acting for the Camera IV",
+        "Advanced Cinematography"
+      ]
+    },
+    {
+      "prefix": "HSC",
+      "name": "HSC",
+      "course_count": 51,
+      "section_count": 142,
+      "colleges": [
+        "bellingham-technical-college",
+        "clover-park-technical-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "north-seattle-college",
+        "skagit-valley-college",
+        "walla-walla-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Applied Math In Context",
+        "Applied Mathematics II",
+        "Basic Communications & Technology",
+        "Civics & PNW History"
+      ]
+    },
+    {
+      "prefix": "DH",
+      "name": "DH",
+      "course_count": 46,
+      "section_count": 141,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Behavior Modification",
+        "Capstone",
+        "Cariology",
+        "Clinical Dental Hygiene Techniques I",
+        "Clinical Dental Hygiene Techniques II"
+      ]
+    },
+    {
+      "prefix": "COLLG",
+      "name": "Success",
+      "course_count": 2,
+      "section_count": 139,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "College Success",
+        "Personal and Academic Success"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 16,
+      "section_count": 139,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Econometrics",
+        "Economic Ethics",
+        "Economic Principles and Applications",
+        "Economic Trends, Issues and Policy [S/B]",
+        "Economics for Managers"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 36,
+      "section_count": 139,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advertising I",
+        "Advertising II",
+        "Branding I",
+        "Capstone I",
+        "Capstone II"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 39,
+      "section_count": 137,
+      "colleges": [
+        "bellevue-college",
+        "cascadia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "lower-columbia-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Biochemistry [M/S]",
+        "Biochemistry I",
+        "Biochemistry II",
+        "Cannabis Chemistry",
+        "Chemical Explorations"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 43,
+      "section_count": 136,
+      "colleges": [
+        "big-bend-community-college",
+        "clover-park-technical-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Advanced Automatic Transmission Service",
+        "Advanced Brake Systems",
+        "Advanced Drivability and Fuel Systems",
+        "Advanced Electrical Systems",
+        "Air Conditioning and Heating"
+      ]
+    },
+    {
+      "prefix": "RT",
+      "name": "RT",
+      "course_count": 71,
+      "section_count": 136,
+      "colleges": [
+        "bellingham-technical-college",
+        "columbia-basin-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiovascular Life Support",
+        "Advanced Cardiovascular Life Support Lab",
+        "Advanced Clinical",
+        "Advanced Pharmacology",
+        "Advanced Pulmonary Diagnostics"
+      ]
+    },
+    {
+      "prefix": "JAPN&",
+      "name": "Japanese",
+      "course_count": 6,
+      "section_count": 131,
+      "colleges": [
+        "bellevue-college",
+        "cascadia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "north-seattle-college",
+        "olympic-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Japanese I [H]",
+        "Japanese II",
+        "Japanese III",
+        "Japanese IV",
+        "Japanese V"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 24,
+      "section_count": 130,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "green-river-college",
+        "highline-college",
+        "lower-columbia-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "south-seattle-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Africa, Middle East, and Asia",
+        "Cities and Power",
+        "Economic Geography",
+        "Europe, the Americas, and Oceania",
+        "Geographic Exploration"
+      ]
+    },
+    {
+      "prefix": "DMA",
+      "name": "DMA",
+      "course_count": 43,
+      "section_count": 129,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "3D Fundamentals",
+        "3D Implementation",
+        "AI for Creative Media",
+        "Audio Storytelling & Podcasting",
+        "Beginning Digital Photography"
+      ]
+    },
+    {
+      "prefix": "EFS",
+      "name": "EFS",
+      "course_count": 16,
+      "section_count": 128,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "AC/DC Electricity: Basic Theory, Fractions & Ohm's Law",
+        "AC/DC Electricity: Electrical Power & Power Applications",
+        "AC/DC Electricity: Series Parallel & Combination Circuits",
+        "Addressable Fire SLC Systems/Design",
+        "Advanced Voice Evacuation Fire Alarm Systems"
+      ]
+    },
+    {
+      "prefix": "PHOTO",
+      "name": "Photography",
+      "course_count": 18,
+      "section_count": 128,
+      "colleges": [
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "spokane-falls-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Photography",
+        "Beginning Black and White Photography",
+        "Beginning Digital Photography",
+        "Color and Digital Photography",
+        "Color Theory: Concept and Practice"
+      ]
+    },
+    {
+      "prefix": "ES",
+      "name": "ES",
+      "course_count": 25,
+      "section_count": 127,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Body Treatments",
+        "Advanced Cosmetic Chemistry",
+        "Advanced Exfoliation",
+        "Anatomy & Physiology for Estheticians",
+        "Basic Body Treatments"
+      ]
+    },
+    {
+      "prefix": "BT",
+      "name": "BT",
+      "course_count": 31,
+      "section_count": 126,
+      "colleges": [
+        "everett-community-college",
+        "spokane-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Administrative Office Management",
+        "Administrative Professional Internship",
+        "Advanced Cooperative Field Experience I",
+        "Advanced Cooperative Field Experience II",
+        "Advanced Cooperative Field Experience III"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "SURG",
+      "course_count": 60,
+      "section_count": 126,
+      "colleges": [
+        "bellingham-technical-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "renton-technical-college",
+        "seattle-central-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Surgical Skills Lab [RE]",
+        "Blood-borne Pathogens and HIV/AIDS",
+        "Care of The Surgical Patient II",
+        "Certification Exam Prep I",
+        "Certification Exam Prep II"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 55,
+      "section_count": 125,
+      "colleges": [
+        "bates-technical-college",
+        "green-river-college",
+        "lake-washington-institute-of-technology",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Application of Occupational Therapy Assistant 1",
+        "Application of OTA Co-Op Experience 2",
+        "Applied Anatomy and Kinesiology Lab",
+        "Assistive Technology",
+        "Clinical Seminar 1"
+      ]
+    },
+    {
+      "prefix": "PARED",
+      "name": "Parent",
+      "course_count": 39,
+      "section_count": 125,
+      "colleges": [
+        "olympic-college",
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Child Development & Parenting",
+        "Confidently Parenting Your 2-Year-Old",
+        "Confidently Parenting Your 3-Year-Old",
+        "Confidently Parenting Your 4-Year-Old",
+        "Coparenting Together"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 51,
+      "section_count": 123,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "big-bend-community-college",
+        "cascadia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college",
+        "olympic-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "African-American History",
+        "African-American History From 1945: CD",
+        "African-American History to 1865: CD",
+        "American Environmental History",
+        "American Military History"
+      ]
+    },
+    {
+      "prefix": "WT",
+      "name": "Welding",
+      "course_count": 31,
+      "section_count": 123,
+      "colleges": [
+        "columbia-basin-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education Experience",
+        "Fabrication Principles Review [RE]",
+        "Fabrication Technique I [RE]",
+        "Fabrication Technique II [RE]",
+        "Fabrication Technique II Lab [RE]"
+      ]
+    },
+    {
+      "prefix": "PNURSE",
+      "name": "Nursing",
+      "course_count": 15,
+      "section_count": 120,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Foundations of Nursing",
+        "Foundations of Nursing Clinical",
+        "Foundations of Nursing Lab",
+        "Foundations of Nursing Simulation",
+        "Med-Surg Nursing I"
+      ]
+    },
+    {
+      "prefix": "GAME",
+      "name": "GAME",
+      "course_count": 34,
+      "section_count": 119,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "2D Digital Imaging",
+        "2D Game Design",
+        "3D Character Design",
+        "3D Game Design",
+        "3D Materials and Textures"
+      ]
+    },
+    {
+      "prefix": "AVIA",
+      "name": "Aviation",
+      "course_count": 39,
+      "section_count": 117,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Advanced Aircraft Systems",
+        "Aerodynamics for Pilots",
+        "Air Traffic Control 1",
+        "Air Traffic Control 2",
+        "Air Traffic Control Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ODLA",
+      "name": "Open",
+      "course_count": 9,
+      "section_count": 117,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "ELA 2 for Open Doors",
+        "ELA 3 for Open Doors",
+        "ELA 4-1 for Open Doors",
+        "ELA 4-2 for Open Doors",
+        "ELA 4-3 for Open Doors"
+      ]
+    },
+    {
+      "prefix": "BNURSE",
+      "name": "Nursing",
+      "course_count": 28,
+      "section_count": 112,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Academic Inquiry and Research in Nursing Science",
+        "Advanced Med-Surg Nursing Clinical",
+        "Advanced Med-Surg Nursing Lab",
+        "Advanced Med-Surg Nursing Simulation",
+        "Applied Critical Thinking in Advanced Med/Surg Nursing"
+      ]
+    },
+    {
+      "prefix": "AHSE",
+      "name": "AHSE",
+      "course_count": 22,
+      "section_count": 109,
+      "colleges": [
+        "lake-washington-institute-of-technology",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "AHA Heartsaver First Aid/CPR",
+        "Basic Life Support for Healthcare Providers",
+        "Basic Skills for High School Equivalency",
+        "Essentials of Intermediate Algebra",
+        "Geometry"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "GEOL",
+      "course_count": 15,
+      "section_count": 109,
+      "colleges": [
+        "bellevue-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "everett-community-college",
+        "green-river-college",
+        "lower-columbia-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "tacoma-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Dinosaurs",
+        "Evolution of The Earth",
+        "Exploring Earth Science",
+        "Geohazards and Natural Disasters",
+        "Geologic Hazards"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "Nursing",
+      "course_count": 42,
+      "section_count": 109,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Acute Care Clinical Preceptorship",
+        "Acute Care Nursing Clinical I",
+        "Acute Care Nursing Clinical II",
+        "Acute Care Nursing I Lab",
+        "Acute Care Nursing Lab II"
+      ]
+    },
+    {
+      "prefix": "OCEA&",
+      "name": "Oceanography",
+      "course_count": 2,
+      "section_count": 109,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "cascadia-college",
+        "centralia-college",
+        "clark-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "lower-columbia-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "tacoma-community-college",
+        "walla-walla-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Introduction to Oceanography",
+        "Introduction to Oceanography with Lab"
+      ]
+    },
+    {
+      "prefix": "RC",
+      "name": "Respiratory",
+      "course_count": 60,
+      "section_count": 108,
+      "colleges": [
+        "highline-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Assessment and Diagnosis",
+        "Advanced Critical Care Clinical Rotation",
+        "Advanced Mechanical Ventilation",
+        "Advanced RC Pathophysiology",
+        "Alternative Procedures In Respiratory Care"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 49,
+      "section_count": 107,
+      "colleges": [
+        "big-bend-community-college",
+        "centralia-college",
+        "clark-college",
+        "edmonds-college",
+        "green-river-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Accounting for Managers",
+        "Applied Management Capstone",
+        "Applied Management Skills",
+        "Applied Professional and Career Development",
+        "Business Analysis"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "MT",
+      "course_count": 40,
+      "section_count": 107,
+      "colleges": [
+        "centralia-college",
+        "columbia-basin-college",
+        "skagit-valley-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Machining Technologies Lab [RE]",
+        "Advanced Manual Machining [RE]",
+        "Advanced Manual Machining Lab [RE]",
+        "Anatomy & Pathology I",
+        "Anatomy & Pathophysiology I - Massage Therapists"
+      ]
+    },
+    {
+      "prefix": "DAS",
+      "name": "Dental",
+      "course_count": 24,
+      "section_count": 106,
+      "colleges": [
+        "clover-park-technical-college",
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Biomedical Sciences",
+        "Certification Review I",
+        "Certification Review II",
+        "Certification Review III",
+        "Clinical Experience I"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "College",
+      "course_count": 3,
+      "section_count": 105,
+      "colleges": [
+        "highline-college",
+        "renton-technical-college",
+        "shoreline-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "College and Career Readiness",
+        "Preparation for College & Career Success",
+        "Strengthening Navigational Skills"
+      ]
+    },
+    {
+      "prefix": "NOS",
+      "name": "NOS",
+      "course_count": 28,
+      "section_count": 104,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Networking",
+        "AI in Cybersecurity",
+        "BASC Capstone Project",
+        "Cloud Security Project",
+        "Cyber Security Fundamentals"
+      ]
+    },
+    {
+      "prefix": "PEH",
+      "name": "PEH",
+      "course_count": 32,
+      "section_count": 104,
+      "colleges": [
+        "big-bend-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "1st Aid-Responding to Emergencies",
+        "Ace Personal Trainer Certification",
+        "Anatomical Kinesiology",
+        "Athletic Training",
+        "Beginning Yoga"
+      ]
+    },
+    {
+      "prefix": "JOURN",
+      "name": "JOURN",
+      "course_count": 23,
+      "section_count": 103,
+      "colleges": [
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "pierce-college-district",
+        "spokane-falls-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Newswriting",
+        "Advanced Newswriting II",
+        "Careers in Digital Media",
+        "College Newspaper",
+        "College Newspaper Production I"
+      ]
+    },
+    {
+      "prefix": "RS",
+      "name": "RS",
+      "course_count": 22,
+      "section_count": 102,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Imaging Modalities",
+        "Digital Image Production & Exposure II",
+        "Digital Image Production and Exposure I",
+        "Fundamentals of Patient Care",
+        "Fundamentals of Patient Care II"
+      ]
+    },
+    {
+      "prefix": "COSMO",
+      "name": "COSMO",
+      "course_count": 23,
+      "section_count": 100,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Hair Coloring",
+        "Application of Haircutting, Hairstyling, and Thermal Styling",
+        "Artificial Hair",
+        "Chemical Texture Services",
+        "Cosmetology Capstone (Capstone)"
+      ]
+    },
+    {
+      "prefix": "DSN",
+      "name": "DSN",
+      "course_count": 47,
+      "section_count": 100,
+      "colleges": [
+        "clover-park-technical-college",
+        "highline-college"
+      ],
+      "sample_titles": [
+        "20/20 Drafting",
+        "Building Information Modeling I",
+        "Building Information Modeling II",
+        "Business Procedures & Sales",
+        "Capstone I"
+      ]
+    },
+    {
+      "prefix": "HSE",
+      "name": "Level",
+      "course_count": 10,
+      "section_count": 99,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Algebra 1 - Level 5",
+        "Algebra 2 - Level 5",
+        "CWP, Environmental Science, English Level 5",
+        "Geometry - Level 5",
+        "Health, Fitness and English Level 5"
+      ]
+    },
+    {
+      "prefix": "ELMT",
+      "name": "ELMT",
+      "course_count": 25,
+      "section_count": 98,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "AC Motor Controls",
+        "AC Motors and Alternators",
+        "AC Theory",
+        "Advanced AC Controls",
+        "Advanced Programmable Controllers"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 37,
+      "section_count": 97,
+      "colleges": [
+        "bates-technical-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "edmonds-college",
+        "everett-community-college",
+        "north-seattle-college",
+        "tacoma-community-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Application of Math/Science In Early Childhood Education",
+        "Child Development: Birth to Six",
+        "Children and Media",
+        "Cognition and General Knowledge",
+        "Cooperative Work Experience"
+      ]
+    },
+    {
+      "prefix": "HDEV",
+      "name": "Academic",
+      "course_count": 5,
+      "section_count": 96,
+      "colleges": [
+        "columbia-basin-college",
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Academic CPR [RE]",
+        "College Connections [RE]",
+        "Cooperative Work Experience",
+        "Creating Academic Success [RE]",
+        "Special Studies [RE]"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 28,
+      "section_count": 95,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "highline-college",
+        "olympic-college",
+        "renton-technical-college",
+        "south-puget-sound-community-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced United Nations I",
+        "American National Government and Politics",
+        "American Political Participation",
+        "Cannabis & Social Justice",
+        "Contemporary World Issues"
+      ]
+    },
+    {
+      "prefix": "CNA",
+      "name": "CNA",
+      "course_count": 18,
+      "section_count": 94,
+      "colleges": [
+        "grays-harbor-college",
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Certified Nursing Assistant Training",
+        "Cisco Cybersecurity",
+        "Cisco I",
+        "Cisco II",
+        "Cisco III"
+      ]
+    },
+    {
+      "prefix": "FYI",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 92,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "First Year Introduction [RE]"
+      ]
+    },
+    {
+      "prefix": "BA",
+      "name": "BA",
+      "course_count": 36,
+      "section_count": 90,
+      "colleges": [
+        "bellevue-college",
+        "grays-harbor-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Adv Cooperative Field Experience-I",
+        "Adv Cooperative Field Experience-II",
+        "Adv Cooperative Field Experience-III",
+        "Adv Cooperative Field Experience-IV",
+        "Business English"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 90,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Fitness-Wellness",
+        "Mind Body Health",
+        "Occupational Wellness",
+        "Wilderness Health and Safety"
+      ]
+    },
+    {
+      "prefix": "NURSE",
+      "name": "NURSE",
+      "course_count": 26,
+      "section_count": 90,
+      "colleges": [
+        "olympic-college",
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Applied Pharmacology and Dosage Calculation",
+        "Clinical Applications Lab I",
+        "Clinical Applications Lab III",
+        "Clinical Nursing Practice I",
+        "Complex Health Disturbances 1 Practicum - 11 Qtr"
+      ]
+    },
+    {
+      "prefix": "RATEC",
+      "name": "RATEC",
+      "course_count": 27,
+      "section_count": 90,
+      "colleges": [
+        "bellevue-college",
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Advanced Radiographic Procedures [RE]",
+        "Clinical Education I",
+        "Clinical Education I [RE]",
+        "Clinical Education II [RE]",
+        "Clinical Education III [RE]"
+      ]
+    },
+    {
+      "prefix": "NUTR",
+      "name": "Nutrition",
+      "course_count": 30,
+      "section_count": 88,
+      "colleges": [
+        "bellevue-college",
+        "bellingham-technical-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "lower-columbia-college",
+        "peninsula-college",
+        "shoreline-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Applied Nutrition for Nursing",
+        "Lifespan Nutrition",
+        "Nutrition and Fitness",
+        "Nutrition in Healthcare I",
+        "Nutrition In Healthcare I"
+      ]
+    },
+    {
+      "prefix": "VT",
+      "name": "VT",
+      "course_count": 33,
+      "section_count": 85,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Anesthesiology",
+        "Animal Anatomy and Physiology I",
+        "Animal Anatomy and Physiology II",
+        "Animal Diseases",
+        "Animal Hospital Office Procedures"
+      ]
+    },
+    {
+      "prefix": "AGHRT",
+      "name": "AGHRT",
+      "course_count": 34,
+      "section_count": 84,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Arboriculture",
+        "AgHort Occupational Preparation",
+        "Arboriculture",
+        "Arboriculture Tools and Equipment",
+        "Basic Crop Science"
+      ]
+    },
+    {
+      "prefix": "CARP",
+      "name": "CARP",
+      "course_count": 16,
+      "section_count": 82,
+      "colleges": [
+        "grays-harbor-college",
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Advanced Cabinetry and Wood Fabrication",
+        "Exterior and Interior Finish",
+        "Foundations and Floor Framing",
+        "Green Construction Principles and Practices",
+        "Intermediate Woodworking and Cabinetry"
+      ]
+    },
+    {
+      "prefix": "NTEC",
+      "name": "NTEC",
+      "course_count": 17,
+      "section_count": 82,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Administering Windows Server Hybrid Core Infrastructure",
+        "AI Prompt Fundamentals",
+        "Capstone Experience: Network Technologies",
+        "Enterprise Networking, Security, and Automation",
+        "Introduction to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "ODHS",
+      "name": "ODHS",
+      "course_count": 20,
+      "section_count": 82,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Academic Skills Lab",
+        "College Prep English",
+        "Competency--Algebra/Int. Math I",
+        "Elementary Algebra",
+        "English Foundations"
+      ]
+    },
+    {
+      "prefix": "MNGT",
+      "name": "MNGT",
+      "course_count": 26,
+      "section_count": 81,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Applied Accounting for Managers",
+        "Applied Financial Management",
+        "Applied Human Resource Development",
+        "Business Development and Negotiations",
+        "Business Strategy and Decision-Making"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "HRM",
+      "course_count": 27,
+      "section_count": 80,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "BAS SHRM Certification Study Preparation",
+        "Capstone: HR as a Strategic Partner and HR Career Planning",
+        "Capstone: HRM as a Business Partner and HR Career Readiness",
+        "Diversity, Equity, Inclusion, Accessibility, & Ethics in Organizations",
+        "Employee and Labor Relations and Risk Management"
+      ]
+    },
+    {
+      "prefix": "HUM&",
+      "name": "Humanities",
+      "course_count": 4,
+      "section_count": 80,
+      "colleges": [
+        "bellingham-technical-college",
+        "centralia-college",
+        "clover-park-technical-college",
+        "everett-community-college",
+        "lower-columbia-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "south-puget-sound-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Humanities I - Language, Thought, and Culture",
+        "Humanities II",
+        "Humanities III (H)",
+        "Introduction to the Humanities"
+      ]
+    },
+    {
+      "prefix": "CCP",
+      "name": "CCP",
+      "course_count": 26,
+      "section_count": 79,
+      "colleges": [
+        "lower-columbia-college",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "AI Literacy for CCP Students",
+        "Educational Interview",
+        "Educational Interview II",
+        "Educational Interview III",
+        "Educational Interview IV"
+      ]
+    },
+    {
+      "prefix": "CS&",
+      "name": "Computer",
+      "course_count": 2,
+      "section_count": 79,
+      "colleges": [
+        "bates-technical-college",
+        "bellingham-technical-college",
+        "big-bend-community-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "lake-washington-institute-of-technology",
+        "olympic-college",
+        "pierce-college-district",
+        "renton-technical-college",
+        "shoreline-community-college",
+        "spokane-falls-community-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Computer Science I C++ [M/S]",
+        "Computer Science I Java [M/S]"
+      ]
+    },
+    {
+      "prefix": "AE",
+      "name": "AE",
+      "course_count": 31,
+      "section_count": 78,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Academic Skills Development I",
+        "Academic Skills Development II",
+        "Algebra Foundations",
+        "Algebra/Geometry",
+        "BEdA and Beyond Plan"
+      ]
+    },
+    {
+      "prefix": "WFT",
+      "name": "Welding",
+      "course_count": 15,
+      "section_count": 77,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Advanced Welding 1",
+        "Advanced Welding 2",
+        "Fabrication Carbon Arc / Plasma Arc Cutting",
+        "FCAW Flux Core Arc Welding",
+        "Gas Metal Arc Welding"
+      ]
+    },
+    {
+      "prefix": "CPW",
+      "name": "CPW",
+      "course_count": 22,
+      "section_count": 76,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        ".NET Programming",
+        ".NET Web Programming",
+        "Advanced .NET Programming",
+        "Advanced .NET Web Programming",
+        "Algorithms"
+      ]
+    },
+    {
+      "prefix": "AUTC",
+      "name": "AUTC",
+      "course_count": 14,
+      "section_count": 75,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Electronics",
+        "Automatic Transmission/Transaxle Repair",
+        "Automotive Mathematics",
+        "Brakes",
+        "Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "BTECA",
+      "name": "BTECA",
+      "course_count": 21,
+      "section_count": 75,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business English I",
+        "Business English II",
+        "Business Keyboarding: Key Numbers and Symbols",
+        "Business Keyboarding: Key the Alphabet by Touch"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 43,
+      "section_count": 75,
+      "colleges": [
+        "clark-college",
+        "spokane-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Acute Care Coding",
+        "Ambulatory Care Coding",
+        "Applied Data, Data Analytics and Data Visualization",
+        "Clinical Practice",
+        "Clinical Preparation"
+      ]
+    },
+    {
+      "prefix": "NRSG",
+      "name": "NRSG",
+      "course_count": 32,
+      "section_count": 75,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Behavioral Health in Nursing 2: Psychiatric Disorders",
+        "Clinical Practicum 1: Long Term/Skilled Nursing",
+        "Clinical Practicum 2: Introduction to Acute Care",
+        "Clinical Practicum 3: Acute Care Nursing",
+        "Clinical Practicum 4: Advanced Acute Care"
+      ]
+    },
+    {
+      "prefix": "DT",
+      "name": "DT",
+      "course_count": 32,
+      "section_count": 74,
+      "colleges": [
+        "grays-harbor-college",
+        "skagit-valley-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Dental Therapy Concepts III",
+        "Advanced Diagnostics, Testing and Repair",
+        "Advanced Diesel Technology",
+        "Advanced Equipment Repair I",
+        "Advanced Standing Dental Therapy Fundamentals"
+      ]
+    },
+    {
+      "prefix": "LEGAL",
+      "name": "LEGAL",
+      "course_count": 37,
+      "section_count": 74,
+      "colleges": [
+        "edmonds-college",
+        "highline-college",
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Business Organizations",
+        "Career and College Success: Paralegal",
+        "Civil Litigation",
+        "Civil Procedure",
+        "Civil Procedures I"
+      ]
+    },
+    {
+      "prefix": "NDT",
+      "name": "NDT",
+      "course_count": 36,
+      "section_count": 74,
+      "colleges": [
+        "bellevue-college",
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced EEG",
+        "Applied Evoked Potential",
+        "Applied Neurophysiology",
+        "Capstone Project (Capstone)",
+        "Clinical Correlates I"
+      ]
+    },
+    {
+      "prefix": "RBM",
+      "name": "RBM",
+      "course_count": 17,
+      "section_count": 74,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Business Technology for Retail Applications (Computer Literacy)",
+        "Consumer Behavior",
+        "Customer Service",
+        "E-Commerce Principles & Applications",
+        "Effective Selling"
+      ]
+    },
+    {
+      "prefix": "DEV",
+      "name": "DEV",
+      "course_count": 28,
+      "section_count": 73,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advanced Data Access Techniques",
+        "Advanced Web Development",
+        "Application Architecture",
+        "AR Development",
+        "Capstone II"
+      ]
+    },
+    {
+      "prefix": "EXPRL",
+      "name": "EXPRL",
+      "course_count": 14,
+      "section_count": 73,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Academic Internship Experience",
+        "Chart Your Course",
+        "Connecting with Community",
+        "Executive Functioning in the Workplace",
+        "Exploring Neurodivergent Identity and Culture"
+      ]
+    },
+    {
+      "prefix": "APLED",
+      "name": "APLED",
+      "course_count": 5,
+      "section_count": 72,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Applied Mathematics",
+        "Applied Written Communication",
+        "Employment Preparation",
+        "Introduction to Computers for Technology",
+        "Leadership Skills for Business and Industry"
+      ]
+    },
+    {
+      "prefix": "DIESL",
+      "name": "DIESL",
+      "course_count": 23,
+      "section_count": 72,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Service Applications",
+        "Advanced Service Techniques",
+        "Automated Manual Transmission Service",
+        "Automatic Transmission Service",
+        "Basic Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "FYS",
+      "name": "Firstyear",
+      "course_count": 2,
+      "section_count": 71,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advanced Transfer Seminar",
+        "First-Year Seminar"
+      ]
+    },
+    {
+      "prefix": "KINS",
+      "name": "KINS",
+      "course_count": 23,
+      "section_count": 71,
+      "colleges": [
+        "bellevue-college",
+        "pierce-college-district",
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Anatomical Kinesiology",
+        "Anatomical Kinesiology for Yoga",
+        "Applied Kinesiology",
+        "Applied Prevention and Care of Injuries",
+        "Coaching Techniques and Business Basics"
+      ]
+    },
+    {
+      "prefix": "AQUA",
+      "name": "AQUA",
+      "course_count": 33,
+      "section_count": 70,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Animal Genetics with Lab",
+        "Applied Techniques: Fall",
+        "Applied Techniques: Spring",
+        "Applied Techniques: Winter",
+        "Aquaculture Internship I"
+      ]
+    },
+    {
+      "prefix": "BTE",
+      "name": "BTE",
+      "course_count": 15,
+      "section_count": 70,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Business Computer Management",
+        "Capstone Project",
+        "Database Management",
+        "Excel I"
+      ]
+    },
+    {
+      "prefix": "EAP",
+      "name": "Academic",
+      "course_count": 18,
+      "section_count": 70,
+      "colleges": [
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Academic Bridge: American Culture and Conversation II",
+        "Academic Bridge: Composition and Reading I",
+        "Academic Bridge: Composition and Reading II",
+        "Academic Bridge: Pronunciation and Conversation I",
+        "Academic Listening and Speaking"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 40,
+      "section_count": 70,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Advanced Weight Training",
+        "Applied Baseball I",
+        "Applied Baseball II",
+        "Applied Soccer I",
+        "Applied Soccer II"
+      ]
+    },
+    {
+      "prefix": "ABECE",
+      "name": "Math",
+      "course_count": 15,
+      "section_count": 69,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ABE Math for College and Career 3",
+        "ABE Math Skills for College and Career 1",
+        "ABE Math Skills for College and Career 2",
+        "ABE Math Skills for College and Career 4",
+        "ABE Math Skills for College and Career 5"
+      ]
+    },
+    {
+      "prefix": "CSS",
+      "name": "First",
+      "course_count": 7,
+      "section_count": 69,
+      "colleges": [
+        "big-bend-community-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Charting Your Course: College Essentials",
+        "College Reading Strategies",
+        "First Quarter Experience",
+        "First Quarter Experience Career Exploration Emphasis",
+        "First Quarter Experience Study Skills and Success Emphasis"
+      ]
+    },
+    {
+      "prefix": "BAKE",
+      "name": "BAKE",
+      "course_count": 21,
+      "section_count": 68,
+      "colleges": [
+        "clover-park-technical-college",
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Bakery Retail Management",
+        "Baking Projects",
+        "Breads",
+        "Cakes",
+        "Capstone"
+      ]
+    },
+    {
+      "prefix": "SHME",
+      "name": "SHME",
+      "course_count": 17,
+      "section_count": 68,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Math",
+        "Architectural Sheet Metal",
+        "Blueprint Reading Applications",
+        "Commercial Projects",
+        "Complex Components Fabrication"
+      ]
+    },
+    {
+      "prefix": "GEOG&",
+      "name": "Geography",
+      "course_count": 5,
+      "section_count": 67,
+      "colleges": [
+        "bellevue-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "olympic-college",
+        "skagit-valley-college",
+        "south-seattle-college",
+        "spokane-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Economic Geography",
+        "Geography of The Pacific Northwest",
+        "Human Geography: Culture and Places",
+        "Introduction to Geography",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 15,
+      "section_count": 67,
+      "colleges": [
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Beginning Guitar Class",
+        "Beginning Piano",
+        "Brass Private",
+        "Cello/Bass Private",
+        "Chamber Singers"
+      ]
+    },
+    {
+      "prefix": "CBAS",
+      "name": "Foundation",
+      "course_count": 9,
+      "section_count": 66,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Big Data & Analytics Foundation",
+        "Capstone Project",
+        "Cybersecurity Analyst",
+        "Cybersecurity Foundation",
+        "Cybersecurity Operations"
+      ]
+    },
+    {
+      "prefix": "FRCH&",
+      "name": "French",
+      "course_count": 6,
+      "section_count": 66,
+      "colleges": [
+        "bellevue-college",
+        "big-bend-community-college",
+        "columbia-basin-college",
+        "everett-community-college",
+        "green-river-college",
+        "north-seattle-college",
+        "olympic-college",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "spokane-community-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "French I [H]",
+        "French II",
+        "French III",
+        "French IV",
+        "French V"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 36,
+      "section_count": 66,
+      "colleges": [
+        "clover-park-technical-college",
+        "shoreline-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Lab Practice & Phlebotomy",
+        "Basic Lab Theory",
+        "Chemistry Practicum",
+        "Clinical Chemistry and Urinalysis",
+        "Clinical Chemistry Lab"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "RADT",
+      "course_count": 34,
+      "section_count": 66,
+      "colleges": [
+        "olympic-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Education III",
+        "Clinical Education IV",
+        "Clinical I"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "HORT",
+      "course_count": 40,
+      "section_count": 65,
+      "colleges": [
+        "columbia-basin-college",
+        "edmonds-college",
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Botany",
+        "Broadleaf Plant Identification",
+        "Careers Seminar",
+        "Crop Growth & Development W/ Lab [RE]",
+        "Cultivated Plants W/Lab [RE]"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 31,
+      "section_count": 64,
+      "colleges": [
+        "bellevue-college",
+        "cascadia-college",
+        "centralia-college",
+        "edmonds-college",
+        "everett-community-college",
+        "green-river-college",
+        "north-seattle-college",
+        "olympic-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "shoreline-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Life & Culture",
+        "Anarchy and Anthropology",
+        "Ancient Cultures of Asia and the Pacific",
+        "Anthropology of Human Rights",
+        "Applied Anthropology"
+      ]
+    },
+    {
+      "prefix": "AVF",
+      "name": "Flight",
+      "course_count": 23,
+      "section_count": 64,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Commercial Pilot Flight (Stage 4)",
+        "Commercial Pilot Flight (Stage 5)",
+        "Commercial Pilot Flight (Stage 7)",
+        "Commercial Pilot Ground School",
+        "Effective Communications In Flight Instruction"
+      ]
+    },
+    {
+      "prefix": "ENVC",
+      "name": "ENVC",
+      "course_count": 29,
+      "section_count": 64,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Wetland Ecology",
+        "Applied Population and Community Ecology",
+        "Behavioral Ecology",
+        "Conservation Biology",
+        "Culminating Project"
+      ]
+    },
+    {
+      "prefix": "NA",
+      "name": "Nursing",
+      "course_count": 7,
+      "section_count": 64,
+      "colleges": [
+        "bellingham-technical-college",
+        "columbia-basin-college",
+        "olympic-college",
+        "renton-technical-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals/Skills for Nursing Assistant",
+        "Nursing Assistant",
+        "Nursing Assistant [RE]",
+        "Nursing Assistant Clinical",
+        "Nursing Assistant Practicum"
+      ]
+    },
+    {
+      "prefix": "CTEC",
+      "name": "CTEC",
+      "course_count": 30,
+      "section_count": 63,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Business Web Practices",
+        "CompTIA A+ Fundamentals",
+        "CompTIA A+ Operating Systems & Networking",
+        "CompTIA Cybersecurity",
+        "CompTIA Security+"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "Life",
+      "course_count": 3,
+      "section_count": 63,
+      "colleges": [
+        "grays-harbor-college",
+        "spokane-falls-community-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Creating Success In College and Life",
+        "First Year Experience",
+        "WorkFirst Life Skills"
+      ]
+    },
+    {
+      "prefix": "PBAK",
+      "name": "PBAK",
+      "course_count": 14,
+      "section_count": 63,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Artisan Breads",
+        "Cake Decorating",
+        "Cakes, Desserts and Tortes",
+        "Capstone Project",
+        "Cookies, Brownies, Bars and Quick Breads"
+      ]
+    },
+    {
+      "prefix": "BROAD",
+      "name": "BROAD",
+      "course_count": 28,
+      "section_count": 62,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Editing Projects",
+        "Audio & Video Engineering",
+        "Audio Engineering",
+        "Audio-Visual Pre-Production Applications",
+        "Basic Audio Equipment"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "Concepts",
+      "course_count": 25,
+      "section_count": 62,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cosmetology Applications I",
+        "Advanced Cosmetology Applications II",
+        "Advanced Cosmetology Concepts I",
+        "Advanced Cosmetology Concepts II",
+        "Advanced Manicuring Applications III"
+      ]
+    },
+    {
+      "prefix": "DATA",
+      "name": "Data",
+      "course_count": 30,
+      "section_count": 62,
+      "colleges": [
+        "bates-technical-college",
+        "bellevue-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced SQL",
+        "Applied Database Concepts",
+        "Applied Programming Concepts",
+        "Business Dashboards",
+        "Business Data Analytics I - SQL Server Administration"
+      ]
+    },
+    {
+      "prefix": "GED",
+      "name": "GED",
+      "course_count": 18,
+      "section_count": 62,
+      "colleges": [
+        "bellingham-technical-college",
+        "edmonds-college",
+        "everett-community-college",
+        "north-seattle-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Basic GED Preparation Communication Level 5",
+        "GED Prep",
+        "GED Prep Level 5",
+        "GED Preparation",
+        "GED Preparation Impact"
+      ]
+    },
+    {
+      "prefix": "P E",
+      "name": "P E",
+      "course_count": 22,
+      "section_count": 62,
+      "colleges": [
+        "centralia-college",
+        "green-river-college",
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Advanced Aerobic Walking",
+        "Advanced Pilates/Yoga",
+        "Advanced Weight Training",
+        "Aerobic Walking",
+        "Conditioning & Wellness"
+      ]
+    },
+    {
+      "prefix": "TRAN",
+      "name": "Transitions",
+      "course_count": 17,
+      "section_count": 62,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "ABE Orientation I",
+        "ABE Orientation II",
+        "ABE Orientation III",
+        "Adult High School Completion-Fine Arts",
+        "IBEST Support II"
+      ]
+    },
+    {
+      "prefix": "CCB",
+      "name": "Prep",
+      "course_count": 9,
+      "section_count": 61,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "College Prep English",
+        "Elementary STEM Algebra",
+        "English Foundations",
+        "GED Prep",
+        "GED Prep Math & Science"
+      ]
+    },
+    {
+      "prefix": "HE",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 61,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Diet, Exercise & Weight Control [PE]",
+        "Health and Fitness for Life [PE]",
+        "Health and Wellness [PE]",
+        "Stress Management [PE]"
+      ]
+    },
+    {
+      "prefix": "SEW",
+      "name": "Sewing",
+      "course_count": 8,
+      "section_count": 61,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Accessories Sewing Lab",
+        "Fashion Sewing Basics",
+        "Quilting Lab",
+        "Repair Or Upcycle Your Wardrobe",
+        "Sewing for Beginners I"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 17,
+      "section_count": 61,
+      "colleges": [
+        "columbia-basin-college",
+        "edmonds-college",
+        "green-river-college",
+        "pierce-college-district",
+        "shoreline-community-college",
+        "skagit-valley-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "2nd Yr Spanish for Academic Reading",
+        "2nd Yr Spanish for Professional Speaking",
+        "Basic Spanish Grammar: Lab",
+        "Beginning Spanish for Professionals [H]",
+        "First Year Conversational Spanish-I"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "CNT",
+      "course_count": 11,
+      "section_count": 60,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Bits and Bytes of Cloud Computing",
+        "Cloud Solutions Architecture",
+        "Foundations and Operations of Cloud Computing",
+        "Introduction to Databases with SQL",
+        "Introduction to Programming"
+      ]
+    },
+    {
+      "prefix": "MIT",
+      "name": "MIT",
+      "course_count": 18,
+      "section_count": 60,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Adobe Animate",
+        "Adobe Illustrator",
+        "Adobe Indesign",
+        "Adobe Photoshop",
+        "Adobe Premiere Pro and After Effects"
+      ]
+    },
+    {
+      "prefix": "PTEC",
+      "name": "Process",
+      "course_count": 20,
+      "section_count": 60,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Dynamic Process Control",
+        "Green Energy",
+        "Industrial Processes and Equipment",
+        "Intro to Wwt",
+        "Introduction to Process Technology"
+      ]
+    },
+    {
+      "prefix": "UPH",
+      "name": "UPH",
+      "course_count": 22,
+      "section_count": 60,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Sewing I",
+        "Advanced Sewing II",
+        "Basic Sewing I",
+        "Basic Sewing II",
+        "Bench Seats I"
+      ]
+    },
+    {
+      "prefix": "CEO",
+      "name": "CEO",
+      "course_count": 24,
+      "section_count": 59,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Career Planning",
+        "English III",
+        "English IV",
+        "English V",
+        "GED Test Preparation I"
+      ]
+    },
+    {
+      "prefix": "ELIUP",
+      "name": "ELIUP",
+      "course_count": 16,
+      "section_count": 59,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Academic Preparation",
+        "Exploring Contemporary Issues",
+        "Integrated Skills 4",
+        "Integrated Skills 5",
+        "Read and React IV"
+      ]
+    },
+    {
+      "prefix": "OLS",
+      "name": "OLS",
+      "course_count": 37,
+      "section_count": 59,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Career Foundations",
+        "Career Pathways",
+        "Citizenship",
+        "Communication in the Workplace"
+      ]
+    },
+    {
+      "prefix": "AMATH",
+      "name": "Math",
+      "course_count": 10,
+      "section_count": 58,
+      "colleges": [
+        "bates-technical-college",
+        "bellingham-technical-college",
+        "peninsula-college",
+        "renton-technical-college",
+        "south-puget-sound-community-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Applied Math for Professional & Tech Programs I",
+        "Applied Occupational Math",
+        "Applied Technical Math",
+        "Corequisite Intermediate Algebra",
+        "Corequisite Precalculus I"
+      ]
+    },
+    {
+      "prefix": "CBE",
+      "name": "CBE",
+      "course_count": 12,
+      "section_count": 58,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrical and Lab",
+        "Air and Water Balancing and Lab",
+        "Air Handlers and Rooftop Units",
+        "Blueprints for HVAC and Building Engineering",
+        "Boiler Operators"
+      ]
+    },
+    {
+      "prefix": "PEC",
+      "name": "PEC",
+      "course_count": 10,
+      "section_count": 58,
+      "colleges": [
+        "north-seattle-college",
+        "seattle-central-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Beginning Physical Fitness",
+        "Beginning Weight Training",
+        "Independent Study",
+        "Intermediate Physical Fitness",
+        "Intermediate Weight Training"
+      ]
+    },
+    {
+      "prefix": "PHLEB",
+      "name": "Phlebotomy",
+      "course_count": 6,
+      "section_count": 58,
+      "colleges": [
+        "columbia-basin-college",
+        "green-river-college",
+        "olympic-college",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Phlebotomy",
+        "Healthcare Provider First Aid/CPR,Aed&Bloodborne",
+        "National Exam Certification Prep",
+        "Phlebotomy I [RE]",
+        "Phlebotomy Laboratory Skills"
+      ]
+    },
+    {
+      "prefix": "CCPNG",
+      "name": "English",
+      "course_count": 11,
+      "section_count": 57,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "CCP Math 78/Level C",
+        "CCP Math 87/D Enhanced",
+        "CCP Math 88/Level D",
+        "Civics, English",
+        "COLL 101, Occupational"
+      ]
+    },
+    {
+      "prefix": "CSD",
+      "name": "CSD",
+      "course_count": 14,
+      "section_count": 56,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Algorithms and Data Structures",
+        "Big Data Application Development",
+        "C++ Programming",
+        "Cloud Computing",
+        "Computer Programming Fundamentals With Python"
+      ]
+    },
+    {
+      "prefix": "CYA",
+      "name": "Cybersecurity",
+      "course_count": 10,
+      "section_count": 55,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Cybersecurity Fundamentals I",
+        "Cybersecurity Fundamentals II",
+        "Full Stack Development for Cybersecurity",
+        "Independent Study",
+        "Introduction to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "MUSPL",
+      "name": "Private",
+      "course_count": 55,
+      "section_count": 55,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Private Guitar Lessons",
+        "Advanced Private Lessons",
+        "Advanced Private Piano Lessons",
+        "Advanced Private Viola Lessons",
+        "Advanced Private Violin Lessons"
+      ]
+    },
+    {
+      "prefix": "AEGS",
+      "name": "AEGS",
+      "course_count": 14,
+      "section_count": 54,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Diversity & Social Justice in Leadership",
+        "Diversity and American Culture",
+        "Health Justice",
+        "Intro to African American Studies",
+        "Intro to American Ethnic Studies"
+      ]
+    },
+    {
+      "prefix": "AUTOB",
+      "name": "AUTOB",
+      "course_count": 16,
+      "section_count": 54,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Alignment - Bumpers",
+        "Alignment - Head Lamps",
+        "Auto Body Math Applications",
+        "Glass Installation",
+        "Introduction to Estimating"
+      ]
+    },
+    {
+      "prefix": "BTECH",
+      "name": "BTECH",
+      "course_count": 18,
+      "section_count": 54,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Access",
+        "Desktop Publishing",
+        "Document Formatting",
+        "Electronic Math Applications",
+        "Excel"
+      ]
+    },
+    {
+      "prefix": "ECL",
+      "name": "English",
+      "course_count": 24,
+      "section_count": 54,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "English for Civic Literacy 1 - ECL 11",
+        "English for Civic Literacy 1 - ECL 12",
+        "English for Civic Literacy 1 - ECL 13",
+        "English for Civic Literacy 1 - ECL 14",
+        "English for Civic Literacy 2 - ECL 21"
+      ]
+    },
+    {
+      "prefix": "ENGLC",
+      "name": "Corequisite",
+      "course_count": 1,
+      "section_count": 54,
+      "colleges": [
+        "pierce-college-district",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Corequisite English Composition"
+      ]
+    },
+    {
+      "prefix": "INFO",
+      "name": "INFO",
+      "course_count": 14,
+      "section_count": 54,
+      "colleges": [
+        "bates-technical-college",
+        "green-river-college",
+        "north-seattle-college",
+        "peninsula-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Independent Projects",
+        "Information and Power in Society",
+        "Information Literacy and Research Skills",
+        "Information Literacy for Undergraduate Research",
+        "IT Applications"
+      ]
+    },
+    {
+      "prefix": "MANF",
+      "name": "MANF",
+      "course_count": 28,
+      "section_count": 54,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Design for Manufacturing",
+        "Business Operations for Manufacturing",
+        "CAD/CAM for Manufacturing I",
+        "CAD/CAM for Manufacturing II",
+        "Composites for Manufacturing"
+      ]
+    },
+    {
+      "prefix": "AM",
+      "name": "AM",
+      "course_count": 20,
+      "section_count": 53,
+      "colleges": [
+        "bellingham-technical-college",
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Additive Manufacturing",
+        "Advanced Manufacturing Career Exploration",
+        "Advanced Manufacturing Pathways",
+        "Applied Material Science",
+        "Applied Metrology"
+      ]
+    },
+    {
+      "prefix": "ARCF",
+      "name": "ARCF",
+      "course_count": 15,
+      "section_count": 52,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Paint Application",
+        "Applied Metal Skills",
+        "Automotive Restoration & Customization Finishing Lab",
+        "Basic Repairs & Assembly",
+        "Custom Fabrication"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 31,
+      "section_count": 52,
+      "colleges": [
+        "clover-park-technical-college",
+        "grays-harbor-college",
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Adolescent Addiction Treatment & Prevention",
+        "Advanced Cooperative Work Internship",
+        "Advanced Counseling & Case Management",
+        "Applied Counseling for The Human Services Professional",
+        "Case Management"
+      ]
+    },
+    {
+      "prefix": "MSEC",
+      "name": "Medical",
+      "course_count": 12,
+      "section_count": 52,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Certified Professional Coder (CPC) Exam Preparation",
+        "Clinical Coding",
+        "Human Relations/Communications for Medical Office Personnel",
+        "Introduction to Medical Practice Management System",
+        "Medical Insurance Billing Internship"
+      ]
+    },
+    {
+      "prefix": "PROJ",
+      "name": "Project",
+      "course_count": 18,
+      "section_count": 52,
+      "colleges": [
+        "columbia-basin-college",
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Advanced Microsoft Project",
+        "Advanced Project Management Capstone",
+        "Agile Project Management [RE]",
+        "Emotional Intelligence & Communication [RE]",
+        "Introduction to Microsoft Project [RE]"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 28,
+      "section_count": 51,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Advanced Excel for Business",
+        "Business Capstone",
+        "Business Computer Applications",
+        "Business Ethics & Sustainability",
+        "Business Mathematics"
+      ]
+    },
+    {
+      "prefix": "CA",
+      "name": "CA",
+      "course_count": 18,
+      "section_count": 51,
+      "colleges": [
+        "columbia-basin-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "A La Carte I (Pick-Up)",
+        "A La Carte II",
+        "Culinary Agriculture 1",
+        "Culinary Agriculture IV",
+        "Culinary Foundations 1"
+      ]
+    },
+    {
+      "prefix": "DRMA&",
+      "name": "Theatre",
+      "course_count": 1,
+      "section_count": 51,
+      "colleges": [
+        "bellevue-college",
+        "centralia-college",
+        "clark-college",
+        "columbia-basin-college",
+        "edmonds-college",
+        "everett-community-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "lower-columbia-college",
+        "olympic-college",
+        "peninsula-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Introduction to Theatre: Theatre Appreciation"
+      ]
+    },
+    {
+      "prefix": "ENGT",
+      "name": "ENGT",
+      "course_count": 28,
+      "section_count": 51,
+      "colleges": [
+        "bellingham-technical-college",
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Advanced Graphics",
+        "Advanced Parametric Modeling",
+        "Applied Industrial Graphics",
+        "Applied Materials Technology",
+        "Applied Mechanics of Materials"
+      ]
+    },
+    {
+      "prefix": "ICS",
+      "name": "ICS",
+      "course_count": 13,
+      "section_count": 51,
+      "colleges": [
+        "columbia-basin-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "American Diversity [H]",
+        "Behavioral Health across the Lifespan",
+        "Child Abuse and Neglect",
+        "Globalization [S/B]",
+        "Growth and Development Across the Lifespan"
+      ]
+    },
+    {
+      "prefix": "MUSTC",
+      "name": "Music",
+      "course_count": 28,
+      "section_count": 51,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Acoustics of Music",
+        "Advanced Electronic Music Production I",
+        "Advanced Electronic Music Production II",
+        "Audio for Interactive Media",
+        "Audio Post II - Digital Radio Production"
+      ]
+    },
+    {
+      "prefix": "AMT&",
+      "name": "AMT&",
+      "course_count": 25,
+      "section_count": 50,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Drawings",
+        "Aircraft Electrical",
+        "Airframe Fuel Systems",
+        "Airframe Inspection",
+        "Assembly and Rigging"
+      ]
+    },
+    {
+      "prefix": "ARCFT",
+      "name": "Airframe",
+      "course_count": 24,
+      "section_count": 50,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Airframe & Powerplant Electrical Systems",
+        "Airframe & Powerplant Electrical Systems Shop",
+        "Airframe Flight Control, Rigging, and Landing Gear Systems",
+        "Airframe Flight Control, Rigging, and Landing Gear Systems Shop",
+        "Airframe Instruments, Fluid Systems, & Inspections"
+      ]
+    },
+    {
+      "prefix": "DANCE",
+      "name": "Technique",
+      "course_count": 14,
+      "section_count": 50,
+      "colleges": [
+        "bellevue-college",
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Ballet Technique I",
+        "Ballet Technique II",
+        "Contemporary Dance I",
+        "Contemporary Dance II",
+        "Dance Ensemble I"
+      ]
+    },
+    {
+      "prefix": "DED",
+      "name": "DED",
+      "course_count": 25,
+      "section_count": 50,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "3D Animation",
+        "3D Modeling I",
+        "3D Modeling II",
+        "3D Modeling III",
+        "Advanced Development Tools"
+      ]
+    },
+    {
+      "prefix": "EFDA",
+      "name": "EFDA",
+      "course_count": 24,
+      "section_count": 50,
+      "colleges": [
+        "columbia-basin-college",
+        "seattle-central-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Amalgam Restorations",
+        "Amalgam Restorations [RE]",
+        "Amalgam Restorations Lab",
+        "Amalgam Restorations Lab [RE]",
+        "Board Exam Preparation"
+      ]
+    },
+    {
+      "prefix": "MATHC",
+      "name": "Corequisite",
+      "course_count": 5,
+      "section_count": 50,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Intermediate Algebra for Precalculus Corequisite",
+        "Introduction to Statistics Corequisite",
+        "Math for Elem Education 1 Corequisite",
+        "Math in Society Corequisite",
+        "Precalculus I Corequisite"
+      ]
+    },
+    {
+      "prefix": "MTEC",
+      "name": "MTEC",
+      "course_count": 13,
+      "section_count": 50,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading I",
+        "Blueprint Reading II",
+        "CAD/CAM Fundamentals",
+        "CNC Lathe Setup & Operation",
+        "CNC Mill Setup & Operation"
+      ]
+    },
+    {
+      "prefix": "PEFSP",
+      "name": "PEFSP",
+      "course_count": 15,
+      "section_count": 50,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Aerobic Walking",
+        "Athletic Conditioning II",
+        "Collegiate Athlete Development I",
+        "Collegiate Athlete Development II",
+        "Fast Fitness"
+      ]
+    },
+    {
+      "prefix": "CATT",
+      "name": "Microsoft",
+      "course_count": 11,
+      "section_count": 49,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Desktop Publishing",
+        "Microsoft Access I",
+        "Microsoft Access II",
+        "Microsoft Excel I",
+        "Microsoft Excel II"
+      ]
+    },
+    {
+      "prefix": "YR",
+      "name": "Level",
+      "course_count": 10,
+      "section_count": 49,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Algebra I Math 88/Level D",
+        "Biology w/Lab",
+        "Civics",
+        "COLL 101",
+        "English 10 (Level C)"
+      ]
+    },
+    {
+      "prefix": "AVIO",
+      "name": "AVIO",
+      "course_count": 16,
+      "section_count": 48,
+      "colleges": [
+        "clover-park-technical-college",
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Avionics Troubleshooting",
+        "Aircraft Basic and Electronic Instrument Systems",
+        "Aircraft Handling and Testing",
+        "Aircraft Maintenance Practices",
+        "Aircraft Wiring Systems"
+      ]
+    },
+    {
+      "prefix": "BCT",
+      "name": "BCT",
+      "course_count": 22,
+      "section_count": 48,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Computer Keyboarding",
+        "Business Communications",
+        "Business English",
+        "Business Math",
+        "Computer Applications"
+      ]
+    },
+    {
+      "prefix": "HSERV",
+      "name": "HSERV",
+      "course_count": 22,
+      "section_count": 48,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Addictions and The Law",
+        "Addictive Disorders & The Family",
+        "Adolescent Addictive Disorders Counseling",
+        "Alcoholism and Other Addictive Disorders",
+        "Crisis Intervention"
+      ]
+    },
+    {
+      "prefix": "LINE",
+      "name": "LINE",
+      "course_count": 16,
+      "section_count": 48,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical Theory",
+        "Basic Rigging and Lifting",
+        "Comprehensive Machinery Operation and Flagging",
+        "Construction Blueprint Reading",
+        "Electrical Circuits and Systems"
+      ]
+    },
+    {
+      "prefix": "SL",
+      "name": "Service",
+      "course_count": 1,
+      "section_count": 48,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Service Learning"
+      ]
+    },
+    {
+      "prefix": "AGSCI",
+      "name": "AGSCI",
+      "course_count": 20,
+      "section_count": 47,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Winemaking",
+        "Essentials of Winemaking",
+        "General Viticulture",
+        "Integrated Pest Management",
+        "Introduction Fruit Science"
+      ]
+    },
+    {
+      "prefix": "BATECH",
+      "name": "BATECH",
+      "course_count": 12,
+      "section_count": 47,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Data Management Tools",
+        "Business Software Essentials",
+        "Business Spreadsheet Analysis & Design",
+        "Cloud-based Productivity & Communication"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 15,
+      "section_count": 47,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Coding and Legal Compliance",
+        "Coding for Professional Services",
+        "Comprehensive Medical Terminology",
+        "Health Information Technologies",
+        "Health Law"
+      ]
+    },
+    {
+      "prefix": "MAP",
+      "name": "MAP",
+      "course_count": 23,
+      "section_count": 47,
+      "colleges": [
+        "big-bend-community-college",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced MS Office and Keyboarding (Mos)",
+        "Applied Mathematics (AMT)",
+        "Applied Mathematics for Workforce Programs I",
+        "Applied Mathematics for Workforce Programs II",
+        "Billing Physician-Related Services"
+      ]
+    },
+    {
+      "prefix": "APPRL",
+      "name": "APPRL",
+      "course_count": 12,
+      "section_count": 46,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Ad&D Skill Development 1",
+        "Ad&D Skill Development 3",
+        "Ad&D Skill Development Intensive",
+        "Apparel Manufacturing",
+        "Computer Applications for Apparel Design 1"
+      ]
+    },
+    {
+      "prefix": "BH",
+      "name": "BH",
+      "course_count": 29,
+      "section_count": 46,
+      "colleges": [
+        "big-bend-community-college",
+        "lake-washington-institute-of-technology",
+        "olympic-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Case Management",
+        "Case Studies in Mental Health Disorders",
+        "Crisis De-escalation in Healthcare",
+        "Group Counseling",
+        "Group Work"
+      ]
+    },
+    {
+      "prefix": "FSE",
+      "name": "Funeral",
+      "course_count": 18,
+      "section_count": 46,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Comprehensive Review",
+        "Embalming Chemistry",
+        "Embalming I",
+        "Embalming II With Lab",
+        "Embalming III with Lab"
+      ]
+    },
+    {
+      "prefix": "GTC",
+      "name": "GTC",
+      "course_count": 23,
+      "section_count": 46,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Graphic Layout I",
+        "Applied Graphic Layout II",
+        "Branding",
+        "Capstone Class (Capstone)",
+        "Computer Operations & Image Management for Graphic Professionals"
+      ]
+    },
+    {
+      "prefix": "HSP",
+      "name": "HSP",
+      "course_count": 16,
+      "section_count": 46,
+      "colleges": [
+        "columbia-basin-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Helping Strategies",
+        "Advocacy in Human Services",
+        "Behavioral Health and Wellness",
+        "Best Practices In Human Services",
+        "Co-Occurring Disorders Assessment and Treatment"
+      ]
+    },
+    {
+      "prefix": "MASP",
+      "name": "MASP",
+      "course_count": 11,
+      "section_count": 46,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Processes",
+        "CNC Machining Center Fundamentals",
+        "CNC Milling",
+        "CNC Turning",
+        "CNC Turning Center Fundamentals"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "Radiographic",
+      "course_count": 33,
+      "section_count": 46,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Image Evaluation",
+        "CAT Scan",
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Education III"
+      ]
+    },
+    {
+      "prefix": "ROBO",
+      "name": "ROBO",
+      "course_count": 30,
+      "section_count": 46,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Hydraulics Lab",
+        "Advanced Machine Controls",
+        "Advanced Pneumatics Lab",
+        "Advanced Pneumatics Theory",
+        "Applied Hydraulics"
+      ]
+    },
+    {
+      "prefix": "TSESL",
+      "name": "Esol",
+      "course_count": 14,
+      "section_count": 46,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "ESOL 1 Integrated Skills",
+        "ESOL 1A Integrated Skills",
+        "ESOL 1B Integrated Skills",
+        "ESOL 2 Integrated Skills",
+        "ESOL 2A Integrated Skills"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 24,
+      "section_count": 45,
+      "colleges": [
+        "everett-community-college",
+        "north-seattle-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Building Construction for Fire Protection",
+        "Emergency Service Leadership",
+        "Emergency Vehicle Driving",
+        "Fire & Life Safety Education",
+        "Fire Behavior and Combustion"
+      ]
+    },
+    {
+      "prefix": "SDEV",
+      "name": "Development",
+      "course_count": 17,
+      "section_count": 45,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Algorithms",
+        "Artificial Intelligence Fundamentals",
+        "Cloud Application Deployment",
+        "Data Analytics and Software Development Capstone",
+        "Data Analytics Technologies"
+      ]
+    },
+    {
+      "prefix": "FS",
+      "name": "Fire",
+      "course_count": 24,
+      "section_count": 44,
+      "colleges": [
+        "columbia-basin-college",
+        "highline-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Fire Science",
+        "Building Construction",
+        "Chemistry of Hazardous Materials [RE]",
+        "Community Relations",
+        "Emergency Vehicle Operations"
+      ]
+    },
+    {
+      "prefix": "HOST",
+      "name": "HOST",
+      "course_count": 22,
+      "section_count": 44,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "AI Unveiled: An Introduction to LLMs and Generative AI",
+        "Budgeting and Revenue Management",
+        "Career Planning and Preparation",
+        "Cooperative Education",
+        "Customer Service Operations"
+      ]
+    },
+    {
+      "prefix": "ABF",
+      "name": "ABF",
+      "course_count": 43,
+      "section_count": 43,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Metal Straightening and Panel Alignment Methods Lab",
+        "Advanced Metal Straightening and Panel Replacement Methods",
+        "Automotive Collision MIG Welding",
+        "Basic Applications of Vinyl Wrapping",
+        "Basic Applications of Vinyl Wrapping (lab)"
+      ]
+    },
+    {
+      "prefix": "EDT",
+      "name": "EDT",
+      "course_count": 23,
+      "section_count": 43,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Applied Engineering Mechanics",
+        "Applied Precision Measurement",
+        "Applied Technical Math and Physics",
+        "Applied Technical Math I",
+        "Applied Technical Math II"
+      ]
+    },
+    {
+      "prefix": "HED",
+      "name": "HED",
+      "course_count": 13,
+      "section_count": 43,
+      "colleges": [
+        "big-bend-community-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Diversity in Health Care",
+        "Human Anatomy",
+        "Human Physiology and Disease",
+        "Medical Ethics",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "VET",
+      "name": "VET",
+      "course_count": 39,
+      "section_count": 43,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Anesthesia Lab",
+        "Anesthesia Lecture",
+        "Animal Anatomy & Physiology Lab",
+        "Animal Anatomy & Physiology Lecture",
+        "Animal Care-Lab I"
+      ]
+    },
+    {
+      "prefix": "APPFS",
+      "name": "Fire",
+      "course_count": 9,
+      "section_count": 42,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Building Construction",
+        "Fire Instructor I",
+        "Fire Officer I",
+        "Fire Officer II",
+        "Fire Protection Codes and Specialties"
+      ]
+    },
+    {
+      "prefix": "DUTEC",
+      "name": "DUTEC",
+      "course_count": 34,
+      "section_count": 42,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Abdominal Scanning and Techniques",
+        "Advanced Studies Echocardiography",
+        "Advanced Studies Obstetrics",
+        "Advanced Studies Vascular Technology",
+        "Basic Echocardiography"
+      ]
+    },
+    {
+      "prefix": "ECC",
+      "name": "Practicum",
+      "course_count": 7,
+      "section_count": 42,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Culture and Diversity",
+        "Curriculum Development II",
+        "Early Childhood Capstone",
+        "Practicum II",
+        "Practicum III"
+      ]
+    },
+    {
+      "prefix": "MFGT",
+      "name": "Manufacturing",
+      "course_count": 16,
+      "section_count": 42,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD/CAM Programming",
+        "Basic Manufacturing",
+        "Basic Manufacturing Part A",
+        "Basic Manufacturing Part B",
+        "Certified Quality Inspector Preparation"
+      ]
+    },
+    {
+      "prefix": "DDSGN",
+      "name": "DDSGN",
+      "course_count": 15,
+      "section_count": 41,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "3D Modeling",
+        "Advanced Digital Imaging",
+        "Advanced User Experience Design",
+        "Digital Illustration",
+        "Digital Photography"
+      ]
+    },
+    {
+      "prefix": "HPER",
+      "name": "HPER",
+      "course_count": 18,
+      "section_count": 41,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Baseball/Softball Methods and Materials",
+        "Baseball/Softball Skills and Rules",
+        "Basic Fitness I",
+        "Basic Fitness II",
+        "Basic Rodeo Skills and Rules"
+      ]
+    },
+    {
+      "prefix": "HSCI",
+      "name": "HSCI",
+      "course_count": 23,
+      "section_count": 41,
+      "colleges": [
+        "bates-technical-college",
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Behavioral & Cultural Issues in Public Health",
+        "Case Management and Community Education [RE]",
+        "Clinical Skills for Substance Use Disorders [RE]",
+        "Community Health Capstone",
+        "Cultural Competence in Substance Use Disorder Counseling [RE]"
+      ]
+    },
+    {
+      "prefix": "VASC",
+      "name": "Vascular",
+      "course_count": 31,
+      "section_count": 41,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Vascular Techniques",
+        "Cardiovascular Pathophysiology",
+        "Cardiovascular Physiology I",
+        "Cardiovascular Physiology II",
+        "Comparative Imaging Analysis"
+      ]
+    },
+    {
+      "prefix": "VCT",
+      "name": "VCT",
+      "course_count": 22,
+      "section_count": 41,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "3D Modeling & Animation With Maya",
+        "Adobe: Animation/Interactive Media",
+        "Adobe: Illustrator (Vector Graphics)",
+        "Adobe: Interactive/Web Design",
+        "Adobe: Raster Graphics w/Photoshop"
+      ]
+    },
+    {
+      "prefix": "AG",
+      "name": "Agriculture",
+      "course_count": 24,
+      "section_count": 40,
+      "colleges": [
+        "columbia-basin-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Precision Agriculture W/ Lab [RE]",
+        "Ag Information & Data Analytics",
+        "Agriculture Business Concepts [RE]",
+        "Agriculture Internship [RE]",
+        "Agriculture Management Capstone"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "Architecture",
+      "course_count": 20,
+      "section_count": 40,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Architectural Fundamentals",
+        "Architectural Technology Projects",
+        "AutoCAD I - Architecture",
+        "AutoCAD II - Architecture",
+        "Building Systems"
+      ]
+    },
+    {
+      "prefix": "AUTOM",
+      "name": "Service",
+      "course_count": 8,
+      "section_count": 40,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Brake Service",
+        "Advanced Disc and Drum Brake Service",
+        "Advanced Wheel Alignment/Steering System Service",
+        "Applied HVAC Service",
+        "Drum and Disc Braking Systems"
+      ]
+    },
+    {
+      "prefix": "CU",
+      "name": "Excel",
+      "course_count": 5,
+      "section_count": 40,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Excel I",
+        "Excel II",
+        "Introduction to Practical Computing",
+        "Word I",
+        "Word I, Excel I"
+      ]
+    },
+    {
+      "prefix": "DHET",
+      "name": "DHET",
+      "course_count": 18,
+      "section_count": 40,
+      "colleges": [
+        "lake-washington-institute-of-technology",
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Basic Mechanic Knowledge and Skills",
+        "Cooperative Work Experience",
+        "Cooperative Work Experience I",
+        "Cooperative Work Experience Seminar I",
+        "Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 31,
+      "section_count": 40,
+      "colleges": [
+        "olympic-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography",
+        "Abdominal Sonography Extended (Small Parts and Superficial Structures)",
+        "Abdominal Sonography I",
+        "Advanced Sonography",
+        "Clinical Education I"
+      ]
+    },
+    {
+      "prefix": "DSGN",
+      "name": "Design",
+      "course_count": 17,
+      "section_count": 40,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Design Essentials: Tools, Techniques, and Workflow",
+        "Design History",
+        "Design Principles",
+        "Design Systems",
+        "Identity Design and Branding"
+      ]
+    },
+    {
+      "prefix": "MMGT",
+      "name": "MMGT",
+      "course_count": 16,
+      "section_count": 40,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Content, Social and Digital Marketing",
+        "Cooperative Education Work Experience (No Seminar)",
+        "Customer Service",
+        "Fundamentals of Advertising",
+        "Fundamentals of Project Management"
+      ]
+    },
+    {
+      "prefix": "NRS A",
+      "name": "Assistant",
+      "course_count": 3,
+      "section_count": 40,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Nurse Assistant Lab",
+        "Nurse Assistant Theory",
+        "Nursing Assistant Clinical"
+      ]
+    },
+    {
+      "prefix": "OLTM",
+      "name": "OLTM",
+      "course_count": 21,
+      "section_count": 40,
+      "colleges": [
+        "lower-columbia-college",
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "A Leaders Introduction to Human Resource Management",
+        "Advanced Project Management",
+        "Business Ethics and Policy",
+        "Capstone",
+        "Coaching and Mentoring"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "Care",
+      "course_count": 8,
+      "section_count": 40,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Application of Care of the Family and Mental Health Patient",
+        "Application of Care of the Medical/Surgical Patient",
+        "Application of Fundamentals in Nursing",
+        "Care of the Family and Mental Health Patient",
+        "Care of the Medical/Surgical Patient"
+      ]
+    },
+    {
+      "prefix": "AEC",
+      "name": "AEC",
+      "course_count": 15,
+      "section_count": 39,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Architectural BIM I",
+        "Architectural BIM II",
+        "Building Information Modeling III",
+        "Building Information Modeling IV",
+        "Civil CAD I"
+      ]
+    },
+    {
+      "prefix": "ARC",
+      "name": "ARC",
+      "course_count": 21,
+      "section_count": 39,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Building Information Modeling",
+        "Applied CADD (Computer Literacy)",
+        "Civil Engineering",
+        "Construction Materials Research",
+        "Cost Estimating I"
+      ]
+    },
+    {
+      "prefix": "CSE",
+      "name": "Computer Science",
+      "course_count": 8,
+      "section_count": 39,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Data Structures & Object-Oriented Programming",
+        "Digital Logic Design",
+        "Discrete Structures",
+        "Engineering and Computer Science Orientation",
+        "Introduction to C"
+      ]
+    },
+    {
+      "prefix": "ECHO",
+      "name": "ECHO",
+      "course_count": 31,
+      "section_count": 39,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Cardiovascular Pathophysiology",
+        "Cardiovascular Physiology I",
+        "Cardiovascular Physiology II",
+        "Comparative Imaging Analysis",
+        "Core Concepts in Echo Vasc"
+      ]
+    },
+    {
+      "prefix": "LA",
+      "name": "LA",
+      "course_count": 23,
+      "section_count": 39,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Contracts",
+        "Criminal Law and Procedure",
+        "Employment Law",
+        "Evidence",
+        "Family Law"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 19,
+      "section_count": 39,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Nursing Concepts I",
+        "Advanced Nursing Concepts II",
+        "Advanced Nursing Concepts III",
+        "Advanced Nursing Practicum I",
+        "Advanced Nursing Practicum II"
+      ]
+    },
+    {
+      "prefix": "SONO",
+      "name": "SONO",
+      "course_count": 17,
+      "section_count": 39,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Case Studies & Journal Review",
+        "Cardiac for General Sonographer",
+        "Diagnostic Ultrasound; 2nd and 3rd trimester",
+        "Diagnostic Ultrasound; Abdomen & Male Pelvis",
+        "Diagnostic Ultrasound; Female Pelvis & 1st tri OB"
+      ]
+    },
+    {
+      "prefix": "AENGL",
+      "name": "College",
+      "course_count": 6,
+      "section_count": 38,
+      "colleges": [
+        "bellingham-technical-college",
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Applied English",
+        "Composition for College",
+        "Editing for College",
+        "Language for College",
+        "Reading for College"
+      ]
+    },
+    {
+      "prefix": "CMA",
+      "name": "Medical",
+      "course_count": 15,
+      "section_count": 38,
+      "colleges": [
+        "bates-technical-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Administrative and Clinical Practice/Review",
+        "Billing and Coding Procedures",
+        "Fundamentals of Administrative Medical Assisting",
+        "Fundamentals of Clinical Medical Assisting",
+        "Introduction to Medical Assisting"
+      ]
+    },
+    {
+      "prefix": "DIGIT",
+      "name": "Project",
+      "course_count": 13,
+      "section_count": 38,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Compositing I",
+        "Compositing II",
+        "Digital Imaging",
+        "Digital Media - Animation",
+        "Digital Media - Audio"
+      ]
+    },
+    {
+      "prefix": "EMTEC",
+      "name": "EMTEC",
+      "course_count": 19,
+      "section_count": 38,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "AC Circuits",
+        "Applied Mechanics",
+        "Automated Manufacturing Systems",
+        "Bearings and Drives",
+        "Computer Programming"
+      ]
+    },
+    {
+      "prefix": "HCML",
+      "name": "Healthcare",
+      "course_count": 19,
+      "section_count": 38,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Business Planning in Healthcare",
+        "Capstone Project",
+        "Capstone Proposal",
+        "Essential Foundations of Healthcare Management",
+        "Field Studies"
+      ]
+    },
+    {
+      "prefix": "ICT",
+      "name": "ICT",
+      "course_count": 37,
+      "section_count": 38,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Acute Coronary Syndrome",
+        "Advanced Cardiac Life Support Course",
+        "Advanced Cardiac Life Support Technical Skills Lab",
+        "Advanced Practices/Management",
+        "Basic Life Support Instructor Course"
+      ]
+    },
+    {
+      "prefix": "PHARM",
+      "name": "Pharmacy",
+      "course_count": 19,
+      "section_count": 38,
+      "colleges": [
+        "spokane-community-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Pharmacology",
+        "Community Pharmacy",
+        "Community Pharmacy Dispensing and Management",
+        "Entering the Work Environment",
+        "Foundations of Pharmacology in Nursing"
+      ]
+    },
+    {
+      "prefix": "SHS",
+      "name": "SHS",
+      "course_count": 27,
+      "section_count": 38,
+      "colleges": [
+        "edmonds-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Addiction and Youth and Family Systems",
+        "Addiction Studies Practicum",
+        "Addiction, Adolescents and Family Systems",
+        "Career and College Success: Human Services",
+        "Case Management and Community Resources"
+      ]
+    },
+    {
+      "prefix": "TSABE",
+      "name": "TSABE",
+      "course_count": 18,
+      "section_count": 38,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Algebra 1",
+        "Algebra 2",
+        "Arithmetic (A)",
+        "Arithmetic B/Pre-Algebra",
+        "Biology"
+      ]
+    },
+    {
+      "prefix": "ACED",
+      "name": "ACED",
+      "course_count": 16,
+      "section_count": 37,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Addictions and Mental Illness",
+        "Adolescent Addiction Assessment & Treatment",
+        "Advanced Techniques for Addiction Counsel",
+        "Air- and Blood-Borne Pathogens",
+        "Case Management In Addiction Medicine"
+      ]
+    },
+    {
+      "prefix": "BTECM",
+      "name": "Medical",
+      "course_count": 8,
+      "section_count": 37,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Coding and Reimbursement",
+        "CPT Coding",
+        "Diagnosis Coding",
+        "Electronic Health Records",
+        "Introduction to the Medical Office"
+      ]
+    },
+    {
+      "prefix": "ELLAB",
+      "name": "English",
+      "course_count": 12,
+      "section_count": 37,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ELL Registration and Enrollment",
+        "Integrated Skills In English 1",
+        "Integrated Skills In English 2",
+        "Integrated Skills In English 3",
+        "Integrated Skills In English 4"
+      ]
+    },
+    {
+      "prefix": "IBOD",
+      "name": "Open",
+      "course_count": 5,
+      "section_count": 37,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Open Doors I-BEST Academic Skills for ECED",
+        "Open Doors I-BEST Academic Skills for EDUC",
+        "Open Doors I-BEST Chemistry Skills",
+        "Open Doors I-BEST English Skills",
+        "Open Doors I-BEST Math Skills"
+      ]
+    },
+    {
+      "prefix": "INV",
+      "name": "Invest",
+      "course_count": 26,
+      "section_count": 37,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Invest Business Technology",
+        "Invest Capstone",
+        "INVEST Career Connections",
+        "INVEST Career Exploration",
+        "Invest Communication and Self-Advocacy"
+      ]
+    },
+    {
+      "prefix": "MED",
+      "name": "Medical",
+      "course_count": 21,
+      "section_count": 37,
+      "colleges": [
+        "peninsula-college",
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Administrative Ambulatory Care",
+        "Advanced Clinical Procedures",
+        "Clinical Practicum for Medical Assistants",
+        "Disease and the Human Body",
+        "Externship for Medical Assistants"
+      ]
+    },
+    {
+      "prefix": "AS",
+      "name": "AS",
+      "course_count": 12,
+      "section_count": 36,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Addiction Counseling Techniques",
+        "Case Management I: Screening, Diagnosis, Assessment, and ASAM",
+        "Co-Occurring Behavioral Health Disorders",
+        "Cultural Diversity; Risk Intervention for Health/HIV",
+        "Group Facilitation for Addiction Treatment"
+      ]
+    },
+    {
+      "prefix": "CES",
+      "name": "CES",
+      "course_count": 15,
+      "section_count": 36,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Art and Soul: Cultural Connections Through Art",
+        "Comedy As Resistance",
+        "Introduction to African American Studies",
+        "Introduction to Asian American Studies",
+        "Introduction to Latinx Studies"
+      ]
+    },
+    {
+      "prefix": "CSNT",
+      "name": "Network",
+      "course_count": 12,
+      "section_count": 36,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "A+ Hardware",
+        "A+ Software Essentials",
+        "Capstone",
+        "Cloud Computing",
+        "Network Administration I"
+      ]
+    },
+    {
+      "prefix": "DES",
+      "name": "Graphic",
+      "course_count": 9,
+      "section_count": 36,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Graphic Design I",
+        "Graphic Design IV",
+        "Graphic Design V",
+        "Graphic Production I",
+        "History of Graphic Design"
+      ]
+    },
+    {
+      "prefix": "EF",
+      "name": "EF",
+      "course_count": 25,
+      "section_count": 36,
+      "colleges": [
+        "cascadia-college"
+      ],
+      "sample_titles": [
+        "Advanced Reading and Writing",
+        "Beginning English Communication",
+        "Beginning Reading",
+        "Beginning Speaking and Listening",
+        "Beginning Writing and Grammar"
+      ]
+    },
+    {
+      "prefix": "FLPC",
+      "name": "Parent",
+      "course_count": 3,
+      "section_count": 36,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Parent Education for Child Care Parents"
+      ]
+    },
+    {
+      "prefix": "OD",
+      "name": "English",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Algebra 2",
+        "Algebra I",
+        "CWP, Environmental Science, English",
+        "English for Civic Literacy levels 1, 2, and 3",
+        "Geometry"
+      ]
+    },
+    {
+      "prefix": "STEM",
+      "name": "Stem",
+      "course_count": 6,
+      "section_count": 36,
+      "colleges": [
+        "bellevue-college",
+        "edmonds-college",
+        "everett-community-college",
+        "highline-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Career and College Success: STEM",
+        "Equity in STEM through Community-centered Experiences",
+        "Interdisciplinary Design Project",
+        "Introductory Scripting using Python",
+        "Stem Exploration: It All Begins With A Question!"
+      ]
+    },
+    {
+      "prefix": "ABEAF",
+      "name": "Math",
+      "course_count": 7,
+      "section_count": 35,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ABE Math for College and Career 3",
+        "ABE Math Skills for College and Career 1",
+        "ABE Math Skills for College and Career 2",
+        "ABE Math Skills for College and Career 4",
+        "ABE Math Skills for College and Career 5"
+      ]
+    },
+    {
+      "prefix": "ARCHT",
+      "name": "ARCHT",
+      "course_count": 23,
+      "section_count": 35,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Architectural Math",
+        "Advanced Commercial Building Materials",
+        "Advanced Commercial Construction Documents/CAD",
+        "Architectural Design 1",
+        "Architectural Math"
+      ]
+    },
+    {
+      "prefix": "CLART",
+      "name": "CLART",
+      "course_count": 35,
+      "section_count": 35,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking",
+        "Beginning Baking",
+        "Beginning Baking Theory",
+        "Bread Production",
+        "Cost Analysis"
+      ]
+    },
+    {
+      "prefix": "CUIS",
+      "name": "CUIS",
+      "course_count": 20,
+      "section_count": 35,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Advanced Culinary Fundamentals",
+        "Advanced Culinary Practices",
+        "Advanced Garde Manger",
+        "Barbeque Basics",
+        "Career Explorations"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 17,
+      "section_count": 35,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Applications in Environmental Sciences I",
+        "Applications in Environmental Sciences II",
+        "Environmental Chemistry With Lab",
+        "Environmental Critical Areas",
+        "Environmental Science Capstone (Capstone)"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 35,
+      "colleges": [
+        "clover-park-technical-college",
+        "columbia-basin-college",
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Geologic Catastrophes in the Pacific Northwest",
+        "Geology of the Cascades Field Trip",
+        "GIS Technologies",
+        "GPS Technologies",
+        "Ice Age Geology Field Trip"
+      ]
+    },
+    {
+      "prefix": "IBE",
+      "name": "Ibest",
+      "course_count": 5,
+      "section_count": 35,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "I-BEST Academic Skills for ECED",
+        "I-BEST Academic Skills for EDUC",
+        "I-BEST Chemistry Skills",
+        "I-BEST English Skills",
+        "I-BEST Math Skills"
+      ]
+    },
+    {
+      "prefix": "NURSL",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 35,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Nursing Care of the Adult Client I Lab",
+        "Nursing Care of the Adult Client II Lab",
+        "Nursing Fundamentals Lab"
+      ]
+    },
+    {
+      "prefix": "OFFAD",
+      "name": "Office",
+      "course_count": 4,
+      "section_count": 35,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Office Administration Internship",
+        "Office Management",
+        "Office Procedures",
+        "Records Management"
+      ]
+    },
+    {
+      "prefix": "WGES",
+      "name": "Women",
+      "course_count": 5,
+      "section_count": 35,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Race, Class, Gender, and Sexuality",
+        "Racism & White Privilege In The U.S.",
+        "Women Across Cultures",
+        "Women, Arts, and Culture",
+        "Women, Gender, and Power"
+      ]
+    },
+    {
+      "prefix": "WTD",
+      "name": "Trades",
+      "course_count": 4,
+      "section_count": 35,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Communication for Trades",
+        "Human Relations for Trades",
+        "Math for the Trades",
+        "Safety Certifications"
+      ]
+    },
+    {
+      "prefix": "ABED",
+      "name": "ABED",
+      "course_count": 8,
+      "section_count": 34,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "ABE Learning Strategies",
+        "ABE Orientation",
+        "Basic Skills for College Preparation",
+        "Grammar and Writing for Advanced ELL",
+        "Math for Everyday Life"
+      ]
+    },
+    {
+      "prefix": "AHST",
+      "name": "Surgical",
+      "course_count": 22,
+      "section_count": 34,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Asepsis & Infection Control In Surgery",
+        "Operating Room Clinical-I",
+        "Operating Room Clinical-II",
+        "Operating Room Seminar-I",
+        "Operating Room Seminar-II"
+      ]
+    },
+    {
+      "prefix": "CAS",
+      "name": "Computer",
+      "course_count": 9,
+      "section_count": 34,
+      "colleges": [
+        "clover-park-technical-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Access I (Computer Literacy)",
+        "College Seminar",
+        "Excel I (Computer Literacy)",
+        "Excel II (Computer Literacy)",
+        "Introduction to Computing (Computer Literacy)"
+      ]
+    },
+    {
+      "prefix": "COSMT",
+      "name": "Cosmetology",
+      "course_count": 15,
+      "section_count": 34,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Haircutting and Styling Lab",
+        "Cosmetology Basic Skills and Salon Practice",
+        "Cosmetology Compendium",
+        "Cosmetology Internship",
+        "Cosmetology Lab & Shop Practice IX"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 6,
+      "section_count": 34,
+      "colleges": [
+        "north-seattle-college",
+        "seattle-central-college",
+        "south-seattle-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Computer Programming I",
+        "Computer Programming II",
+        "Computers for Math and Science",
+        "Introduction to Computer Programming",
+        "Web Design I"
+      ]
+    },
+    {
+      "prefix": "IELP",
+      "name": "IELP",
+      "course_count": 10,
+      "section_count": 34,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Advanced Academic Grammar",
+        "Advanced English & Science/CWP",
+        "Advanced English & US History/Government",
+        "Essential Oral Communication and Professional Portfolio",
+        "Essential Technology and Study Skills"
+      ]
+    },
+    {
+      "prefix": "AMGT",
+      "name": "Management",
+      "course_count": 13,
+      "section_count": 33,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Applied Management Capstone",
+        "BAS Independent Study",
+        "BAS Internship",
+        "Business Planning and Strategy",
+        "Contemporary Issues in Business & Management"
+      ]
+    },
+    {
+      "prefix": "BIR",
+      "name": "Repair",
+      "course_count": 22,
+      "section_count": 33,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Brass Repair Techniques",
+        "Advanced Woodwind Repair Techniques",
+        "Band Instrument Safety, Cleaning & Sanitization",
+        "Brasswind Performance and Testing Techniques",
+        "Capstone Project in Band Instrument Repair"
+      ]
+    },
+    {
+      "prefix": "DENHY",
+      "name": "DENHY",
+      "course_count": 33,
+      "section_count": 33,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Dental Hygiene Theory V",
+        "Advanced Dental Hygiene Theory VI",
+        "Clinical Dental Hygiene and Fundamentals I",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene IV"
+      ]
+    },
+    {
+      "prefix": "FACM",
+      "name": "FACM",
+      "course_count": 16,
+      "section_count": 33,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Boiler Operations",
+        "Advanced Projects",
+        "Basic Refrigeration",
+        "Boiler Operations and Certifications",
+        "Computer Applications"
+      ]
+    },
+    {
+      "prefix": "INDES",
+      "name": "Design",
+      "course_count": 26,
+      "section_count": 33,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "AutoCAD for Interior Design",
+        "Capstone Design Proposal",
+        "Capstone Design Studio I",
+        "Contract Documents",
+        "Design and Fabrication"
+      ]
+    },
+    {
+      "prefix": "INTL",
+      "name": "Beginning",
+      "course_count": 9,
+      "section_count": 33,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Advanced ELL",
+        "Beginning ELL Literacy",
+        "Beginning International Academic Support",
+        "High Beginning ELL",
+        "High Intermediate ELL"
+      ]
+    },
+    {
+      "prefix": "NSCI",
+      "name": "NSCI",
+      "course_count": 4,
+      "section_count": 33,
+      "colleges": [
+        "cascadia-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Environmental Biology",
+        "Evolution of Earth Systems",
+        "Inquiry Based Science for Teachers",
+        "Nature"
+      ]
+    },
+    {
+      "prefix": "OFTEC",
+      "name": "OFTEC",
+      "course_count": 15,
+      "section_count": 33,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Business English",
+        "Digital Productivity Tools",
+        "Fundamentals of Project Management",
+        "Integrated Office Projects Capstone"
+      ]
+    },
+    {
+      "prefix": "PE-ED",
+      "name": "PE-ED",
+      "course_count": 9,
+      "section_count": 33,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Adult CPR & AED",
+        "Diversity in Sport",
+        "Exploring Body Image",
+        "First Aid",
+        "Health Education"
+      ]
+    },
+    {
+      "prefix": "SUDP",
+      "name": "SUDP",
+      "course_count": 22,
+      "section_count": 33,
+      "colleges": [
+        "centralia-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Assess & Treatment Plans",
+        "Case Management I",
+        "Case Management II",
+        "Co-Occurring Behavioral Health Disorders",
+        "Counseling Adolescents"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "ACT",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Collision Major Repair (Capstone)",
+        "Body Shop Equipment",
+        "Collision Estimating",
+        "Fundamentals of Collision Repair",
+        "Glass, Trim, & Hardware"
+      ]
+    },
+    {
+      "prefix": "CARPT",
+      "name": "CARPT",
+      "course_count": 9,
+      "section_count": 32,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Floor Systems",
+        "Introduction to Framing",
+        "Optical Instruments",
+        "Power Tools",
+        "Roofing Construction"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "CDL",
+      "course_count": 6,
+      "section_count": 32,
+      "colleges": [
+        "big-bend-community-college",
+        "centralia-college",
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "CDL Licensing Preparation",
+        "Commercial Driver's License (CDL)",
+        "Introduction to Commercial Driving",
+        "Introduction to Truck Maintenance",
+        "Safety Procedures and Emergency Handling"
+      ]
+    },
+    {
+      "prefix": "CECO",
+      "name": "CECO",
+      "course_count": 17,
+      "section_count": 32,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Language Arts",
+        "Advanced Math",
+        "Advanced Science",
+        "Advanced Social Studies",
+        "Building College Engagement and Readiness"
+      ]
+    },
+    {
+      "prefix": "DVOP",
+      "name": "DVOP",
+      "course_count": 20,
+      "section_count": 32,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "AWS DevOps Engineering",
+        "Cisco Infrastructure Automation",
+        "Cisco Network Infrastructure II",
+        "Cisco Network Infrastructure III",
+        "Cisco Network Infrastructure IV"
+      ]
+    },
+    {
+      "prefix": "ELCT",
+      "name": "Assembly",
+      "course_count": 4,
+      "section_count": 32,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Advanced Aircraft Assembly and Materials",
+        "Aerospace Assembly and Safety Techniques",
+        "Avionics Wiring and Fiber Optics Integration",
+        "Precision Assembly Techniques"
+      ]
+    },
+    {
+      "prefix": "IESL",
+      "name": "IESL",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Grammar I",
+        "Grammar II",
+        "Grammar III",
+        "Grammar IV",
+        "Reading I"
+      ]
+    },
+    {
+      "prefix": "INDUS",
+      "name": "Welding",
+      "course_count": 5,
+      "section_count": 32,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Basic Woodworking",
+        "Introduction to Building Construction Trades",
+        "Welding Survey 1",
+        "Welding Survey 2",
+        "Welding Survey 3"
+      ]
+    },
+    {
+      "prefix": "PT",
+      "name": "PT",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Lab",
+        "Advanced Pharmacy Practice",
+        "Clinical Capstone Research",
+        "Community Pharmacy Clinical Capstone (Capstone)",
+        "Community Practice W/Lab"
+      ]
+    },
+    {
+      "prefix": "SBS",
+      "name": "SBS",
+      "course_count": 7,
+      "section_count": 32,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Alternative Energy Systems",
+        "Basic Diagnostics and Testing",
+        "Building Envelope",
+        "Moisture Mitigation",
+        "Service Learning Project (Capstone)"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "AT",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Automotive Electrical I",
+        "Automotive Electrical II",
+        "Automotive Engines & Cooling Systems",
+        "Automotive HVAC Systems",
+        "Automotive Parts & Service Specialist"
+      ]
+    },
+    {
+      "prefix": "BIM",
+      "name": "Office",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Microsoft Office",
+        "Basic Keyboarding",
+        "Intermediate Keyboarding",
+        "Internet Communications",
+        "Introduction to Microsoft Office"
+      ]
+    },
+    {
+      "prefix": "CNE",
+      "name": "CNE",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Administering Windows Server Hybrid - Services",
+        "Administering Windows Server Hybrid-Infrastructure",
+        "CCCA Cyber Operations",
+        "CCNA 1: Introduction to Networks",
+        "CCNA 2: Switching, Routing and Wireless Essentials"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "EET",
+      "course_count": 16,
+      "section_count": 31,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "A.C. Principles of Electronics",
+        "Analog Circuits and Devices",
+        "Biomedical Equipment I",
+        "Biomedical Technician Externship",
+        "Digital Electronics & Plcs II"
+      ]
+    },
+    {
+      "prefix": "ELTRO",
+      "name": "ELTRO",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Basic DC-1",
+        "Control Devices and Robotics",
+        "Cooperative Work Experience",
+        "Digital Electronics",
+        "Graphic Interface Programs for PLCs"
+      ]
+    },
+    {
+      "prefix": "ABDY",
+      "name": "Autobody",
+      "course_count": 18,
+      "section_count": 30,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Detail",
+        "Autobody Construction I",
+        "Autobody Construction II",
+        "Autobody Plastics Repair and Refinishing",
+        "Autobody Structure and Mechanics"
+      ]
+    },
+    {
+      "prefix": "AUDIO",
+      "name": "Audio",
+      "course_count": 12,
+      "section_count": 30,
+      "colleges": [
+        "spokane-falls-community-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Audio Engineering I",
+        "Audio Engineering II",
+        "Audio Recording I",
+        "Digital Audio I",
+        "Digital Audio III"
+      ]
+    },
+    {
+      "prefix": "DENLB",
+      "name": "DENLB",
+      "course_count": 20,
+      "section_count": 30,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Crown and Bridge",
+        "Advanced Dental Ceramics",
+        "Advanced Dentures",
+        "Advanced Orthodontics",
+        "Advanced Rpds"
+      ]
+    },
+    {
+      "prefix": "DRAMA",
+      "name": "DRAMA",
+      "course_count": 11,
+      "section_count": 30,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Beginning Acting",
+        "Community Service Course",
+        "Directing for The Stage",
+        "Intermediate Acting",
+        "Introduction Cinema"
+      ]
+    },
+    {
+      "prefix": "ESRT",
+      "name": "ESRT",
+      "course_count": 13,
+      "section_count": 30,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning & Heat Pumps",
+        "Blueprint Reading",
+        "Capstone HVACR Project",
+        "Commercial DD0/BASC HVAC Controls",
+        "Commercial HVACR Equipment"
+      ]
+    },
+    {
+      "prefix": "GERM&",
+      "name": "German",
+      "course_count": 3,
+      "section_count": 30,
+      "colleges": [
+        "bellevue-college",
+        "green-river-college",
+        "olympic-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "German I",
+        "German II",
+        "German III"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 19,
+      "section_count": 29,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Cooperative Work Experience",
+        "Crop Growth & Development",
+        "Crop Production Management",
+        "Field Based Integrated Pest Mgmt",
+        "Hispanic Orchard Employee Education Program II"
+      ]
+    },
+    {
+      "prefix": "AMA",
+      "name": "AMA",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "bates-technical-college",
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Terminology - Pathophysiology",
+        "Beginning Medical Terminology",
+        "Digital Media Transcription",
+        "Electronic Health Records",
+        "First Aid/CPR"
+      ]
+    },
+    {
+      "prefix": "DET",
+      "name": "DET",
+      "course_count": 20,
+      "section_count": 29,
+      "colleges": [
+        "bellingham-technical-college",
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Advanced Diagnostics",
+        "Applied Failure Analysis",
+        "Chassis Electrical Systems",
+        "Chassis Electrical Systems Lab",
+        "Drive Train"
+      ]
+    },
+    {
+      "prefix": "DHY",
+      "name": "Dental",
+      "course_count": 22,
+      "section_count": 29,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Advanced Practicum In Dental Hygiene I",
+        "Advanced Restorative Practice I",
+        "Advanced Restorative Practice II",
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene IV"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "ENT",
+      "course_count": 17,
+      "section_count": 29,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Advanced Drafting [RE]",
+        "Architectural/Structural Drafting [RE]",
+        "Architecture & Engineering Blueprint Reading [RE]",
+        "Construction Estimating [RE]",
+        "Construction Specifications [RE]"
+      ]
+    },
+    {
+      "prefix": "MAST",
+      "name": "MAST",
+      "course_count": 26,
+      "section_count": 29,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology II",
+        "Anatomy & Physiology III",
+        "Asian Bodywork Modalities",
+        "Clinic"
+      ]
+    },
+    {
+      "prefix": "RADTX",
+      "name": "RADTX",
+      "course_count": 29,
+      "section_count": 29,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice I",
+        "Clinical Practice II",
+        "Clinical Practice III",
+        "Clinical Practice IV",
+        "Clinical Practice V"
+      ]
+    },
+    {
+      "prefix": "SSBH",
+      "name": "SSBH",
+      "course_count": 8,
+      "section_count": 29,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Abuse in the Family",
+        "Behavioral Health Interviewing and Assessment",
+        "Identity and Values in the Family",
+        "Introduction to Human Services",
+        "Law and Ethics in Social Services"
+      ]
+    },
+    {
+      "prefix": "SURV",
+      "name": "SURV",
+      "course_count": 17,
+      "section_count": 29,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Arc GIS I",
+        "Boundary Law I",
+        "Boundary Surveys",
+        "Cooperative Work Experience",
+        "Emerging Technology"
+      ]
+    },
+    {
+      "prefix": "BASAM",
+      "name": "Management",
+      "course_count": 13,
+      "section_count": 28,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Accounting Principles for Managers",
+        "Applied Management Internship",
+        "Business Principles",
+        "Business Research Applications",
+        "Capstone: Strategic Management & Policy"
+      ]
+    },
+    {
+      "prefix": "BH&",
+      "name": "BH&",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "big-bend-community-college",
+        "lake-washington-institute-of-technology",
+        "olympic-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Counseling Techniques",
+        "Assessment of Mental Health Disorders",
+        "Behavioral Neuroscience",
+        "Case Management",
+        "Ethics in Behavioral Healthcare"
+      ]
+    },
+    {
+      "prefix": "CMATH",
+      "name": "Corequisite",
+      "course_count": 3,
+      "section_count": 28,
+      "colleges": [
+        "renton-technical-college",
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Statistics Corequisite",
+        "Math in Society Corequisite",
+        "Precalculus I Corequisite"
+      ]
+    },
+    {
+      "prefix": "CSBS",
+      "name": "CSBS",
+      "course_count": 23,
+      "section_count": 28,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Application of Artificial Intelligence",
+        "Application of Cloud Computing",
+        "Capstone Project I",
+        "Capstone Project II",
+        "Capstone Project III"
+      ]
+    },
+    {
+      "prefix": "ELCN",
+      "name": "ELCN",
+      "course_count": 10,
+      "section_count": 28,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "AC Theory and NEC",
+        "Applied Electrical Circuits and Construction",
+        "Commercial Wiring Installation",
+        "Controls and Automation",
+        "Controls and Automation Lab"
+      ]
+    },
+    {
+      "prefix": "ESTE",
+      "name": "ESTE",
+      "course_count": 7,
+      "section_count": 28,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Electric Motors & Maintenance",
+        "Introduction to Basic Electronics",
+        "Introduction To Controls",
+        "Principles of Electricity Theory",
+        "Principles of Power Generation and Distribution"
+      ]
+    },
+    {
+      "prefix": "ETRIC",
+      "name": "ETRIC",
+      "course_count": 11,
+      "section_count": 28,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD Operations",
+        "CAD Design Applications",
+        "Code Applications",
+        "Electrical Math",
+        "Electrical Systems With Simulation"
+      ]
+    },
+    {
+      "prefix": "HEQ",
+      "name": "HEQ",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical Applications",
+        "Basic Electrical Theory",
+        "Basic Engine Applications",
+        "Basic Principles of Engine Theory",
+        "Cooperative Education Seminar"
+      ]
+    },
+    {
+      "prefix": "HIIM",
+      "name": "HIIM",
+      "course_count": 21,
+      "section_count": 28,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "AI, Informatics and Healthcare",
+        "Alternative Care Record Systems",
+        "Basic ICD-10 Coding",
+        "Coding Practicum & Career Prep",
+        "Cybersecurity Fundamentals"
+      ]
+    },
+    {
+      "prefix": "MUSL",
+      "name": "MUSL",
+      "course_count": 25,
+      "section_count": 28,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Applied Bass I",
+        "Applied Bass III",
+        "Applied Bass IV",
+        "Applied Bassoon I",
+        "Applied Cello I"
+      ]
+    },
+    {
+      "prefix": "NAC",
+      "name": "Nursing",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "clover-park-technical-college",
+        "peninsula-college",
+        "shoreline-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Nursing Assistant Care",
+        "Fundamentals of Patient Care",
+        "Nursing Assistant (NAC) Theory and Skills Lab",
+        "Nursing Assistant (NAC) Theory and Skills Lab I",
+        "Nursing Assistant Clinical Experience"
+      ]
+    },
+    {
+      "prefix": "VETT",
+      "name": "VETT",
+      "course_count": 18,
+      "section_count": 28,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Lab Sciences",
+        "Anesthesia",
+        "Dentistry",
+        "Exotic Animal Medicine",
+        "Humanity of Veterinary Medicine"
+      ]
+    },
+    {
+      "prefix": "AP",
+      "name": "Anatomy",
+      "course_count": 4,
+      "section_count": 27,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Bringing Anatomy and Physiology to Life",
+        "Cadaver Anatomy",
+        "Essentials of Human Anatomy and Physiology 1",
+        "Survey of Human Anatomy and Physiology"
+      ]
+    },
+    {
+      "prefix": "LBM",
+      "name": "LBM",
+      "course_count": 11,
+      "section_count": 27,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Business and Personal Mathematics",
+        "Conflict Resolution",
+        "E-Business Strategies",
+        "Human Relations In Organizations",
+        "Improving Human Effectiveness"
+      ]
+    },
+    {
+      "prefix": "OPM",
+      "name": "OPM",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "bellingham-technical-college",
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Facility Layout and Materials Handling",
+        "Focused Study I",
+        "Focused Study II",
+        "Focused Study III",
+        "Forecasting and System Design"
+      ]
+    },
+    {
+      "prefix": "OSH",
+      "name": "OSH",
+      "course_count": 17,
+      "section_count": 27,
+      "colleges": [
+        "columbia-basin-college",
+        "edmonds-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Accident Prevention, Inspection & Investigations [RE]",
+        "Ergonomics",
+        "Ergonomics [RE]",
+        "Fundamentals of Occupational Safety & Health [RE]",
+        "Handling Hazardous Materials"
+      ]
+    },
+    {
+      "prefix": "PHA",
+      "name": "Pharmacy",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Healthcare Systems, Insurance and Billing",
+        "Intro to the Pharmacy and Pharmacy Assistant",
+        "Job Skills and National Exam Preparation",
+        "Orientation to Pharmacy Practice",
+        "Pharmacology II"
+      ]
+    },
+    {
+      "prefix": "AES",
+      "name": "American",
+      "course_count": 9,
+      "section_count": 26,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Asian American and Pacific Islander Studies",
+        "From Rhymes to Reason: The Culture of Hip Hop",
+        "Gender, Race, and Class",
+        "Introduction to African American Studies",
+        "Introduction to Chicanx/Latinx Studies"
+      ]
+    },
+    {
+      "prefix": "ANES",
+      "name": "Anesthesia",
+      "course_count": 19,
+      "section_count": 26,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support and Pediatric Advanced Life Support",
+        "Anesthesia Equipment: Principles and Applications",
+        "Anesthesia Technology Clinical Practicum I",
+        "Anesthesia Technology Clinical Practicum II",
+        "Anesthesia Technology Clinical Practicum III"
+      ]
+    },
+    {
+      "prefix": "APDZ",
+      "name": "Design",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Branded Interaction",
+        "Design and Creativity",
+        "Design and Innovation",
+        "Design Practice Internship",
+        "Design Project Iteration"
+      ]
+    },
+    {
+      "prefix": "ARWC",
+      "name": "ARWC",
+      "course_count": 15,
+      "section_count": 26,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Projects",
+        "Cabinet Installation - Residential / Commercial",
+        "Cabinetmaking / 32mm System",
+        "Cabinetmaking / Commercial Construction",
+        "Employment Preparation"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 8,
+      "section_count": 26,
+      "colleges": [
+        "clark-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "American Deaf Culture",
+        "American Sign Language IV",
+        "American Sign Language-I",
+        "American Sign Language-II",
+        "American Sign Language-III"
+      ]
+    },
+    {
+      "prefix": "ATMOS",
+      "name": "Weather",
+      "course_count": 1,
+      "section_count": 26,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Introduction to Weather"
+      ]
+    },
+    {
+      "prefix": "BMGT",
+      "name": "BMGT",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Applied Principles of Management",
+        "Business Calculations",
+        "Business Communication",
+        "Business Finance and Dynamic Decision-Making",
+        "Designing Your Professional Technical Journey"
+      ]
+    },
+    {
+      "prefix": "CARTS",
+      "name": "CARTS",
+      "course_count": 14,
+      "section_count": 26,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Breakfast Methods",
+        "Catering/Banquets",
+        "Cooking Techniques",
+        "Cooking Techniques II",
+        "Culinary Flavor Profiles"
+      ]
+    },
+    {
+      "prefix": "ELLAF",
+      "name": "Skills",
+      "course_count": 9,
+      "section_count": 26,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Foundations In ELL A--Speaking/Listening",
+        "Foundations in ELL B--Integrated Skills",
+        "Foundations In ELL B--Speaking/Listening",
+        "Foundations In ELL C--Integrated Skills",
+        "Foundations in ESL A--Integrated Skills"
+      ]
+    },
+    {
+      "prefix": "HD",
+      "name": "HD",
+      "course_count": 8,
+      "section_count": 26,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Assertive Communication",
+        "Career Exploration",
+        "Healthy Self-Esteem",
+        "International Student First Year Experience",
+        "Learning Strategies for Student Success"
+      ]
+    },
+    {
+      "prefix": "HEAL",
+      "name": "HEAL",
+      "course_count": 15,
+      "section_count": 26,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Clinical Procedures III",
+        "CPR & First Aid for Healthcare Providers",
+        "Externship"
+      ]
+    },
+    {
+      "prefix": "HSER",
+      "name": "HSER",
+      "course_count": 19,
+      "section_count": 26,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Adolescent Chemical Dependency Counseling",
+        "Adolescent Development",
+        "Adulthood and Aging",
+        "Advanced Field Experience",
+        "Advanced Field Experience Seminar"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 10,
+      "section_count": 26,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Mathematics, Basic Physics, Weight and Balance",
+        "Business Mathematics",
+        "Intermediate Algebra",
+        "Introduction to Algebra",
+        "Math for Cosmo/Esth Professionals"
+      ]
+    },
+    {
+      "prefix": "NR",
+      "name": "Forest",
+      "course_count": 13,
+      "section_count": 26,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Cooperative Work Experience",
+        "Forest Ecology - Disturbances",
+        "Forest Ecology - Habitats",
+        "Forest Ecology - Plant Taxonomy",
+        "Forest Measurement"
+      ]
+    },
+    {
+      "prefix": "CAH",
+      "name": "Medical",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Computer Applications (Computer Literacy)",
+        "Introduction to Medical Laboratory Technology",
+        "Medical Terminology I"
+      ]
+    },
+    {
+      "prefix": "CSIA",
+      "name": "Security",
+      "course_count": 11,
+      "section_count": 25,
+      "colleges": [
+        "columbia-basin-college",
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Computer Forensics Fundamentals [RE]",
+        "Cryptology",
+        "Cyber Crime and Terrorism",
+        "Cyber Security and Information Assurance",
+        "Cyber Security Capstone"
+      ]
+    },
+    {
+      "prefix": "FRSH",
+      "name": "Reading",
+      "course_count": 10,
+      "section_count": 25,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Applied Math II FS",
+        "Elementary Algebra",
+        "Introduction to Elementary Algebra",
+        "Pathways to College Success",
+        "Pre-Algebra"
+      ]
+    },
+    {
+      "prefix": "HUMAN",
+      "name": "HUMAN",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "bellevue-college",
+        "green-river-college",
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Intro to the Art of Film",
+        "Introduction to Gender Studies",
+        "Introduction to Western Religions",
+        "Life and Culture for Study Abroad",
+        "Literature and Film"
+      ]
+    },
+    {
+      "prefix": "IBH",
+      "name": "IBH",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Application of Evidence Based Practice",
+        "Behavioral Health Disorders in Integrated Care",
+        "Field Placement 1",
+        "Field Placement 2",
+        "Interdisciplinary Teamwork"
+      ]
+    },
+    {
+      "prefix": "MANU",
+      "name": "MANU",
+      "course_count": 8,
+      "section_count": 25,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Advanced Computer Numerical Control",
+        "Capstone Project",
+        "Computer Aided Manufacturing I",
+        "Intro to Computer Numerical Control",
+        "Machining Operations and Procedures"
+      ]
+    },
+    {
+      "prefix": "PREP",
+      "name": "PREP",
+      "course_count": 9,
+      "section_count": 25,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "English Portfolio",
+        "Introduction to College in Spanish",
+        "Math Foundations",
+        "Math Portfolio 1",
+        "Portfolio 1"
+      ]
+    },
+    {
+      "prefix": "ACTG",
+      "name": "Accounting",
+      "course_count": 12,
+      "section_count": 24,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Accounting Digital Office",
+        "Accounting Spreadsheets I",
+        "Bookkeeping",
+        "Business Office I",
+        "Business Office II (Capstone)"
+      ]
+    },
+    {
+      "prefix": "CCNT",
+      "name": "CCNT",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Cisco Enterprise Networking, Security & Automation",
+        "Cisco Networking Fundamentals",
+        "Cisco Routing & Switching",
+        "Cloud Administration",
+        "Cloud Computing"
+      ]
+    },
+    {
+      "prefix": "CRC",
+      "name": "Machine",
+      "course_count": 23,
+      "section_count": 24,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Introduction to Captioning/Alternative Careers",
+        "Machine Shorthand Jury Charge 100 WPM",
+        "Machine Shorthand Jury Charge 120 WPM",
+        "Machine Shorthand Jury Charge 140 WPM",
+        "Machine Shorthand Jury Charge 160 WPM"
+      ]
+    },
+    {
+      "prefix": "CTM",
+      "name": "Driving",
+      "course_count": 3,
+      "section_count": 24,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Over The Road Driving",
+        "Range Operations and Equipment",
+        "Transport Careers: Commercial Driving"
+      ]
+    },
+    {
+      "prefix": "EDCAP",
+      "name": "EDCAP",
+      "course_count": 7,
+      "section_count": 24,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Career Connections",
+        "College Connections",
+        "Edcap Re-Engage",
+        "GED® Academic Preparation",
+        "GED® Math Preparation"
+      ]
+    },
+    {
+      "prefix": "ELECT",
+      "name": "ELECT",
+      "course_count": 24,
+      "section_count": 24,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Theory 1",
+        "Circuit Theory I Lab",
+        "Circuit Theory II",
+        "Circuit Theory II Lab",
+        "Digital Concepts"
+      ]
+    },
+    {
+      "prefix": "FIREA",
+      "name": "Firefighter",
+      "course_count": 3,
+      "section_count": 24,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Firefighter I",
+        "Firefighter II",
+        "Hazardous Materials Responder Operations Level"
+      ]
+    },
+    {
+      "prefix": "GRDSN",
+      "name": "GRDSN",
+      "course_count": 20,
+      "section_count": 24,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "After Effects I",
+        "After Effects II",
+        "Cooperative Education Seminar",
+        "Cooperative Education Work Experience",
+        "Design Process I"
+      ]
+    },
+    {
+      "prefix": "HDM",
+      "name": "HDM",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrical",
+        "Drive Train",
+        "Heating, Ventilation and Air Conditioning",
+        "Hydraulics and Pneumatics",
+        "Introduction to Electrical"
+      ]
+    },
+    {
+      "prefix": "HEALTH",
+      "name": "Healthcare",
+      "course_count": 2,
+      "section_count": 24,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Healthcare and the Human Body",
+        "Safety, Basic Life Support and Infection Control"
+      ]
+    },
+    {
+      "prefix": "HIN",
+      "name": "Watch",
+      "course_count": 12,
+      "section_count": 24,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Introduction to Watch Technology",
+        "Watch Tech V: Introduction to Precision Timing",
+        "Watch Tech V: Practicum",
+        "Watch Tech: Introduction to Automatic Watches",
+        "Watch Technology I: Practicum"
+      ]
+    },
+    {
+      "prefix": "HISTO",
+      "name": "Histotechnology",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Histology Internship (Capstone)",
+        "Histology Seminar",
+        "Histotechnology I",
+        "Histotechnology II",
+        "Histotechnology III"
+      ]
+    },
+    {
+      "prefix": "INST",
+      "name": "INST",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Electrical Fundamentals",
+        "Analytical Measurement",
+        "Control Strategies",
+        "Data Acquisition Systems",
+        "Digital Automation Fundamentals"
+      ]
+    },
+    {
+      "prefix": "PHLE",
+      "name": "Phlebotomy",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Basic Laboratory for The Phlebotomist",
+        "Phlebotomy Clinical Experience",
+        "Phlebotomy Clinical Seminar",
+        "Phlebotomy Education W/Lab"
+      ]
+    },
+    {
+      "prefix": "PNURS",
+      "name": "PNURS",
+      "course_count": 13,
+      "section_count": 24,
+      "colleges": [
+        "bates-technical-college",
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Surgical Clinical",
+        "Fund III-Mental Health",
+        "Fundamentals III - Pediatrics",
+        "Fundamentals III-Reproductive Health",
+        "Fundamentals IV: Medical-Surgical Nursing II"
+      ]
+    },
+    {
+      "prefix": "BASM",
+      "name": "BASM",
+      "course_count": 17,
+      "section_count": 23,
+      "colleges": [
+        "grays-harbor-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Accounting for Managers",
+        "BASM Capstone I: Workplace Project Experience",
+        "Business Processes and Excel",
+        "Capstone II: Applied Management",
+        "Facilitating Change and Development"
+      ]
+    },
+    {
+      "prefix": "CHIN&",
+      "name": "Chinese",
+      "course_count": 3,
+      "section_count": 23,
+      "colleges": [
+        "bellevue-college",
+        "pierce-college-district",
+        "seattle-central-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Chinese I",
+        "Chinese II",
+        "Chinese III"
+      ]
+    },
+    {
+      "prefix": "DAST",
+      "name": "Dental",
+      "course_count": 19,
+      "section_count": 23,
+      "colleges": [
+        "columbia-basin-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Dental Assistant Clinical Experience [RE]",
+        "Dental Assisting Law & Ethics [RE]",
+        "Dental Sciences I [RE]",
+        "Dental Sciences II [RE]",
+        "Dental Sciences II Lab [RE]"
+      ]
+    },
+    {
+      "prefix": "RAIT",
+      "name": "RAIT",
+      "course_count": 15,
+      "section_count": 23,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advanced Sectional Anatomy",
+        "Body Pathophysiology",
+        "Capstone Project",
+        "Capstone Proposal",
+        "Clinical Practicum II in MRI"
+      ]
+    },
+    {
+      "prefix": "WATER",
+      "name": "Water",
+      "course_count": 15,
+      "section_count": 23,
+      "colleges": [
+        "cascadia-college",
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education Work Experience (No Seminar)",
+        "Differential Leveling",
+        "Hydrologic Field Projects",
+        "Hydrologic Measurement",
+        "Introduction to Water and Wastewater"
+      ]
+    },
+    {
+      "prefix": "AHEA",
+      "name": "Medical",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Billing and Coding",
+        "Intermediate Medical Billing",
+        "Intermediate Medical Coding",
+        "Introduction to Medical Administration",
+        "Introduction to Medical Coding and Billing"
+      ]
+    },
+    {
+      "prefix": "ARAB",
+      "name": "Arabic",
+      "course_count": 3,
+      "section_count": 22,
+      "colleges": [
+        "bellevue-college",
+        "everett-community-college",
+        "green-river-college",
+        "highline-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Arabic II",
+        "Arabic III",
+        "Elementary Arabic"
+      ]
+    },
+    {
+      "prefix": "BASHS",
+      "name": "Human",
+      "course_count": 12,
+      "section_count": 22,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Advanced Case Management In HS",
+        "Advanced Co-Occuring Disorders Treatment",
+        "Ethics In Human Services",
+        "Human Services Field Placement I",
+        "Human Services Field Placement II"
+      ]
+    },
+    {
+      "prefix": "CSSP",
+      "name": "CSSP",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Internship I",
+        "Clinical Internship II",
+        "Intro Central Service/ Sterile Processing",
+        "Materiel Management/Central Service Applications",
+        "Principles & Methods of Cleaning & Disinfecting"
+      ]
+    },
+    {
+      "prefix": "HCI",
+      "name": "Healthcare",
+      "course_count": 22,
+      "section_count": 22,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Agile Project Management for Healthcare",
+        "Applied Statistical Software for Healthcare Informatics",
+        "Clinical Informatics",
+        "Data Standards in Healthcare Informatics",
+        "Database and Data Warehouse Concepts in Healthcare Informatics"
+      ]
+    },
+    {
+      "prefix": "LGL",
+      "name": "Legal Studies",
+      "course_count": 15,
+      "section_count": 22,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Business Communication and Human Relations",
+        "Business English",
+        "Business Law Procedures",
+        "Business Math",
+        "Civil Litigation"
+      ]
+    },
+    {
+      "prefix": "MFG T",
+      "name": "Machining",
+      "course_count": 9,
+      "section_count": 22,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading and Schematics",
+        "Introduction to Machining",
+        "Machine Operator 1",
+        "Machine Operator 2",
+        "Machining and Manufacturing Processes Lab for Engineers"
+      ]
+    },
+    {
+      "prefix": "MPT",
+      "name": "MPT",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "2.5 Axis Milling",
+        "CAM for 3-Axis Milling",
+        "CAM for Multi-Axis Milling",
+        "CNC Turning",
+        "Integrated Robotics"
+      ]
+    },
+    {
+      "prefix": "PMD",
+      "name": "Paramedic",
+      "course_count": 13,
+      "section_count": 22,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Extended Paramedic Internship [RE]",
+        "Paramedic I [RE]",
+        "Paramedic I Lab [RE]",
+        "Paramedic II [RE]",
+        "Paramedic II Lab [RE]"
+      ]
+    },
+    {
+      "prefix": "TSHS",
+      "name": "TSHS",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Art History",
+        "Biology",
+        "Chemistry",
+        "Computer Skills",
+        "Health"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "Barbering",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "bates-technical-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Applications",
+        "Advanced Barbering Principles",
+        "Barbering and Business Management",
+        "Barbering Application Fundamentals",
+        "Barbering Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CRT",
+      "name": "Industry",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Admin Industry Simulation",
+        "Auto Collision Exterior Lighting & Plastics",
+        "Automotive Refinishing Basics",
+        "Field-Based Experiences",
+        "Final Industry Certification"
+      ]
+    },
+    {
+      "prefix": "CYBR",
+      "name": "CYBR",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "bates-technical-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Cyber Security Policies and Framework",
+        "Cybersecurity Analyst I",
+        "Cybersecurity Analyst II",
+        "Encryption",
+        "Ethical Hacking Essentials"
+      ]
+    },
+    {
+      "prefix": "DNTU",
+      "name": "DNTU",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Dental Appliances",
+        "Advanced Special Services",
+        "Alternative Rpd Systems",
+        "Clinical Denture Procedures III",
+        "Clinical Denture Procedures V"
+      ]
+    },
+    {
+      "prefix": "ELLC",
+      "name": "College",
+      "course_count": 6,
+      "section_count": 21,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ELL for College and Career 1",
+        "ELL for College and Career 2",
+        "ELL for College and Career 3",
+        "ELL for College and Career 4",
+        "ELL for College and Career 5"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "Medical",
+      "course_count": 9,
+      "section_count": 21,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Electronic Health Records",
+        "Medical Billing",
+        "Medical Coding 1: ICD-10-CM",
+        "Medical Coding 2: CPT",
+        "Medical Coding 3: Advanced Coding & Practicum"
+      ]
+    },
+    {
+      "prefix": "IS",
+      "name": "IS",
+      "course_count": 17,
+      "section_count": 21,
+      "colleges": [
+        "olympic-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education Work Experience (No Seminar)",
+        "Cyber Defender 1",
+        "Cyber Defense: AI & Malware Forensics",
+        "Fundamental IT Applications",
+        "Independent Study"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Manufacturing",
+      "course_count": 17,
+      "section_count": 21,
+      "colleges": [
+        "bates-technical-college",
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Additive Manufacturing - Knowledge",
+        "Additive Manufacturing - Skills",
+        "Automated Fabrication Knowledge",
+        "Automated Fabrication Skills",
+        "Computer-Aided Design for Manufacturing"
+      ]
+    },
+    {
+      "prefix": "NMTEC",
+      "name": "NMTEC",
+      "course_count": 21,
+      "section_count": 21,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advanced Topics in Nuclear Medicine",
+        "Applied Anatomy, Physiology, & Clinical Applications",
+        "Basic Nuclear Medicine Science",
+        "Clinical Education I",
+        "Clinical Education II"
+      ]
+    },
+    {
+      "prefix": "SUDS",
+      "name": "SUDS",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Adolescent Substance Use Disorder Assessment and Treatment",
+        "Alcohol/Drug Pathophysiology and Pharmacology",
+        "Co-Occurring Disorders: Mental Health Disorders in SUDS",
+        "Cooperative Work Experience",
+        "Group Counseling: Theories and Applications"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surveying",
+      "course_count": 5,
+      "section_count": 21,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Construction Surveying",
+        "Field Equipment and Operations",
+        "Fundamentals of Surveying",
+        "Survey Computations and Mapping",
+        "Survey Technician Certification Prep"
+      ]
+    },
+    {
+      "prefix": "BASF",
+      "name": "BASF",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Advanced Harvest Systems",
+        "Advanced Resource Assessment",
+        "Advanced Silviculture",
+        "Forest Practices, Law, and Policy",
+        "Independent Forestry Project"
+      ]
+    },
+    {
+      "prefix": "CBD",
+      "name": "CBD",
+      "course_count": 19,
+      "section_count": 20,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Applied Chemistry for the Beverage Industry",
+        "Barrel Maturation and Blending",
+        "Beverage Chemistry/Biochemistry (Qc/Qa)",
+        "Business Operations and Marketing",
+        "Craft Brewing"
+      ]
+    },
+    {
+      "prefix": "CTS",
+      "name": "CTS",
+      "course_count": 14,
+      "section_count": 20,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Active Directory",
+        "Client Operating Systems",
+        "Computer Hardware",
+        "Computer Software",
+        "Cooperative Work Experience"
+      ]
+    },
+    {
+      "prefix": "IST",
+      "name": "IST",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Electronics and Control Circuits",
+        "Fluid Power Transmission",
+        "Industrial Electricity I",
+        "Instrumentation II & Control Actuators",
+        "Introduction Preventive/Predictive Maintenance"
+      ]
+    },
+    {
+      "prefix": "ITPM",
+      "name": "ITPM",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Business Continuity Planning & Reporting",
+        "Cloud & Container Security",
+        "Cloud & Docker Security Fundamentals",
+        "Compliance Auditing & Regulatory Standards",
+        "Data Privacy and IT Security Legal Regulations"
+      ]
+    },
+    {
+      "prefix": "MASST",
+      "name": "MASST",
+      "course_count": 17,
+      "section_count": 20,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Anatomy, Physiology & Pathology I",
+        "Anatomy, Physiology & Pathology II",
+        "Anatomy, Physiology & Pathology III",
+        "Business and Ethics I",
+        "Business and Ethics II"
+      ]
+    },
+    {
+      "prefix": "MNURS",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 20,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Foundations of Nursing Lab",
+        "Med-Surg Nursing I Lab"
+      ]
+    },
+    {
+      "prefix": "PLST",
+      "name": "PLST",
+      "course_count": 12,
+      "section_count": 20,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Law: Paralegal Practice in Contracts and Business Law",
+        "Civil Procedure I",
+        "Criminal Procedure for Paralegals",
+        "Employment and Labor Law",
+        "Family Law"
+      ]
+    },
+    {
+      "prefix": "RPT",
+      "name": "Radiation",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Radiation Effects [RE]",
+        "Radiation Monitoring [RE]",
+        "Radiation Protection [RE]",
+        "Radioactive Materials Handling [RE]",
+        "Radiological Safety and Response [RE]"
+      ]
+    },
+    {
+      "prefix": "SEC",
+      "name": "Security",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Development, Security, and Operations",
+        "Digital Forensics",
+        "Information Security Essentials",
+        "Linux Tools for Security",
+        "Network Security and Firewalls"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 14,
+      "section_count": 19,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Ag Safety and Pesticides",
+        "Agricultural Weeds Identification and Control",
+        "Agriculture Sales and Marketing",
+        "Crop Production",
+        "Ecological Based Pest Management"
+      ]
+    },
+    {
+      "prefix": "CART",
+      "name": "CART",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Beverage",
+        "Capstone",
+        "Costing, Planning, and Procurement",
+        "Customer Service",
+        "Food Service Safety and Sanitation"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "CET",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Survey Seminar",
+        "Autocad Civil 3D I",
+        "Boundary Law & Land Description",
+        "Construction and Highway Surveys",
+        "Environmental Mapping"
+      ]
+    },
+    {
+      "prefix": "ENGLP",
+      "name": "Reading",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "edmonds-college",
+        "highline-college"
+      ],
+      "sample_titles": [
+        "English Composition I Plus Extra Support",
+        "Reading and Essay Development",
+        "Reading and Writing College Prep Skills",
+        "Reading and Writing Improvement"
+      ]
+    },
+    {
+      "prefix": "MGO",
+      "name": "MGO",
+      "course_count": 8,
+      "section_count": 19,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "At Sea Internship",
+        "Introduction to Shop and Tools",
+        "Leadership and Management",
+        "Marine Engineering Practicum",
+        "Marine Mathematics"
+      ]
+    },
+    {
+      "prefix": "PHAR",
+      "name": "Pharmacy",
+      "course_count": 16,
+      "section_count": 19,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "A Mini Dose of Pharmacy",
+        "Introduction to Pharmacy",
+        "Pharmacology I",
+        "Pharmacology II",
+        "Pharmacy Advanced Simulation Lab"
+      ]
+    },
+    {
+      "prefix": "PUBH",
+      "name": "Health",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Community Health Education and Advocacy",
+        "Determinants of Health",
+        "Health Policy, Equity, and Justice",
+        "Principles of Applied Epidemiology",
+        "Professional Development & Capstone Preparation"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "SCI",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "big-bend-community-college",
+        "north-seattle-college",
+        "olympic-college",
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Edible Plants - Northwest Field Trip",
+        "Introduction to Medical Ethics",
+        "Introduction to Science",
+        "Introduction to Social Determinants of Health",
+        "Introduction to the History of Science"
+      ]
+    },
+    {
+      "prefix": "SCIE",
+      "name": "Reading",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "centralia-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "College & Career Success: STEM",
+        "Listening Speaking 1",
+        "Listening Speaking 2",
+        "Listening Speaking 3",
+        "Reading Writing 1"
+      ]
+    },
+    {
+      "prefix": "AIIS",
+      "name": "Indigenous",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "cascadia-college",
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Contemporary Issues of Native Nations",
+        "Film & Cinema Through The Indigenous Lens",
+        "History of American Indian Education",
+        "Indigenous Representations in Film and Cinema",
+        "Indigenous Women of North America"
+      ]
+    },
+    {
+      "prefix": "AIRC",
+      "name": "AIRC",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education Seminar",
+        "Cooperative Education Work Experience",
+        "Fundamentals of Air Conditioning",
+        "Fundamentals of Air Conditioning Lab",
+        "Fundamentals of Direct Digital Control"
+      ]
+    },
+    {
+      "prefix": "CSCI",
+      "name": "Computer Science",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Animation and Generative AI",
+        "Foundations of Computing",
+        "Introduction to Data Science",
+        "Object-Oriented Programming II with Java",
+        "Python I"
+      ]
+    },
+    {
+      "prefix": "DEN",
+      "name": "Dental",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Dental Assisting Lab Practicum",
+        "Dental Assisting Radiology",
+        "Foundations of Clinica Procedures",
+        "Fundamentals of Dental Safety",
+        "Introduction to Dental Assisting"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Abuse & Neglect Children",
+        "Course Organization",
+        "CTE Student Leadership Organizations",
+        "Diverse Need of Students",
+        "Industrial Safety"
+      ]
+    },
+    {
+      "prefix": "EWL",
+      "name": "English",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "English for Work Literacy 1 - EWL 12",
+        "English for Work Literacy 1 - EWL 13",
+        "English for Work Literacy 1 - EWL 14",
+        "English for Work Literacy 2 - EWL 22",
+        "English for Work Literacy 2 - EWL 23"
+      ]
+    },
+    {
+      "prefix": "HDC",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 18,
+      "colleges": [
+        "north-seattle-college",
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Career Planning and Personal Evaluation",
+        "Orientation to College Success"
+      ]
+    },
+    {
+      "prefix": "HT",
+      "name": "Medical",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Diseases of The Human Body",
+        "Essentials of Anatomy Physiology",
+        "Fundamentals of Medical Terminology",
+        "Introduction to Medical Coding",
+        "Introduction to Medical Insurance Billing"
+      ]
+    },
+    {
+      "prefix": "ITP",
+      "name": "Information Technology Programming",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Applied Interpreting I",
+        "ASL Linguistic Principles",
+        "Ethics and Principles in Educational Interpreting",
+        "Interpreting I",
+        "Theories of Discourse Analysis"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "MECH",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Controls and Instrumentation",
+        "Digital Fundamentals and Programmable Logic Controllers",
+        "Electrical Components",
+        "Electro-Pneumatic and Hydraulic Control Circuits",
+        "Introduction to Robotics"
+      ]
+    },
+    {
+      "prefix": "NURA",
+      "name": "Nurse",
+      "course_count": 2,
+      "section_count": 18,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Nurse Assistant Practicum",
+        "Nurse Assistant Theory"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "bates-technical-college",
+        "grays-harbor-college",
+        "green-river-college",
+        "walla-walla-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "College Preparatory Reading/Study I",
+        "Critical Reading",
+        "Reading Improvement",
+        "Reading Mastery",
+        "Transitional Reading"
+      ]
+    },
+    {
+      "prefix": "SOFT",
+      "name": "SOFT",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Python Programming",
+        "Capstone Project",
+        "Data Structures",
+        "Introduction to Deep Learning Fundamentals",
+        "Mobile Application Development I"
+      ]
+    },
+    {
+      "prefix": "VME",
+      "name": "VME",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Audio Production I",
+        "Conceptual Solutions II",
+        "Digital Imaging I",
+        "Lighting Techniques I",
+        "Professional Practices I"
+      ]
+    },
+    {
+      "prefix": "AI",
+      "name": "AI",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Agentic AI & Intelligent Workflows",
+        "Agentic AI Application Development",
+        "AI Impacts, Applications, and Design",
+        "Anthropic Claude & Constitutional AI Systems",
+        "Artificial Intelligence and Robotics Fundamentals"
+      ]
+    },
+    {
+      "prefix": "AMTC",
+      "name": "Automotive",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Automotive Chassis",
+        "Automotive Drivetrains",
+        "Automotive Electrical Systems",
+        "Automotive Engines",
+        "Computer Engine Controls"
+      ]
+    },
+    {
+      "prefix": "ASP",
+      "name": "Substance",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Adolescent SUD Assessment & Treatment",
+        "Advanced Individual Service Planning",
+        "Community Prevention",
+        "Cultural Diversity Counseling for Addiction Studies",
+        "Field Experience In Chemical Dependency"
+      ]
+    },
+    {
+      "prefix": "BASBH",
+      "name": "BASBH",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Advanced Counseling Techniques",
+        "Behavioral Healthcare in Primary Care",
+        "Case Management",
+        "Ethics in Behavioral Healthcare",
+        "Family Counseling"
+      ]
+    },
+    {
+      "prefix": "BIOEQ",
+      "name": "Biomedical",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Biomedical AC Lab",
+        "Biomedical AC Math",
+        "Biomedical AC Theory",
+        "Biomedical DC Lab",
+        "Biomedical DC Math"
+      ]
+    },
+    {
+      "prefix": "BRW",
+      "name": "BRW",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Beverage Biochemistry",
+        "Brewery Capstone Project",
+        "Brewery Internship",
+        "Brewery Lab I",
+        "Brewery Lab II"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "Lineman",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "grays-harbor-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Applied Electricity",
+        "Control Fundamentals",
+        "Industrial Electricity & Controls",
+        "Lineman Apprentice Rsi I",
+        "Lineman Apprentice Rsi IV"
+      ]
+    },
+    {
+      "prefix": "FILMP",
+      "name": "Film",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Digital Video Editing I",
+        "Digital Video Editing II",
+        "Film Production I",
+        "Film Production II",
+        "Film Production III"
+      ]
+    },
+    {
+      "prefix": "HUC",
+      "name": "Unit",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Communications In The Health Unit Coordinator Role",
+        "Anatomy & Physiology for Health Unit Coordinator",
+        "Clinical Experience",
+        "Electrocardiogram Monitor Technician",
+        "Introduction to Communication In The Health Unit Coordinator Role"
+      ]
+    },
+    {
+      "prefix": "IMAGE",
+      "name": "Clinical",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Cross Sectional Anatomy [RE]",
+        "CT Clinical Practicum I [RE]",
+        "CT Instrumentation [RE]",
+        "Mammography [RE]",
+        "Mammography Clinical [RE]"
+      ]
+    },
+    {
+      "prefix": "INTST",
+      "name": "INTST",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Geography of World Affairs",
+        "International Business",
+        "Introduction to Globalization",
+        "Middle East Politics & Society"
+      ]
+    },
+    {
+      "prefix": "JRNL",
+      "name": "Newswriting",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Advanced News-writing",
+        "Advanced Newswriting",
+        "Beginning Newswriting",
+        "Cooperative Education",
+        "Newspaper Production Editing"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Access to justice",
+        "Civil Procedure and Litigation",
+        "Contracts, Consumer Law and Access to Justice",
+        "Intro to Legal Research, Writing and Analysis",
+        "Introduction to Law and The Legal Process"
+      ]
+    },
+    {
+      "prefix": "SDS",
+      "name": "Skills",
+      "course_count": 7,
+      "section_count": 17,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Career and Life Planning",
+        "College Navigation Skills I",
+        "College Navigation Skills II",
+        "Stress Management",
+        "Study Skills"
+      ]
+    },
+    {
+      "prefix": "SEIUN",
+      "name": "SEIUN",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "BT-30 Benton",
+        "BT-30 Grant",
+        "BT-30 Okanogan",
+        "BT-30 Pierce",
+        "BT-30 Snohomish"
+      ]
+    },
+    {
+      "prefix": "SW",
+      "name": "Social",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Assessment and engagement across practice areas",
+        "Diversity, human rights, and social justice",
+        "Generalist practice: communities and society",
+        "Generalist practice: groups",
+        "Generalist practice: individuals and families"
+      ]
+    },
+    {
+      "prefix": "TRON",
+      "name": "TRON",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Critical Thought and App",
+        "Embedded Controllers",
+        "Hydraulics and Pneumatics",
+        "Independent Projects",
+        "Industrial Robotics II"
+      ]
+    },
+    {
+      "prefix": "VLBSN",
+      "name": "Nursing",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Clinical Applications Lab III",
+        "Dosages & Pharmacology Module",
+        "Foundational Skills Lab",
+        "Foundational Skills Theory Online Module",
+        "Foundations of Professional Nursing"
+      ]
+    },
+    {
+      "prefix": "ABT",
+      "name": "Repair",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Advanced Auto Body",
+        "Estimating and Shop Management",
+        "Non-Structural Repair",
+        "Refinishing",
+        "Structural Repair"
+      ]
+    },
+    {
+      "prefix": "AMES",
+      "name": "American",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Intersections of Race, Gender, Class and Sexuality",
+        "Introduction to American Ethnic Studies",
+        "Introduction to Critical Filipinx/Filipino American Studies",
+        "Social Inequality and Change in American Sports"
+      ]
+    },
+    {
+      "prefix": "AUTOA",
+      "name": "Service",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Service Technician 1",
+        "Automotive Service Technician 2",
+        "Automotive Service Technician Internship 1",
+        "Automotive Service Technician Internship 2",
+        "General Service Tech I"
+      ]
+    },
+    {
+      "prefix": "BASTE",
+      "name": "BASTE",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Bilingual Teaching",
+        "Effective and Meaningful Curriculum Design",
+        "Individualized Teaching",
+        "Integrated Health and Physical Education",
+        "Issues of Child Abuse in Education"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "BOT",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "big-bend-community-college",
+        "everett-community-college",
+        "seattle-central-college",
+        "south-puget-sound-community-college",
+        "spokane-falls-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Global Ethnobotany",
+        "Introduction to Botany",
+        "Mycology",
+        "The Plant Kingdom"
+      ]
+    },
+    {
+      "prefix": "CMT",
+      "name": "CMT",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "3D Printing - Additive Manufacturing",
+        "Advanced Machining (Mills and Lathes)",
+        "CNC Mills and Lathes",
+        "CNC Programming",
+        "Fundamental of Machining"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "Composites",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "bellingham-technical-college",
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Composition",
+        "Composite Design & Fabrication I: Ski Building",
+        "Composites Design and Fabrication II: Aerospace Applications",
+        "Materials Testing",
+        "Survey of Composites"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "Practical",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Principles and Procedures I",
+        "Intermediate Principles and Procedures I",
+        "Intermediate Principles and Procedures II",
+        "Practical Application I",
+        "Practical Application III"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Central Service Basic Sciences",
+        "Central Service Clinical Practicum I",
+        "Central Service Clinical Practicum II",
+        "Central Service Standard Practices of Sterilization",
+        "Central Service Technician Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CT",
+      "name": "CT",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "everett-community-college",
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Composite Technology 1",
+        "Composite Technology 2",
+        "Computed Tomography Lab & Clinical Introduction",
+        "Computed Tomography Registry Review",
+        "Digital Image Production for Computed Tomography"
+      ]
+    },
+    {
+      "prefix": "DBOA",
+      "name": "Dental",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Dental Charting, Scheduling and Recall Management",
+        "Dental Documents and Inventory Systems",
+        "Dental Terminology & Procedures",
+        "Dentrix Advanced Training"
+      ]
+    },
+    {
+      "prefix": "DGS",
+      "name": "DGS",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Constitution Law and Issues",
+        "Critical Thinking for Equity",
+        "Cultural Awareness & Business Etiquette",
+        "Food, Culture,& Politics",
+        "Immigration Law and the Rights of Non-Citizens"
+      ]
+    },
+    {
+      "prefix": "DOSM",
+      "name": "DOSM",
+      "course_count": 16,
+      "section_count": 16,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Brachytherapy for Medical Dosimetrists",
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Education III",
+        "Clinical Education IV"
+      ]
+    },
+    {
+      "prefix": "FSLM",
+      "name": "Fire",
+      "course_count": 14,
+      "section_count": 16,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Applications of Fire Research",
+        "Building Construction for Fire Protection",
+        "Community Risk Reduction for the Fire Service",
+        "Disaster Planning",
+        "Fire and Emergency Services Administration"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "cascadia-college",
+        "skagit-valley-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Advanced GIS Project",
+        "Cooperative Education",
+        "Geographic Information Systems II",
+        "Introduction to Geographic Information Systems",
+        "Introduction to Geographical Information Systems"
+      ]
+    },
+    {
+      "prefix": "HLSV",
+      "name": "Life",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Basic Life Support for Healthcare",
+        "Nursing Assistant - Certified"
+      ]
+    },
+    {
+      "prefix": "HM",
+      "name": "HM",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Event Management",
+        "Front Office Procedures",
+        "Hospitality Mathematics",
+        "Hotel/Restaurant Law",
+        "Human Relations"
+      ]
+    },
+    {
+      "prefix": "HPM",
+      "name": "Health",
+      "course_count": 15,
+      "section_count": 16,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Applied Research Methods",
+        "Chronic Disease Prevention & Interventions",
+        "Community Health",
+        "Epidemiology and Health Care Statistics",
+        "Foundations of Health Promotion"
+      ]
+    },
+    {
+      "prefix": "INTP",
+      "name": "Interpreting",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Consecutive Interpreting I [RE]",
+        "Consecutive Interpreting II [RE]",
+        "Introduction to the Interpreting Profession [RE]",
+        "Medical Terminology for Interpreters I [RE]",
+        "Medical Terminology for Interpreters II [RE]"
+      ]
+    },
+    {
+      "prefix": "LSCR",
+      "name": "Supply",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Contract Management [RE]",
+        "Intro to Purchasing and Supply Chain Management [RE]",
+        "Introduction to Logistics [RE]",
+        "Introduction to Supply Chain Resilience [RE]",
+        "Supply Chain Analytics [RE]"
+      ]
+    },
+    {
+      "prefix": "MATSI",
+      "name": "Supplemental",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Mathematics, Basic Physics, Weight and Balance SUPPLEMENTAL INSTRUCTION",
+        "Business Mathematics Supplemental Instruction",
+        "Cosmetology/Esthetics Mathematics Supplemental Instruction",
+        "Health Mathematics Supplemental Instruction",
+        "Industrial Mathematics Supplemental Instruction"
+      ]
+    },
+    {
+      "prefix": "NOP",
+      "name": "NOP",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Advanced Facility Components [RE]",
+        "Advanced Operational Systems [RE]",
+        "Advanced Thermodynamics and Heat Transfer [RE]",
+        "Chemical & Water Treatment Systems [RE]",
+        "Hydraulic and Fluid Flows [RE]"
+      ]
+    },
+    {
+      "prefix": "REST",
+      "name": "Dining",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Excel for Restaurants",
+        "Food & Beverage Cost Control",
+        "Kitchen & Dining Management (Capstone)",
+        "Operations Management",
+        "Restaurant Dining"
+      ]
+    },
+    {
+      "prefix": "VICOM",
+      "name": "VICOM",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Designing with Illustrator",
+        "Drawing for Illustration I",
+        "Graphic Design I",
+        "Internship",
+        "Introduction to Design Software Applications"
+      ]
+    },
+    {
+      "prefix": "VISCM",
+      "name": "VISCM",
+      "course_count": 13,
+      "section_count": 16,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Digital Imaging",
+        "Design Lab",
+        "Layout and Publication Design I",
+        "Layout and Publication Design II",
+        "Portfolio/Professional Practices"
+      ]
+    },
+    {
+      "prefix": "A SIM",
+      "name": "Flight",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Basic Instrument Flight Simulation",
+        "Commercial Pilot Flight Simulation",
+        "Flight Procedures for Non-Pilots",
+        "Private Pilot Flight Simulation"
+      ]
+    },
+    {
+      "prefix": "AGSC",
+      "name": "AGSC",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural Chemistry",
+        "Applied Outdoor Safety for Agriculture, Landscaping, and Turf",
+        "Basic Soil Science",
+        "Cultivated Plants",
+        "Field Crop Production"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Automotive Drivetrains Lab",
+        "Automotive Drivetrains Lecture",
+        "Automotive Electrical",
+        "Automotive Electrical Lab",
+        "Automotive Fundamentals & Engines"
+      ]
+    },
+    {
+      "prefix": "BMST",
+      "name": "BMST",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Service I",
+        "Biomedical Engineering Applications",
+        "Biomedical I",
+        "Biomedical III",
+        "Blood Borne Pathogens"
+      ]
+    },
+    {
+      "prefix": "DIES",
+      "name": "Diesel",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical",
+        "Diesel Engines/Fuel Systems",
+        "Diesel Fundamentals",
+        "Diesel Procedures",
+        "Drive Trains"
+      ]
+    },
+    {
+      "prefix": "EEST",
+      "name": "EEST",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Capstone Project",
+        "Electronic Devices II",
+        "Electronics Applied Math II",
+        "Electronics Laboratory II",
+        "Electronics Theory II"
+      ]
+    },
+    {
+      "prefix": "EGS",
+      "name": "EGS",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "African American Experience",
+        "African American Roots",
+        "Ethnic Studies for Educators",
+        "Exploring Pixels: Video Game Play, Representation, & Culture",
+        "Histories and Cultures of Oceania"
+      ]
+    },
+    {
+      "prefix": "HOS",
+      "name": "HOS",
+      "course_count": 15,
+      "section_count": 15,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Barista Lab I: Practical Applications",
+        "Barista Theory I: Operations and Management",
+        "Career Planning and Human Resources Management",
+        "Costing, Purchasing and Inventory",
+        "Customer Service Practicum I"
+      ]
+    },
+    {
+      "prefix": "IEP",
+      "name": "Intensive",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "English for Specific Purposes",
+        "Intensive Listening and Speaking 1",
+        "Intensive Reading 1",
+        "Intensive Reading 2",
+        "Intensive Writing 1"
+      ]
+    },
+    {
+      "prefix": "KREA&",
+      "name": "Korean",
+      "course_count": 2,
+      "section_count": 15,
+      "colleges": [
+        "olympic-college",
+        "pierce-college-district",
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Korean I",
+        "Korean II"
+      ]
+    },
+    {
+      "prefix": "MEDAS",
+      "name": "Medical",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Communication Skills for Medical Assistants",
+        "Examroom (Clinical) Procedures",
+        "Healthcare Calculations",
+        "Human Body Functions and Medical Terminology II",
+        "Human Body Structure & Medical Terminology I"
+      ]
+    },
+    {
+      "prefix": "MRI",
+      "name": "MRI",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced MRI Physics & Imaging Techniques",
+        "Clinical Techniques Lab",
+        "Cross-Sect Anat II: Thorax, Abdomen, & Pelvis",
+        "Cross-Sectional Anatomy III: Musculoskeletal & Extremities",
+        "Expanded MRI Equipment Operation & Clinical Protocols"
+      ]
+    },
+    {
+      "prefix": "NT",
+      "name": "NT",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Basic Nuclear Math & Physics [RE]",
+        "Basic Reactor Safety, Theory, & Operations [RE]",
+        "Internship Seminar [RE]",
+        "Introduction to Clean Energy [RE]",
+        "Mechanical & Fluid Power Transmission [RE]"
+      ]
+    },
+    {
+      "prefix": "PEDCO",
+      "name": "Parent",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Manito Parent Co-op",
+        "Mead Parent Co-op",
+        "Moses Lake Parent Co-op",
+        "Newport Parent Co-op",
+        "Northwest Parent Co-op"
+      ]
+    },
+    {
+      "prefix": "TEC-D",
+      "name": "TEC-D",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Applied Problem Solving",
+        "Blueprint Reading",
+        "Computational Techniques/Technicians",
+        "Computer-Aided Design II",
+        "Introduction to GIS"
+      ]
+    },
+    {
+      "prefix": "ASST",
+      "name": "Project",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Project Coordination",
+        "AI Ethics and Prompt Engineering",
+        "AI for Data Analytics",
+        "AI for Project Collaboration",
+        "Computer and Keyboarding Basics"
+      ]
+    },
+    {
+      "prefix": "BAST",
+      "name": "Teaching",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Capstone",
+        "Math Methods",
+        "Professional Leadership & Advocacy",
+        "Science Methods",
+        "Special Education Methods"
+      ]
+    },
+    {
+      "prefix": "BTM",
+      "name": "Management",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Business Process Management",
+        "Business Productivity Applications",
+        "Cloud Foundations",
+        "Customer Relations Management",
+        "Data Analysis & Visualization"
+      ]
+    },
+    {
+      "prefix": "CNCTE",
+      "name": "CNCTE",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Culminating Cte Teacher Project",
+        "History & Philosophy of Cte",
+        "Intro to Cte Teacher Education",
+        "Occupational Analysis & Skills Stds",
+        "Role & Responsibility of Cte Teacher"
+      ]
+    },
+    {
+      "prefix": "DSL",
+      "name": "Diesel",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Diesel Applied Electrical",
+        "Diesel Cooperative Education",
+        "Diesel Electrical Theory",
+        "Diesel Engines I",
+        "Diesel Engines II"
+      ]
+    },
+    {
+      "prefix": "EAPAB",
+      "name": "English",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "English for Academic Purposes A",
+        "English for Academic Purposes B"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emergency",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "clark-college",
+        "columbia-basin-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician",
+        "Emergency Medical Technician (Accelerated)",
+        "Emergency Medical Technician-Basic [RE]"
+      ]
+    },
+    {
+      "prefix": "ENG T",
+      "name": "Engineering",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Graphics: 3D CAD",
+        "Engineering Technology Skills Building",
+        "Engineering Technology Skills Building 2",
+        "Intermediate CAD With Catia 3D Experience",
+        "Introduction to Catia 3D Experience"
+      ]
+    },
+    {
+      "prefix": "ESLC",
+      "name": "College",
+      "course_count": 6,
+      "section_count": 14,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ESL for College and Career 1",
+        "ESL for College and Career 2",
+        "ESL for College and Career 3",
+        "ESL for College and Career 4",
+        "ESL for College and Career 5"
+      ]
+    },
+    {
+      "prefix": "ESTM",
+      "name": "Industrial",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Industrial Mechanics",
+        "Industrial Safety & Material Handling",
+        "Refrigeration Basics"
+      ]
+    },
+    {
+      "prefix": "EV",
+      "name": "EV",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Vineyard Management",
+        "Intro to Enology & Viticulture for Wine Business",
+        "Introduction to Viticulture and Enology",
+        "Science of Winemaking I",
+        "Sensory Analysis of Wine"
+      ]
+    },
+    {
+      "prefix": "GUID",
+      "name": "Strategies",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Strategies for Success"
+      ]
+    },
+    {
+      "prefix": "JD",
+      "name": "John",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Agriculture Safety",
+        "Forklift Safety Training and Certification",
+        "Internship Work Experience II",
+        "John Deere Electrical",
+        "John Deere Engine Testing, Repair, and Performan"
+      ]
+    },
+    {
+      "prefix": "MVM",
+      "name": "Technology",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Introduction to Automotive Technology I",
+        "Introduction to Automotive Technology II",
+        "Introduction to Motor Vehicle Maint Technology I"
+      ]
+    },
+    {
+      "prefix": "RCP",
+      "name": "Care",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Adult Critical Care Clinical I",
+        "Adult Critical Care Clinical II",
+        "Adv Cardiopulmonary Diagnostics",
+        "Advanced Cardiopulmonary Physiology",
+        "Cardiology for Respiratory Care"
+      ]
+    },
+    {
+      "prefix": "BUSIT",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Business and Data Analytics with AI",
+        "SQL Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CEPRF",
+      "name": "Marine",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "ABYC Marine Electrical Certification",
+        "ABYC Marine Standards Certification",
+        "ABYC Marine Systems Certification",
+        "Adult Family Home",
+        "SVC Marine Surveying: Yachts and Small Craft"
+      ]
+    },
+    {
+      "prefix": "ELI",
+      "name": "English",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Beginner English Skills Support",
+        "Beginner English: Reading/Writing/Grammar",
+        "Beginner Speaking and Listening",
+        "College and Career Success for ELI Students",
+        "Intermediate English"
+      ]
+    },
+    {
+      "prefix": "ELRN",
+      "name": "Basics",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "AI Basics for Students",
+        "Computer Basics",
+        "Orientation to Canvas"
+      ]
+    },
+    {
+      "prefix": "ESLWRITE",
+      "name": "Writing",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "ESL Writing & Grammar Advanced (Level 4-5)",
+        "ESL Writing & Grammar Intermediate (Level 2-3)"
+      ]
+    },
+    {
+      "prefix": "GRAPH",
+      "name": "Design",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Advertising Design",
+        "Digital Design Tools and Visual Communication",
+        "Graphic Design for the Web",
+        "History of Graphic Design",
+        "Packaging Design"
+      ]
+    },
+    {
+      "prefix": "HCM",
+      "name": "Healthcare",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "everett-community-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Healthcare Operations Management",
+        "Healthcare Risk Management and Liability",
+        "Human Resources and the Healthcare Manager",
+        "Introduction to Healthcare Careers",
+        "Introduction to Healthcare Risk Management"
+      ]
+    },
+    {
+      "prefix": "HVACR",
+      "name": "HVACR",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "A/C & Heat Pumps",
+        "A/C & Heat Pumps Lab",
+        "Advanced Commercial Refrigeration",
+        "Advanced Commercial Refrigeration Lab",
+        "Advanced Control Theory"
+      ]
+    },
+    {
+      "prefix": "MC",
+      "name": "Coding",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diagnosis Coding",
+        "Advanced Procedure Coding",
+        "Applied Medical Terminology",
+        "Health Information and Delivery Systems",
+        "Introduction to Diagnosis Coding"
+      ]
+    },
+    {
+      "prefix": "OCEA",
+      "name": "Environmental",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "bellevue-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Environmental Oceanography",
+        "Marine Biology"
+      ]
+    },
+    {
+      "prefix": "OR-PR",
+      "name": "OR-PR",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Applied Clinical Pedorthics",
+        "Applied Pedorthics Lab",
+        "Foundations of Orthotic Technology",
+        "Foundations of Orthotic Technology Lab",
+        "Foundations of Pedorthics"
+      ]
+    },
+    {
+      "prefix": "SUD",
+      "name": "Substance",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Case Management & Record Keeping",
+        "Co-Occuring Disorders In SUD Counseling",
+        "Group Process In Substance Use Disorder Training",
+        "Intro to Substance Use Disorder(s)",
+        "Physiological Actions of Alcohol & Drugs"
+      ]
+    },
+    {
+      "prefix": "WS",
+      "name": "Womens",
+      "course_count": 2,
+      "section_count": 13,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Gender, Media, and Popular Culture [S/B]",
+        "Women's Cultural Heritage [H]"
+      ]
+    },
+    {
+      "prefix": "AHBC",
+      "name": "Coding",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "CPT and HCPCS Coding",
+        "Health Care Reimbursement",
+        "ICD-10-CM Coding",
+        "Introduction to Medical Billing"
+      ]
+    },
+    {
+      "prefix": "AHEM",
+      "name": "Clinical",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Clinical Procedures I",
+        "Clinical Procedures II",
+        "Medical Assistant Practicum"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "bellevue-college",
+        "centralia-college",
+        "everett-community-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Life in the Universe",
+        "Life In The Universe",
+        "Selected Topics In Advanced Astronomy",
+        "The Solar System & The Universe (NS)"
+      ]
+    },
+    {
+      "prefix": "BARBR",
+      "name": "BARBR",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Barbering Professional Success and Development",
+        "Capstone",
+        "Lab Clinic II",
+        "Lab Clinic III",
+        "Shaving and Basic Facial"
+      ]
+    },
+    {
+      "prefix": "CCBS",
+      "name": "Prep",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Computer Basics",
+        "GED Prep Math & Science",
+        "GED Prep Social Studies & Language Arts",
+        "Integrated Math I"
+      ]
+    },
+    {
+      "prefix": "CHP",
+      "name": "Health",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Community Health Advocacy",
+        "Community Health Communications and Informatics",
+        "Community Health Professional Capstone",
+        "Disaster Preparedness",
+        "Environmental Health"
+      ]
+    },
+    {
+      "prefix": "CHST",
+      "name": "CHST",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "wenatchee-valley-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Chican@/x Experience in Contemporary Society",
+        "Identity, Art & Culture",
+        "La Chicana/x/e"
+      ]
+    },
+    {
+      "prefix": "DRAFT",
+      "name": "Drafting",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Architectural Drafting Advanced",
+        "Architectural Drafting I",
+        "Architectural Drafting III",
+        "Architectural Drafting in Revit",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "DVS",
+      "name": "English",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "ABE Math",
+        "Adult Basic Skills - Adult Secondary Education I",
+        "Beginning English Language Acquisition",
+        "Intermediate English Language Acquisition"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "Current",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Alternating Current Circuits [RE]",
+        "Applied Electronics [RE]",
+        "Digital Fundamentals [RE]",
+        "Direct Current Circuits [RE]",
+        "Semiconductors and Op Amps [RE]"
+      ]
+    },
+    {
+      "prefix": "ERTECH",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Emergency Room/Patient Care Technician",
+        "Emergency Room/Patient Care Technician Lab"
+      ]
+    },
+    {
+      "prefix": "FAD",
+      "name": "Industrial",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Industrial First Aid and C.P.R. Plus Bloodborne Pathogens"
+      ]
+    },
+    {
+      "prefix": "HCAD",
+      "name": "Healthcare",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Healthcare Administration Capstone",
+        "Healthcare Information & Data Analytics",
+        "Healthcare Operations Management & Evaluation",
+        "Human Resources and Organizational Culture in Healthcare",
+        "Legal Issues and Ethics in Healthcare Administration"
+      ]
+    },
+    {
+      "prefix": "IT-CS",
+      "name": "Programming",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "cascadia-college"
+      ],
+      "sample_titles": [
+        "Discrete Structures 1",
+        "Foundations of Software Development",
+        "Intermediate Programming",
+        "Introduction to Computer Science",
+        "Introduction to Programming"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "LEGL",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Civil Procedure",
+        "Contracts",
+        "Criminal Law",
+        "Electronic Discovery",
+        "Family Law"
+      ]
+    },
+    {
+      "prefix": "MATHM",
+      "name": "Module",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Elementary Algebra-Resource Module",
+        "Intermediate Algebra-Resource Module",
+        "Pre-Algebra Resource Module"
+      ]
+    },
+    {
+      "prefix": "MFUND",
+      "name": "Math",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "cascadia-college"
+      ],
+      "sample_titles": [
+        "Algebra for Precalculus",
+        "Condensed Essentials of Intermediate Algebra",
+        "Math Fundamentals",
+        "Math Fundamentals - Integrated Math I",
+        "Math Fundamentals - Integrated Math II"
+      ]
+    },
+    {
+      "prefix": "ODBI",
+      "name": "Math",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Computer Basics",
+        "GED Prep Math & Science",
+        "GED Prep Social Studies & Language Arts",
+        "Integrated Math I"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Physical",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "clark-college",
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Energy and Matter: Physical Sciences",
+        "General Physical Science",
+        "Physical Science"
+      ]
+    },
+    {
+      "prefix": "PROP",
+      "name": "Repairs",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electrical Repairs",
+        "Basic Plumbing Repairs",
+        "Painting and Drywall Repairs"
+      ]
+    },
+    {
+      "prefix": "QA",
+      "name": "Quality",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Quality Assurance for Machining",
+        "Intermediate Quality Assurance for Machining",
+        "Introduction to Quality Assurance for Machining"
+      ]
+    },
+    {
+      "prefix": "WIN",
+      "name": "Wine",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Elements of Wine Production",
+        "Food & Wine Pairing: Other Ferments",
+        "Introduction to Enology & VIticulture",
+        "Introduction to Food and Wine Pairing",
+        "Introduction to Washington Wines"
+      ]
+    },
+    {
+      "prefix": "ADESL",
+      "name": "Esol",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Conversational English",
+        "ESOL 4 Reading and Writing",
+        "ESOL 4 Speaking and Listening",
+        "ESOL 5 Bridge Reading/Writing",
+        "ESOL 5 Bridge Speaking and Listening"
+      ]
+    },
+    {
+      "prefix": "AUTOT",
+      "name": "AUTOT",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions",
+        "Brakes and Suspension",
+        "Engine Emission Management Systems",
+        "Heating and Air Conditioning",
+        "Manual Gear Trains"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "ETEC",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Applied Technical Math",
+        "Engineering Technology Internship",
+        "Introduction to Composites",
+        "Manufacturing Basics",
+        "Mechanical Components and Power Transmission"
+      ]
+    },
+    {
+      "prefix": "FSD",
+      "name": "FSD",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Culinary Foundations: Global Approaches",
+        "Fundamentals of Classical Techniques",
+        "Health and Sanitation",
+        "Intro to Pastry & Breads: Traditional and GF",
+        "Management Practicum"
+      ]
+    },
+    {
+      "prefix": "HPHYS",
+      "name": "Radiation",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Health Physics Seminar",
+        "Internal Dosimetry",
+        "Medical Health Physics",
+        "Nuclear and Radiological Regulatory Framework",
+        "Radiation Biology"
+      ]
+    },
+    {
+      "prefix": "IBEST",
+      "name": "Ibest",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Academic I-BEST Support II",
+        "Academic Support for Accounting I",
+        "Academic Support for Accounting IV",
+        "Academic Support for Business and Technology I",
+        "Academic Support for Medical Admin Assistant I"
+      ]
+    },
+    {
+      "prefix": "INTD",
+      "name": "Drafting",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Architectural Drafting I",
+        "Architectural Drafting Revit",
+        "Internship",
+        "Introduction to Interior Design",
+        "Manual Drafting"
+      ]
+    },
+    {
+      "prefix": "MBS",
+      "name": "MBS",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Advanced Methods in Molecular Biology",
+        "Bioinformatics",
+        "Modern Genetics",
+        "Modern Topics in Bioethics",
+        "Molecular Biosciences Seminar"
+      ]
+    },
+    {
+      "prefix": "METR",
+      "name": "METR",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "bellevue-college",
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Atmosphere and The Environment",
+        "Global Warming: Causes and Consequences",
+        "Introduction to the Weather and Climate w/Lab"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "MRKT",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Advertising [RE]",
+        "Introduction to Digital Marketing [RE]",
+        "Market Research [RE]",
+        "Measurement and Analytics [RE]",
+        "Online Video & TV Strategy [RE]"
+      ]
+    },
+    {
+      "prefix": "PHSCI",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Physical Science of Yakima County",
+        "Physical Science Survey I"
+      ]
+    },
+    {
+      "prefix": "RES",
+      "name": "Real",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Applications of Real Estate Math",
+        "Multi-Family Property Management",
+        "Property Management-Commercial",
+        "Real Estate Finance Residential",
+        "Real Estate Finance-Commercial"
+      ]
+    },
+    {
+      "prefix": "WST",
+      "name": "Water",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Water Cooperative Education",
+        "Water Distribution",
+        "Water Laboratory",
+        "Water Regulations",
+        "Water Sources"
+      ]
+    },
+    {
+      "prefix": "ACCTG",
+      "name": "Accounting",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Accounting with Quickbooks",
+        "Auditing",
+        "Income Tax Accounting I",
+        "Intermediate Accounting I",
+        "Intermediate Accounting III"
+      ]
+    },
+    {
+      "prefix": "AHCN",
+      "name": "Care",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Care Navigation I",
+        "Advanced Care Navigation II",
+        "Behavioral Health Care Navigation",
+        "Essentials Care Navigation I",
+        "Essentials of Care Navigation II"
+      ]
+    },
+    {
+      "prefix": "AHMA",
+      "name": "AHMA",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Clinical Lab Skills",
+        "Clinical Theory",
+        "Medical Assisting Externship",
+        "Medical Assisting Externship Seminar"
+      ]
+    },
+    {
+      "prefix": "AUTOG",
+      "name": "Systems",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Applied Learning GM Electrical Systems",
+        "Applied Learning GM Engine Mechanical",
+        "Applied Learning GM Engine Performance",
+        "Applied Learning GM Heating & Air Cond Systems",
+        "GM Automatic Transmissions/Transaxles"
+      ]
+    },
+    {
+      "prefix": "CEAL",
+      "name": "CEAL",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Acrylic Painting",
+        "Collage",
+        "Drawing"
+      ]
+    },
+    {
+      "prefix": "CJUS",
+      "name": "CJUS",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Criminal Justice Internship",
+        "Drugs and Our Society",
+        "Line Officer Function",
+        "The Art of Public and Private Investigation"
+      ]
+    },
+    {
+      "prefix": "CULIN",
+      "name": "Culinary",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Applied Food Service Computation",
+        "Commercial Baking I",
+        "Culinary Internship",
+        "Culinary Management",
+        "Culinary Techniques"
+      ]
+    },
+    {
+      "prefix": "CVT",
+      "name": "CVT",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support (ACLS)",
+        "Advanced Cardiovascular Pharmacology and IV Therapy",
+        "Infection Prevention and Control",
+        "Interventional Cardiology Procedures",
+        "Patient Care in Cardiovascular Settings"
+      ]
+    },
+    {
+      "prefix": "DNTA",
+      "name": "Dental",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Chairside Skills",
+        "Clinical Experience I",
+        "Clinical Experience II",
+        "Clinical Seminar",
+        "Dental Materials II"
+      ]
+    },
+    {
+      "prefix": "FDM",
+      "name": "Funeral",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Comprehensive Review",
+        "Funeral Directing",
+        "Funeral Service Ethics",
+        "Funeral Service Internship",
+        "Funeral Service Law and Compliance"
+      ]
+    },
+    {
+      "prefix": "HEA",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "north-seattle-college",
+        "seattle-central-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Global Health",
+        "Health and Human Sexuality",
+        "Health and Wellness",
+        "Human Wellness and Fitness"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Art of Nursing",
+        "Comics & Graphic Novels",
+        "Film & Culture",
+        "Global Cinema",
+        "Mythology & Symbolism"
+      ]
+    },
+    {
+      "prefix": "IFAD",
+      "name": "First",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "8-Hour First Aid/CPR",
+        "First Aid / CPR for Health Care Providers",
+        "HIV/AIDS Training"
+      ]
+    },
+    {
+      "prefix": "INDT",
+      "name": "Metal",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "grays-harbor-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Cooperative Work Experience",
+        "Introduction to Industrial Technology: Automotive & Diesel",
+        "Metal Fabrication II",
+        "Metal Fabrication III",
+        "Plant Maintenance"
+      ]
+    },
+    {
+      "prefix": "ITAD",
+      "name": "ITAD",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Cloud Computing",
+        "Discrete Mathematics for Developers",
+        "Introduction to Machine Learning",
+        "Mobile Application Development",
+        "Software and Data Engineering"
+      ]
+    },
+    {
+      "prefix": "JOBDV",
+      "name": "Career",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Career and College Success: Business",
+        "College and Career Success",
+        "Resumes and Interviewing"
+      ]
+    },
+    {
+      "prefix": "LHO",
+      "name": "LHO",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Fall Plant Identification",
+        "Integrated Pest and Weed Management",
+        "Internship In Landscape Horticulture",
+        "Introduction to Arboriculture",
+        "Irrigation and Drainage"
+      ]
+    },
+    {
+      "prefix": "MS",
+      "name": "MS",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading Fundamentals",
+        "Fundamentals of Composites for The Non-Composites Technician",
+        "Fundamentals of Welding for The Non-Welding Major"
+      ]
+    },
+    {
+      "prefix": "NATR",
+      "name": "Natural",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "peninsula-college",
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Cooperative Work Experience",
+        "Introduction to Natural Resources",
+        "Natural Ecosystems",
+        "Natural Resources Internship",
+        "River Restoration"
+      ]
+    },
+    {
+      "prefix": "OBT",
+      "name": "Word",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Microsoft Office Basics",
+        "MS Word I"
+      ]
+    },
+    {
+      "prefix": "PRLEA",
+      "name": "Park",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Park Ranger Law Enforcement Academy Module 1",
+        "Park Ranger Law Enforcement Academy Module 2",
+        "Park Ranger Law Enforcement Academy Module 3",
+        "Park Ranger Law Enforcement Academy Module 4",
+        "Park Ranger Law Enforcement Academy Module 5"
+      ]
+    },
+    {
+      "prefix": "AD",
+      "name": "Application",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Application Architecture",
+        "Application Testing",
+        "Artificial Intelligence",
+        "Data Science Development",
+        "Project Management In Software Development"
+      ]
+    },
+    {
+      "prefix": "AGM",
+      "name": "AGM",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural Equipment Operation",
+        "Diesel I",
+        "Drivetrains I",
+        "Hydraulics I",
+        "Shop Skills I"
+      ]
+    },
+    {
+      "prefix": "ASTRO",
+      "name": "Astronomy",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Introduction to Astronomy",
+        "Life in the Universe--Astrobiology",
+        "Stellar Astronomy"
+      ]
+    },
+    {
+      "prefix": "CARDIO",
+      "name": "Cardiac",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Cardiac Monitoring Lab",
+        "Cardiac Rhythm Recognition and Interpretation"
+      ]
+    },
+    {
+      "prefix": "DIVST",
+      "name": "Africanamerican",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "African-American History From 1945: CD",
+        "African-American History to 1865: CD",
+        "Health in Society: CD",
+        "Introduction to Diversity Studies: CD",
+        "Introduction to Women's Studies: CD"
+      ]
+    },
+    {
+      "prefix": "HL ED",
+      "name": "Total",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Food and Health",
+        "Total Wellness"
+      ]
+    },
+    {
+      "prefix": "HUMDV",
+      "name": "Stress",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "peninsula-college",
+        "shoreline-community-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Human Relations",
+        "Psychology of Self Esteem",
+        "Stress Management",
+        "Topics In Stress and Anxiety Management"
+      ]
+    },
+    {
+      "prefix": "MEDC",
+      "name": "Coding",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Diagnostic & CPT Coding",
+        "CPT Coding for the Outpatient Coder",
+        "Diagnostic Coding for the Outpatient Coder",
+        "Electronic Health Records and Data Entry",
+        "Medical Insurance Billing for the Medical Office"
+      ]
+    },
+    {
+      "prefix": "MIS",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "spokane-community-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Information Technology in Business"
+      ]
+    },
+    {
+      "prefix": "PE-RD",
+      "name": "Ballroom",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Ballroom Dance",
+        "Introduction to Backpacking",
+        "Outdoor Winter Sports & Survival"
+      ]
+    },
+    {
+      "prefix": "TLM",
+      "name": "Management",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Airline, Airport, & Seaport Management",
+        "Capstone Project/Strategic Management",
+        "Domestic and International Freight Management",
+        "Introduction to Logistics Management",
+        "Procurement and Supply Management"
+      ]
+    },
+    {
+      "prefix": "WWT",
+      "name": "Wastewater",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Municipal Wastewater Treatment 1",
+        "Municipal Wastewater Treatment 2",
+        "Wastewater Collection",
+        "Wastewater Laboratory",
+        "Wastewater Work Experience"
+      ]
+    },
+    {
+      "prefix": "ACD",
+      "name": "Digital",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Digital Drawing and Character Design",
+        "Digital Storytelling and Scriptwriting",
+        "Multimedia Production",
+        "Photoshop",
+        "Vector Based Drawing"
+      ]
+    },
+    {
+      "prefix": "AHEL",
+      "name": "Phlebotomy",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Clinical Laboratory Applications",
+        "Introduction to Clinical Laboratory",
+        "Introduction to Phlebotomy",
+        "Phlebotomy Practicum"
+      ]
+    },
+    {
+      "prefix": "AHPT",
+      "name": "Pharmacy",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Advanced Pharmacology",
+        "Pharmacy Externship",
+        "Pharmacy Law",
+        "Pharmacy Technician Review",
+        "Pharmacy Technician Skills I"
+      ]
+    },
+    {
+      "prefix": "AMMET",
+      "name": "AMMET",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Applied Statics and Mechanics of Materials",
+        "Calculus and Advanced Mathematics",
+        "Lean Manufacturing",
+        "Quality and Continuous Improvement"
+      ]
+    },
+    {
+      "prefix": "AOT",
+      "name": "Office",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "General Office Procedures [RE]",
+        "Office Orientation [RE]"
+      ]
+    },
+    {
+      "prefix": "AUTOC",
+      "name": "Mcap",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Applied Learning Auto Transmissions",
+        "Applied Learning Electrical Systems",
+        "Applied Learning Heating and Air Conditioning",
+        "Applied Learning Manual Transmissions/Transaxles",
+        "M-CAP Automatic Transmissions/Transaxles"
+      ]
+    },
+    {
+      "prefix": "BOTAN",
+      "name": "Plant",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Introduction to Mycology",
+        "Introductory Plant Biology",
+        "Plant Identification and Classification"
+      ]
+    },
+    {
+      "prefix": "CEAC",
+      "name": "CEAC",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Art Workshop with Donna Letterese",
+        "Dance, from Formal to Fun",
+        "Photography: PNW through a lens",
+        "Vibrant Watercolors - Highlighting the Life around the Sound"
+      ]
+    },
+    {
+      "prefix": "CEHS",
+      "name": "CEHS",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Harbor Institute Conference Series",
+        "Italian Language",
+        "Writing"
+      ]
+    },
+    {
+      "prefix": "CL",
+      "name": "Computer",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Computer Applications",
+        "Powerpoint",
+        "Spreadsheets",
+        "Using The Computer and Managing Files",
+        "Word Processing"
+      ]
+    },
+    {
+      "prefix": "DEVED",
+      "name": "Reading",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Computer Comfort",
+        "Introduction to College Reading",
+        "Reading and Thinking for Academics I"
+      ]
+    },
+    {
+      "prefix": "ECS",
+      "name": "Practicum",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Ece Curriculum: Math, Science & Technology",
+        "Issues & Trends",
+        "Leadership In Early Childhood Education",
+        "Practicum: Domains of Development",
+        "Practicum: Environments"
+      ]
+    },
+    {
+      "prefix": "HONOR",
+      "name": "HONOR",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "highline-college",
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Honors Project",
+        "Second Year Interdisciplinary Projects Seminar I",
+        "Transfer Success"
+      ]
+    },
+    {
+      "prefix": "HPF",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Health and Wellness"
+      ]
+    },
+    {
+      "prefix": "IC",
+      "name": "Instrumentation",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Instrumentation I [RE]",
+        "Instrumentation II [RE]",
+        "Instrumentation III [RE]",
+        "PLC Programming & Computer Interfacing [RE]"
+      ]
+    },
+    {
+      "prefix": "IHCM",
+      "name": "Health",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Foundations of Supervision in Healthcare",
+        "Integration of Behavioral Health and Primary Care",
+        "Interprofessional Education and Collaboration",
+        "Managing Interdisciplinary Teams",
+        "Strategic Leadership in Health and Human Services"
+      ]
+    },
+    {
+      "prefix": "LIB",
+      "name": "Information",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "big-bend-community-college",
+        "grays-harbor-college",
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Critical Information Studies & Research Methods",
+        "Introduction to Information Resources"
+      ]
+    },
+    {
+      "prefix": "MATHF",
+      "name": "Math",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Math Foundations I",
+        "Math Foundations II",
+        "Math Foundations III"
+      ]
+    },
+    {
+      "prefix": "MATHP",
+      "name": "Plus",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "College Algebra for Business & Social Science",
+        "Introduction to Statistics Plus Extra Support",
+        "Precalculus I Plus Extra Support"
+      ]
+    },
+    {
+      "prefix": "MTS",
+      "name": "MTS",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Auxiliary Machinery and Ship Design",
+        "Engineering for Deck Ratings",
+        "Naval Architecture",
+        "QMED: Diesel Engines",
+        "RFPEW Introduction"
+      ]
+    },
+    {
+      "prefix": "PS",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Introduction to Physical Science"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Counseling Theory and Practice [RE]",
+        "Introduction to Social Work",
+        "Social Work Ethics [RE]"
+      ]
+    },
+    {
+      "prefix": "WTECH",
+      "name": "WTECH",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Disinfection and Chemical Feed Systems",
+        "Drawings and Manuals",
+        "Pre-Employment Seminar",
+        "Pumps and Pumping Systems",
+        "Utility Worker Safety"
+      ]
+    },
+    {
+      "prefix": "AME",
+      "name": "American",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "north-seattle-college",
+        "seattle-central-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "American Indian Contemporary & Social Issues",
+        "Ethnic Studies: Identities, Solidarity, & Power",
+        "Indigenous People and The U.S.",
+        "Race & Culture: an American History"
+      ]
+    },
+    {
+      "prefix": "CNCM",
+      "name": "CNCM",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading & Gd&T",
+        "CNC Lathe II",
+        "CNC Mill II",
+        "CNC Troubleshooting"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Intercultural Communication: CD"
+      ]
+    },
+    {
+      "prefix": "EARTH",
+      "name": "Earth",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Earth Science"
+      ]
+    },
+    {
+      "prefix": "ETHS",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "African American Experience",
+        "American Ethnic Minorities"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Basic Hearing Instrument Sciences",
+        "Healthcare and Business Ethics",
+        "Hearing Healthcare Management II",
+        "Hearing Instrument Specialist Laboratory I",
+        "Hearing Physiology and Anatomy"
+      ]
+    },
+    {
+      "prefix": "ITAL",
+      "name": "Italian",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "bellevue-college",
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Italian I",
+        "Italian II",
+        "Italian III"
+      ]
+    },
+    {
+      "prefix": "LC",
+      "name": "LC",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "seattle-central-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "The Art and Science of Losing: Finding Yourself through the Literature and Psychology of Loss",
+        "The Stories We Keep: Thinking and Writing in Historical Narratives.",
+        "Topics in LC"
+      ]
+    },
+    {
+      "prefix": "MMD",
+      "name": "MMD",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Digital Storytelling/Scriptwriting (T)",
+        "Internet Trends/Media Criticism",
+        "Internship",
+        "Multimedia Production"
+      ]
+    },
+    {
+      "prefix": "POW",
+      "name": "POW",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Projects",
+        "Carburetor Service and Repair",
+        "Computerized System Basics",
+        "Electronic Fuel Injection"
+      ]
+    },
+    {
+      "prefix": "PSYCH",
+      "name": "PSYCH",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "highline-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Biopsychology",
+        "Fundamentals of Psychological Research",
+        "Psychological Research Methods",
+        "Psychology of Human Relations",
+        "Social Psychology"
+      ]
+    },
+    {
+      "prefix": "PTCS",
+      "name": "Professional",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Professional Technical Computational Skills"
+      ]
+    },
+    {
+      "prefix": "SBST",
+      "name": "Building",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Building and Energy Codes In Washington State",
+        "Building Components and Systems",
+        "Building Science",
+        "Energy Policy",
+        "Lighting"
+      ]
+    },
+    {
+      "prefix": "ABS",
+      "name": "ABS",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Advanced Field Placement I",
+        "Economic-Political Systems: Public Implications",
+        "Information Literacy and Program Assessment",
+        "Professionalism and Ethical Practice",
+        "Writing In The Human Services"
+      ]
+    },
+    {
+      "prefix": "ACHV",
+      "name": "Achieve",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Achieve Orientation and Success Seminar",
+        "Achieve Practicum Seminar",
+        "Advising Seminar: Campus and Career 1",
+        "Advising Seminar: Campus and Career 4"
+      ]
+    },
+    {
+      "prefix": "AGBS",
+      "name": "Agricultural",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Agricultural and Water Policy",
+        "Agricultural Sales and Marketing",
+        "Computer Application In Agriculture",
+        "Farm Records and Analysis"
+      ]
+    },
+    {
+      "prefix": "AGGEN",
+      "name": "Equipment",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Equipment Operation and Maintenance",
+        "Shop Skills"
+      ]
+    },
+    {
+      "prefix": "AHEP",
+      "name": "Clinical",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Clinical Procedures III",
+        "Introduction to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "AMM",
+      "name": "Automotive",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Automatic Transmission Lab",
+        "Automatic Transmissions",
+        "Automotive Maintenance and Light Repair",
+        "Automotive Maintenance and Light Repair Lab",
+        "Automotive Manual Transmission"
+      ]
+    },
+    {
+      "prefix": "ART H",
+      "name": "Renaissance",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "cascadia-college",
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Renaissance to Modern: Survey of Art II",
+        "Understanding World Art"
+      ]
+    },
+    {
+      "prefix": "AUTOH",
+      "name": "Systems",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Applied Learning Brake Systems",
+        "Applied Learning Electrical Systems",
+        "Applied Learning Heating & Air Cond Systems",
+        "Applied Learning Steering & Suspension Systems",
+        "Honda Engine Management and Emissions Systems"
+      ]
+    },
+    {
+      "prefix": "AVIO&",
+      "name": "Aircraft",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Digital Electronic Instrument Systems",
+        "Aircraft Fiber Optic Systems",
+        "Aircraft Wiring Systems"
+      ]
+    },
+    {
+      "prefix": "CDEV",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "College Foundations I"
+      ]
+    },
+    {
+      "prefix": "CSPS",
+      "name": "CSPS",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Cultural Dynamics: Exploring Identity through Race, Gender, Class and Society",
+        "Effective Oral Communication and Interviewing",
+        "Introduction to Relevant State and Local Laws",
+        "Law Enforcement Career Preparation",
+        "Social Services Leadership"
+      ]
+    },
+    {
+      "prefix": "CWE",
+      "name": "CWE",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Baccalaureate Internship",
+        "Internship",
+        "Portfolio, Job Search Preparation and Job Shadow"
+      ]
+    },
+    {
+      "prefix": "EASC",
+      "name": "Meteorology",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Meteorology"
+      ]
+    },
+    {
+      "prefix": "ECPE",
+      "name": "Spot",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Parent Toddler Relationships",
+        "Tot Spot"
+      ]
+    },
+    {
+      "prefix": "EDPL",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "College Success"
+      ]
+    },
+    {
+      "prefix": "ENGF",
+      "name": "English",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced English Foundations",
+        "Intermediate English Foundations"
+      ]
+    },
+    {
+      "prefix": "ENV S",
+      "name": "Natural",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Natural Science and the Environment"
+      ]
+    },
+    {
+      "prefix": "ERA",
+      "name": "Electronics",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Adv AC/DC Electronics",
+        "Digital Electronics",
+        "Solid State Devices"
+      ]
+    },
+    {
+      "prefix": "ERSI",
+      "name": "Earth",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Earth Systems",
+        "Introduction to Earth Sciences"
+      ]
+    },
+    {
+      "prefix": "ESLAF",
+      "name": "Credit",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ESL 1 (10-Credit Pathway)",
+        "ESL 2 (10-Credit Pathway)",
+        "Foundations In ESL A (10-Credit Pathway)",
+        "Foundations In ESL B (10-Credit Pathway)",
+        "Foundations in ESL C (10-Credit Pathway)"
+      ]
+    },
+    {
+      "prefix": "ESLSPEAK",
+      "name": "Speaking",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "ESL Speaking & Listening Advanced (Level 4-5)",
+        "ESL Speaking & Listening Intermediate (Level 2-3)"
+      ]
+    },
+    {
+      "prefix": "EVPL",
+      "name": "Event",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Event Coordination",
+        "Event Planning and Best Practices",
+        "Event Planning Practicum",
+        "Event Planning/Entertainment and Production",
+        "Event Planning/Risk Management"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "Exercise",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Anatomical Kinesiology [RE]",
+        "Exercise Science Practicum [RE]",
+        "Introduction to Exercise Science [PE]"
+      ]
+    },
+    {
+      "prefix": "GWS",
+      "name": "Gender",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Gender, Race and Class",
+        "Gender, Violence and Social Change",
+        "Women In U.S. History"
+      ]
+    },
+    {
+      "prefix": "H DEV",
+      "name": "H DEV",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Career and Life Planning",
+        "Human Relations in the Workplace",
+        "Stress Management"
+      ]
+    },
+    {
+      "prefix": "HNRS",
+      "name": "HNRS",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Honors Capstone",
+        "Honors College Seminar",
+        "Honors Seminar",
+        "Honors Transfer Seminar",
+        "Questions and Methods"
+      ]
+    },
+    {
+      "prefix": "HSPTR",
+      "name": "Hospitality",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Cruises",
+        "Internship In Hospitality",
+        "Introduction to Hospitality",
+        "North American Geography",
+        "Tours"
+      ]
+    },
+    {
+      "prefix": "I T",
+      "name": "Development",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Introduction to Game Development",
+        "Programming III",
+        "Web Development II"
+      ]
+    },
+    {
+      "prefix": "LAS",
+      "name": "Latin",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Latin America in Film",
+        "Latin American Culture Through Literature"
+      ]
+    },
+    {
+      "prefix": "LS",
+      "name": "Skills",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Research",
+        "Research Skills for BAS"
+      ]
+    },
+    {
+      "prefix": "OCED",
+      "name": "OCED",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Industrial Safety",
+        "Technical Reading",
+        "Writing In The Workplace"
+      ]
+    },
+    {
+      "prefix": "P-MUS",
+      "name": "Voice",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Voice"
+      ]
+    },
+    {
+      "prefix": "PEDNC",
+      "name": "Ballroom",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Ballroom Dance-Intermediate: Mixed",
+        "Ballroom Dance: Mixed",
+        "Swing Dance-Beginning",
+        "Swing Dance-Intermediate"
+      ]
+    },
+    {
+      "prefix": "WIRE",
+      "name": "Substation",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Circuit Breaker Maintenance & Testing and Substation Testing & Commissioning",
+        "Substation Hazards / Safety and Power Transformers",
+        "Three Phase AC and Washington Administrative Code"
+      ]
+    },
+    {
+      "prefix": "WRITE",
+      "name": "Writing",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Writing Skills I",
+        "Writing Skills III"
+      ]
+    },
+    {
+      "prefix": "AENG",
+      "name": "Writing",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Writing In The Workplace"
+      ]
+    },
+    {
+      "prefix": "AEP",
+      "name": "Reading",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Academic Reading and Writing",
+        "Intro to College Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "AHPH",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy Externship",
+        "Phlebotomy Lab",
+        "Phlebotomy Theory"
+      ]
+    },
+    {
+      "prefix": "AHSP",
+      "name": "Sterile",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Sterile Processing Clinic I",
+        "Sterile Processing Clinic II",
+        "Sterile Processing Clinical Seminar",
+        "Sterile Processing Fundamentals Lab",
+        "Sterile Processing Fundamentals Lecture"
+      ]
+    },
+    {
+      "prefix": "AIA",
+      "name": "Accounting",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Cost Accounting",
+        "Intermediate Accounting I",
+        "Intermediate Accounting II",
+        "International Accounting",
+        "Multinational Accounting Ethics"
+      ]
+    },
+    {
+      "prefix": "BAS",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "BAS Internship",
+        "Human Resources Management",
+        "Management, Leadership, and Organizations",
+        "Managerial Accounting",
+        "Operations Management"
+      ]
+    },
+    {
+      "prefix": "BHAV",
+      "name": "Behavioral",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Assessment and Goal Planning",
+        "Behavioral Health Systems of Care",
+        "Internship",
+        "Overview of Behavioral Health Disorders",
+        "Professional Development for Behavioral Health"
+      ]
+    },
+    {
+      "prefix": "BIT",
+      "name": "Survey",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Survey of Business and Information Technology"
+      ]
+    },
+    {
+      "prefix": "BNURS",
+      "name": "Nursing",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Connecting Research to Nursing",
+        "Nursing Leadership In Health Systems",
+        "Professional Role Development and Writing for Nurses"
+      ]
+    },
+    {
+      "prefix": "CELS",
+      "name": "Basics",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Computer Basics I",
+        "Computer Basics III",
+        "Keyboarding Basics",
+        "Student Success",
+        "Team Building and Leadership"
+      ]
+    },
+    {
+      "prefix": "CEON",
+      "name": "Forest",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Forest and Stream Ecology of the PNW",
+        "What Happened When St. Helens Blew?"
+      ]
+    },
+    {
+      "prefix": "CINEM",
+      "name": "Cinema",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Cinema History"
+      ]
+    },
+    {
+      "prefix": "CO-OP",
+      "name": "Preparing",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education/Internship",
+        "Preparing for Career Work Experience"
+      ]
+    },
+    {
+      "prefix": "CSI",
+      "name": "Development",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Database Development",
+        "Computer Programming IV",
+        "Cross Platform Development",
+        "Introduction to Data Structures and Algorithms",
+        "Web Development IV"
+      ]
+    },
+    {
+      "prefix": "CYKCW",
+      "name": "Kids",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Kids College Program: BioWorks",
+        "Kids College Program: ChefLab",
+        "Kids College Program: GeoExplorers",
+        "Kids College Program: InventWorks",
+        "Kids College Program: SparkWorks"
+      ]
+    },
+    {
+      "prefix": "ENGSI",
+      "name": "English",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "English 101 Supplemental Instruction"
+      ]
+    },
+    {
+      "prefix": "ESLAB",
+      "name": "Eslabe",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "ESL Registration and Enrollment",
+        "Special Topics In ESL/ABE"
+      ]
+    },
+    {
+      "prefix": "F A",
+      "name": "First",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Tech",
+        "First Aid for Healthcare Providers",
+        "Industrial First Aid"
+      ]
+    },
+    {
+      "prefix": "FMT",
+      "name": "Exercise",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Biomechanics",
+        "Exercise and the Cardiovascular System",
+        "Health Appraisal and Exercise Prescription",
+        "Leadership Dynamics"
+      ]
+    },
+    {
+      "prefix": "GESC",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "Roots of Science",
+        "Science Seminar",
+        "Science Seminar II",
+        "Science Seminar III"
+      ]
+    },
+    {
+      "prefix": "GS",
+      "name": "Global",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "cascadia-college",
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Globalization, Culture and Identity",
+        "Introduction to Global Studies"
+      ]
+    },
+    {
+      "prefix": "HEOC",
+      "name": "Certificate",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Activity Director",
+        "Certificate in Food, Nutrition, and Health",
+        "Certificate in Healing Environments for Body, Mind, and Spirit",
+        "Introduction to Natural Health and Healing",
+        "Patient Care Technician (Voucher Included)"
+      ]
+    },
+    {
+      "prefix": "HSCD",
+      "name": "Addictions",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Addictions Treatment: Ethics & The Law",
+        "Case Management & Recordkeeping for The Chemical Dependency Professional",
+        "Introduction to Addictions"
+      ]
+    },
+    {
+      "prefix": "HSSA",
+      "name": "Chemical",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Chemical Dependency Counseling & Ethics",
+        "Internship",
+        "Intervention in Chemical Dependency",
+        "Mental Health Issues--CDP",
+        "Phys/Pharm of Alcohol and Drugs"
+      ]
+    },
+    {
+      "prefix": "IDS",
+      "name": "IDS",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sustainability",
+        "Irish Life and Culture",
+        "Literature, Science and Gender",
+        "Science/Economics/Politics-Sustainable Resources"
+      ]
+    },
+    {
+      "prefix": "IMPT",
+      "name": "Case",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Case Management: Impact"
+      ]
+    },
+    {
+      "prefix": "INTDS",
+      "name": "Design",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Building Systems / Lighting",
+        "Computer Aided Design II",
+        "Drafting for Interior Design",
+        "Interior Design Studio I",
+        "Introduction to Interior Design"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "clark-college",
+        "edmonds-college",
+        "green-river-college",
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Basic Japanese Grammar: Lab",
+        "Independent Study",
+        "Introduction to Japanese Life and Culture",
+        "Japanese Culture and Society"
+      ]
+    },
+    {
+      "prefix": "LIBR",
+      "name": "LIBR",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "highline-college",
+        "lower-columbia-college",
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Collection Development",
+        "Cooperative Work Experience",
+        "Foundations of Research",
+        "Library Administration and Management",
+        "Technical Services & Cataloging for Small"
+      ]
+    },
+    {
+      "prefix": "MEDIC",
+      "name": "Paramedic",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "bellingham-technical-college"
+      ],
+      "sample_titles": [
+        "Paramedic Application and Capstone",
+        "Paramedic Clinical Experience IV",
+        "Paramedic Concepts IV"
+      ]
+    },
+    {
+      "prefix": "MOA",
+      "name": "Healthcare",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Building Cultural Bridges in Healthcare Communication",
+        "Foundation of Insurance with Medical Billing & Coding",
+        "Front Office Operation in Healthcare",
+        "Introduction to Medical Language",
+        "Legal & Ethical Foundation of Healthcare"
+      ]
+    },
+    {
+      "prefix": "NRG",
+      "name": "Technology",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Building Systems and Blueprint Reading",
+        "Buildings In Context",
+        "Career Seminar for Clean Technology",
+        "Introduction to Battery Technology",
+        "Solar Electric Design & Applications"
+      ]
+    },
+    {
+      "prefix": "PEHW",
+      "name": "Yoga",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Cardio Fusion/Core Workout",
+        "Yoga I"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Religion In America",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Global",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Counternarratives of Northwest History: Since Time Immemorial",
+        "Global Issues/Social Science"
+      ]
+    },
+    {
+      "prefix": "STEP",
+      "name": "Strategies",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Strategies Targeting Educational Progress"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Intro to Acting",
+        "Theatre Workshop"
+      ]
+    },
+    {
+      "prefix": "WMATH",
+      "name": "Professional",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Professional Technical Applied Math"
+      ]
+    },
+    {
+      "prefix": "ACOM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Communication In The Workplace"
+      ]
+    },
+    {
+      "prefix": "AGECN",
+      "name": "Management",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Economics In Agriculture",
+        "Farm Management",
+        "Winery Business Management"
+      ]
+    },
+    {
+      "prefix": "AGSY",
+      "name": "AGSY",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Capstone Project Design",
+        "Food Systems Science",
+        "Soil Ecology and Biogeochemistry"
+      ]
+    },
+    {
+      "prefix": "AHLTH",
+      "name": "Comprehensive",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Comprehensive Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "ALSA",
+      "name": "ALSA",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "grays-harbor-college"
+      ],
+      "sample_titles": [
+        "Group Dynamics",
+        "HIV & Other Issues In Substance Use Disorders",
+        "Pharmacology of Alcohol/Drugs",
+        "Relapse Prevention"
+      ]
+    },
+    {
+      "prefix": "AUTOF",
+      "name": "AUTOF",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Electrical & Electronic Systems",
+        "Ford ASSET Cooperative Internship 1",
+        "Fundamentals of Auto Service Training",
+        "Noise, Vibration and Harshness"
+      ]
+    },
+    {
+      "prefix": "BHSS",
+      "name": "Behavioral",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Behavioral Health Assessment, Screening and Referral",
+        "Introduction to Behavioral Health Support Specialist",
+        "Law and Ethics in Behavioral Health",
+        "Professional Development"
+      ]
+    },
+    {
+      "prefix": "BLPT",
+      "name": "Blueprint",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading for Industrial Technology",
+        "Blueprint Reading for Welders",
+        "Machinists Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "BOTA",
+      "name": "Plant",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Dendrology (NS)",
+        "Plant Identification & Classification (NS)"
+      ]
+    },
+    {
+      "prefix": "BPA",
+      "name": "BPA",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Cookies and Petits Fours",
+        "Pastry Techniques-Viennoiserie",
+        "Sanitation",
+        "Yeast Breads"
+      ]
+    },
+    {
+      "prefix": "BPR",
+      "name": "Blueprint",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading [RE]",
+        "Blueprint Reading I (WT) [RE]",
+        "Blueprint Reading II (WT) [RE]"
+      ]
+    },
+    {
+      "prefix": "BTWRT",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business English"
+      ]
+    },
+    {
+      "prefix": "CAST",
+      "name": "CAST",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Child Maltreatment & Advocacy",
+        "Gender, Violence and Social Change",
+        "Professional and Systemic Responses"
+      ]
+    },
+    {
+      "prefix": "CEART",
+      "name": "Painting",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "edmonds-college",
+        "skagit-valley-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Ceramics",
+        "Community Education Visual Arts: Painting",
+        "Film Appreciation for Film Lovers",
+        "Oil Painting"
+      ]
+    },
+    {
+      "prefix": "CEBT",
+      "name": "Business",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Business & Technology",
+        "Business Communications"
+      ]
+    },
+    {
+      "prefix": "CEHHL",
+      "name": "Games",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Board Games",
+        "Card Games",
+        "Health and Wellness"
+      ]
+    },
+    {
+      "prefix": "CEHLT",
+      "name": "CEHLT",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Infant Emergency Preparedness",
+        "Sound Bath Journey",
+        "Tools for Stress and Self-Connection"
+      ]
+    },
+    {
+      "prefix": "CEP",
+      "name": "Employment",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Employment Training"
+      ]
+    },
+    {
+      "prefix": "CHED",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Community Health and Education Capstone I",
+        "Health Behavioral Change Theoretical Foundations",
+        "Intro Principles",
+        "Principles of Higher Education In Allied Health"
+      ]
+    },
+    {
+      "prefix": "CNPRF",
+      "name": "Certification",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "CPR / BLS Training for Healthcare Providers",
+        "Flagging Certification",
+        "Forklift Operator Certification"
+      ]
+    },
+    {
+      "prefix": "CSC&",
+      "name": "Programming",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Intermediate Programming",
+        "Programming Fundamentals"
+      ]
+    },
+    {
+      "prefix": "CSRE",
+      "name": "Community",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Community Fitness"
+      ]
+    },
+    {
+      "prefix": "CYFS",
+      "name": "CYFS",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Applied Research Methods and Info Literacy",
+        "Introduction to Child, Youth and Family Studies",
+        "Resources and System Navigation",
+        "Social Justice In CYFS Studies"
+      ]
+    },
+    {
+      "prefix": "DENTL",
+      "name": "Dental",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Dental Assisting Externship",
+        "Dental Office Administration",
+        "Orientation to Dental Assisting"
+      ]
+    },
+    {
+      "prefix": "DFT",
+      "name": "Mechanical",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "Mechanical Design",
+        "Parametric Modeling"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Reading & Writing",
+        "Basic Reading & Writing",
+        "Business Communications"
+      ]
+    },
+    {
+      "prefix": "ETHNC",
+      "name": "ETHNC",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "American Minorities",
+        "Introduction to the Chicano Movement: Culture, Politics, and Thought",
+        "Pacific Northwest Indigenous People"
+      ]
+    },
+    {
+      "prefix": "FLPT",
+      "name": "Programmable",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "Hydraulics/Pneumatic Fundamentals",
+        "Introduction to Programmable Logic Controls (PLC's)"
+      ]
+    },
+    {
+      "prefix": "H R",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Human Relation-Workplace"
+      ]
+    },
+    {
+      "prefix": "HEMED",
+      "name": "Cprfirst",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "spokane-community-college"
+      ],
+      "sample_titles": [
+        "CPR/First Aid/AED for Adults"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "College and Career Success for Health Sciences"
+      ]
+    },
+    {
+      "prefix": "HSCHI",
+      "name": "Compl",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "High School Compl Civics",
+        "HS Comp Wa State History",
+        "HS Compl Contemp History",
+        "HS Compl US Hist/Gov"
+      ]
+    },
+    {
+      "prefix": "HSS",
+      "name": "Field",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Field Experience I",
+        "Field Experience II",
+        "Introduction to Human Services"
+      ]
+    },
+    {
+      "prefix": "IBN",
+      "name": "International",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Ethics and International Business",
+        "International Finance",
+        "International Management",
+        "International Project Management"
+      ]
+    },
+    {
+      "prefix": "IMIN",
+      "name": "Instrumentation",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Advanced Instrumentation",
+        "Instrumentation Fundamentals",
+        "Process Technology Equipment",
+        "Programmable Logic Controllers"
+      ]
+    },
+    {
+      "prefix": "INDS",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "renton-technical-college"
+      ],
+      "sample_titles": [
+        "First Aid/CPR & AED"
+      ]
+    },
+    {
+      "prefix": "INTS",
+      "name": "Integrated",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Integrated Studies",
+        "Integrated Studies Link"
+      ]
+    },
+    {
+      "prefix": "IT-OPS",
+      "name": "IT-OPS",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "cascadia-college"
+      ],
+      "sample_titles": [
+        "Cloud Foundations",
+        "Desktop Support Technician",
+        "Networking Fundamentals",
+        "Virtualization Technologies"
+      ]
+    },
+    {
+      "prefix": "LMLIB",
+      "name": "Library",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "spokane-falls-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Library Organizations and Careers",
+        "Library Organization and Collections",
+        "Library Paraprofessional Practicum"
+      ]
+    },
+    {
+      "prefix": "MEDIA",
+      "name": "Design",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Infographic and Data Visualization",
+        "Introduction to Graphic Design",
+        "Principles of Digital Photography",
+        "User Interface and User Experience Design"
+      ]
+    },
+    {
+      "prefix": "MTTH",
+      "name": "Prealgebra",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "HS Pre-Algebra I",
+        "HS Pre-Algebra II"
+      ]
+    },
+    {
+      "prefix": "PEHR",
+      "name": "Hiking",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Alpine Ski and Snowboard",
+        "Hiking In North Central Washington"
+      ]
+    },
+    {
+      "prefix": "PMFG",
+      "name": "Industrial",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Advanced Industrial Maintenance",
+        "Electric Motors and Control Equipment",
+        "Electrical and Electronic Fundamentals",
+        "Industrial & Predictive Maintenance Fundamentals"
+      ]
+    },
+    {
+      "prefix": "PTECH",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Technical Writing"
+      ]
+    },
+    {
+      "prefix": "PTWR",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Introduction to Applied Technical Writing"
+      ]
+    },
+    {
+      "prefix": "QSCI",
+      "name": "Quantitative",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Quantitative Analysis of The Environment",
+        "Quantitative Analysis of the Environment II"
+      ]
+    },
+    {
+      "prefix": "SNR",
+      "name": "Senior",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Senior Fitness"
+      ]
+    },
+    {
+      "prefix": "SSER",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "highline-college"
+      ],
+      "sample_titles": [
+        "College Skills Lab"
+      ]
+    },
+    {
+      "prefix": "TECHF",
+      "name": "Technology",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Technology Literacy I",
+        "Technology Literacy II"
+      ]
+    },
+    {
+      "prefix": "TRK",
+      "name": "Truck",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Truck Driver Training",
+        "Truck Driver Training Lab"
+      ]
+    },
+    {
+      "prefix": "VISCO",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Career and College Success: Visual Communication",
+        "Video Editing I"
+      ]
+    },
+    {
+      "prefix": "WBAS",
+      "name": "Welding",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Welding Basics"
+      ]
+    },
+    {
+      "prefix": "WKED",
+      "name": "Professional",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Professional Preparation-Occupation Specific I",
+        "Professional Preparation-Occupation Specific II"
+      ]
+    },
+    {
+      "prefix": "AHMI",
+      "name": "Spanish",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Spanish Medical Interpreter"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "History of Photography",
+        "Survey of Asian Art",
+        "Survey of Western Art: Modern/Postmodern"
+      ]
+    },
+    {
+      "prefix": "CECOM",
+      "name": "CECOM",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Crash Course to Japanese: Travel & Restaurant Edition",
+        "Manuscript to Masterpiece",
+        "Spanish: Conversational"
+      ]
+    },
+    {
+      "prefix": "CELEI",
+      "name": "Series",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Beer 101: A Series designed for Brew Enthusiasts to Connoisseurs",
+        "Line Dancing Series",
+        "Turn Your Life into a Book: Writing a Memoir"
+      ]
+    },
+    {
+      "prefix": "CEPER",
+      "name": "CEPER",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Botanist, Gardener, Herbalist, Chef",
+        "Concrete Mama: A History of Washington State Penitentiary",
+        "Mahjong: Playing for Every Level"
+      ]
+    },
+    {
+      "prefix": "COOP",
+      "name": "Work",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Work Experience Seminar"
+      ]
+    },
+    {
+      "prefix": "CSB",
+      "name": "CSB",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Data Structures and Algorithms",
+        "Deep Learning",
+        "Technical Project Management"
+      ]
+    },
+    {
+      "prefix": "CTNA",
+      "name": "Certified",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Certified Nursing Assistant Program"
+      ]
+    },
+    {
+      "prefix": "FSS",
+      "name": "Family",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Family Resources: Personal, Public and Legal Perspectives",
+        "Family Systems: CD",
+        "Sexuality and Interpersonal Relationships"
+      ]
+    },
+    {
+      "prefix": "G S",
+      "name": "Studium",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Studium Generale"
+      ]
+    },
+    {
+      "prefix": "HMDS",
+      "name": "Tutor",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Tutor Training I"
+      ]
+    },
+    {
+      "prefix": "HSCSC",
+      "name": "HSCSC",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Molecules to Organisms",
+        "Scientific Processes in Bio"
+      ]
+    },
+    {
+      "prefix": "HSSA&",
+      "name": "Chemical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "grays-harbor-college",
+        "peninsula-college",
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Introduction to Chemical Dependency"
+      ]
+    },
+    {
+      "prefix": "INTER",
+      "name": "Science",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Good Vibes Only? Happiness, Identity, and Culture Unpacked",
+        "Imagine A World: Creating Fantasy and Science Fiction",
+        "The Art and Science of Dreams"
+      ]
+    },
+    {
+      "prefix": "LOG",
+      "name": "Transportation",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Applied Warehousing and Inventory Management",
+        "Transportation and Distribution"
+      ]
+    },
+    {
+      "prefix": "PEMAR",
+      "name": "Self",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "clark-college"
+      ],
+      "sample_titles": [
+        "Self Defense"
+      ]
+    },
+    {
+      "prefix": "PHLB",
+      "name": "Phlebotomy",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Phlebotomy Technician Program"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical II",
+        "Medical Surgical Nursing III"
+      ]
+    },
+    {
+      "prefix": "PSAD",
+      "name": "Public",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Foundations of Public Safety",
+        "Public Safety and Legal Issues",
+        "Public Safety Leadership"
+      ]
+    },
+    {
+      "prefix": "PVR",
+      "name": "Professional",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "grays-harbor-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Professional Vocational Relationships"
+      ]
+    },
+    {
+      "prefix": "ROBT",
+      "name": "Robotics",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "Introduction to Robotics",
+        "Robotics in Automation"
+      ]
+    },
+    {
+      "prefix": "SD",
+      "name": "Software",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "whatcom-community-college",
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Essential College Skills",
+        "Software Development Internship"
+      ]
+    },
+    {
+      "prefix": "SPED",
+      "name": "Early",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Inclusion In Early Childhood",
+        "Intervention Strategies for Infants & Toddlers with Special Needs",
+        "Introduction Exceptionality Early Childhood"
+      ]
+    },
+    {
+      "prefix": "TURF",
+      "name": "Turf",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Turf Equipment Operations I",
+        "Turfgrass Cultural Practices"
+      ]
+    },
+    {
+      "prefix": "WMN",
+      "name": "Gender",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "north-seattle-college",
+        "seattle-central-college",
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Introduction to Gender & Women Studies",
+        "Reading the Romance"
+      ]
+    },
+    {
+      "prefix": "WRT",
+      "name": "Writing",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Writing In The Workplace"
+      ]
+    },
+    {
+      "prefix": "ABER",
+      "name": "Portfolio",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "High School Equivalency Test Preparation",
+        "HS21+ Portfolio II"
+      ]
+    },
+    {
+      "prefix": "ADHS",
+      "name": "United",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "United States History to 1877"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Livestock",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Livestock Production",
+        "Livestock Selection and Carcass Evaluation"
+      ]
+    },
+    {
+      "prefix": "AOS",
+      "name": "Excel",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Excel Basics",
+        "Introduction to Microsoft Excel"
+      ]
+    },
+    {
+      "prefix": "ATMS",
+      "name": "Science",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cascadia-college"
+      ],
+      "sample_titles": [
+        "The Science of Weather"
+      ]
+    },
+    {
+      "prefix": "CEBUS",
+      "name": "Executive",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Executive Presence for Professionals",
+        "Starting and Operating a Mobile Food Business"
+      ]
+    },
+    {
+      "prefix": "CEET",
+      "name": "Statics",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Statics & Mechanics of Materials"
+      ]
+    },
+    {
+      "prefix": "CEHFW",
+      "name": "Groov",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "All Levels Hatha Yoga",
+        "GROOV3 Dance Fitness"
+      ]
+    },
+    {
+      "prefix": "CEHG",
+      "name": "Homesteading",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Homesteading Basics",
+        "Sustainable Gardening with Aquaponics"
+      ]
+    },
+    {
+      "prefix": "CEPET",
+      "name": "Continuing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "skagit-valley-college",
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Continuing Nosework",
+        "Fun4K9Z: Introduction to Dog Agility"
+      ]
+    },
+    {
+      "prefix": "CIVL",
+      "name": "Theory",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Theory of Urban Design and Planning"
+      ]
+    },
+    {
+      "prefix": "DRW",
+      "name": "Mechanical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Mechanical Drawing for Vocational Application [RE]"
+      ]
+    },
+    {
+      "prefix": "FRSC",
+      "name": "Survey",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Survey of Forensic Science"
+      ]
+    },
+    {
+      "prefix": "GWST",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Human Sexuality"
+      ]
+    },
+    {
+      "prefix": "H ED",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Introduction to Health"
+      ]
+    },
+    {
+      "prefix": "HP",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "College Success for Health Professions"
+      ]
+    },
+    {
+      "prefix": "HSCHP",
+      "name": "High",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "High School Cmpl Health",
+        "HS Completion PE"
+      ]
+    },
+    {
+      "prefix": "I S",
+      "name": "Humanities",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Introduction to Indigenous Humanities",
+        "Understanding the Humanities"
+      ]
+    },
+    {
+      "prefix": "ISD",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Intro to the American College for Int'l Students"
+      ]
+    },
+    {
+      "prefix": "JOUR",
+      "name": "Journalism",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Introduction to Journalism"
+      ]
+    },
+    {
+      "prefix": "JR",
+      "name": "Readiness",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Job Readiness Level 1 Communications",
+        "Job Readiness Level 2 Communications"
+      ]
+    },
+    {
+      "prefix": "LAN",
+      "name": "Linguistics",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Introduction to Linguistics"
+      ]
+    },
+    {
+      "prefix": "M A",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "MA Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "MDG",
+      "name": "Certificate",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Certificate in Agile Project Management & Data Analytics"
+      ]
+    },
+    {
+      "prefix": "MEY",
+      "name": "Meteorology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Meteorology"
+      ]
+    },
+    {
+      "prefix": "NAIL",
+      "name": "Nail",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Nail Technology II Practical Application",
+        "Principles and Procedures of Nail Technology II"
+      ]
+    },
+    {
+      "prefix": "NASC",
+      "name": "Inquirybased",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Inquiry-Based Science"
+      ]
+    },
+    {
+      "prefix": "NME",
+      "name": "Media",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "New Media I"
+      ]
+    },
+    {
+      "prefix": "OPD",
+      "name": "Elective",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Elective and Personal Pathway (PPR)"
+      ]
+    },
+    {
+      "prefix": "PHYSC",
+      "name": "Finding",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Finding Things Out: Energy"
+      ]
+    },
+    {
+      "prefix": "PMT",
+      "name": "Precision",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Precision Machining"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Psychology of The Workplace (Diversity)"
+      ]
+    },
+    {
+      "prefix": "RCPM",
+      "name": "Real",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Real Estate and Fair Housing Law",
+        "Sustainable Facilities Management"
+      ]
+    },
+    {
+      "prefix": "RDTH",
+      "name": "Transitional",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "HS Transitional Reading"
+      ]
+    },
+    {
+      "prefix": "SALI",
+      "name": "Salish",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "whatcom-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to The Salish Sea"
+      ]
+    },
+    {
+      "prefix": "SFTY",
+      "name": "First",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lower-columbia-college"
+      ],
+      "sample_titles": [
+        "AHA First Aid/Basic Life Support",
+        "HIV/7"
+      ]
+    },
+    {
+      "prefix": "SOCSI",
+      "name": "Contemporary",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Contemporary Global Issues"
+      ]
+    },
+    {
+      "prefix": "SPS",
+      "name": "Sterile",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Sterile Processing Services 141"
+      ]
+    },
+    {
+      "prefix": "SPT",
+      "name": "Sterile",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Foundations of Sterile Processing [RE]",
+        "Sterile Processing Clinical [RE]"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "Skills",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Intro to Research Skills"
+      ]
+    },
+    {
+      "prefix": "STYSK",
+      "name": "Academic",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Academic Success Strategies"
+      ]
+    },
+    {
+      "prefix": "WRKFR",
+      "name": "Flagger",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "clover-park-technical-college"
+      ],
+      "sample_titles": [
+        "Flagger Certification Training - ATSSA"
+      ]
+    },
+    {
+      "prefix": "ACOMP",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Technical Algebra/Trigonometry 1"
+      ]
+    },
+    {
+      "prefix": "ADS",
+      "name": "Survey",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Survey of Addictions"
+      ]
+    },
+    {
+      "prefix": "AFS",
+      "name": "Agricultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "columbia-basin-college"
+      ],
+      "sample_titles": [
+        "Introduction to Agricultural Systems"
+      ]
+    },
+    {
+      "prefix": "BUSA",
+      "name": "Small",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lake-washington-institute-of-technology"
+      ],
+      "sample_titles": [
+        "Small Business Management"
+      ]
+    },
+    {
+      "prefix": "C B T",
+      "name": "Keyboarding",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Introduction to Keyboarding"
+      ]
+    },
+    {
+      "prefix": "CCE",
+      "name": "Multicultural",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Multicultural Dialogues In Early Childhood Educ"
+      ]
+    },
+    {
+      "prefix": "CE ARFFC",
+      "name": "Rescue",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "Air Rescue Fire Fighting Certification-Non credit"
+      ]
+    },
+    {
+      "prefix": "CE OPEMU",
+      "name": "Music",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "big-bend-community-college"
+      ],
+      "sample_titles": [
+        "OE Music"
+      ]
+    },
+    {
+      "prefix": "CEAG",
+      "name": "Sustainable",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Sustainable Landscaping: Connecting Your Yard to Nature"
+      ]
+    },
+    {
+      "prefix": "CELNG",
+      "name": "Spanish",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Spanish I"
+      ]
+    },
+    {
+      "prefix": "CEPE",
+      "name": "Senior",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Senior Fitness"
+      ]
+    },
+    {
+      "prefix": "CEPG",
+      "name": "Ukulele",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Ukulele for Beginners"
+      ]
+    },
+    {
+      "prefix": "CETEC",
+      "name": "Mastering",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Mastering Google Gemini AI"
+      ]
+    },
+    {
+      "prefix": "CHRC",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Education in Healthcare"
+      ]
+    },
+    {
+      "prefix": "CYTEC",
+      "name": "Underwater",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Underwater Robotics"
+      ]
+    },
+    {
+      "prefix": "DESJ",
+      "name": "Artificial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Artificial Intelligence in Society"
+      ]
+    },
+    {
+      "prefix": "EASIA",
+      "name": "Japanese",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "shoreline-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Japanese Civilization"
+      ]
+    },
+    {
+      "prefix": "FRCH",
+      "name": "Francophone",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "green-river-college"
+      ],
+      "sample_titles": [
+        "Introduction to Francophone Life and Culture"
+      ]
+    },
+    {
+      "prefix": "GLOB",
+      "name": "Current",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Current Global Issues"
+      ]
+    },
+    {
+      "prefix": "GOVT",
+      "name": "Civics",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Civics"
+      ]
+    },
+    {
+      "prefix": "HMATH",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "skagit-valley-college"
+      ],
+      "sample_titles": [
+        "Math for Health Professions"
+      ]
+    },
+    {
+      "prefix": "HMG",
+      "name": "Hospitality",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-seattle-college"
+      ],
+      "sample_titles": [
+        "Hospitality Management"
+      ]
+    },
+    {
+      "prefix": "HMGMT",
+      "name": "Elements",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Elements of Hospitality Management"
+      ]
+    },
+    {
+      "prefix": "HSCFA",
+      "name": "Comp",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "HS Comp Fine Arts"
+      ]
+    },
+    {
+      "prefix": "HSCM",
+      "name": "Adult",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bates-technical-college"
+      ],
+      "sample_titles": [
+        "Adult HS Pre Algebra"
+      ]
+    },
+    {
+      "prefix": "HUM S",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Human Services"
+      ]
+    },
+    {
+      "prefix": "IIS",
+      "name": "East",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "south-puget-sound-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to East Asian Studies: Diversity"
+      ]
+    },
+    {
+      "prefix": "INSTD",
+      "name": "State",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "State of Capitalism: CD"
+      ]
+    },
+    {
+      "prefix": "ISS",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "pierce-college-district"
+      ],
+      "sample_titles": [
+        "Social Studies for Teachers"
+      ]
+    },
+    {
+      "prefix": "KLA",
+      "name": "Klallam",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Introduction to the Klallam Language"
+      ]
+    },
+    {
+      "prefix": "LIB-R",
+      "name": "Internet",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Internet Research Skills"
+      ]
+    },
+    {
+      "prefix": "MAKAH",
+      "name": "Makah",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "peninsula-college"
+      ],
+      "sample_titles": [
+        "Introduction to the Makah Language"
+      ]
+    },
+    {
+      "prefix": "MATHI",
+      "name": "Integrated",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "olympic-college"
+      ],
+      "sample_titles": [
+        "Integrated Intermediate Algebra"
+      ]
+    },
+    {
+      "prefix": "MO",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Medical Office Procedures"
+      ]
+    },
+    {
+      "prefix": "NAL",
+      "name": "Native",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "wenatchee-valley-college"
+      ],
+      "sample_titles": [
+        "Native American Language III: Nimipu"
+      ]
+    },
+    {
+      "prefix": "NAT S",
+      "name": "Sustainability",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "everett-community-college"
+      ],
+      "sample_titles": [
+        "Sustainability and Systems"
+      ]
+    },
+    {
+      "prefix": "PNRSE",
+      "name": "Practical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Practical Nurse (PN) II"
+      ]
+    },
+    {
+      "prefix": "RADON",
+      "name": "Clinical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice VIII"
+      ]
+    },
+    {
+      "prefix": "RAIM",
+      "name": "Essentials",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bellevue-college"
+      ],
+      "sample_titles": [
+        "Essentials of Imaging & Therapy"
+      ]
+    },
+    {
+      "prefix": "ROBAI",
+      "name": "Robotics",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Special Topics: Robotics and AI"
+      ]
+    },
+    {
+      "prefix": "SCPRF",
+      "name": "Educator",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "seattle-central-college"
+      ],
+      "sample_titles": [
+        "Educator Clock Hour Form"
+      ]
+    },
+    {
+      "prefix": "SOCSC",
+      "name": "Psychosocial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "tacoma-community-college"
+      ],
+      "sample_titles": [
+        "Psychosocial Issues in Healthcare II"
+      ]
+    },
+    {
+      "prefix": "SST",
+      "name": "Social",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "Social Studies for Teachers (SS)"
+      ]
+    },
+    {
+      "prefix": "SUPR",
+      "name": "Sustainability",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cascadia-college"
+      ],
+      "sample_titles": [
+        "Special Topics in Sustainability I"
+      ]
+    },
+    {
+      "prefix": "SUTC",
+      "name": "Technology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "yakima-valley-college"
+      ],
+      "sample_titles": [
+        "Basic Technology II"
+      ]
+    },
+    {
+      "prefix": "TRDS",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "centralia-college"
+      ],
+      "sample_titles": [
+        "College & Career Success: TRDS"
+      ]
+    },
+    {
+      "prefix": "TRIO",
+      "name": "Financial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "walla-walla-community-college"
+      ],
+      "sample_titles": [
+        "Financial Literacy and College Costs"
+      ]
+    },
+    {
+      "prefix": "UGR",
+      "name": "UGR",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "north-seattle-college"
+      ],
+      "sample_titles": [
+        "Independent Research"
+      ]
+    },
+    {
+      "prefix": "WOMEN",
+      "name": "Womens",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "edmonds-college"
+      ],
+      "sample_titles": [
+        "Introduction to Women's Studies: CD"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/wi/subject-vocab.json
+++ b/data/wi/subject-vocab.json
@@ -1,0 +1,2475 @@
+{
+  "state": "wi",
+  "generated_at": "2026-06-06T15:41:41.107Z",
+  "subjects": [
+    {
+      "prefix": "10",
+      "name": "10",
+      "course_count": 244,
+      "section_count": 376,
+      "colleges": [
+        "southwest-wisconsin-technical-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Abstracting Principles and Practice I",
+        "Abstracting Principles and Practice II",
+        "Accounting 1",
+        "Accounting 2"
+      ]
+    },
+    {
+      "prefix": "INDS",
+      "name": "INDS",
+      "course_count": 34,
+      "section_count": 255,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Hydraulic Circuits",
+        "Basic Hydraulic Principles",
+        "Basic Hydraulics",
+        "Basic Pneumatic Circuits",
+        "Basic Pneumatic Principles"
+      ]
+    },
+    {
+      "prefix": "101",
+      "name": "101",
+      "course_count": 184,
+      "section_count": 254,
+      "colleges": [
+        "northcentral-technical-college",
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "10-key By Touch",
+        "Accounting 1",
+        "Accounting 2",
+        "Accounting Capstone",
+        "Accounting Fundamentals"
+      ]
+    },
+    {
+      "prefix": "108",
+      "name": "108",
+      "course_count": 52,
+      "section_count": 238,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adv Anatomy & Physiology",
+        "Body, Structure & Function",
+        "Calculus 1",
+        "Cents & Sensibility"
+      ]
+    },
+    {
+      "prefix": "105",
+      "name": "105",
+      "course_count": 142,
+      "section_count": 208,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Emergency Resuscitation",
+        "Advanced Cariology and Nutrition",
+        "Advanced Dental Health Safety",
+        "Advanced Firefighter Concepts",
+        "Advanced Hematology"
+      ]
+    },
+    {
+      "prefix": "106",
+      "name": "106",
+      "course_count": 108,
+      "section_count": 182,
+      "colleges": [
+        "northcentral-technical-college",
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Civil 3D",
+        "Advanced Drive Applications",
+        "Applied Mechanics For Technicians",
+        "Architectural Design 1",
+        "Architectural Design 3"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 18,
+      "section_count": 138,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Clinical Care Mgmt",
+        "Mental Health & Comm Concepts",
+        "Nsg: Clin Care Across Lifespan",
+        "Nurs Intro Clinical Practice",
+        "Nursing Adv Clinical Practice"
+      ]
+    },
+    {
+      "prefix": "104",
+      "name": "104",
+      "course_count": 76,
+      "section_count": 130,
+      "colleges": [
+        "northcentral-technical-college",
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Lumber Grading",
+        "Advanced Wood Manufacturing",
+        "Class B CDL 1",
+        "Class B CDL 2",
+        "CNC Router 1"
+      ]
+    },
+    {
+      "prefix": "475",
+      "name": "475",
+      "course_count": 25,
+      "section_count": 130,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "ACLS - Advanced Cardiac Life Support",
+        "Advanced Cardiac Life Support Refresher (ACLS)",
+        "Babysitting Certification",
+        "BLS (Basic Life Support) CPR",
+        "BLS (Basic Life Support) CPR Refresher"
+      ]
+    },
+    {
+      "prefix": "BSCE",
+      "name": "BSCE",
+      "course_count": 29,
+      "section_count": 100,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "American Government",
+        "Art Appreciation",
+        "Developmental Psychology",
+        "Economics"
+      ]
+    },
+    {
+      "prefix": "31",
+      "name": "31",
+      "course_count": 58,
+      "section_count": 89,
+      "colleges": [
+        "southwest-wisconsin-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Mathematics",
+        "Arc Cutting & Gouging",
+        "Basic Facials",
+        "Basic Hair Design",
+        "Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "809",
+      "name": "809",
+      "course_count": 18,
+      "section_count": 84,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Contemporary Moral Problems",
+        "Developmental Psychology",
+        "Economics",
+        "Intro to Amer Government"
+      ]
+    },
+    {
+      "prefix": "801",
+      "name": "801",
+      "course_count": 9,
+      "section_count": 82,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Comm for Transport",
+        "Creative Writing - Nonfiction",
+        "English 1",
+        "English 2",
+        "English Composition I"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 12,
+      "section_count": 82,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "American Literature to 1865",
+        "Applied Written/Job Seek Comm",
+        "English Composition 1",
+        "English Composition 2",
+        "English Composition I"
+      ]
+    },
+    {
+      "prefix": "890",
+      "name": "Strengths",
+      "course_count": 4,
+      "section_count": 80,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Career Skills",
+        "Strengths Seminar",
+        "Strengths Seminar (TD)",
+        "Strengths Seminar Liberal Arts"
+      ]
+    },
+    {
+      "prefix": "504",
+      "name": "Trades",
+      "course_count": 58,
+      "section_count": 71,
+      "colleges": [
+        "northcentral-technical-college",
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Application of Investigations",
+        "Application of Traffic Respons",
+        "Basic CAD/CAM For Machine Trades Apprentice",
+        "Basic Computers And Digital"
+      ]
+    },
+    {
+      "prefix": "102",
+      "name": "102",
+      "course_count": 28,
+      "section_count": 60,
+      "colleges": [
+        "northcentral-technical-college",
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Editing Techniques",
+        "Advanced Page Layout",
+        "Advanced Press Operations",
+        "Business Analysis Fundamentals",
+        "Business Concepts"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 23,
+      "section_count": 57,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Solar & Sustainability",
+        "Basic HVAC CAD",
+        "Drafting-HVAC",
+        "Electricity Principles",
+        "Electricity Theory"
+      ]
+    },
+    {
+      "prefix": "100",
+      "name": "100",
+      "course_count": 41,
+      "section_count": 54,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Agricultural Accounting",
+        "Agricultural Internship",
+        "Agriculture Equipment Safety",
+        "Animal Management",
+        "Animal Nursing"
+      ]
+    },
+    {
+      "prefix": "543",
+      "name": "Nursing",
+      "course_count": 17,
+      "section_count": 52,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Clinical Care Mgmt",
+        "Mental Health & Community Conc",
+        "Nsg: Clinical Care Across Life",
+        "Nsg: Complex Health Alterat 2",
+        "Nsg: Intermed Clin Practice"
+      ]
+    },
+    {
+      "prefix": "SCIL",
+      "name": "SCIL",
+      "course_count": 9,
+      "section_count": 50,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Anatomy & Physiology",
+        "Anatomy & Physiology 1",
+        "Environmental Science",
+        "Gen Anatomy & Physiology",
+        "Human Reproductive Biology"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 12,
+      "section_count": 48,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Business Analytics",
+        "Business Ethics",
+        "Business Mgmt Career Planning",
+        "Business Mgmt Internship",
+        "Global Business"
+      ]
+    },
+    {
+      "prefix": "NETW",
+      "name": "NETW",
+      "course_count": 25,
+      "section_count": 48,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Become an OS Power User",
+        "Bits/Bytes of Computer Network",
+        "CCNA 1: Intro to Networks",
+        "CCNA 2:Switch/Routing/Wire Ess",
+        "CCNA 3:Netwkg/Security/Automat"
+      ]
+    },
+    {
+      "prefix": "806",
+      "name": "806",
+      "course_count": 13,
+      "section_count": 45,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Anatomy & Physiology",
+        "Anatomy and Physiology I",
+        "Anatomy and Physiology II",
+        "College Chemistry 1",
+        "College Chemistry 2"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 12,
+      "section_count": 43,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Calculus & Analytic Geometry 1",
+        "College Algebra",
+        "College Technical Math 1",
+        "College Technical Math 1A",
+        "Elem Algebra with Apps"
+      ]
+    },
+    {
+      "prefix": "103",
+      "name": "103",
+      "course_count": 29,
+      "section_count": 41,
+      "colleges": [
+        "northcentral-technical-college",
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Baking And Specialty Decorating",
+        "Baking Fundamentals",
+        "Breakfast Cuisine",
+        "Complex Carbohydrates",
+        "Computer Applications for Busi"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 22,
+      "section_count": 40,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Shielded Metal Arc Welding",
+        "Advanced Gas Metal Arc Welding",
+        "CNC Fabrication",
+        "Fabrication",
+        "Gas Metal Arc Welding"
+      ]
+    },
+    {
+      "prefix": "305",
+      "name": "305",
+      "course_count": 18,
+      "section_count": 34,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT",
+        "Application of Investigations",
+        "Application of Traffic Response",
+        "Critical Care Transport Paramedic",
+        "Emergency Medical Responder (EMR)/ Emergency Medical Technician (EMT) - Part 1"
+      ]
+    },
+    {
+      "prefix": "PROG",
+      "name": "PROG",
+      "course_count": 17,
+      "section_count": 34,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        ".NET Application Development",
+        ".NET-ASP",
+        "3D Simulation Development",
+        "Data Structures",
+        "Database 1"
+      ]
+    },
+    {
+      "prefix": "804",
+      "name": "804",
+      "course_count": 10,
+      "section_count": 32,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Math 1 - Wood",
+        "Basic Statistics",
+        "Calculus & Analytic Geometry 1",
+        "College Algebra",
+        "College Mathematics"
+      ]
+    },
+    {
+      "prefix": "TRCK",
+      "name": "TRCK",
+      "course_count": 15,
+      "section_count": 29,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Operating Procedures",
+        "Basic Ops of a Manual Trans 1",
+        "Basic Ops of a Manual Trans 2",
+        "Basic Ops/Comm Motor Vehicle",
+        "CDL Lab Pintle Hook Restrict"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "SCI",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "General Chemistry",
+        "General Physics 1",
+        "Intro to Biochemistry",
+        "Introduction to Astronomy",
+        "Prep for Basic Chemistry"
+      ]
+    },
+    {
+      "prefix": "SFTY",
+      "name": "SFTY",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Confined Space Entry & Rescue",
+        "Electrical Standards",
+        "Ergonomic Fundamentals",
+        "Evacuation & Emergency Plans",
+        "Hazardous Materials"
+      ]
+    },
+    {
+      "prefix": "98F",
+      "name": "Candidate",
+      "course_count": 4,
+      "section_count": 26,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Candidate Physical Ability Test (CPAT) - Full Session",
+        "Candidate Physical Ability Test (CPAT) - Test Out",
+        "Fire Fighter 1 Practical Exam",
+        "Fire Fighter II Practical Exam"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Accounting Capstone",
+        "Accounting Database Analytics",
+        "Accounting I",
+        "Accounting II",
+        "Accounting Internship"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "CRIM",
+      "course_count": 9,
+      "section_count": 26,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "CJ Student Success",
+        "Community Policing Strategies",
+        "Constitutional Law",
+        "Contemp. Issues in Crim. Just.",
+        "Corrections, Intro to"
+      ]
+    },
+    {
+      "prefix": "428",
+      "name": "Rider",
+      "course_count": 5,
+      "section_count": 25,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Rider Course",
+        "Basic Rider Course 2",
+        "Group Dynamics",
+        "Multiple Offender Program",
+        "Traffic Safety - Point Reduction"
+      ]
+    },
+    {
+      "prefix": "ELMC",
+      "name": "ELMC",
+      "course_count": 19,
+      "section_count": 24,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Applied EM Machine Principles",
+        "Automated Processes",
+        "Automated Systems Interfacing",
+        "Basic Electronics with Digital",
+        "Control Applications"
+      ]
+    },
+    {
+      "prefix": "30",
+      "name": "30",
+      "course_count": 13,
+      "section_count": 23,
+      "colleges": [
+        "southwest-wisconsin-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT (AEMT)",
+        "Basic Carpentry",
+        "Basic Electrical",
+        "Basic Plumbing",
+        "Blueprint Reading for Construction"
+      ]
+    },
+    {
+      "prefix": "531",
+      "name": "531",
+      "course_count": 18,
+      "section_count": 23,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Emergency Resuscitation",
+        "Adv. Patient Assess Principles",
+        "Adv. Pre-Hospital Pharmacology",
+        "Advanced EMT",
+        "Advanced EMT- Clinical"
+      ]
+    },
+    {
+      "prefix": "201",
+      "name": "Design",
+      "course_count": 9,
+      "section_count": 22,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Adobe Illustrator",
+        "Adobe Photoshop",
+        "Design Fundamentals",
+        "Drawing",
+        "Graphic Design & Marketing"
+      ]
+    },
+    {
+      "prefix": "32",
+      "name": "32",
+      "course_count": 20,
+      "section_count": 22,
+      "colleges": [
+        "southwest-wisconsin-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Braking Systems",
+        "Advanced Electrical Systems",
+        "Advanced Engine Systems",
+        "Ag Power Occup Internship",
+        "Ag Shop Safety & Practices"
+      ]
+    },
+    {
+      "prefix": "20",
+      "name": "20",
+      "course_count": 14,
+      "section_count": 21,
+      "colleges": [
+        "southwest-wisconsin-technical-college"
+      ],
+      "sample_titles": [
+        "American Literature: Beginnings - 1865",
+        "Anatomy and Physiology I",
+        "Anatomy and Physiology II",
+        "College Algebra",
+        "English Composition 2"
+      ]
+    },
+    {
+      "prefix": "315",
+      "name": "315",
+      "course_count": 19,
+      "section_count": 21,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Chemical Services 1",
+        "Cosmetology Laws",
+        "Dental & General Anatomy",
+        "Dental Assistant Clinical",
+        "Dental Assistant Professional"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "AGRI",
+      "course_count": 21,
+      "section_count": 21,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Reproduction",
+        "Agriculture Equipment",
+        "Agriculture Sales",
+        "Agronomy Internship",
+        "Animal Science Internship"
+      ]
+    },
+    {
+      "prefix": "412",
+      "name": "Diesel",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Diesel & Heavy Equipment Inter",
+        "Diesel Advanced Electricity",
+        "Diesel Basic Engines",
+        "Diesel Electricity Fundamental",
+        "Diesel Electricity Trblshootng"
+      ]
+    },
+    {
+      "prefix": "601",
+      "name": "601",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Electricity in HVACR",
+        "Digital Drawing and Drafting",
+        "Electric Circuits for HVACR",
+        "Energy & Sustainability Princi",
+        "Heat Pumps"
+      ]
+    },
+    {
+      "prefix": "CLT",
+      "name": "CLT",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Hematology",
+        "Advanced Microbiology",
+        "Basic Immunology Concepts",
+        "Basic Lab Skills",
+        "Clinical Chemistry"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Applied HIM Technology 1",
+        "CPT Coding",
+        "Fundamentals of HIM",
+        "HC Statistics & Data Analytics",
+        "Healthcare Informatics"
+      ]
+    },
+    {
+      "prefix": "PMED",
+      "name": "Paramedic",
+      "course_count": 14,
+      "section_count": 18,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Adv. Patient Assess Principles",
+        "Adv. Pre-hospital Pharmacology",
+        "EMS Fundamental",
+        "EMS Operations",
+        "Paramedic Capstone"
+      ]
+    },
+    {
+      "prefix": "154",
+      "name": "154",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Crystal Report Writer w/ SQL",
+        "Database Foundations w/ SQL",
+        "Database Server Administration",
+        "IT Field Study",
+        "IT Pathways"
+      ]
+    },
+    {
+      "prefix": "COSM",
+      "name": "Services",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Salon & Spa Services",
+        "Advanced Salon Operations",
+        "Chemical Services 1",
+        "Chemical Services 2",
+        "Facial Services"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Customer Relationship Mgmt",
+        "Entrepreneurial Communication",
+        "Entrepreneurial Ideas",
+        "Marketing Principles",
+        "Marketing Prof Practice"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "Radiography",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Imaging Equipment Operation",
+        "Imaging Modalities",
+        "Introduction to Radiography",
+        "Radiographic Imaging",
+        "Radiographic Pathology"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "AI Foundations for Business",
+        "Applied Business Software",
+        "Database",
+        "Digital Creativity: Pub & Tool",
+        "Foundations of Bus Writing"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced EMT",
+        "Advanced Prehospital Skills",
+        "EMR/EMT 1",
+        "EMT Part 2"
+      ]
+    },
+    {
+      "prefix": "MDES",
+      "name": "MDES",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Additive Manufacturing",
+        "Blueprint Reading",
+        "CAD, 2D",
+        "Mechanical Design Concepts",
+        "Mechanical Design Proj Mgmt"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Respiratory Airway Management",
+        "Respiratory Clinical 1",
+        "Respiratory Clinical 2",
+        "Respiratory Clinical 3",
+        "Respiratory Life Support"
+      ]
+    },
+    {
+      "prefix": "404",
+      "name": "404",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Occup & Bus Operations",
+        "Automotive Climate Control",
+        "Automotive Trade Simulation",
+        "Basic Electrical Systems",
+        "Basic Maintenance"
+      ]
+    },
+    {
+      "prefix": "509",
+      "name": "Medical",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Human Body in Health & Disease",
+        "Medical Asst Admin Procedures",
+        "Medical Asst Clin Experience 1",
+        "Medical Asst Clin Experience 2",
+        "Medical Asst Clin Procedures 1"
+      ]
+    },
+    {
+      "prefix": "620",
+      "name": "620",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Adv. PLC Programming",
+        "Automation Systems Integration",
+        "Basic Industrial Controls",
+        "Fluid Power Fund",
+        "Industrial Electricity"
+      ]
+    },
+    {
+      "prefix": "HR",
+      "name": "Human",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Employee Benefits",
+        "Employee Relations",
+        "Human Resource Law",
+        "Human Resources Capstone",
+        "Human Resources Internship"
+      ]
+    },
+    {
+      "prefix": "442",
+      "name": "Welding",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Welding",
+        "Welding for Diesel & Heavy Eq",
+        "Welding Inspection",
+        "Welding-SMAW 1",
+        "Welding-TIG 1"
+      ]
+    },
+    {
+      "prefix": "614",
+      "name": "Arch",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced BIM",
+        "Arch History, Theory & Drawing",
+        "Arch. Studio 1 - 3D Modeling",
+        "Arch. Studio 2 - CAD Software",
+        "Arch. Studio 6 - BIM Commer 2"
+      ]
+    },
+    {
+      "prefix": "AMNT",
+      "name": "Automotive",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Auto Axles & Drive Trains",
+        "Auto Engine Performance 1",
+        "Auto Trnsmission & Trnsaxles",
+        "Automotive Brake Systems",
+        "Automotive Electricity 1"
+      ]
+    },
+    {
+      "prefix": "CHLD",
+      "name": "CHLD",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "ECE: Early Language & Literacy",
+        "ECE: Field Experience 1",
+        "ECE: Field Experience 3",
+        "ECE: Foundations of ECE",
+        "ECE: Hlth Safety & Nutrition"
+      ]
+    },
+    {
+      "prefix": "DATA",
+      "name": "Data",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Artificial Intelligence Reveal",
+        "Beginners Guide-Data Analyst",
+        "BI Data 1-Paginated",
+        "BI Data 2-Interactive",
+        "BI Data 3-Visualization"
+      ]
+    },
+    {
+      "prefix": "DNTL",
+      "name": "Dental",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Community Dental Health",
+        "Dental & General Anatomy",
+        "Dental Assistant Clinical",
+        "Dental Assistant Professional",
+        "Dental Chairside"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "LEGL",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Administration of Estates",
+        "Business Law",
+        "Civil Litigation I",
+        "Criminal Law-Paralegal",
+        "Employment Law"
+      ]
+    },
+    {
+      "prefix": "MEDI",
+      "name": "Medical",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Digital Literacy Healthcare",
+        "Human Body in Health & Disease",
+        "Med Asst Clin Procedures 2",
+        "Med Asst Lab Procedures 2",
+        "Med Office Insurance & Finance"
+      ]
+    },
+    {
+      "prefix": "QUAL",
+      "name": "Quality",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Manufacturing Skills Standards",
+        "Mfg & Quality Assurance"
+      ]
+    },
+    {
+      "prefix": "314",
+      "name": "Field",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electricity For Gas Utility",
+        "Calculation For Utilities",
+        "Directional Drilling",
+        "Gas Utility Field Training 1",
+        "Gas Utility Field Training 2"
+      ]
+    },
+    {
+      "prefix": "526",
+      "name": "526",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Imaging Equipment Operation",
+        "Imaging Modalities",
+        "Introduction to Radiography",
+        "Radiographic Image Analysis",
+        "Radiographic Imaging"
+      ]
+    },
+    {
+      "prefix": "307",
+      "name": "307",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "ECE: Family & Community Rel",
+        "ECE: Field Experience 1",
+        "ECE: Field Experience 3",
+        "ECE: Foundations of ECE",
+        "ECE: Guiding Child Behavior"
+      ]
+    },
+    {
+      "prefix": "410",
+      "name": "410",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Commercial Blueprint Reading",
+        "Commercial Systems",
+        "Construction Industry Basics",
+        "Estimating Bids & Specs",
+        "Exterior Finishes"
+      ]
+    },
+    {
+      "prefix": "508",
+      "name": "Dental",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Dental & General Anatomy",
+        "Dental Assistant Clinical",
+        "Dental Chairside",
+        "Dental Health Safety",
+        "Dental Materials"
+      ]
+    },
+    {
+      "prefix": "520",
+      "name": "520",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Children and Family Studies",
+        "Cultural Issues in Human Serv",
+        "Field Study 1 - Human Services",
+        "Group Design and Facilitation",
+        "Interviewing and Documentation"
+      ]
+    },
+    {
+      "prefix": "GRPH",
+      "name": "GRPH",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Drawing & Illustration Concept",
+        "Graphic Design Foundation",
+        "Graphic Design Project Mgmt",
+        "Motion Graphics",
+        "Photoshop Fundamentals"
+      ]
+    },
+    {
+      "prefix": "WOOD",
+      "name": "WOOD",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Const Basics & Print Reading",
+        "Construction Industry Skills",
+        "Construction Safety",
+        "Framing Methods/Bldg the Envel",
+        "Frmng Mthds/Bldng the Envl Lab"
+      ]
+    },
+    {
+      "prefix": "151",
+      "name": "Cybersecurity",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Cybersecurity Essentials",
+        "Cybersecurity Operations",
+        "Introduction to Cybersecurity",
+        "Wireless and Mobile Security"
+      ]
+    },
+    {
+      "prefix": "513",
+      "name": "513",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Hematology",
+        "Basic Immunology Concepts",
+        "Basic Lab Skills",
+        "Clinical Chemistry",
+        "Clinical Microbiology"
+      ]
+    },
+    {
+      "prefix": "AEST",
+      "name": "AEST",
+      "course_count": 10,
+      "section_count": 11,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Aesthetician Skills",
+        "Advanced Skin Science",
+        "Aesthetic Guest Service & Prac",
+        "Aesthetic Health & Safety",
+        "Anatomy & Phys Aesthetics"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "DMS",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Cross Sectional Anatomy",
+        "DMS Clinical Experience 3",
+        "Intro to DMS",
+        "OB/GYN Sonography 2",
+        "Registry Review"
+      ]
+    },
+    {
+      "prefix": "512",
+      "name": "Surgical",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Exploring Surgical Issues",
+        "Intro to Surgical Technology",
+        "Surgical Interventions 1",
+        "Surgical Tech Fundamentals 1",
+        "Surgical Technology Clinical 1"
+      ]
+    },
+    {
+      "prefix": "515",
+      "name": "Respiratory",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Respiratory Airway Management",
+        "Respiratory Clinical 1",
+        "Respiratory Clinical 2",
+        "Respiratory Clinical 3",
+        "Respiratory Disease"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Culinary Arts Internship",
+        "Food Safety & Sanitation",
+        "Food Theory",
+        "Garde Manger",
+        "Intro to Baking & Pastry"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "Diesel",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Mobile Hydraulics",
+        "Basic DC Electricity",
+        "Chassis I",
+        "Chassis II",
+        "Diesel Engine Oper & Tune-up"
+      ]
+    },
+    {
+      "prefix": "DRNE",
+      "name": "Drone",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Drone Agriculture Operations",
+        "Drone Commercial Operations",
+        "Drone Mapping & Modeling",
+        "Drone Recreational Operations"
+      ]
+    },
+    {
+      "prefix": "006",
+      "name": "006",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Animal Science",
+        "Career Dev in Agriculture",
+        "Crop Management",
+        "Introduction to Plant Science",
+        "Introduction to Soils"
+      ]
+    },
+    {
+      "prefix": "116",
+      "name": "116",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Employee Benefits",
+        "Employee Relations",
+        "Employment Law",
+        "HR Essentials",
+        "Intro to HR Management"
+      ]
+    },
+    {
+      "prefix": "150",
+      "name": "Fund",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Cisco 1: Networking Fund",
+        "IT Hardware/Software Fund",
+        "Network Security 1"
+      ]
+    },
+    {
+      "prefix": "324",
+      "name": "Machine",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "CNC Milling Machine Fundamentals 1",
+        "CNC Turning Machine Fundamentals 1",
+        "Introduction To Machine Tool",
+        "Machine Tool Processes 1",
+        "Machine Tool Programming 1"
+      ]
+    },
+    {
+      "prefix": "413",
+      "name": "Electconst",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "AC Thry Mtrs Conduts & Lghtng",
+        "Elect-Const JAC 1 Wkbk 1-6",
+        "Elect-Const JAC 1 Wkbk 7-12",
+        "Elect-Const JAC 3 Wkbk 1-6",
+        "Elect-Const JAC 4 Wkbk 1-6"
+      ]
+    },
+    {
+      "prefix": "50",
+      "name": "Electrician",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "southwest-wisconsin-technical-college"
+      ],
+      "sample_titles": [
+        "Construction Electrician I",
+        "Construction Electrician III",
+        "Construction Electrician V",
+        "Construction Electrician VII",
+        "Industrial Electrician I"
+      ]
+    },
+    {
+      "prefix": "522",
+      "name": "522",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "EDU: Child & Adol Dev",
+        "EDU: Equity in Education",
+        "EDU: Intro to Ed Practices",
+        "EDU: Practicum 2",
+        "Edu: Soc Emot Learn & Ment Hlt"
+      ]
+    },
+    {
+      "prefix": "AODA",
+      "name": "AODA",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Experience II",
+        "Counseling Theory",
+        "Culturally Skilled Counseling",
+        "Family Systems",
+        "Intro Interview&Counsel Skills"
+      ]
+    },
+    {
+      "prefix": "152",
+      "name": "Programming",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "IT Project Management",
+        "Python Programming",
+        "Software Design 3",
+        "Software Systems",
+        "Web Programming 1"
+      ]
+    },
+    {
+      "prefix": "310",
+      "name": "310",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Designing And Timing Your Garden",
+        "Fruit Crop Production I",
+        "Garden Production Basics",
+        "Greenhouse Operation and Design",
+        "Hydroponics"
+      ]
+    },
+    {
+      "prefix": "474",
+      "name": "474",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "CDL Hazardous Materials",
+        "Intro to CNC Milling",
+        "Plumbing 54 Hour Exam Prep",
+        "Transit / Level / Laser",
+        "Transition To Trainer: Your Role As A Journey Worker"
+      ]
+    },
+    {
+      "prefix": "503",
+      "name": "Fire",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Bldng Construc for Fire Protec",
+        "Fire Behavior and Combustion",
+        "Fire Protection Hydraulics",
+        "Fire Protection Systems",
+        "Fire Safety and Survival"
+      ]
+    },
+    {
+      "prefix": "530",
+      "name": "530",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "CPT Coding",
+        "Data Management in HIM",
+        "Healthcare Revenue Management",
+        "Healthcare Stats and Analytics",
+        "HIT Capstone"
+      ]
+    },
+    {
+      "prefix": "606",
+      "name": "606",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Calc in Engineering",
+        "AutoCAD",
+        "Geometric Dim & Tolerance",
+        "Mechanisms and Dynamics",
+        "Solidworks"
+      ]
+    },
+    {
+      "prefix": "803",
+      "name": "American",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "American History 1607-1865",
+        "American History 1865-Present",
+        "The World in Twentieth Century"
+      ]
+    },
+    {
+      "prefix": "ARCT",
+      "name": "ARCT",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Architectural Drafting 2",
+        "CAD Architecture",
+        "Draft Fund/Wood Frame Construc",
+        "Mechanical Systems",
+        "Revit Architecture"
+      ]
+    },
+    {
+      "prefix": "EPD",
+      "name": "EPD",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Basic EPD Electricity",
+        "Basic EPD Safety",
+        "Intermediate EPD Electricity",
+        "Intro to Pole Climbing",
+        "OH Line Design & Construction"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "Horticulture",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Turf Management",
+        "Horticulture Internship",
+        "Horticulture Lab",
+        "Horticulture Soils",
+        "Intro to Horticulture"
+      ]
+    },
+    {
+      "prefix": "LES",
+      "name": "Library",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Public Library Admin",
+        "Fnd of Library & Info Services",
+        "Fund of Reference Services",
+        "Information Literacy",
+        "Library and Web Technologies"
+      ]
+    },
+    {
+      "prefix": "110",
+      "name": "110",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Civil Litigation 1",
+        "Criminal Procedures",
+        "Family Law",
+        "Intro to Paralegal & Ethics",
+        "Legal Research"
+      ]
+    },
+    {
+      "prefix": "427",
+      "name": "Sanitary",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Green Plumbing Applications",
+        "Plumbing Advanced Topic/TSA",
+        "Sanitary Drains 1",
+        "Sanitary Drains 2",
+        "Water Distribution 1"
+      ]
+    },
+    {
+      "prefix": "471",
+      "name": "471",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Change for Org. Effectiveness",
+        "Crucial Conversations",
+        "Emotional Intelligence: Practical Strategies for Leaders",
+        "Executive Strategic Thinking and Vision",
+        "Nonprofit Management Series"
+      ]
+    },
+    {
+      "prefix": "514",
+      "name": "Practice",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Activity Analysis & Appl",
+        "Geriatric Practice",
+        "Intro to Occup Therapy",
+        "Med & Psychosocial Conditions",
+        "OT Pediatric Practice"
+      ]
+    },
+    {
+      "prefix": "524",
+      "name": "524",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "PTA Applied Kinesiology 1",
+        "PTA Cardio & Integ Mgmt",
+        "PTA Clinical Practice 1",
+        "PTA Patient Interventions",
+        "PTA Princ of Musculo Rehab"
+      ]
+    },
+    {
+      "prefix": "664",
+      "name": "664",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "3D Printing",
+        "Intro to Indus Cntrl Systems",
+        "Intro to Industrial IoT",
+        "Intro to Mechatronics",
+        "Safeguarding & Safety Circuits"
+      ]
+    },
+    {
+      "prefix": "807",
+      "name": "807",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Total Fitness",
+        "Weight Training",
+        "Wellness Today"
+      ]
+    },
+    {
+      "prefix": "FOTE",
+      "name": "FOTE",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "EDU: Behavior Management",
+        "EDU: Equity in Education",
+        "EDU: Intro to Ed Practices",
+        "EDU: Overview of Autism",
+        "EDU: Techniques in Soc Stu"
+      ]
+    },
+    {
+      "prefix": "MACH",
+      "name": "Machining",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading & Measuremnt",
+        "CNC Equations 1",
+        "Intro to CAD/CAM",
+        "Intro to Machining",
+        "Machine Tool Operation Basics"
+      ]
+    },
+    {
+      "prefix": "MASG",
+      "name": "Massage",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Massage Therapy 1",
+        "Massage Therapy 2",
+        "Massage Therapy Practice 2",
+        "Massage Therapy Practice 3",
+        "MT Applied Kinesiology 1"
+      ]
+    },
+    {
+      "prefix": "MOPP",
+      "name": "MOPP",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Engines/Systems,Intro to",
+        "Electricity for Powersports 1",
+        "Electricity for Powersports 2",
+        "Engine Theory 1A",
+        "Engine Theory 1B"
+      ]
+    },
+    {
+      "prefix": "PT",
+      "name": "Kinesiology",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "PTA Applied Kinesiology 1",
+        "PTA Applied Kinesiology 2",
+        "PTA Clinical Practice 2",
+        "PTA Patient Interventions"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surgical",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Exploring Surgical Issues",
+        "Intro to Surgical Technology",
+        "Surgical Interventions 1",
+        "Surgical Tech Fundamentals 1",
+        "Surgical Technology Clinical 1"
+      ]
+    },
+    {
+      "prefix": "304",
+      "name": "304",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Design and Graphic Fundamental",
+        "Design Field Experience/Co-Op",
+        "Health, Safety & Welfare",
+        "INDS Studio 3 - Intro to Comm",
+        "INDS Studio 4 - Adv Commercia"
+      ]
+    },
+    {
+      "prefix": "473",
+      "name": "Food",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Food Safety & Sanitation Certification",
+        "Food Safety Recertification Refresher",
+        "Responsible Beverage Service"
+      ]
+    },
+    {
+      "prefix": "481",
+      "name": "481",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Construction Project Managemen",
+        "Energy Modeling 2",
+        "HVAC for BSEM",
+        "Intro to Building Science",
+        "Intro to Energy Effic & Mgmt"
+      ]
+    },
+    {
+      "prefix": "501",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Digital Literacy for Healthcar",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "ABDY",
+      "name": "Collision",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Collision",
+        "Collision Capstone",
+        "Intro to Collision Fundamental",
+        "Non-Structural Fundamentals",
+        "Refinish/Painting Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Data Analytics",
+        "Engineering Economy",
+        "Engineering Principles",
+        "Intro to Manufacturing Safety",
+        "Intro to Precision Measurement"
+      ]
+    },
+    {
+      "prefix": "160",
+      "name": "Healthcare",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Healthcare Admin &organization",
+        "Healthcare Business Term",
+        "Med Law Ethics & Prof",
+        "Spreadsheets for Healthcare"
+      ]
+    },
+    {
+      "prefix": "662",
+      "name": "662",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Circuits",
+        "Data Comm & Networking",
+        "Embedded Systems",
+        "Integrated Circuit Apps",
+        "Intro to LabVIEW"
+      ]
+    },
+    {
+      "prefix": "FARM",
+      "name": "Management",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Farm Bus Analysis&Mrkt Strat",
+        "Land Use Management",
+        "Mktg/Fin Mgmt in Grain Prod",
+        "Progressive Dairy Management"
+      ]
+    },
+    {
+      "prefix": "GASU",
+      "name": "Utility",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Elect for Gas Utility",
+        "Gas Utility Field Training 1",
+        "Gas Utility Field Training 2",
+        "Gas Utility Field Training 3",
+        "Gas Utility Industry Skills"
+      ]
+    },
+    {
+      "prefix": "001",
+      "name": "Plant",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Fundmntls of Plant Idntificatn",
+        "Greenhouse Fundamentals",
+        "Holistic Plant Health Care",
+        "Landscape Installation & Maint"
+      ]
+    },
+    {
+      "prefix": "156",
+      "name": "Data",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Data Governance & Ethics",
+        "Introduction to Data Analytics",
+        "Modern AI & Machine Learning",
+        "Predictive Analytics"
+      ]
+    },
+    {
+      "prefix": "196",
+      "name": "196",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Leadership Development",
+        "Project Management",
+        "Supervision",
+        "Team Building"
+      ]
+    },
+    {
+      "prefix": "457",
+      "name": "Welding",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading for Welding",
+        "Fabrication Welding 1"
+      ]
+    },
+    {
+      "prefix": "778",
+      "name": "Chemistry",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Chemistry",
+        "Introduction To HESI"
+      ]
+    },
+    {
+      "prefix": "DESK",
+      "name": "Management",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Documentation",
+        "Endpoint Management",
+        "IT Service Management",
+        "Professional Skills"
+      ]
+    },
+    {
+      "prefix": "FMED",
+      "name": "FMED",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Firefighting Concepts",
+        "Fire Dept Apparatus Ops",
+        "FireMedic Internship",
+        "Special Rescue"
+      ]
+    },
+    {
+      "prefix": "478",
+      "name": "Find",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Find Your Fit: LEGO Mindstorms",
+        "Find Your Future: Python Code Academy",
+        "Graphic Communications Camp"
+      ]
+    },
+    {
+      "prefix": "660",
+      "name": "Dcac",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "DC/AC 1",
+        "DC/AC 2",
+        "Electronic Skills"
+      ]
+    },
+    {
+      "prefix": "701",
+      "name": "Video",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Video Production 1",
+        "Video Production 4"
+      ]
+    },
+    {
+      "prefix": "805",
+      "name": "Music",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Music Appreciation"
+      ]
+    },
+    {
+      "prefix": "856",
+      "name": "Developmental",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Developmental Biology",
+        "Developmental Chemistry"
+      ]
+    },
+    {
+      "prefix": "FORL",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Latin American Studies",
+        "Spanish 1"
+      ]
+    },
+    {
+      "prefix": "PCOM",
+      "name": "Digital",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Digital Content Writing",
+        "Digital Media Communications",
+        "Document Design"
+      ]
+    },
+    {
+      "prefix": "SUPL",
+      "name": "Mgmt",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Supply Chain Mgmt",
+        "Princ of Distrib & Logistics",
+        "Princ of Inventory Mgmt"
+      ]
+    },
+    {
+      "prefix": "203",
+      "name": "Digital",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Digital Photography 1"
+      ]
+    },
+    {
+      "prefix": "206",
+      "name": "Motion",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Compositing and Video Effects",
+        "Intro to Motion Graphics"
+      ]
+    },
+    {
+      "prefix": "472",
+      "name": "Motion",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Motion Graphics",
+        "Short Narrative Production"
+      ]
+    },
+    {
+      "prefix": "600",
+      "name": "Wild",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Wild Mushroom Foray"
+      ]
+    },
+    {
+      "prefix": "631",
+      "name": "Career",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Connecting Things",
+        "IoT Career Development"
+      ]
+    },
+    {
+      "prefix": "788",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "College Success-financial Aid Essentials For College Students"
+      ]
+    },
+    {
+      "prefix": "815",
+      "name": "Hist",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Art Hist: Prehist to Medieval",
+        "Art History: Renaiss to Modern"
+      ]
+    },
+    {
+      "prefix": "470",
+      "name": "Tractor",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Tractor Safety"
+      ]
+    },
+    {
+      "prefix": "480",
+      "name": "Design",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "PV Design and Install 1"
+      ]
+    },
+    {
+      "prefix": "608",
+      "name": "Blossoms",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Blossoms & Brushes"
+      ]
+    },
+    {
+      "prefix": "663",
+      "name": "Electronic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Electronic CAD Applications"
+      ]
+    },
+    {
+      "prefix": "802",
+      "name": "Spanish",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "western-technical-college"
+      ],
+      "sample_titles": [
+        "Spanish 1"
+      ]
+    },
+    {
+      "prefix": "985",
+      "name": "Clinical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "EMT Clinical Simulation Day"
+      ]
+    },
+    {
+      "prefix": "98L",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "Physical Readiness Test"
+      ]
+    },
+    {
+      "prefix": "98N",
+      "name": "National",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northcentral-technical-college"
+      ],
+      "sample_titles": [
+        "National Registry - EMT"
+      ]
+    },
+    {
+      "prefix": "CYBR",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "chippewa-valley-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Information Security"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/wy/subject-vocab.json
+++ b/data/wy/subject-vocab.json
@@ -1,0 +1,2500 @@
+{
+  "state": "wy",
+  "generated_at": "2026-06-06T15:41:41.119Z",
+  "subjects": [
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 107,
+      "section_count": 417,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Advanced Audio Recording",
+        "Audio Recording",
+        "Aural Theory I",
+        "Aural Theory II",
+        "Aural Theory III"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 29,
+      "section_count": 219,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Algebra and Trigonometry",
+        "Appl Differential Equations I",
+        "Applied Technical Mathematics",
+        "BEG AND INTERMEDIATE ALGEBRA",
+        "Business Calculus I"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 40,
+      "section_count": 209,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Accelerated Writing/Reading",
+        "American Literature I",
+        "Applied Technical Writing",
+        "Co-Requisite for ENGL 1010",
+        "Creative Writing II"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 33,
+      "section_count": 152,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Animal Biology",
+        "Animal Biology Lab",
+        "BIOL 1000 Lab",
+        "BIOL 1010 Lab",
+        "Biological Research"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 49,
+      "section_count": 108,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Art & Graphic Design 1st Yr SE",
+        "Art and Human Culture",
+        "Art History I",
+        "Art History II",
+        "Art History: Postmodern Art"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 19,
+      "section_count": 103,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Biological Psychology",
+        "Drugs and Behavior",
+        "Field Studies",
+        "FORENSIC PSYCHOLOGY",
+        "General Psychology"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 22,
+      "section_count": 101,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Business/Professional Comm",
+        "Capstone: Communication",
+        "Communication Internship",
+        "Cooperative Work Experience",
+        "Cross-Cultural Communication"
+      ]
+    },
+    {
+      "prefix": "ZOO",
+      "name": "Human",
+      "course_count": 10,
+      "section_count": 99,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Fsh and Wldlfe Mngmnt Anthrop",
+        "Human Anatomy",
+        "Human Anatomy & Physiology II",
+        "Human Anatomy and Physiology I",
+        "Human Anatomy Lab"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 43,
+      "section_count": 83,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Adv Metal Fabrication Techniq",
+        "ADV SHIELD METAL ARC WELDING",
+        "Advanced Gas Metal Arc Welding",
+        "Advanced Welding Processes",
+        "Allied Cutting Processes"
+      ]
+    },
+    {
+      "prefix": "CRMJ",
+      "name": "CRMJ",
+      "course_count": 39,
+      "section_count": 82,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Research Methods CJ",
+        "Capstone Dir Stud in Crim Just",
+        "CJ Senior Seminar",
+        "Counseling Skills",
+        "Crash Investigation"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 15,
+      "section_count": 77,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "CHEM 1000 Lab",
+        "CHEM 1020 Lab",
+        "General Chemistry I",
+        "General Chemistry I Lab",
+        "GENERAL CHEMISTRY I LAB"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 11,
+      "section_count": 77,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "American & Wyoming Government",
+        "App Tech US and WY Govt",
+        "Basics in U.S. and Wy Govt",
+        "Directed Study Political Sci",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "CMAP",
+      "name": "CMAP",
+      "course_count": 33,
+      "section_count": 76,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "ADOBE PHOTOSHOP",
+        "Applied Networking I",
+        "Applied Networking II",
+        "Computer Hardware Maintenance",
+        "Computer Information Systems"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 17,
+      "section_count": 75,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "NCLEX Content Review",
+        "NURS 1100 Lab",
+        "NURS 2300 Lab",
+        "Nurse Pharm I",
+        "Nurse Pharm II"
+      ]
+    },
+    {
+      "prefix": "PEAC",
+      "name": "PEAC",
+      "course_count": 31,
+      "section_count": 63,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Trapshooting",
+        "Aerobic Condition I-Fitness",
+        "Aerobic Condition II-Fitness",
+        "Basic Self-Defense",
+        "Basic Self-Defense II"
+      ]
+    },
+    {
+      "prefix": "CMV",
+      "name": "CMV",
+      "course_count": 10,
+      "section_count": 61,
+      "colleges": [
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "CDL Prep",
+        "CLP Transport Safety and Reg",
+        "CMV Entry Level Driver Train",
+        "CMV/Equipment Inspection",
+        "Driving - Range"
+      ]
+    },
+    {
+      "prefix": "VTTK",
+      "name": "VTTK",
+      "course_count": 35,
+      "section_count": 58,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Animal Care I",
+        "Animal Care II",
+        "Animal Care III",
+        "Animal Health I - Infectious",
+        "Appl Prin of Chem for Vet Tech"
+      ]
+    },
+    {
+      "prefix": "HLTK",
+      "name": "Health",
+      "course_count": 12,
+      "section_count": 57,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Assistive Tech Practicum",
+        "Equine Assisted Therapy Pract",
+        "Health Care Ethics",
+        "Health Econ/Ethics/Policies",
+        "Interprof. Health Care Team"
+      ]
+    },
+    {
+      "prefix": "BADM",
+      "name": "Business",
+      "course_count": 14,
+      "section_count": 54,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Bus Administration Capstone",
+        "Business and Professional Writ",
+        "Business Communications",
+        "Business Ethics",
+        "Business Mathematics I"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 10,
+      "section_count": 42,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "American Women's History",
+        "History of N American Indians",
+        "The United States from 1865",
+        "United States to 1865",
+        "Western Civilization I"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "Agriculture",
+      "course_count": 15,
+      "section_count": 41,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Ag Innovation and Tech",
+        "Agricultural Internship I",
+        "Agricultural Internship II",
+        "Agriculture Capstone Project",
+        "Agriculture Communic/Ldership"
+      ]
+    },
+    {
+      "prefix": "ANSC",
+      "name": "Livestock",
+      "course_count": 21,
+      "section_count": 41,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "ANSC 1010 Lab",
+        "Artificial Insemination",
+        "Beef Production",
+        "Comp Anat/Physiol Domestic An",
+        "Equine Management"
+      ]
+    },
+    {
+      "prefix": "NRST",
+      "name": "Nursing",
+      "course_count": 7,
+      "section_count": 41,
+      "colleges": [
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Cert Nurse Asst II",
+        "Explorations:",
+        "Medication Assit Cert",
+        "Nursing Assistant",
+        "Practical Nursing Foundations"
+      ]
+    },
+    {
+      "prefix": "PEAT",
+      "name": "Varsity",
+      "course_count": 4,
+      "section_count": 41,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Rodeo Activities",
+        "Varsity III:",
+        "Varsity Sports: FR Volleyball",
+        "Varsity Sports: SO Volleyball"
+      ]
+    },
+    {
+      "prefix": "HMDV",
+      "name": "HMDV",
+      "course_count": 9,
+      "section_count": 37,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "CAREER DEVELOPMENT",
+        "CHOOSING HAPPINESS",
+        "College Orientation",
+        "College Studies",
+        "Gs First Year Seminar"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 11,
+      "section_count": 37,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Counseling Skills",
+        "Criminology",
+        "Deviant Behavior",
+        "Educ/Good Life-1st Year Sem",
+        "Environmental Sociology"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 21,
+      "section_count": 36,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Auditioning",
+        "Costume Construction",
+        "FUND OF MUSIC FOR THEATRE MJR",
+        "INTRO TO DESIGN"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 14,
+      "section_count": 35,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "App Orgnztnl Bhvr and Ldrshp",
+        "APPLIED HUMAN RESOURCES MGT",
+        "Applied Supervision",
+        "Business Ethics",
+        "Conflict Management"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Statistics",
+      "course_count": 2,
+      "section_count": 34,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Statistics",
+        "Intro Stats for Social Science"
+      ]
+    },
+    {
+      "prefix": "STRT",
+      "name": "Strategies",
+      "course_count": 1,
+      "section_count": 34,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Strategies for Success"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 33,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Economics, Law, and Government",
+        "Global Economic Issues",
+        "Independent Study",
+        "Macroeconomics",
+        "Microeconomics"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 11,
+      "section_count": 32,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Accounting for Bookkeepers",
+        "Accounting for Decision Makers",
+        "Advanced Quickbooks",
+        "Income Tax",
+        "Intermediate Accounting I"
+      ]
+    },
+    {
+      "prefix": "EQST",
+      "name": "Horse",
+      "course_count": 28,
+      "section_count": 32,
+      "colleges": [
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Applied Horse & Stall Care I",
+        "Applied Horse & Stall Care II",
+        "Applied Horse & Stall Care III",
+        "Applied Horse & Stall Care IV",
+        "Competitive Equine Judging"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "College Physics I",
+        "College Physics I Lab",
+        "College Physics II",
+        "COLLEGE PHYSICS LAB",
+        "Concepts of Physics"
+      ]
+    },
+    {
+      "prefix": "AVTN",
+      "name": "Pilot",
+      "course_count": 10,
+      "section_count": 29,
+      "colleges": [
+        "casper-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Commercial Pilot Flight I",
+        "Commercial Pilot Flight II",
+        "Commercial Pilot Ground Pt. I",
+        "Commercial Pilot Ground Pt. II",
+        "Cooperative Work Experience"
+      ]
+    },
+    {
+      "prefix": "ES",
+      "name": "ES",
+      "course_count": 13,
+      "section_count": 29,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Dynamics",
+        "Electric Circuit Analysis",
+        "Engineering Surveying",
+        "Fluid Dynamics",
+        "FYS: Intro Engineering Study"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "ANTH 1100 Lab",
+        "Archaeological Tour: Peru",
+        "Intro to Biological Anthropolo",
+        "Intro to Cultural Anthropology",
+        "Intro to Forensic Anthropology"
+      ]
+    },
+    {
+      "prefix": "ELAP",
+      "name": "Electrical",
+      "course_count": 8,
+      "section_count": 28,
+      "colleges": [
+        "casper-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "ELECTRICAL APPRENTICESHIP 1A",
+        "ELECTRICAL APPRENTICESHIP 3A",
+        "ELECTRICAL APPRENTICESHIP 4B",
+        "Electrical Apprenticeship II",
+        "Electrical Apprenticeship III"
+      ]
+    },
+    {
+      "prefix": "ELTR",
+      "name": "ELTR",
+      "course_count": 15,
+      "section_count": 27,
+      "colleges": [
+        "casper-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "ADV PROGRAM LOGIC CONTROLLERS",
+        "BASIC ELECTRICITY, AC",
+        "BASIC ELECTRICITY, DC",
+        "CONTROL SYSTEM COMMUNICATIONS",
+        "Cooperative Work Experience"
+      ]
+    },
+    {
+      "prefix": "ENTK",
+      "name": "Drafting",
+      "course_count": 19,
+      "section_count": 26,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Architectural Drafting I",
+        "Architectural Drafting II",
+        "CAD 3D Mod/Mech Design II",
+        "CAD-3D Mod/Mech Design I",
+        "Computer Aided Drafting 3-D"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 9,
+      "section_count": 26,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "First Year Spanish I",
+        "First Year Spanish II",
+        "Intro Read/Comp/Conversation",
+        "Second Year Spanish I",
+        "Second Year Spanish II"
+      ]
+    },
+    {
+      "prefix": "CSMO",
+      "name": "Cosmetology",
+      "course_count": 15,
+      "section_count": 25,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Clinical Applications III",
+        "Clinical Applications IV",
+        "Clinical Applications VIII",
+        "Cosmetology Assessment",
+        "Cosmetology Chemistry I"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "Dental",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Dental Biology",
+        "Dental Hygiene Clinic II",
+        "Dental Hygiene Principles",
+        "Dental Hygiene Seminar II",
+        "Dental Radiology"
+      ]
+    },
+    {
+      "prefix": "HLED",
+      "name": "HLED",
+      "course_count": 8,
+      "section_count": 23,
+      "colleges": [
+        "casper-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Diet and Exercise",
+        "Health for Elem Educators",
+        "NUTRITION",
+        "Outdoor Emergency Care",
+        "Personal Health"
+      ]
+    },
+    {
+      "prefix": "RDTK",
+      "name": "RDTK",
+      "course_count": 20,
+      "section_count": 23,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "1st Yr Clinical Education I",
+        "1st Yr Clinical Education II",
+        "2nd Yr Clinical Education IV",
+        "2nd Yr Clinical Education V",
+        "Advanced Modality Clinical Ed"
+      ]
+    },
+    {
+      "prefix": "AGEC",
+      "name": "AGEC",
+      "course_count": 9,
+      "section_count": 22,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "AG Capstone Project",
+        "Agri-Business Finance",
+        "Agricultural Macroeconomics",
+        "Agricultural Marketing",
+        "Agricultural Microeconomics"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Auto Alignment and Suspension",
+        "AUTO ELECTRICAL SYSTEMS II",
+        "Automotive Electrical Systems",
+        "AUTOMOTIVE ELECTRONICS",
+        "Basic Auto Mechanics"
+      ]
+    },
+    {
+      "prefix": "PHTO",
+      "name": "PHTO",
+      "course_count": 18,
+      "section_count": 22,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Beginning Digital Photography",
+        "Commercial Portrait I",
+        "Commercial Portrait II",
+        "Digital Color Photography",
+        "Digital Imaging I"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary Anatomy and P",
+        "Intro to Respiratory Therapy",
+        "Resp Spec Practicum",
+        "Respiratory Lab I",
+        "Respiratory Lab III"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "GEOL",
+      "course_count": 10,
+      "section_count": 21,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Deep Impact",
+        "Earth: Its Physical Environmen",
+        "Field Trip/Collect Gemstones",
+        "Geochem Cycles & Earth System",
+        "Lapidary"
+      ]
+    },
+    {
+      "prefix": "KIN",
+      "name": "KIN",
+      "course_count": 15,
+      "section_count": 21,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED FITNESS",
+        "Assess/Eval Ath Injury Lower",
+        "Athletic Training Clinical II",
+        "FUNDAMENT OF EXERCISE SCIENCE",
+        "Intro to Athletic Training"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Emergency Med Tech - Advanced",
+        "Emergency Medical Tech - Basic",
+        "Paramedic Capstone",
+        "Paramedic I",
+        "Paramedic II"
+      ]
+    },
+    {
+      "prefix": "COSC",
+      "name": "COSC",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Computational Thinking & Prog",
+        "COMPUTER SCI PRINC AND PRACT",
+        "Computer Science I",
+        "Cooperative Experience",
+        "Data Structures"
+      ]
+    },
+    {
+      "prefix": "EDEC",
+      "name": "EDEC",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Curr Plan/Develop Child Lab",
+        "Curr. Plan & Dev. for Yng Chld",
+        "Early Childhood Practicum",
+        "Engaging Families in Erly Clhd",
+        "Infant & Toddler Care Lab"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "Mdcl",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Clinical Medical Assistant",
+        "Clncal Rle of the Mdcl Assis I",
+        "MEDA 1520 Lab",
+        "Medical Office Assistant",
+        "Pharmacology for the Mdcl Assi"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Consumer Behavior",
+        "Digital Marketing II",
+        "Integrated Marketing Communica",
+        "Introduction to Marketing",
+        "Marketing Seminar"
+      ]
+    },
+    {
+      "prefix": "MLTK",
+      "name": "Clinical",
+      "course_count": 14,
+      "section_count": 18,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Clinical Chemistry",
+        "Clinical Microbiology II",
+        "Clinical Pathophysiology",
+        "Clinical Prac: Chemistry",
+        "Clinical Prac: Hematology"
+      ]
+    },
+    {
+      "prefix": "COTA",
+      "name": "COTA",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Clinical Conditions",
+        "Clinical Theory & Practice I",
+        "Clinical Theory/Prac I Lab",
+        "Fieldwork A",
+        "Fieldwork B"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "DESL",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Auto and Desl Ind Sfty Stds",
+        "Cooperative Work Experience",
+        "Desl Fuel Stms, Emsns & Diag",
+        "DIESEL ENGINE MANAGEMENT I",
+        "DIESEL ENGINE MANAGEMENT II"
+      ]
+    },
+    {
+      "prefix": "IMAG",
+      "name": "Sonography",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Abdomen Registry Review",
+        "Abdominal Sono I Lab",
+        "Abdominal Sonography I",
+        "Cardiac Sonography I",
+        "Cardiac Sonography I Lab"
+      ]
+    },
+    {
+      "prefix": "IMGT",
+      "name": "IMGT",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Data Analytics",
+        "INFO MANAGEMENT AND SECURITY",
+        "INTERNSHIP: INFORMATION MGT",
+        "INTRO TO BUSINESS ANALYTICS",
+        "INTRO TO HLTH INFO MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "MCHT",
+      "name": "MCHT",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Advanced Machining Practice",
+        "Basic Machining Practice",
+        "Blueprint Reading",
+        "CNC Machining Center",
+        "Computer-Assist Manufacturng"
+      ]
+    },
+    {
+      "prefix": "MOLB",
+      "name": "Microbiology",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "GEN MICROBIOLOGY LAB",
+        "General Microbiology",
+        "General Microbiology Lab",
+        "Medical Microbiology",
+        "Medical Microbiology Lab"
+      ]
+    },
+    {
+      "prefix": "OEPR",
+      "name": "OEPR",
+      "course_count": 13,
+      "section_count": 14,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Basic Search and Rescue",
+        "Challenge Course Facilitation",
+        "Intro to Ski Area Operations",
+        "Intro to Snow Science",
+        "Land Based Activities"
+      ]
+    },
+    {
+      "prefix": "EDFD",
+      "name": "Education",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Educational Psychology",
+        "Foundations of Education",
+        "Intro to Education"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Advanced Firefighting",
+        "Apparatus and Procedures",
+        "Fire Serv Field Internship",
+        "Fund of Fire Prevention",
+        "Hazardous Materials"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "TECH",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "northern-wyoming-community-college-district",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "CTE Professional Skills",
+        "GEN METALLURGY",
+        "INDUSTRIAL SAFETY",
+        "INTRO TO TECH MATH",
+        "READING TECHNICAL SCHEMATICS"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 11,
+      "section_count": 12,
+      "colleges": [
+        "casper-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Ballet Studies",
+        "Beginning Ballet I",
+        "Beginning Jazz Dance I",
+        "Beginning Modern Dance I",
+        "Beginning Tap Dance I"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "Legal",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Civil Procedure",
+        "Family Law",
+        "Indep Study Legal Assistant",
+        "Intro to Paralegal Studies",
+        "Intro to the Paralegal Profess"
+      ]
+    },
+    {
+      "prefix": "PROF",
+      "name": "PROF",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Community Leadership",
+        "Developing Organizational Lead",
+        "Discov/Utiliz Ideas & Info",
+        "Personal Finance",
+        "Problem Solv in Organizations"
+      ]
+    },
+    {
+      "prefix": "AUBR",
+      "name": "Auto",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Auto Body Paint II",
+        "Auto Body Repair I",
+        "Auto Body Repair II",
+        "Auto Body Welding",
+        "Auto Paint I"
+      ]
+    },
+    {
+      "prefix": "EDEL",
+      "name": "School",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "ART IN THE ELEMENTARY SCHOOL",
+        "Family, School, and Community",
+        "Literacy Foundations",
+        "Literature for Children",
+        "Mentoring in Education"
+      ]
+    },
+    {
+      "prefix": "FCSC",
+      "name": "Nutrition",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Child Development",
+        "Child Development Lab",
+        "Nutrition Controversies",
+        "Principles of Nutrition"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Corporate Finance",
+        "INTRO TO INVESTING",
+        "Invest and Retirement Plan",
+        "Managerial Financial Economics",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "INDM",
+      "name": "Industrial",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "INDUST HYDRAUL I (FLUID POWER)",
+        "INDUST HYDRAUL II(FLUID POWR)",
+        "INDUSTRIAL HYDRAULICS III",
+        "INDUSTRIAL MECHANICS I",
+        "INDUSTRIAL MECHANICS II"
+      ]
+    },
+    {
+      "prefix": "TREX",
+      "name": "Transition",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Transition Experience"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Class Observ and Sub Training",
+        "Effective Substitute Teaching",
+        "Practicum in Teaching"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "eastern-wyoming-college",
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Computer Software/Med Office",
+        "Intro to Health Care Careers",
+        "Intro to Health Information",
+        "Medical Office Admin Procedure",
+        "Telehealth Coordinator"
+      ]
+    },
+    {
+      "prefix": "IST",
+      "name": "Electricity",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "AC Electricity",
+        "DC Electricity",
+        "Intro to Industrial Safety",
+        "Mechanical Drives",
+        "Trade Skills Fundamentals"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Human Geography",
+        "Intro to Natural Resources",
+        "Intro to Physical Geography",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "GUNS",
+      "name": "Firearms",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Color Case Hardening",
+        "Firearms Bench Metal",
+        "Firearms Machine Shop I",
+        "Firearms Machine Shop II",
+        "Firearms Repair and Restoratio"
+      ]
+    },
+    {
+      "prefix": "SLPA",
+      "name": "SLPA",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Anat & Phys of the Spch Mech",
+        "Behavior Management for SLPAs",
+        "Field Observation II",
+        "Intro to Comm Disord & Treat",
+        "Intro to SLPA"
+      ]
+    },
+    {
+      "prefix": "EDST",
+      "name": "EDST",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Educational Assessment",
+        "Foundations of Develop & Learn",
+        "Human Life Span Development"
+      ]
+    },
+    {
+      "prefix": "MICR",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Medical Microbiology",
+        "Medical Microbiology Lab"
+      ]
+    },
+    {
+      "prefix": "PEPR",
+      "name": "Coaching",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Foundation of Coaching",
+        "Prev/Care of Athletic Injuries",
+        "Sports Officiating",
+        "Theory of Coaching"
+      ]
+    },
+    {
+      "prefix": "CNTK",
+      "name": "CNTK",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Arch/Construction Planning",
+        "Construction Material & Method",
+        "Cooperative Work Experience",
+        "Independent Study",
+        "Materials Handling and Constru"
+      ]
+    },
+    {
+      "prefix": "CSEC",
+      "name": "CSEC",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Computer Forensics",
+        "Computer Network Security +",
+        "Cooperative Work Experience",
+        "INTRO TO NETWORKS",
+        "Network Security Fundamentals"
+      ]
+    },
+    {
+      "prefix": "GIST",
+      "name": "GIST",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "casper-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Advanced GIS",
+        "Intro to Geographic Info Sys",
+        "Intro to GPS & Maps",
+        "Intro to RPAS",
+        "Introduction to GIS"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "HUMN",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "casper-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "American Culture & Values",
+        "First-Year Seminar:",
+        "Seminar in Humanities"
+      ]
+    },
+    {
+      "prefix": "OEAC",
+      "name": "OEAC",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Avalanche Training",
+        "Explorations:",
+        "Outdoor Rock Climbing",
+        "Whitewater Kayaking I"
+      ]
+    },
+    {
+      "prefix": "REWM",
+      "name": "Rangeland",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Principles of Rangeland Mgmt",
+        "Range and Pasture Monitoring",
+        "Rangeland Ecosystems",
+        "Rangeland Plant Taxonomy"
+      ]
+    },
+    {
+      "prefix": "ADDN",
+      "name": "ADDN",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "casper-college",
+        "northern-wyoming-community-college-district"
+      ],
+      "sample_titles": [
+        "Addiction Practicum",
+        "Addictions Assessment",
+        "Anger,Trauma & Addiction",
+        "Ethics & Professional Issues",
+        "Motivational Interviewing"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Entrepreneurship",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "eastern-wyoming-college",
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Creating a Business Plan",
+        "Creative Entrepreneurship",
+        "Intro to Entrepreneurship",
+        "Social and Internet Tech"
+      ]
+    },
+    {
+      "prefix": "ITEC",
+      "name": "Teach",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Teach & Learn W/ Educ Tech"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "CASE MNGMNT AND DOCUMENTATION",
+        "Intro to Social Work"
+      ]
+    },
+    {
+      "prefix": "AECL",
+      "name": "Agroecology",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "AECL 1000 Lab",
+        "Agroecology"
+      ]
+    },
+    {
+      "prefix": "AIML",
+      "name": "Artificial",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "A I & Info Literacy",
+        "Computer Vision",
+        "Ethics in Artificial Intellig",
+        "Introduction to Artificial In",
+        "Natural Language Processing"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "casper-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "casper-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Introduction to Astronomy",
+        "Survey of Astronomy",
+        "Survey of Astronomy Lab"
+      ]
+    },
+    {
+      "prefix": "HMSV",
+      "name": "Human",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "eastern-wyoming-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Ethics for Helping Professions",
+        "Field Exp in Human Services I",
+        "Orientation to Human Services",
+        "Service Learn in Community Eng"
+      ]
+    },
+    {
+      "prefix": "MEDC",
+      "name": "Coding",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "laramie-county-community-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Disease Process for Coding",
+        "MEDICAL INDUSTRY CERT EXAM",
+        "Prof Practice Exp (Coding)",
+        "Reimbursement Methodologies"
+      ]
+    },
+    {
+      "prefix": "PHTK",
+      "name": "Pharmacy",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Pharmacology I",
+        "Pharmacy Calculations I",
+        "Pharmacy Experiential Train II",
+        "Pharmacy Law and Ethics",
+        "Pharmacy Simulation Lab I"
+      ]
+    },
+    {
+      "prefix": "AGTK",
+      "name": "AGTK",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "casper-college",
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Beginning Hydraulics",
+        "Hoof Trimming",
+        "Precision Ag 1 - Mech Systems",
+        "Prev Equip Maint and Mgmt"
+      ]
+    },
+    {
+      "prefix": "BARB",
+      "name": "Barbering",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Barbering Assessment",
+        "Barbering Crossover",
+        "Clinical Applications III",
+        "Techniques in Barbering"
+      ]
+    },
+    {
+      "prefix": "CNSL",
+      "name": "CNSL",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "laramie-county-community-college",
+        "northern-wyoming-community-college-district"
+      ],
+      "sample_titles": [
+        "Counseling Skills/Helping Prof",
+        "Practicum in Human Services",
+        "Topics:"
+      ]
+    },
+    {
+      "prefix": "CROP",
+      "name": "Crop",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "eastern-wyoming-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Field Crop Production",
+        "Forage Crop Science",
+        "Pest Identification and Mgmt",
+        "Pesticide Safety & Application"
+      ]
+    },
+    {
+      "prefix": "EDEX",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Intro to Special Education"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "Allied",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Allied Health 1st Year Seminar",
+        "Applied Allied Hlth Concepts",
+        "Introduction to Allied Hlth Pr"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "HOSP",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "casper-college",
+        "northern-wyoming-community-college-district"
+      ],
+      "sample_titles": [
+        "Hospitality and Tourism Pract",
+        "Intro to Hosp/Tourism Mgt",
+        "Lodging Operations Mgmt"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "First",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "First Year Japanese I",
+        "First Year Japanese II"
+      ]
+    },
+    {
+      "prefix": "PLOP",
+      "name": "Plant",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "PLANT OPERATIONS ELECTRICAL",
+        "PLANT OPERATIONS I",
+        "PLANT OPERATIONS II",
+        "PLANT OPERATIONS INSTRUMNTATN"
+      ]
+    },
+    {
+      "prefix": "SOIL",
+      "name": "Soil",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "casper-college",
+        "laramie-county-community-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Intro to Soil Science"
+      ]
+    },
+    {
+      "prefix": "SOSC",
+      "name": "Science",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "eastern-wyoming-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Soc Science First Yr Seminar",
+        "Social Science Capstone Exper"
+      ]
+    },
+    {
+      "prefix": "BOTK",
+      "name": "Keyboarding",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Cooperative Work Experience",
+        "Keyboarding Speed & Accuracy"
+      ]
+    },
+    {
+      "prefix": "CSCO",
+      "name": "Ccna",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "CCNA Cert Exam Review",
+        "CCNA I Intro to Networks",
+        "CCNA III Networking,Sec,Auto"
+      ]
+    },
+    {
+      "prefix": "DSCI",
+      "name": "Operations",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "laramie-county-community-college",
+        "northwest-college",
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Operations and Supply"
+      ]
+    },
+    {
+      "prefix": "HOEC",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Leadership",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "PERSONAL LEADERSHIP",
+        "PRINCIPLES OF LEADERSHIP"
+      ]
+    },
+    {
+      "prefix": "LIFE",
+      "name": "Life",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Life Science",
+        "Life Science Lab"
+      ]
+    },
+    {
+      "prefix": "PTAT",
+      "name": "PTAT",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Orthopedics for the PTA",
+        "PTA Clinical Practicum I",
+        "Therapeutic Procedures for PT"
+      ]
+    },
+    {
+      "prefix": "BIOLL",
+      "name": "Biology",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "General Biology I Lab"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "INTERNSHIP: COMP INFO SYSTEMS",
+        "IT FUNDAMENTALS"
+      ]
+    },
+    {
+      "prefix": "EMGT",
+      "name": "Paramedic",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Paramedic Capstone",
+        "Paramedic Vehicular II"
+      ]
+    },
+    {
+      "prefix": "ENR",
+      "name": "Environmental",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Environmental Science Lab"
+      ]
+    },
+    {
+      "prefix": "FDSC",
+      "name": "Meat",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "casper-college",
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Principles of Meat Evaluation"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "First Year French I",
+        "Second Year French I"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Healthcare Mana",
+        "Health Informatics"
+      ]
+    },
+    {
+      "prefix": "INST",
+      "name": "International",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Intro International Relations",
+        "Intro to Global Studies"
+      ]
+    },
+    {
+      "prefix": "INSTAA",
+      "name": "Program",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Program Assessment Requirement"
+      ]
+    },
+    {
+      "prefix": "INSTAS",
+      "name": "Program",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Program Assessment Requirement"
+      ]
+    },
+    {
+      "prefix": "LINX",
+      "name": "Linux",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Linux Administration I"
+      ]
+    },
+    {
+      "prefix": "MCH",
+      "name": "Machine",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "MACHINE TOOL PROCESSES I",
+        "MACHINE TOOL PROCESSES II"
+      ]
+    },
+    {
+      "prefix": "MSFT",
+      "name": "Cyber",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northern-wyoming-community-college-district"
+      ],
+      "sample_titles": [
+        "Cyber Security & Ntwk Capstone",
+        "Networking Internship"
+      ]
+    },
+    {
+      "prefix": "OCTH",
+      "name": "Occupational",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Intro Occupational Therapy"
+      ]
+    },
+    {
+      "prefix": "ORTM",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Foundations Recreation/Tourism",
+        "Outdoor Leadership"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "casper-college",
+        "northern-wyoming-community-college-district"
+      ],
+      "sample_titles": [
+        "Ethics in Practice",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "PHLB",
+      "name": "Phlebotomy",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "PHLEBOTOMY PRINC AND PRACTICE"
+      ]
+    },
+    {
+      "prefix": "RELI",
+      "name": "Religion",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Introduction to Religion"
+      ]
+    },
+    {
+      "prefix": "ZOOL",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Human Anat & Physiology II Lab"
+      ]
+    },
+    {
+      "prefix": "AMST",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "The American Mosaic"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northern-wyoming-community-college-district"
+      ],
+      "sample_titles": [
+        "Explorations:"
+      ]
+    },
+    {
+      "prefix": "COMP",
+      "name": "Computing",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Computing and Society"
+      ]
+    },
+    {
+      "prefix": "EDCI",
+      "name": "Classroom",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "laramie-county-community-college"
+      ],
+      "sample_titles": [
+        "Classroom Management"
+      ]
+    },
+    {
+      "prefix": "GWST",
+      "name": "Genderwomens",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Intro Gender/Women's Studies"
+      ]
+    },
+    {
+      "prefix": "HORT",
+      "name": "Horticulture",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "northwest-college"
+      ],
+      "sample_titles": [
+        "Introduction to Horticulture"
+      ]
+    },
+    {
+      "prefix": "INET",
+      "name": "Word",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "casper-college"
+      ],
+      "sample_titles": [
+        "Word Press"
+      ]
+    },
+    {
+      "prefix": "ISAA",
+      "name": "Intrdisciplin",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Intrdisciplin Studies Capstone"
+      ]
+    },
+    {
+      "prefix": "ISAS",
+      "name": "Intrdisciplin",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Intrdisciplin Studies Capstone"
+      ]
+    },
+    {
+      "prefix": "LIBS",
+      "name": "Library",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Library Research Methods"
+      ]
+    },
+    {
+      "prefix": "PVET",
+      "name": "Prevet",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Pre-Vet Medicine Capstone"
+      ]
+    },
+    {
+      "prefix": "SDEV",
+      "name": "Software",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "western-wyoming-community-college"
+      ],
+      "sample_titles": [
+        "SOFTWARE DEVELPMENT SKILLS I"
+      ]
+    },
+    {
+      "prefix": "VTAD",
+      "name": "Program",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-wyoming-college"
+      ],
+      "sample_titles": [
+        "Program Assessment Requirement"
+      ]
+    }
+  ],
+  "program_titles": []
+}


### PR DESCRIPTION
## What changes for someone using the site

This adds the precomputed **subject catalog** (`subject-vocab.json`) for **25 states that were missing it** — including **California and Texas**. Two user-visible effects:

1. **Schedule Builder quick-add chips** now reflect each state's most-offered subjects. California's chips go from `ENGL · COMM · STAT · PSYC · POLS` to also include **`MATH · ART · BIOL`**; Texas shows `ENGL · MATH · HIST · GOVT · EDUC · BIOL · MUAP · PSYC`. (This is the payoff of the chip helper from #1253, now that these states have a vocab to draw from.)
2. **`/ask` subject answers** for these states get richer hydration (course/section counts, college coverage, deep links) instead of falling back to "no signal".

## How it works (technical)

**Correction to the original plan:** we thought CA/TX were Supabase-only and would need `build-subject-vocab.ts` extended to query Supabase. Not so — all 25 states have committed flat course files (`data/{state}/courses/...`, e.g. CA: 198 files spanning 2026 terms), so the **existing** builder already produces real vocab from disk. It had simply never been run for them.

So this is a **data-only PR, no code change**: ran `npx tsx scripts/build-subject-vocab.ts <25 states>`, which aggregates sections by prefix (sorted by `section_count` desc) and writes one JSON per state. `lib/programs/subject-vocab.ts` (already on `main`) is the consumer.

## Scope
- Generates vocab for exactly these 25: `ak ar az ca co hi id il in ks la mn mt nd ne nm nv ok or sd tx ut wa wi wy`.
- Does **not** regenerate the existing 26 files (avoids churn).
- 7,831 subjects total (CA alone: 1,561; the long tail is college-specific prefixes — chips use only the top 8, which are the common subjects).

## Test plan
- All 25 files: valid JSON, non-empty `subjects`, sorted by `section_count` desc (scripted check).
- `loadSubjectVocab('ca')` returns sensible top prefixes: `ENGL, MATH, COMM, ART, BIOL, HIST, PSYC, CHEM`.
- `npx tsc --noEmit` clean (no code changed).
- **Live render** on this branch (which includes #1253): `/ca/schedule` chips = `ENGL, COMM, STAT, PSYC, POLS, MATH, ART, BIOL`; `/tx/schedule` = `ENGL, MATH, HIST, GOVT, EDUC, BIOL, MUAP, PSYC`.
- Staged only the 25 `data/*/subject-vocab.json` files — no other diff.

## Files
- `data/{ak,ar,az,ca,co,hi,id,il,in,ks,la,mn,mt,nd,ne,nm,nv,ok,or,sd,tx,ut,wa,wi,wy}/subject-vocab.json` (new, 25 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
