### PR TITLE
fix(copy): "{state} community colleges" — kill doubled-noun system label

### DIFF
--- a/app/[state]/about/page.tsx
+++ b/app/[state]/about/page.tsx
@@ -70,7 +70,7 @@ export default async function AboutPage({ params }: Props) {
         name: "What does auditing a course cost?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: `At most ${config.systemName} colleges, audit students pay the same tuition and fees as credit students.${config.seniorWaiver ? ` ${config.name} residents aged ${config.seniorWaiver.ageThreshold}+ may qualify for free tuition under state law.` : ""}`,
+          text: `At most ${config.name} community colleges, audit students pay the same tuition and fees as credit students.${config.seniorWaiver ? ` ${config.name} residents aged ${config.seniorWaiver.ageThreshold}+ may qualify for free tuition under state law.` : ""}`,
         },
       },
     ],
@@ -220,7 +220,7 @@ export default async function AboutPage({ params }: Props) {
             What Does It Cost?
           </h2>
           <p className="text-gray-600 dark:text-slate-400 mb-3">
-            {`At most ${config.systemName} colleges, audit students pay the same tuition and fees as credit students. Check each college's page for specific cost details.`}
+            {`At most ${config.name} community colleges, audit students pay the same tuition and fees as credit students. Check each college's page for specific cost details.`}
           </p>
           {config.seniorWaiver && (
             <div className="bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 rounded-lg p-4">

--- a/app/[state]/colleges/page.tsx
+++ b/app/[state]/colleges/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
   const config = requireStateConfig(state);
   return {
-    title: `All ${config.collegeCount} ${config.systemName} Colleges — ${config.branding.siteName}`,
+    title: `All ${config.collegeCount} ${config.name} Community Colleges — ${config.branding.siteName}`,
     description: `Browse all ${config.name} community colleges — see course counts, transfer data, and campus locations.`,
     keywords: config.branding.metaKeywords,
     alternates: { canonical: `/${state}/colleges` },
@@ -58,7 +58,7 @@ export default async function CollegesPage({ params }: Props) {
   const collectionLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    name: `All ${config.collegeCount} ${config.systemName} Colleges`,
+    name: `All ${config.collegeCount} ${config.name} Community Colleges`,
     description: `Browse all ${config.name} community colleges — see course counts, transfer data, and campus locations.`,
     url: `${siteUrl}/${state}/colleges`,
     numberOfItems: sorted.length,
@@ -91,7 +91,7 @@ export default async function CollegesPage({ params }: Props) {
       </Link>
 
       <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2">
-        All {config.collegeCount} {config.systemName} Colleges
+        All {config.collegeCount} {config.name} Community Colleges
       </h1>
       <p className="text-gray-600 dark:text-slate-400 mb-8">
         Browse courses and transfer info across all {config.collegeCount}{" "}

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -176,7 +176,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const term = termLabel(currentTerm);
 
   const pageTitle = `${parsed.prefix} ${parsed.number}: ${title} — ${config.name} Community Colleges`;
-  const description = `${parsed.prefix} ${parsed.number} (${title}, ${credits} ${credits === 1 ? "credit" : "credits"}) — ${sections.length} sections at all ${collegeCount} ${config.systemName} colleges for ${term}${onlineCount > 0 ? `, ${onlineCount} online` : ""}. See schedules, open seats, and transfer credit.`;
+  const description = `${parsed.prefix} ${parsed.number} (${title}, ${credits} ${credits === 1 ? "credit" : "credits"}) — ${sections.length} sections at all ${collegeCount} ${config.name} community colleges for ${term}${onlineCount > 0 ? `, ${onlineCount} online` : ""}. See schedules, open seats, and transfer credit.`;
 
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/course/${code}`;
 

--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -22,6 +22,7 @@ import { track } from "@/lib/analytics";
 import AdUnit from "@/components/AdUnit";
 import { stashFavoriteDraft, favoriteDedupKey } from "@/lib/anon-draft";
 import { plannerHref } from "@/lib/planner-link";
+import { communityCollegesLabel } from "@/lib/states/registry";
 
 // ---------------------------------------------------------------------------
 // Types matching the API response
@@ -587,7 +588,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">Find a Course</h1>
         <p className="text-gray-600 dark:text-slate-400 mt-1">
-          Search across all {collegeCount} {systemName} colleges at once
+          Search across all {collegeCount} {communityCollegesLabel(state)} at once
         </p>
       </div>
 
@@ -1085,7 +1086,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
               <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
           </div>
-          <h3 className="font-medium text-gray-900 dark:text-slate-100">Search all {systemName} colleges at once</h3>
+          <h3 className="font-medium text-gray-900 dark:text-slate-100">Search all {communityCollegesLabel(state)} at once</h3>
           <p className="mt-1 text-sm text-gray-500 dark:text-slate-400 max-w-md mx-auto">
             Enter a subject code (ENG), course number (ENG 111), or keyword
             (psychology) to find sections across all {collegeCount} community colleges.

--- a/app/[state]/courses/page.tsx
+++ b/app/[state]/courses/page.tsx
@@ -43,14 +43,14 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   // dropped from the canonical so day/time/zip variants consolidate to one page).
   if (q && q.length >= 2) {
     return {
-      title: `"${q}" Courses — Search All ${config.collegeCount} ${config.systemName} Colleges | ${config.branding.siteName}`,
+      title: `"${q}" Courses — Search All ${config.collegeCount} ${config.name} Community Colleges | ${config.branding.siteName}`,
       description: `Find "${q}" course sections across all ${config.collegeCount} ${config.name} community colleges at once — compare schedule, location, format, and transfer credit.`,
       keywords: config.branding.metaKeywords,
       alternates: { canonical: `/${state}/courses?q=${encodeURIComponent(q)}` },
     };
   }
   return {
-    title: `Find a Course — Search All ${config.collegeCount} ${config.systemName} Colleges | ${config.branding.siteName}`,
+    title: `Find a Course — Search All ${config.collegeCount} ${config.name} Community Colleges | ${config.branding.siteName}`,
     description: `Search for courses across all ${config.collegeCount} ${config.name} community colleges at once. Find the best schedule, location, and format for auditing.`,
     keywords: config.branding.metaKeywords,
     alternates: { canonical: `/${state}/courses` },
@@ -175,7 +175,7 @@ export default async function CoursesPage({ params, searchParams }: Props) {
   const searchActionLd = {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    name: `Find a Course — Search All ${config.collegeCount} ${config.systemName} Colleges`,
+    name: `Find a Course — Search All ${config.collegeCount} ${config.name} Community Colleges`,
     url: `${siteUrl}/${state}/courses`,
     potentialAction: {
       "@type": "SearchAction",

--- a/app/[state]/layout.tsx
+++ b/app/[state]/layout.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${baseUrl}/${state}/opengraph-image`,
         width: 1200,
         height: 630,
-        alt: `${config.name} community college course finder — search ${config.collegeCount} ${config.systemName} colleges, transfer equivalencies, and schedules`,
+        alt: `${config.name} community college course finder — search ${config.collegeCount} ${config.name} community colleges, transfer equivalencies, and schedules`,
       }],
     },
     twitter: {
@@ -120,7 +120,7 @@ export default async function StateLayout({ children, params }: Props) {
                 )}
                 <li>
                   <Link href={`/${state}/colleges`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
-                    All {config.systemName} Colleges
+                    All {config.name} Community Colleges
                   </Link>
                 </li>
               </ul>

--- a/app/[state]/online/page.tsx
+++ b/app/[state]/online/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   if (!onlineQualifies(data) || !data) return { title: "Not Found" };
 
   const title = `Online Community College Courses in ${config.name} (${termLabel(data.term)})`;
-  const description = `Find ${data.totalSections} online sections across ${data.totalColleges} ${config.systemName} colleges for ${termLabel(data.term)}. ${data.totalUniqueCourses} unique courses available online — compare schedules and transfer options.`;
+  const description = `Find ${data.totalSections} online sections across ${data.totalColleges} ${config.name} community colleges for ${termLabel(data.term)}. ${data.totalUniqueCourses} unique courses available online — compare schedules and transfer options.`;
   const canonical = `${siteUrl()}/${state}/online`;
 
   return {
@@ -89,7 +89,7 @@ export default async function OnlinePage(props: PageProps) {
     "@context": "https://schema.org",
     "@type": "ItemList",
     name: `Online community college courses in ${config.name}`,
-    description: `${data.totalSections} online sections across ${data.totalColleges} ${config.systemName} colleges for ${termLabel(data.term)}.`,
+    description: `${data.totalSections} online sections across ${data.totalColleges} ${config.name} community colleges for ${termLabel(data.term)}.`,
     numberOfItems: data.colleges.length,
     url: `${url}/${state}/online`,
     itemListElement: data.colleges.slice(0, 25).map((c, i) => ({
@@ -129,7 +129,7 @@ export default async function OnlinePage(props: PageProps) {
           </h1>
           <p className="text-gray-600 dark:text-slate-400 mt-3 leading-relaxed max-w-3xl">
             {data.totalSections} online sections across {data.totalColleges}{" "}
-            {config.systemName} colleges for {termLabel(data.term)}.{" "}
+            {config.name} community colleges for {termLabel(data.term)}.{" "}
             {data.totalUniqueCourses} unique courses delivered fully online or
             via Zoom — same credits, same transfer eligibility as in-person
             sections.

--- a/app/[state]/opengraph-image.tsx
+++ b/app/[state]/opengraph-image.tsx
@@ -104,7 +104,7 @@ export default async function Image({
               maxWidth: "800px",
             }}
           >
-            {`Search ${config.collegeCount} ${config.systemName} colleges · Transfer equivalencies · Schedule builder${config.seniorWaiver ? ` · Free for ${config.seniorWaiver.ageThreshold}+` : ""}`}
+            {`Search ${config.collegeCount} ${config.name} community colleges · Transfer equivalencies · Schedule builder${config.seniorWaiver ? ` · Free for ${config.seniorWaiver.ageThreshold}+` : ""}`}
           </div>
         </div>
       </div>

--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const b = config.branding;
   return {
     title: `${config.name} Community College Course Finder`,
-    description: `Search courses, check transfer equivalencies, find late-start sections, and compare ${config.collegeCount} ${config.systemName} colleges. ${b.tagline}`,
+    description: `Search courses, check transfer equivalencies, find late-start sections, and compare ${config.collegeCount} ${config.name} community colleges. ${b.tagline}`,
     keywords: b.metaKeywords,
     alternates: { canonical: `/${state}` },
   };
@@ -143,7 +143,7 @@ export default async function HomePage({ params }: Props) {
             Find {config.name} Community College Courses
           </h1>
           <p className="text-lg text-gray-600 dark:text-slate-400 mb-8">
-            Search by zip code to find nearby {config.systemName} colleges,
+            Search by zip code to find nearby {config.name} community colleges,
             browse courses, check transfer equivalencies, and build your
             schedule.
           </p>
@@ -300,7 +300,7 @@ export default async function HomePage({ params }: Props) {
                 Search All Courses
               </h3>
               <p className="text-sm text-gray-600 dark:text-slate-400">
-                Search across all {config.collegeCount} {config.systemName} colleges at once by subject, keyword, or course number.
+                Search across all {config.collegeCount} {config.name} community colleges at once by subject, keyword, or course number.
               </p>
             </Link>
             {config.transferSupported && (
@@ -353,7 +353,7 @@ export default async function HomePage({ params }: Props) {
                 Browse All Colleges
               </h3>
               <p className="text-sm text-gray-600 dark:text-slate-400">
-                View audit policies, senior waivers, course counts, and campus info for every {config.systemName} college.
+                View audit policies, senior waivers, course counts, and campus info for every {config.name} community college.
               </p>
             </Link>
             {showOnline && (
@@ -365,7 +365,7 @@ export default async function HomePage({ params }: Props) {
                   Online Courses
                 </h3>
                 <p className="text-sm text-gray-600 dark:text-slate-400">
-                  {onlineSections} online sections across {onlineColleges} {config.systemName} colleges this term.
+                  {onlineSections} online sections across {onlineColleges} {config.name} community colleges this term.
                 </p>
               </Link>
             )}

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -80,7 +80,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
   const term = await getCurrentTerm(state);
   const title = `${program.name} Programs at ${config.name} Community Colleges`;
-  const description = `${data.totalColleges} ${config.systemName} colleges offer ${program.name.toLowerCase()} coursework — ${data.totalSections} sections across ${data.totalUniqueCourses} courses for ${termLabel(term)}. Compare colleges and transfer options.`;
+  const description = `${data.totalColleges} ${config.name} community colleges offer ${program.name.toLowerCase()} coursework — ${data.totalSections} sections across ${data.totalUniqueCourses} courses for ${termLabel(term)}. Compare colleges and transfer options.`;
   const canonical = `${siteUrl()}/${state}/program/${slug}`;
 
   return {

--- a/app/[state]/schedule/ScheduleClient.tsx
+++ b/app/[state]/schedule/ScheduleClient.tsx
@@ -7,6 +7,7 @@ import ScheduleResults from "@/components/schedule/ScheduleResults";
 import type { ScheduleFormData } from "@/components/schedule/ScheduleForm";
 import type { ScheduleResponse } from "@/lib/types";
 import { track } from "@/lib/analytics";
+import { communityCollegesLabel } from "@/lib/states/registry";
 
 interface UniversityOption {
   slug: string;
@@ -98,7 +99,7 @@ function paramsToDefaults(p: URLSearchParams): Partial<ScheduleFormData> | null 
   return defaults;
 }
 
-export default function ScheduleClient({ state, systemName, collegeCount, defaultZip, universities, terms, quickAddSubjects }: ScheduleClientProps) {
+export default function ScheduleClient({ state, collegeCount, defaultZip, universities, terms, quickAddSubjects }: ScheduleClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [response, setResponse] = useState<ScheduleResponse | null>(null);
@@ -202,7 +203,7 @@ export default function ScheduleClient({ state, systemName, collegeCount, defaul
         </h1>
         <p className="text-gray-600 dark:text-slate-400 mt-1">
           Tell us your constraints and we&apos;ll build conflict-free schedules
-          across all {collegeCount} {systemName} colleges.
+          across all {collegeCount} {communityCollegesLabel(state)}.
         </p>
       </div>
 

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -86,8 +86,8 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   ).length;
   const term = termLabel(currentTerm);
 
-  const title = `${subject} Courses — All ${config.systemName} Colleges (${term})`;
-  const description = `Browse ${filtered.length} ${subject} sections across ${collegeCount} ${config.systemName} colleges for ${term}. ${uniqueCourses} unique courses${onlineCount > 0 ? `, ${onlineCount} available online` : ""}. Compare schedules, credits, and transfer options.`;
+  const title = `${subject} Courses — All ${config.name} Community Colleges (${term})`;
+  const description = `Browse ${filtered.length} ${subject} sections across ${collegeCount} ${config.name} community colleges for ${term}. ${uniqueCourses} unique courses${onlineCount > 0 ? `, ${onlineCount} available online` : ""}. Compare schedules, credits, and transfer options.`;
 
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/subject/${rawPrefix}`;
 
@@ -222,7 +222,7 @@ export default async function StateSubjectPage(props: PageProps) {
     "@type": "ItemList",
     "@id": `${siteUrl}/${state}/subject/${rawPrefix}#itemlist`,
     name: `${subject} Courses — ${config.systemName}`,
-    description: `${sections.length} ${subject} sections across ${collegeCount} ${config.systemName} colleges for ${term}.`,
+    description: `${sections.length} ${subject} sections across ${collegeCount} ${config.name} community colleges for ${term}.`,
     numberOfItems: courses.length,
     url: `${siteUrl}/${state}/subject/${rawPrefix}`,
     // Connect to the site-wide WebSite/Organization graph from the root

--- a/components/blog/BlogProgrammaticLinks.tsx
+++ b/components/blog/BlogProgrammaticLinks.tsx
@@ -24,11 +24,11 @@ type ProgrammaticLink = {
   href: string;
 };
 
-function linksForCategory(state: string, category: string, stateName: string, systemName: string): ProgrammaticLink[] {
+function linksForCategory(state: string, category: string, stateName: string): ProgrammaticLink[] {
   // Common base — every state-tagged post benefits from the colleges
   // directory (high-leverage page that lists all colleges in the state).
   const collegesLink: ProgrammaticLink = {
-    label: `Browse all ${systemName} colleges`,
+    label: `Browse all ${stateName} community colleges`,
     href: `/${state}/colleges`,
   };
 
@@ -106,8 +106,7 @@ export default function BlogProgrammaticLinks({
   const links = linksForCategory(
     state,
     category,
-    config.name,
-    config.systemName
+    config.name
   );
 
   if (links.length === 0) return null;

--- a/components/blog/StateToolsCTA.tsx
+++ b/components/blog/StateToolsCTA.tsx
@@ -14,7 +14,7 @@ export default function StateToolsCTA({ state, variant }: StateToolsCTAProps) {
       : `Use the ${config.name} tools`;
   const subhead =
     variant === "top"
-      ? `Skip to the search and transfer tools for ${config.systemName} colleges.`
+      ? `Skip to the search and transfer tools for ${config.name} community colleges.`
       : `Search ${config.systemName} courses, look up transfer credit, or build a schedule.`;
 
   return (

--- a/lib/insights-prose.ts
+++ b/lib/insights-prose.ts
@@ -27,6 +27,7 @@
 import type { CollegeInsights } from "@/lib/college-insights";
 import type { StateInsights } from "@/lib/state-insights";
 import { subjectName } from "@/lib/subjects";
+import { communityCollegesLabel } from "@/lib/states/registry";
 
 // ---------------------------------------------------------------------------
 // Banned-phrase list (enforced at test time)
@@ -118,20 +119,13 @@ function subjectLabel(prefix: string): string {
 }
 
 /**
- * Form a noun phrase like "23 VCCS colleges" or "23 California Community
- * Colleges schools" depending on whether the system name already ends in
- * "Colleges" (e.g. "California Community Colleges"). Avoids the awkward
- * "Colleges colleges" duplication when the system name is plural.
+ * Form a noun phrase like "23 California community colleges" from the state
+ * slug (via communityCollegesLabel), so it reads naturally for every system
+ * and avoids the doubled "Colleges colleges" / awkward "CCs colleges" the old
+ * systemName-based version produced.
  */
-function systemColleges(systemName: string, count: number): string {
-  const noun = /colleges$/i.test(systemName) ? "schools" : "colleges";
-  return `${count} ${systemName} ${noun}`;
-}
-
-/** Single-college form: "VCCS college" or "California Community Colleges school". */
-function systemCollegeSingular(systemName: string): string {
-  const noun = /colleges$/i.test(systemName) ? "school" : "college";
-  return `${systemName} ${noun}`;
+function systemColleges(state: string, count: number): string {
+  return `${count} ${communityCollegesLabel(state)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -151,9 +145,9 @@ export function renderCollegeProse(insights: CollegeInsights): string[] {
     const sr = insights.sectionRank;
     const key = `${insights.collegeId}:catalog`;
     const variants = [
-      `Across ${insights.collegeName}'s catalog this term, ${approxCount(insights.termSectionCount)} course sections are listed — the ${ordinal(sr.position)}-largest catalog among the ${systemColleges(insights.systemName, sr.outOf)} with current data.`,
-      `${insights.collegeName} lists ${approxCount(insights.termSectionCount)} sections this term, putting it ${ordinal(sr.position)} of ${systemColleges(insights.systemName, sr.outOf)} by catalog size.`,
-      `Among ${systemColleges(insights.systemName, sr.outOf)} with current course data, ${insights.collegeName} ranks ${ordinal(sr.position)} by section count, with ${approxCount(insights.termSectionCount)} sections this term.`,
+      `Across ${insights.collegeName}'s catalog this term, ${approxCount(insights.termSectionCount)} course sections are listed — the ${ordinal(sr.position)}-largest catalog among the ${systemColleges(insights.state, sr.outOf)} with current data.`,
+      `${insights.collegeName} lists ${approxCount(insights.termSectionCount)} sections this term, putting it ${ordinal(sr.position)} of ${systemColleges(insights.state, sr.outOf)} by catalog size.`,
+      `Among ${systemColleges(insights.state, sr.outOf)} with current course data, ${insights.collegeName} ranks ${ordinal(sr.position)} by section count, with ${approxCount(insights.termSectionCount)} sections this term.`,
     ];
     sentences.push(variants[pickVariant(key, variants.length)]);
   } else if (insights.termSectionCount) {
@@ -203,8 +197,8 @@ export function renderCollegeProse(insights: CollegeInsights): string[] {
     const lsr = insights.lateStartRank;
     const key = `${insights.collegeId}:latestart`;
     const variants = [
-      `Late-start sections — those beginning more than two weeks after the term's earliest start date — number ${approxCount(insights.lateStartCount)} at ${insights.collegeName}, placing it ${ordinal(lsr.position)} of ${systemColleges(insights.systemName, lsr.outOf)} for late-start availability this term.`,
-      `${insights.collegeName} has ${approxCount(insights.lateStartCount)} late-start sections (more than two weeks past the earliest term start), ranking ${ordinal(lsr.position)} among ${systemColleges(insights.systemName, lsr.outOf)} for that availability.`,
+      `Late-start sections — those beginning more than two weeks after the term's earliest start date — number ${approxCount(insights.lateStartCount)} at ${insights.collegeName}, placing it ${ordinal(lsr.position)} of ${systemColleges(insights.state, lsr.outOf)} for late-start availability this term.`,
+      `${insights.collegeName} has ${approxCount(insights.lateStartCount)} late-start sections (more than two weeks past the earliest term start), ranking ${ordinal(lsr.position)} among ${systemColleges(insights.state, lsr.outOf)} for that availability.`,
       `For students who missed the main registration window, ${insights.collegeName} offers ${approxCount(insights.lateStartCount)} late-start sections this term — ${ordinal(lsr.position)} of ${lsr.outOf} in the ${insights.systemName}.`,
     ];
     sentences.push(variants[pickVariant(key, variants.length)]);
@@ -308,7 +302,7 @@ export function renderStateProse(insights: StateInsights): string[] {
     const variants = [
       `Across the ${insights.systemName}, ${insights.collegesWithData} ${isPlural ? "colleges report" : "college reports"} ${approxCount(insights.totalSections)} course sections in the current term.`,
       `The ${insights.systemName} runs ${approxCount(insights.totalSections)} course sections across ${insights.collegesWithData} ${isPlural ? "colleges" : "college"} this term.`,
-      `${systemColleges(insights.systemName, insights.collegesWithData)} ${isPlural ? "list" : "lists"} ${approxCount(insights.totalSections)} sections this term across their combined catalogs.`,
+      `${systemColleges(insights.state, insights.collegesWithData)} ${isPlural ? "list" : "lists"} ${approxCount(insights.totalSections)} sections this term across their combined catalogs.`,
     ];
     sentences.push(variants[pickVariant(key, variants.length)]);
   }
@@ -368,7 +362,7 @@ export function renderStateProse(insights: StateInsights): string[] {
     const variants = [
       `Per the California ASSIST registry, the ${insights.systemName} maintains ${approxCount(insights.assistAgreementCount)} per-major articulation agreements with UC and CSU campuses — the deepest single pipeline runs from ${lead.ccName} to ${lead.uniName} with ${lead.agreementCount} majors.`,
       `The California ASSIST registry lists ${approxCount(insights.assistAgreementCount)} per-major agreements across the ${insights.systemName}, with the deepest CC-to-university pipeline being ${lead.ccName} → ${lead.uniName} (${lead.agreementCount} majors).`,
-      `Across the California ASSIST registry, ${insights.systemName} colleges hold ${approxCount(insights.assistAgreementCount)} major-specific articulation agreements — ${lead.ccName} → ${lead.uniName} is the deepest at ${lead.agreementCount} majors.`,
+      `Across the California ASSIST registry, ${insights.stateName} community colleges hold ${approxCount(insights.assistAgreementCount)} major-specific articulation agreements — ${lead.ccName} → ${lead.uniName} is the deepest at ${lead.agreementCount} majors.`,
     ];
     sentences.push(variants[pickVariant(key, variants.length)]);
   }
@@ -378,8 +372,8 @@ export function renderStateProse(insights: StateInsights): string[] {
     const sw = insights.seniorWaiver;
     const key = `${insights.state}:senior`;
     const variants = [
-      `${insights.stateName} residents ${sw.ageThreshold} and older may attend ${insights.systemName} colleges tuition-free under ${sw.legalCitation}.`,
-      `Under ${sw.legalCitation}, ${insights.stateName} waives tuition at ${insights.systemName} colleges for residents ${sw.ageThreshold} and older.`,
+      `${insights.stateName} residents ${sw.ageThreshold} and older may attend ${insights.stateName} community colleges tuition-free under ${sw.legalCitation}.`,
+      `Under ${sw.legalCitation}, ${insights.stateName} waives tuition at ${insights.stateName} community colleges for residents ${sw.ageThreshold} and older.`,
       `The ${insights.systemName} participates in ${insights.stateName}'s senior tuition waiver — residents ${sw.ageThreshold}+ enroll without paying tuition, per ${sw.legalCitation}.`,
     ];
     sentences.push(variants[pickVariant(key, variants.length)]);
@@ -392,7 +386,7 @@ export function renderStateProse(insights: StateInsights): string[] {
     const variants = [
       `Federal College Scorecard data puts the ${insights.systemName} median in-state tuition at ${dollar(sc.medianTuition)} per year, with former students earning a median of ${dollar(sc.medianEarnings)} ten years after entry.`,
       `Across the ${insights.systemName}, median in-state tuition is ${dollar(sc.medianTuition)} per year and median earnings ten years after enrollment are ${dollar(sc.medianEarnings)}, per the federal College Scorecard.`,
-      `Per federal College Scorecard data, ${insights.systemName} colleges charge a median ${dollar(sc.medianTuition)} in-state tuition annually; alumni earn a median ${dollar(sc.medianEarnings)} a decade after entry.`,
+      `Per federal College Scorecard data, ${insights.stateName} community colleges charge a median ${dollar(sc.medianTuition)} in-state tuition annually; alumni earn a median ${dollar(sc.medianEarnings)} a decade after entry.`,
     ];
     sentences.push(variants[pickVariant(key, variants.length)]);
   }

--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -310,6 +310,19 @@ export function hasProgramsCoverage(slug: string): boolean {
 }
 
 /**
+ * Grammatical "{State} community colleges" label for a state slug.
+ *
+ * Avoids the doubled-noun bug from appending "colleges" to a systemName that
+ * already ends in "Colleges" (e.g. "Texas Community Colleges" made the old
+ * `${systemName} colleges` render "Texas Community Colleges colleges"). Server
+ * components with a StateConfig in scope can write `${config.name} community
+ * colleges` directly; client components that only have the slug use this.
+ */
+export function communityCollegesLabel(slug: string): string {
+  return `${configs[slug]?.name ?? slug.toUpperCase()} community colleges`;
+}
+
+/**
  * Returns the slugs whose pages should be pre-rendered at build time
  * (`prerenderAtBuild: true` in the StateConfig). All other states' pages
  * defer to ISR-on-demand rendering.


### PR DESCRIPTION
## What changes for a student

Across every state's pages, the site repeated the word "colleges" whenever the system name already ended in it — Texas read "Search across all 59 **Texas Community Colleges colleges**", California read "California **CCs colleges**", and page titles said "All 59 Texas Community **Colleges Colleges**". This fixes all of those to a clean, consistent **"{state} community colleges"** — e.g. "59 Texas community colleges", "California community colleges" — across body copy, page titles, headings, and the structured data search engines read.

It's a trust/polish fix: a doubled-noun bug that made an otherwise authoritative site read as machine-generated. No new features — the same pages just read correctly now.

## How it works

The bug was `${config.systemName} colleges` repeated across ~30 spots. Since `systemName` is often "Texas Community Colleges" / "California CCs", appending "colleges" doubled or mangled it.

- **`lib/states/registry.ts`** — new `communityCollegesLabel(slug)` helper returning "{State} community colleges".
- **Server pages** (state home, course search, schedule, program, online, about, colleges, subject, course, layout, og-image) — body copy, `<title>`s, H1s, and JSON-LD `name` fields now use `config.name` + "community colleges" (the pattern already used correctly in a couple of existing spots).
- **`lib/insights-prose.ts`** — the `systemColleges()` prose helper now takes the state slug and routes through the new helper, fixing the awkward "California CCs colleges" / "…Colleges schools" output in state + college insight prose. Removed a dead `systemCollegeSingular` helper.
- **3 client components** (CourseSearchClient, ScheduleClient, BlogProgrammaticLinks) derive the label from their `state` slug.

### Scope notes (named honestly)
- **`lib/programs/copy.ts` deferred** — same phrasing, but it uses a separate placeholder-substitution engine whose `{stateName}` token isn't available in every template (changing it leaked a literal `{stateName}` on program pages). Left for a focused follow-up.
- **Branding taglines untouched** — the hand-written per-state taglines use acronym forms like "VCCS colleges" / "NCCCS colleges", which are grammatically correct and not the doubling bug.

## Test plan
- `npm run typecheck` ✅ · `eslint` on all touched files ✅ (0 new warnings) · `vitest insights-prose` 16/16 ✅
- **Live page sweep** (worktree dev server): no doubling on `/tx /ca /fl /ny /il /ga /nc /wa /va`, `/tx/colleges /ca/colleges /tx/courses /ca/courses /tx/schedule /tx/online`. Confirmed `/tx` renders "59 Texas community colleges", `/ca` "California community colleges", titles read "All 59 Texas Community Colleges" (no "Colleges Colleges").
- Verified the remaining "VCCS/NCCCS colleges" strings are the hand-written acronym taglines (correct), not the bug.

**DO NOT MERGE — opened for review.**
