### PR TITLE
fix(copy): "50 states and D.C." — D.C. is not a state

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -7,7 +7,7 @@ import NotifyBanner from "@/components/NotifyBanner";
 import AccountPromo from "@/components/auth/AccountPromo";
 import StateContext from "@/components/StateContext";
 import { getCurrentTerm, getNextTerm } from "@/lib/terms";
-import { getAllStates, hasPrereqsCoverage, isValidState } from "@/lib/states/registry";
+import { getAllStates, hasPrereqsCoverage, isValidState, statesCoveredLabel } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getArticlesByState, getStateTopicLinks, categoryLabel } from "@/lib/blog";
 import { getQualifyingProgramSlugs, getProgramBySlug } from "@/lib/programs";
@@ -376,7 +376,7 @@ export default async function HomePage({ params }: Props) {
               href="/colleges"
               className="text-teal-600 hover:text-teal-700 transition-colors"
             >
-              browse colleges in all {getAllStates().length} states
+              browse colleges in all {statesCoveredLabel()}
             </Link>
           </p>
         </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getAllStates } from "@/lib/states/registry";
+import { getAllStates, statesCoveredLabel } from "@/lib/states/registry";
 
 export const metadata: Metadata = {
   title: "About — Community College Path",
-  description:
-    "Community College Path is a free course finder and transfer guide for community college students. Search courses, check transfers, plan schedules — across 26 states in one place.",
+  description: `Community College Path is a free course finder and transfer guide for community college students. Search courses, check transfers, plan schedules — across ${statesCoveredLabel()} in one place.`,
   alternates: { canonical: "/about" },
 };
 
@@ -33,7 +32,7 @@ export default function AboutPage() {
           </h2>
           <p className="mb-3">
             Community College Path is a free course navigator covering {totalColleges}+ community
-            colleges across {states.length} states. Search for courses, compare sections across
+            colleges across {statesCoveredLabel()}. Search for courses, compare sections across
             campuses, check transfer credit, and plan your schedule — without bouncing between
             a dozen different college websites.
           </p>

--- a/app/colleges/page.tsx
+++ b/app/colleges/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getAllStates } from "@/lib/states/registry";
+import { getAllStates, statesCoveredLabel } from "@/lib/states/registry";
 import { loadInstitutions } from "@/lib/institutions";
 import { getCourseCount } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
