### PR TITLE
feat(transfer): carry program subject into the transfer page (?subject=)

### DIFF
--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -118,6 +118,13 @@ export default async function ProgramPage(props: PageProps) {
   const data = await loadProgramData(state, slug);
   if (!data || !qualifies(data)) notFound();
 
+  // The program's first candidate prefix that actually appears in this state's
+  // course data — handles prefix variance (e.g. "accounting" is ACC nationally
+  // but ACCT in TX). Carried into the transfer page to pre-filter the subject.
+  const inDataPrefixes = new Set(data.flatSections.map((s) => s.course_prefix));
+  const transferPrefix =
+    program.prefixes.find((p) => inDataPrefixes.has(p)) ?? program.prefixes[0];
+
   const config = requireStateConfig(state);
   const [term, requirementEntries] = await Promise.all([
     getCurrentTerm(state),
@@ -404,7 +411,7 @@ export default async function ProgramPage(props: PageProps) {
               coursework; you earn the degree, and its earnings, at a four-year
               university.{" "}
               <Link
-                href={`/${state}/transfer`}
+                href={`/${state}/transfer?subject=${encodeURIComponent(transferPrefix)}`}
                 className="font-medium underline hover:no-underline"
               >
                 See where it transfers &rarr;

--- a/app/[state]/transfer/TransferClient.tsx
+++ b/app/[state]/transfer/TransferClient.tsx
@@ -19,6 +19,12 @@ interface Props {
   defaultUniversity: string;
   state: string;
   popularCourses: string[];
+  /** Pre-seed the subject filter — e.g. a program page's "See where it
+   *  transfers" link passing ?subject=ACCT. */
+  initialSubject?: string;
+  /** Pre-select the receiving university (?to=<slug>); ignored when it isn't a
+   *  known university, falling back to defaultUniversity. */
+  initialUniversity?: string;
 }
 
 type ViewMode = "browse" | "compare";
@@ -31,10 +37,16 @@ export default function TransferClient({
   defaultUniversity,
   state,
   popularCourses,
+  initialSubject,
+  initialUniversity,
 }: Props) {
   const [viewMode, setViewMode] = useState<ViewMode>("browse");
-  const [selectedUniversity, setSelectedUniversity] = useState(defaultUniversity);
-  const [subjectFilter, setSubjectFilter] = useState("");
+  const [selectedUniversity, setSelectedUniversity] = useState(
+    initialUniversity && universities.some((u) => u.slug === initialUniversity)
+      ? initialUniversity
+      : defaultUniversity,
+  );
+  const [subjectFilter, setSubjectFilter] = useState(initialSubject ?? "");
   const [typeFilter, setTypeFilter] = useState<
     "" | "direct" | "elective" | "no-credit"
   >("");
@@ -479,6 +491,9 @@ export default function TransferClient({
             className="w-full rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm dark:text-slate-100 focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-200"
           >
             <option value="">All Subjects ({subjects.length})</option>
+            {subjectFilter && !subjects.includes(subjectFilter) && (
+              <option value={subjectFilter}>{subjectFilter}</option>
+            )}
             {subjects.map((s) => (
               <option key={s} value={s}>
                 {s}

--- a/app/[state]/transfer/page.tsx
+++ b/app/[state]/transfer/page.tsx
@@ -22,6 +22,7 @@ export const maxDuration = 60;
 
 type Props = {
   params: Promise<{ state: string }>;
+  searchParams: Promise<{ subject?: string; to?: string }>;
 };
 
 export function generateStaticParams() {
@@ -40,8 +41,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function TransferPage({ params }: Props) {
+export default async function TransferPage({ params, searchParams }: Props) {
   const { state } = await params;
+  const { subject: initialSubject, to: initialUniversity } = await searchParams;
   const config = requireStateConfig(state);
   if (!config.transferSupported) notFound();
   const universities = await getUniversities(state);
@@ -135,6 +137,8 @@ export default async function TransferPage({ params }: Props) {
         defaultUniversity={defaultUni}
         state={state}
         popularCourses={config.popularCourses}
+        initialSubject={initialSubject}
+        initialUniversity={initialUniversity}
       />
 
       {/* Browse transfer pathways by university — hub-page directory */}


### PR DESCRIPTION
## What changes for a student

On a program page (e.g. `/tx/program/accounting`), the **"See where it transfers →"** link used to dump you on a blank `/tx/transfer` with nothing filled in — you had to re-pick everything. Now it lands you on the transfer page **pre-filtered to that program's subject**: click it from Accounting and you arrive with the Subject filter already set to ACCT, showing only the accounting-course equivalencies for the default university (which you can change). The search→transfer journey now carries your context forward, the same idea as the new "Add to planner" links.

## How it works

The transfer page **already had** a working subject filter — it just never read the URL. This wires that up:

- **`transfer/page.tsx`** reads `?subject=<PREFIX>` and `?to=<uni-slug>` from the URL **server-side** and passes them as `initialSubject` / `initialUniversity` props (avoids the Next 16 `useSearchParams` + Suspense dance).
- **`TransferClient.tsx`** seeds its existing `subjectFilter` and `selectedUniversity` from those props (the university is validated against the known list, else falls back to the default). If the seeded subject isn't in the loaded list yet, it's still rendered as a selected `<select>` option so the control reflects it.
- **`program/[slug]/page.tsx`** link now passes `?subject=<primary in-data prefix>`. The prefix is derived from the program's candidate `prefixes` **intersected with the state's actual course sections** (`data.flatSections`), which handles prefix variance — accounting is `ACC` nationally but `ACCT` in TX, so TX correctly carries `ACCT`.

### Known v1 gap (named honestly)
A multi-subject program like *business-administration* (`BUS, ACCT, ECON, …`) carries only its **primary** prefix — the existing filter is single-select. Widening to a comma-separated `?subjects=` matched as a set is a clean follow-up.

## Test plan
- `npm run typecheck` ✅ · `eslint` (0 new warnings) ✅ · `npm run build` → compiled + **161/161 static pages generated**, no prerender errors ✅
- **Live Playwright flow (worktree dev server):** `/tx/program/accounting` link carries `?subject=ACCT` (in-data prefix, not "ACC"); `/tx/transfer?subject=ACCT` seeds the Subject filter to ACCT and shows ACCT equivalencies; `/tx/transfer?subject=ACCT&to=angelo-state-university` seeds both; an invalid `?to=` falls back to the default without crashing; bare `/tx/transfer` is unchanged.
- Screenshot-confirmed: ACCT pre-filtered, "63 courses", ACCT 2301 → ACCT 210.

**DO NOT MERGE — opened for review.**
