### PR TITLE
perf(schedule): fetch only the sections a query needs, not the whole catalog

### DIFF
--- a/lib/__tests__/load-courses-for-schedule.test.ts
+++ b/lib/__tests__/load-courses-for-schedule.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { dedupeSections } from "../courses";
+import type { CourseSection } from "../types";
+
+function sec(over: Partial<CourseSection>): CourseSection {
+  return {
+    college_code: "c1",
+    term: "2026SP",
+    course_prefix: "HIST",
+    course_number: "101",
+    course_title: "US History",
+    credits: 3,
+    crn: "1000",
+    days: "MWF",
+    start_time: "9:00 AM",
+    end_time: "9:50 AM",
+    start_date: "",
+    location: "",
+    campus: "",
+    mode: "in-person",
+    instructor: null,
+    seats_open: 5,
+    seats_total: 30,
+    prerequisite_text: null,
+    prerequisite_courses: [],
+    ...over,
+  } as CourseSection;
+}
+
+describe("dedupeSections", () => {
+  it("collapses a section that matched two sub-queries (prefix AND title)", () => {
+    const out = dedupeSections([
+      sec({ crn: "1000" }),
+      sec({ crn: "1000" }), // identical identity → dropped
+      sec({ crn: "2000", course_title: "World History" }),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((s) => s.crn)).toEqual(["1000", "2000"]);
+  });
+
+  it("keeps same-CRN rows that differ by college / prefix / number", () => {
+    const out = dedupeSections([
+      sec({ college_code: "c1", crn: "1" }),
+      sec({ college_code: "c2", crn: "1" }), // different college
+      sec({ college_code: "c1", crn: "1", course_prefix: "HIS" }), // different prefix
+      sec({ college_code: "c1", crn: "1", course_number: "102" }), // different number
+    ]);
+    expect(out).toHaveLength(4);
+  });
+
+  it("preserves the order of first occurrences", () => {
+    const out = dedupeSections([
+      sec({ crn: "3" }),
+      sec({ crn: "1" }),
+      sec({ crn: "3" }),
+      sec({ crn: "2" }),
+    ]);
+    expect(out.map((s) => s.crn)).toEqual(["3", "1", "2"]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(dedupeSections([])).toEqual([]);
+  });
+});

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -605,6 +605,162 @@ export async function loadCoursesBySubject(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Scoped fetch for the Smart Schedule Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Full-row identity for de-duplicating unioned query results. The only rows we
+ * must collapse are the SAME database row returned by both the prefix and the
+ * title query; using the entire row (mapRow produces a stable key order) means
+ * genuinely-distinct sections — even ones sharing a CRN (lecture + lab) or a
+ * meeting time (different instructor/location) — are all preserved.
+ */
+function sectionKey(s: CourseSection): string {
+  return JSON.stringify(s);
+}
+
+/**
+ * De-duplicate sections that matched more than one sub-query (e.g. a course
+ * found by both its prefix and a title keyword). Pure — exported for tests.
+ */
+export function dedupeSections(sections: CourseSection[]): CourseSection[] {
+  const seen = new Set<string>();
+  const out: CourseSection[] = [];
+  for (const s of sections) {
+    const k = sectionKey(s);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(s);
+  }
+  return out;
+}
+
+/** Escape SQL LIKE wildcards so a user token is matched literally by ILIKE. */
+function escapeLike(token: string): string {
+  return token.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+type PageQuery = (
+  start: number,
+  end: number
+) => PromiseLike<{ data: unknown[] | null; error: { message: string } | null }>;
+
+/** Run a paginated Supabase query (1000-row pages) until a short page. */
+async function paginateSections(
+  build: PageQuery,
+  label: string
+): Promise<CourseSection[]> {
+  const PAGE_SIZE = 1000;
+  const all: CourseSection[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await build(offset, offset + PAGE_SIZE - 1);
+    if (error) {
+      console.error(`${label} error:`, error.message);
+      break;
+    }
+    if (!data || data.length === 0) break;
+    all.push(...data.map(mapRow));
+    if (data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return all;
+}
+
+/**
+ * Load only the sections a Smart Schedule Builder query can match, instead of
+ * the full term catalog. Two kinds of targeted Supabase queries, unioned:
+ *   - one `.in("course_prefix", prefixes)` for resolved subjects / course codes
+ *   - one per keyword group, AND-ing `.ilike("course_title", "%token%")` per token
+ *
+ * This mirrors the predicate in lib/schedule.ts `matchesSubjectQuery`, so the
+ * candidate set after `filterSections` is identical to filtering the output of
+ * `loadAllCourses` — only far smaller on the wire (e.g. CA "history" pulls a
+ * few thousand rows instead of the full ~54k term catalog).
+ */
+export async function loadCoursesForScheduleQuery(
+  term: string,
+  state: string,
+  prefixes: string[],
+  keywordGroups: string[][]
+): Promise<CourseSection[]> {
+  const uniqPrefixes = Array.from(
+    new Set(prefixes.map((p) => p.trim().toUpperCase()).filter(Boolean))
+  ).sort();
+  const cleanGroups = keywordGroups
+    .map((g) => g.map((t) => t.toLowerCase()).filter(Boolean))
+    .filter((g) => g.length > 0);
+  if (uniqPrefixes.length === 0 && cleanGroups.length === 0) return [];
+
+  const groupKeys = cleanGroups.map((g) => g.join("+")).sort();
+  const key = `scheduleQuery:${state}:${term}:${uniqPrefixes.join("|")}::${groupKeys.join(",")}`;
+
+  return cached(key, async () => {
+    const queries: Promise<CourseSection[]>[] = [];
+
+    if (uniqPrefixes.length > 0) {
+      queries.push(
+        paginateSections(
+          (start, end) =>
+            supabase
+              .from("courses")
+              .select(COURSE_COLUMNS)
+              .eq("state", state)
+              .eq("term", term)
+              .in("course_prefix", uniqPrefixes)
+              .order("id", { ascending: true })
+              .range(start, end),
+          "loadCoursesForScheduleQuery(prefixes)"
+        )
+      );
+    }
+
+    for (const tokens of cleanGroups) {
+      queries.push(
+        paginateSections((start, end) => {
+          let q = supabase
+            .from("courses")
+            .select(COURSE_COLUMNS)
+            .eq("state", state)
+            .eq("term", term);
+          for (const t of tokens) {
+            q = q.ilike("course_title", `%${escapeLike(t)}%`);
+          }
+          return q.order("id", { ascending: true }).range(start, end);
+        }, `loadCoursesForScheduleQuery(kw:${tokens.join("+")})`)
+      );
+    }
+
+    const results = await Promise.all(queries);
+    return dedupeSections(results.flat());
+  });
+}
+
+/**
+ * Cheap check: does this (state, term) have any course rows at all? Used to
+ * distinguish "the term has no data yet" from "your query matched nothing"
+ * now that the schedule builder fetches a scoped slice rather than everything.
+ * Fails open (true) on error so a transient failure never shows "no data".
+ */
+export async function termHasAnyData(
+  state: string,
+  term: string
+): Promise<boolean> {
+  return cached(`termHasData:${state}:${term}`, async () => {
+    const { count, error } = await supabase
+      .from("courses")
+      .select("id", { count: "exact", head: true })
+      .eq("state", state)
+      .eq("term", term);
+    if (error) {
+      console.error("termHasAnyData error:", error.message);
+      return true;
+    }
+    return (count ?? 0) > 0;
+  });
+}
+
 /**
  * Single scan returning both distinct course codes and per-prefix section
  * counts for a state+term. Used by the sitemap so it doesn't have to pull

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -18,7 +18,7 @@ import type {
   ScoreBreakdown,
   TransferStatus,
 } from "./types";
-import { loadAllCourses } from "./courses";
+import { loadCoursesForScheduleQuery, termHasAnyData } from "./courses";
 import { getZipCoordinates, calculateDistance } from "./geo";
 import { parseTimeToMinutes, daysToBitmask } from "./time-utils";
 import { isInProgress } from "./course-status";
@@ -109,9 +109,23 @@ export async function generateSchedules(
     request.timeWindowEnd
   );
 
-  // Stage 1: Filter all sections to candidates
+  // Stage 1: Fetch only the sections this query can match (by resolved prefix
+  // and/or title keyword) instead of the whole term catalog, then filter.
+  // filterSections re-applies the exact same predicate, so the candidate set is
+  // identical to filtering loadAllCourses(...) — just far smaller on the wire.
   const term = request.term || await getCurrentTerm(state);
-  const allSections = await loadAllCourses(term, state);
+  const prefixesToFetch = Array.from(
+    new Set([
+      ...subjectPrefixes,
+      ...exactCourses.map((c) => c.split("-")[0]),
+    ])
+  );
+  const allSections = await loadCoursesForScheduleQuery(
+    term,
+    state,
+    prefixesToFetch,
+    keywordGroups
+  );
   const hideFullSections = request.hideFullSections !== false; // default true
   const { sections: candidates, filteredFullCount } = filterSections(
     allSections,
@@ -193,8 +207,14 @@ export async function generateSchedules(
 
   const timeTakenMs = Math.round(performance.now() - t0);
 
+  // A scoped-empty fetch no longer implies the term has no data — it usually
+  // just means the query matched nothing. Only claim "no data yet" when the
+  // term genuinely has zero rows (one cheap head-count, on the empty path only).
+  const termEmpty =
+    allSections.length === 0 ? !(await termHasAnyData(state, term)) : false;
+
   let message: string | undefined;
-  if (allSections.length === 0) {
+  if (termEmpty) {
     message =
       "No course data available for this term yet. Check back soon — new schedules are added regularly.";
   } else if (candidateCourses === 0) {


### PR DESCRIPTION
## What changes for someone using the site

The **Smart Schedule Builder gets dramatically faster in large states.** A California search like "history courses" was taking ~4.7 seconds; it now returns in roughly **0.6–1.2 seconds**. The schedules that come back are the same — this is purely a speed (and consistency) fix.

## How it works (technical)

`generateSchedules` previously called `loadAllCourses(term, state)`, which pulls a state's **entire** term catalog from Supabase on every request and filters in JS. California's `2026SP` term is **54,219 sections** — a "history" query only needs ~2.5k of them.

New `loadCoursesForScheduleQuery(term, state, prefixes, keywordGroups)` (in `lib/courses.ts`) issues targeted queries instead and unions them:
- `.in("course_prefix", prefixes)` for resolved subjects / course codes
- one `.ilike("course_title", "%token%")` chain per keyword group (tokens AND-ed)

`generateSchedules` builds the prefix set from `subjectPrefixes` + exact-course prefixes and passes the keyword groups. **`filterSections` still re-applies the exact same matcher**, so the candidate set is unchanged — the scoped fetch just supplies a complete superset instead of the whole catalog. Cold CA timings dropped from ~4.7s to ~0.6–1.2s.

### Two correctness details
- **Ordered pagination.** The new loader paginates with `.order("id")`. The old unordered full-catalog pagination could *skip and duplicate* rows across pages — that's why repeated prod calls returned slightly different candidate counts. The scoped path is deterministic and complete (verified: loader row counts equal `COUNT(*)` of each sub-query; the only gaps are exact-duplicate table rows, which collapse harmlessly and which the builder's existing Stage-2 dedup would drop anyway). `loadAllCourses` itself is unchanged (still used elsewhere) — out of scope to fix here.
- **Empty-state message.** "No course data available for this term yet" is now gated on a cheap `(state, term)` head count (`termHasAnyData`), because a scoped-empty result means "your query matched nothing", not "the term has no data".

## Out of scope
- The `course-search` route (separate loader); a persistent/edge response cache; fixing `loadAllCourses`'s unordered pagination globally.

## Test plan
- **`lib/__tests__/load-courses-for-schedule.test.ts`** (new): `dedupeSections` collapses the same row fetched twice, keeps genuinely-distinct rows (shared CRN / shared meeting time), preserves order.
- **Completeness** (live, real Supabase): for CA, the loader's unique row count equals `COUNT(*)` for `course_prefix IN (HIST,HIS,AMH)` (2478=2478) and for `title ILIKE %intro%+%psychology%` (1235=1235); `%history%` is 3312 vs 3315 = three exact-duplicate table rows correctly collapsed.
- **Latency** (local dev → prod Supabase): CA "chemistry" 1218ms, "sociology courses" 899ms, "art" 574ms, "nursing" 823ms — vs the ~4659ms full-catalog baseline.
- `npx tsc --noEmit` clean · ESLint clean on changed files · `npm run build` clean. Staged only the 3 source/test files.

## Files
- `lib/courses.ts` — `loadCoursesForScheduleQuery`, `dedupeSections` (exported), `termHasAnyData`, helpers.
- `lib/schedule.ts` — `generateSchedules` uses the scoped loader; empty-state message gated on `termHasAnyData`.
- `lib/__tests__/load-courses-for-schedule.test.ts` (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