@@ -146,7 +146,7 @@ export default async function AllCollegesPage() {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     name: "All Community Colleges",
-    description: `Browse ${totalColleges} community colleges across ${states.length} states.`,
+    description: `Browse ${totalColleges} community colleges across ${statesCoveredLabel()}.`,
     url: `${siteUrl}/colleges`,
     mainEntity: {
       "@type": "ItemList",
@@ -182,7 +182,7 @@ export default async function AllCollegesPage() {
         All Community Colleges
       </h1>
       <p className="text-gray-600 dark:text-slate-400 mb-8 max-w-2xl">
-        Browse {totalColleges} community colleges across {states.length} states
+        Browse {totalColleges} community colleges across {statesCoveredLabel()}
         {totalCourses > 0 && (
           <>
             {" "}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import ConsentPrompt from "@/components/auth/ConsentPrompt";
 import DraftDrainPrompt from "@/components/auth/DraftDrainPrompt";
 import JsonLd from "@/components/JsonLd";
 import Footer from "@/components/Footer";
-import { getAllStates } from "@/lib/states/registry";
+import { getAllStates, statesCoveredLabel } from "@/lib/states/registry";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
     default: "Community College Path — Course Finder & Transfer Guide",
     template: "%s | Community College Path",
   },
-  description: `Search courses, plan transfers, and build schedules across ${_totalColleges}+ community colleges in ${_states.length} states. Free course finder for community college students.`,
+  description: `Search courses, plan transfers, and build schedules across ${_totalColleges}+ community colleges in ${statesCoveredLabel()}. Free course finder for community college students.`,
   openGraph: {
     type: "website",
     siteName: "Community College Path",
@@ -72,7 +72,7 @@ const siteJsonLd = {
       "@id": `${SITE_URL}/#website`,
       url: SITE_URL,
       name: "Community College Path",
-      description: `Search courses, plan transfers, and build schedules across ${_totalColleges}+ community colleges in ${_states.length} states.`,
+      description: `Search courses, plan transfers, and build schedules across ${_totalColleges}+ community colleges in ${statesCoveredLabel()}.`,
       potentialAction: {
         "@type": "SearchAction",
         target: {
@@ -87,7 +87,7 @@ const siteJsonLd = {
       "@id": `${SITE_URL}/#organization`,
       url: SITE_URL,
       name: "Community College Path",
-      description: `An independent guide to ${_totalColleges}+ community colleges across ${_states.length} U.S. states. Free course finder, transfer lookup, and schedule planning tools for community college students.`,
+      description: `An independent guide to ${_totalColleges}+ community colleges across ${statesCoveredLabel()}. Free course finder, transfer lookup, and schedule planning tools for community college students.`,
       sameAs: [],
     },
   ],

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getAllStates } from "@/lib/states/registry";
+import { getAllStates, statesCoveredLabel } from "@/lib/states/registry";
 
 export const metadata: Metadata = {
   title: "Page not found — Community College Path",
@@ -118,7 +118,7 @@ export default function NotFound() {
             Pick a state
           </h2>
           <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
-            We cover {states.length} states. Jump straight to one.
+            We cover {statesCoveredLabel()}. Jump straight to one.
           </p>
           <ul className="mt-3 flex flex-wrap gap-2">
             {states.map((s) => (

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { getAllStates } from "@/lib/states/registry";
+import { getAllStates, statesCoveredLabel } from "@/lib/states/registry";
 
 export const runtime = "nodejs";
 export const alt = "Community College Path — Community College Course Finder";
@@ -101,7 +101,7 @@ export default async function Image() {
               lineHeight: 1.4,
             }}
           >
-            {totalColleges}+ community colleges across {states.length} states.
+            {totalColleges}+ community colleges across {statesCoveredLabel()}.
             Course search, transfer lookup, schedule builder.
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getAllStates } from "@/lib/states/registry";
+import { getAllStates, statesCoveredLabel, coveredStateCount } from "@/lib/states/registry";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 import CourseSearchHero from "@/components/CourseSearchHero";
@@ -13,7 +13,7 @@ const STATE_LIST_SENTENCE =
   STATE_NAMES.length <= 1
     ? STATE_NAMES.join("")
     : `${STATE_NAMES.slice(0, -1).join(", ")}, and ${STATE_NAMES[STATE_NAMES.length - 1]}`;
-const META_DESCRIPTION = `Search community college courses, transfer credits, and schedules across ${STATE_NAMES.length} states. Free, no signup.`;
+const META_DESCRIPTION = `Search community college courses, transfer credits, and schedules across ${statesCoveredLabel()}. Free, no signup.`;
 
 export const metadata: Metadata = {
   title: "Community College Path — Find any community college course in one search",
@@ -137,7 +137,7 @@ export default async function LandingPage() {
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 pb-20 sm:pt-24 sm:pb-28">
           <div className="text-center">
             <span className="inline-flex items-center gap-1.5 rounded-full bg-teal-100 dark:bg-teal-900/40 text-teal-800 dark:text-teal-200 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.2em]">
-              ✓ {totalColleges} colleges · {states.length} states · always free
+              ✓ {totalColleges} colleges · {statesCoveredLabel()} · always free
             </span>
             <h1 className="mt-6 text-4xl sm:text-6xl lg:text-[64px] font-semibold leading-[1.05] tracking-[-0.025em] text-slate-900 dark:text-slate-100">
               Find any community college course in{" "}
@@ -346,10 +346,10 @@ export default async function LandingPage() {
                 </div>
                 <div>
                   <div className="text-3xl font-semibold text-teal-300">
-                    {states.length}
+                    {coveredStateCount()}
                   </div>
                   <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 mt-1">
-                    states
+                    states + D.C.
                   </div>
                 </div>
                 <div>

--- a/components/CourseSearchHero.tsx
+++ b/components/CourseSearchHero.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
+import { statesCoveredLabel } from "@/lib/states/registry";
 
 const PLACEHOLDER_QUERIES = [
   "ENG 111",
@@ -265,7 +266,7 @@ export default function CourseSearchHero({
           onClick={() => setPickerOpen((o) => !o)}
           className="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 dark:border-slate-700 px-3 py-1 text-slate-500 dark:text-slate-400 hover:border-teal-600 hover:text-teal-700 transition-colors"
         >
-          all {states.length} states
+          all {statesCoveredLabel()}
         </button>
 
       </div>

--- a/components/USMap.tsx
+++ b/components/USMap.tsx
@@ -30,7 +30,7 @@ export default function USMap() {
         viewBox="0 0 975 610"
         className="w-full h-auto"
         role="img"
-        aria-label={`Map of US states. ${states.length} active, click to browse a state.`}
+        aria-label={`Map of US states and D.C. ${states.length} active, click to browse.`}
       >
         <g>
           {fc.features.map((f, i) => {

--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -322,6 +322,26 @@ export function communityCollegesLabel(slug: string): string {
   return `${configs[slug]?.name ?? slug.toUpperCase()} community colleges`;
 }
 
+/** Number of registered states, excluding D.C. (a federal district, not a
+ *  state). Use for any "{N} states" count so `getAllStates().length` — which
+ *  includes D.C. — doesn't overstate the number of states. */
+export function coveredStateCount(): number {
+  const all = getAllStates();
+  return all.length - (all.some((s) => s.slug === "dc") ? 1 : 0);
+}
+
+/**
+ * "{N} states and D.C." for coverage copy. D.C. is a federal district, not a
+ * state, so `getAllStates().length` (which includes it) must not be labelled
+ * "N states". Notes D.C. separately; falls back to "{N} states" if D.C. isn't
+ * registered.
+ */
+export function statesCoveredLabel(): string {
+  const all = getAllStates();
+  const hasDC = all.some((s) => s.slug === "dc");
+  return `${coveredStateCount()} states${hasDC ? " and D.C." : ""}`;
+}
+
 /**
  * Returns the slugs whose pages should be pre-rendered at build time
  * (`prerenderAtBuild: true` in the StateConfig). All other states' pages


### PR DESCRIPTION
## What changes for a student

The site said it covers **"51 states"** in a bunch of places — the homepage hero and stat tile, the description search engines and social cards show on every page, the 404 page, the search box, and the about/colleges pages. But D.C. isn't a state: the registry has 50 states **plus** D.C. (51 jurisdictions). Every one of those now reads **"50 states and D.C."** The homepage stat tile that showed a big "51" over the word "states" now shows "50" over "states + D.C." (One about-page description was also stale at a hardcoded "26 states" — now correct too.)

Small accuracy/trust fix — nothing functional changes.

## How it works

Two registry helpers do the counting, derived from the registry so they never go stale (D.C. is identified by its `dc` slug — no hardcoded numbers):

- **`coveredStateCount()`** → `50` (registry entries minus D.C.) — for the stat tile's number.
- **`statesCoveredLabel()`** → `"50 states and D.C."` — for all the sentence copy.

Replaced every `{getAllStates().length} states` (and one hardcoded "26 states") across page body copy, page `<title>`s, the root-layout `meta`/OpenGraph/Twitter descriptions, the OG image, and JSON-LD. The USMap aria-label now says "Map of US states and D.C."

**Left as-is on purpose:** the map legend "{N} live" and the "see all {N} as a list" toggle are counts of *active jurisdictions/list items* (51 live regions, including D.C.), not "{N} states" claims — so they stay 51.

## Test plan
- `npm run typecheck` ✅ · `eslint` on all 10 touched files ✅ · no test references the old count
- **Live sweep** (worktree dev server): `/`, `/tx`, `/about`, `/colleges`, and a 404 page all render "50 states and D.C." with **zero** remaining "{N} states" where N≠50. Homepage stat tile confirmed showing "50 / states + D.C."

**DO NOT MERGE — opened for review.**
