### PR TITLE
feat(oh): programs for OH 5 templated colleges (0 → 746, planner unlock)

### DIFF
--- a/data/oh/programs/cuyahoga-community-college-district.json
+++ b/data/oh/programs/cuyahoga-community-college-district.json
@@ -1,0 +1,26817 @@
+{
+  "college_slug": "cuyahoga-community-college-district",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.tri-c.edu/programs/",
+  "scraped_at": "2026-06-06T17:57:57.657Z",
+  "programs": [
+    {
+      "title": "3D Animation, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/3d-animation-short-term-certificate/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "1640",
+              "title": "3D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2040",
+              "title": "3D Motion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2341",
+              "title": "Illustration for Story",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1201",
+              "title": "Typography I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2271",
+              "title": "2D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2541",
+              "title": "Individual Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/accounting-aab/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 26 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1520",
+              "title": "QuickBooks Immersion",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1551",
+              "title": "Excel for Accountants",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1041",
+              "title": "Individual Taxation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2310",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2100",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "3D Design, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/3d-design-short-term-certificate/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "1640",
+              "title": "3D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2040",
+              "title": "3D Motion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1200",
+              "title": "Game Design I: Introduction to Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1400",
+              "title": "Game Design II: Game Engines",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2440",
+              "title": "3D Simulation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2540",
+              "title": "3D Studio",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2641",
+              "title": "Illustration Studio",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2541",
+              "title": "Individual Projects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting/CPA Preparation, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/accounting-cpa-preparation-post-degree-professional-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1041",
+              "title": "Individual Taxation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2041",
+              "title": "Business Taxation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2310",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2320",
+              "title": "Intermediate Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2510",
+              "title": "Auditing",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting, Finance, and Tax Online Certificates — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/accounting-finance-tax-online-certificates/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZFIN",
+              "number": "1054",
+              "title": "Bookkeeping Administration Certification (Online)",
+              "credits": 28,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZFIN",
+              "number": "1066",
+              "title": "Investing in Stocks and Bonds (Online)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZFIN",
+              "number": "1067",
+              "title": "Intuit QuickBooks Online Plus (Online)",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "3D Digital Design & Manufacturing Technology, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/3d-digital-design-manufacturing-technology-certificate-proficiency/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1250",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1261",
+              "title": "Product Ideation & Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1270",
+              "title": "Additive Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1300",
+              "title": "Engineering Materials and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2601",
+              "title": "3D Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2151",
+              "title": "3D Digital Design & Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2160",
+              "title": "3D Scanning, Reverse Engineering, and Quality Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2990",
+              "title": "Product Development and Manufacture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2941",
+              "title": "Additive Manufacturing Internship",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Specialist, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/administrative-specialist-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1100",
+              "title": "Workplace Collaborative Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1150",
+              "title": "Word for Business Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1700",
+              "title": "Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2040",
+              "title": "Emerging Workplace Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2211",
+              "title": "Presentation Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2200",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language, Associate of Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/american-sign-language-aa/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1010",
+              "title": "Beginning American Sign Language I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1001",
+              "title": "Fingerspelling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1100",
+              "title": "Deaf Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1020",
+              "title": "Beginning American Sign Language II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1050",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105L",
+              "title": "Human Biology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2010",
+              "title": "Intermediate American Sign Language I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2020",
+              "title": "Intermediate American Sign Language II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2010",
+              "title": "Child Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIS",
+              "number": "1310",
+              "title": "Interpreting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2412",
+              "title": "Advanced American Sign Language I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Carpentry Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-carpentry-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1320",
+              "title": "Introduction to Hand and Power Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1351",
+              "title": "Metal Studs and Dry Walls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1381",
+              "title": "Wood Framing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1310",
+              "title": "Carpentry Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1331",
+              "title": "Concrete Footers and Walls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1370",
+              "title": "Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2361",
+              "title": "Suspended Ceilings",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1491",
+              "title": "Residential Steel Framing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1610",
+              "title": "Interior Finish",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2341",
+              "title": "Concrete Specialities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2370",
+              "title": "Interior Systems Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1390",
+              "title": "Welding for Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2560",
+              "title": "Interior Systems III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1510",
+              "title": "Green Building & Sustainability I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Massage Therapy, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/advanced-massage-therapy-short-term-certificate/",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MT",
+              "number": "1280",
+              "title": "Somatic Studies III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2202",
+              "title": "Massage Modalities and Career Paths",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2311",
+              "title": "Advanced Massage Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2380",
+              "title": "Advanced Massage Therapy Clinic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Construction, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-building-construction-short-term-certificate/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "1010",
+              "title": "Construction Measurements and Calculations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1020",
+              "title": "Comprehension and Communication for Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1030",
+              "title": "Basic Construction Language",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1040",
+              "title": "Spatial and Mechanical Reasoning",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1050",
+              "title": "Construction Industry Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1060",
+              "title": "Construction Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "1120",
+              "title": "Building Construction Laboratory",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Cement Masonry Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-cement-masonry-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCM",
+              "number": "1300",
+              "title": "Fundamentals of Concrete Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1401",
+              "title": "Concrete Forming and Finishing Basic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1321",
+              "title": "Introduction to Plan Reading",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1341",
+              "title": "OSHA Standards for Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1330",
+              "title": "Concrete Construction Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1411",
+              "title": "Commercial and Residential Form and Finish",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2320",
+              "title": "Bluprint Fundamentals - Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2521",
+              "title": "Basic Cement Patching",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2701",
+              "title": "Advanced Concrete Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2710",
+              "title": "Concrete Specialty Products",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2500",
+              "title": "Fundamentals of Concrete Curing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2531",
+              "title": "Concrete Restoration",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Construction Tending and Hazardous Material Abatement Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-construction-tending-hazardous-material-abatement-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATLB",
+              "number": "1010",
+              "title": "Craft Orientation for Laborers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "1020",
+              "title": "Measurements and Leveling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "1210",
+              "title": "Concrete Placement",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "1340",
+              "title": "Mason Tending",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "2650",
+              "title": "Demolition Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "2110",
+              "title": "Small Engines & Concrete Saws",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "2120",
+              "title": "Pneumatic Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Floorlaying Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-floorlaying-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1450",
+              "title": "Floorlaying Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1600",
+              "title": "Modular Tile",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1610",
+              "title": "Jute & Action Back Carpeting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1620",
+              "title": "Ceramics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1630",
+              "title": "Wood Flooring I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1640",
+              "title": "Sheet Goods Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1650",
+              "title": "Sheet Goods - Flash Coving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1720",
+              "title": "Geometric Layout and Inlay",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1730",
+              "title": "Unitary Back and Enhancer Back Carpeting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1300",
+              "title": "Residential Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "2300",
+              "title": "Ceramics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "2400",
+              "title": "Sheet Goods-Specialty Products",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2631",
+              "title": "Construction Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2990",
+              "title": "Construction Estimating & Cost Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Glazing Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-glazing-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATGL",
+              "number": "1330",
+              "title": "Hand Tools for Glaziers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1300",
+              "title": "Introduction to Painting, Drywall Finishing, and Glazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1320",
+              "title": "Safety Standards for Construction (OSHA-10)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "1620",
+              "title": "Glass and Mirror Replacement and Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "1630",
+              "title": "Basic Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "1640",
+              "title": "Door Fabrication and Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1650",
+              "title": "Blueprints I: Construction Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1011",
+              "title": "Business Math Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2330",
+              "title": "Transits, Leveling Instruments, and Lasers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2350",
+              "title": "Curtainwall Fabric & Install",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2320",
+              "title": "Safe Work Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2340",
+              "title": "Advanced Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1640",
+              "title": "Rigging & Hoisting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Drywall Finishing Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-drywall-finishing-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATDW",
+              "number": "1310",
+              "title": "Tools and Methods of Drywall Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "1330",
+              "title": "Materials and Methods of Drywall Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1300",
+              "title": "Introduction to Painting, Drywall Finishing, and Glazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1320",
+              "title": "Safety Standards for Construction (OSHA-10)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "1620",
+              "title": "Taping Tools & Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1340",
+              "title": "Wall Preparation and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1650",
+              "title": "Blueprints I: Construction Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1510",
+              "title": "Green Building & Sustainability I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "2350",
+              "title": "Filling Compounds/Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2320",
+              "title": "Safe Work Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "2340",
+              "title": "Texturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2340",
+              "title": "Bluepints II: Advanced Reading and Estimating",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2360",
+              "title": "Foreman Training",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Ironworking Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-ironworking-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATIW",
+              "number": "1300",
+              "title": "Structural Steel Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1310",
+              "title": "Safety for Ironworkers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1320",
+              "title": "Steel Construction Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1330",
+              "title": "Erection Concepts & Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1410",
+              "title": "Practical Applications of Reinforcing Steel",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1600",
+              "title": "Welding Fundamentals for Ironworkers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2300",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2310",
+              "title": "Welding Specialties",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2320",
+              "title": "Welding Blueprints and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2330",
+              "title": "Pre-Construction Planning of Specialty Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2340",
+              "title": "Specialty Installation Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2350",
+              "title": "Ornamental Systems & Railings",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2360",
+              "title": "Ornamental Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2500",
+              "title": "Rigging and Hoisting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Manufacturing Technology  (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-manufacturing-technology-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATMT",
+              "number": "1100",
+              "title": "Manufacturing Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1110",
+              "title": "Manufacturing Skills II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1200",
+              "title": "Machine Tool Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1300",
+              "title": "Manufacturing Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1500",
+              "title": "Manufacturing Tech Skills I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1600",
+              "title": "Introduction to CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2300",
+              "title": "Advanced Manufacturing Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2500",
+              "title": "Manufacturing Technology Skills II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2600",
+              "title": "CNC Programming/Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2620",
+              "title": "CAM Principles",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2700",
+              "title": "Manufacturing Technology Skills III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2990",
+              "title": "Manufacturing Operation Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Millwrighting Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-millwrighting-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1320",
+              "title": "Introduction to Millwrighting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1330",
+              "title": "Print Reading for Millwrights",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1350",
+              "title": "Hydraulics/Centrifugal Pumps",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1450",
+              "title": "Heavy Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1490",
+              "title": "Millwright Pile Driver Weld I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1720",
+              "title": "Machinery Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2120",
+              "title": "Shaft Alignment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1310",
+              "title": "Carpentry Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2130",
+              "title": "Shaft Alignment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2230",
+              "title": "Millwright Pile Driver Weld II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2350",
+              "title": "Floor Conveyor",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2520",
+              "title": "Millwright PileDriver Weld III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2700",
+              "title": "Millwright-Pile Driver Weld IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2631",
+              "title": "Construction Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2990",
+              "title": "Construction Estimating & Cost Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Operating Engineering Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-operating-engineers-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATOE",
+              "number": "1100",
+              "title": "Operating Engineering Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "1200",
+              "title": "Basic Mechanical Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "1650",
+              "title": "Graders and Plans",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "1700",
+              "title": "Paving, Tractor, Backhoe Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2100",
+              "title": "Mobile Crane",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2600",
+              "title": "Bulldozer Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2200",
+              "title": "Mechanical Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2620",
+              "title": "Backhoe Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2640",
+              "title": "Advanced Grader Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2660",
+              "title": "Grader Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Associate of Applied Science in Painting Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-painting-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATPT",
+              "number": "1300",
+              "title": "Introduction to Painting, Drywall Finishing, and Glazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1320",
+              "title": "Safety Standards for Construction (OSHA-10)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1330",
+              "title": "Filling Compounds and Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1340",
+              "title": "Wall Preparation and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1011",
+              "title": "Business Math Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1620",
+              "title": "Wood Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1630",
+              "title": "Color Mixing and Matching",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1640",
+              "title": "Rigging & Hoisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1650",
+              "title": "Blueprints I: Construction Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1660",
+              "title": "Labor in American Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2320",
+              "title": "Safe Work Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2330",
+              "title": "Spray & Industrial Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2400",
+              "title": "Advanced Rigging & Hoisting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2370",
+              "title": "Abrasives Blasting Techniques",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2380",
+              "title": "Special Coating and Decorative Finishes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2340",
+              "title": "Bluepints II: Advanced Reading and Estimating",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2350",
+              "title": "Advanced Spray and Industrial Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2360",
+              "title": "Foreman Training",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Pile Driving Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-pile-driving-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1310",
+              "title": "Carpentry Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1340",
+              "title": "Introduction to Pile Driving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "1330",
+              "title": "Print Reading for Pile Driving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1450",
+              "title": "Heavy Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1490",
+              "title": "Millwright Pile Driver Weld I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "1310",
+              "title": "Technical Measurements, Hand & Power Tool Use in Pile Driving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "1370",
+              "title": "Pile Driving on Land and Water",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1510",
+              "title": "Green Building & Sustainability I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2230",
+              "title": "Millwright Pile Driver Weld II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2020",
+              "title": "Pile Driving Technologies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2520",
+              "title": "Millwright PileDriver Weld III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2700",
+              "title": "Millwright-Pile Driver Weld IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2710",
+              "title": "Millwright-Pile Driver Weld V",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2990",
+              "title": "Construction Estimating & Cost Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Plumbing Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-plumbing-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATPL",
+              "number": "1000",
+              "title": "Care and Use of Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1010",
+              "title": "Soldering and Brazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1070",
+              "title": "Pipe Fittings, Valves, and Supports",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1030",
+              "title": "State of Ohio Plumbing Code I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1220",
+              "title": "Gas Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1230",
+              "title": "Water Supply",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2320",
+              "title": "State of Ohio Plumbing Code III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2350",
+              "title": "Electricity for Plumbers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2410",
+              "title": "City & State Backflow Cert",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Sheet Metal Working Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-sheet-metal-working-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATSM",
+              "number": "1010",
+              "title": "Benefits Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1020",
+              "title": "Trade History",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1030",
+              "title": "Layout and Fabrication I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1060",
+              "title": "Sheet Metal OSHA 30",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1220",
+              "title": "Layout and Fabrication II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1230",
+              "title": "Field Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2540",
+              "title": "SMART ICRA",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2310",
+              "title": "Refrigeration I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2420",
+              "title": "Refrigeration II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1050",
+              "title": "Fire Life Safety Tech I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2790",
+              "title": "Sheet Metal Foreman Training",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Pipefitting Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-industrial-technology-pipefitting-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATPF",
+              "number": "1210",
+              "title": "Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1000",
+              "title": "Care and Use of Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1341",
+              "title": "OSHA Standards for Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "1220",
+              "title": "Basic Pipefitting Layout",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "1360",
+              "title": "Hydronic Heating and Cooling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2510",
+              "title": "Pumps",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "2340",
+              "title": "Steam Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2560",
+              "title": "Foreman Certification",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certified Associate in Project Management (CAPM) — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/applied-project-management-capm-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLSS",
+              "number": "1132",
+              "title": "Certified Associate in Project Management (CAPM) Exam Prep (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1144",
+              "title": "PMI Exam Prep: Certified Associate in Project Management (CAPM)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate of Arts with a concentration in Art History — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-art-history/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1081",
+              "title": "2D Design and Color",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning ( or any Ohio Transfer 36 Approved Mathematics elective )",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1040",
+              "title": "Survey of Non-Western Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2020",
+              "title": "Art History Survey: Prehistoric to Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2030",
+              "title": "Art History Survey: Late Renaissance to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of Arts with a Concentration in Anthropology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-anthropology/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1010",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1210",
+              "title": "Human Evolution",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2010",
+              "title": "Peoples and Cultures of the World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2110",
+              "title": "Archaeology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2030",
+              "title": "Environmental Geography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1020",
+              "title": "The Individual in Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2030",
+              "title": "Culture and Belief",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts with a Concentration in English — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-english/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or any Ohio Transfer 36 Approved Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2030",
+              "title": "Environmental Geography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1500",
+              "title": "United States History to 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "150H",
+              "title": "Honors United States History to 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1520",
+              "title": "United States History Since 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "152H",
+              "title": "Honors United States History since 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1020",
+              "title": "State & Local Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2030",
+              "title": "Comparative Politics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2070",
+              "title": "International Relations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2310",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2350",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2510",
+              "title": "African-American Literature I (OAH062/TMAH)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2520",
+              "title": "African-American Literature II (OAH062/TMAH)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2730",
+              "title": "Exploration of World Mythology (OAH063/TMAH)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2320",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2360",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Associate of Arts with a Concentration in Jazz Studies — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-jazz-studies/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or any approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1301",
+              "title": "Applied Piano Minor I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1461",
+              "title": "Applied Music I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1570",
+              "title": "Technology Tools I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1600",
+              "title": "Traditional Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1611",
+              "title": "Ear Training I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1510",
+              "title": "Choral Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1520",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1550",
+              "title": "Instrumental Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1302",
+              "title": "Applied Piano Minor II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1471",
+              "title": "Applied Music II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1620",
+              "title": "Traditional Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1631",
+              "title": "Ear Training II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1720",
+              "title": "Arranging I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2301",
+              "title": "Applied Piano Minor III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2461",
+              "title": "Applied Music III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1650",
+              "title": "Jazz Theory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2541",
+              "title": "Jazz History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2611",
+              "title": "Ear Training III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1010",
+              "title": "Survey of European Classical Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1020",
+              "title": "Survey of Jazz",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1030",
+              "title": "Survey of Rock and Roll",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1040",
+              "title": "Survey of African-American Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1050",
+              "title": "Survey of World Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2302",
+              "title": "Applied Piano Minor IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2471",
+              "title": "Applied Music IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2631",
+              "title": "Ear Training IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2650",
+              "title": "Jazz Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts with a Concentration in Music — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-music/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or any approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1250",
+              "title": "Class Keyboard I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1461",
+              "title": "Applied Music I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1600",
+              "title": "Traditional Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1611",
+              "title": "Ear Training I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1010",
+              "title": "Survey of European Classical Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1020",
+              "title": "Survey of Jazz",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1030",
+              "title": "Survey of Rock and Roll",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1040",
+              "title": "Survey of African-American Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1050",
+              "title": "Survey of World Music",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1510",
+              "title": "Choral Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1530",
+              "title": "Concert Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1550",
+              "title": "Instrumental Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1260",
+              "title": "Class Keyboard II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1471",
+              "title": "Applied Music II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1620",
+              "title": "Traditional Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1631",
+              "title": "Ear Training II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2461",
+              "title": "Applied Music III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2600",
+              "title": "Traditional Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2611",
+              "title": "Ear Training III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2471",
+              "title": "Applied Music IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2620",
+              "title": "Traditional Theory IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2631",
+              "title": "Ear Training IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts with a Concentration in Communication Studies — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-communication-studies/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic (or Any Ohio Transfer 36 Approved Mathematics class)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1020",
+              "title": "The Individual in Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "102H",
+              "title": "Honors Individual in Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1210",
+              "title": "Small Group Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2000",
+              "title": "Introduction to Communication Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2160",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2020",
+              "title": "Introduction to Conflict and Peace Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts with a Concentration in Theatre — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-theatre-arts/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1010",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1430",
+              "title": "Introduction to Scenery and Stagecrafts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or any Ohio Transfer 36 Approved Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1500",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1550",
+              "title": "Practicum in Technical Theatre",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1540",
+              "title": "Rehearsal and Performance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "2010",
+              "title": "Script Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2030",
+              "title": "Environmental Geography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1500",
+              "title": "United States History to 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "150H",
+              "title": "Honors United States History to 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1520",
+              "title": "United States History Since 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "152H",
+              "title": "Honors United States History since 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1020",
+              "title": "State & Local Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2030",
+              "title": "Comparative Politics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2070",
+              "title": "International Relations",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts with a Concentration in Sociology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-sociology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2010",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2020",
+              "title": "Sociology of the Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2550",
+              "title": "Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts with a concentration in Studio/Fine Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-arts-concentration-studio-fine-arts/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1081",
+              "title": "2D Design and Color",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1070",
+              "title": "3D Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1700",
+              "title": "Ceramics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2050",
+              "title": "Painting I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2000",
+              "title": "Life Drawing I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2020",
+              "title": "Art History Survey: Prehistoric to Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or any Ohio Transfer 36 Approved Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2030",
+              "title": "Art History Survey: Late Renaissance to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2790",
+              "title": "Portfolio Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of Science with a Concentration in Chemistry — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-science-concentration-chemistry/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1300",
+              "title": "General Chemistry Iand General Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "130H",
+              "title": "Honors General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1610",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "161H",
+              "title": "Honors Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1310",
+              "title": "General Chemistry IIand General Chemistry Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131H",
+              "title": "Honors General Chemistry II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1620",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "162H",
+              "title": "Honors Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2310",
+              "title": "General Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2300",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2320",
+              "title": "General Physics II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation Maintenance Engineering Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/automation-maintenance-engineering-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1410",
+              "title": "Applied Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1420",
+              "title": "Applied Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2240",
+              "title": "Applied National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2210",
+              "title": "Commercial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1340",
+              "title": "Industrial Piping and Tubing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2500",
+              "title": "Programmable Logic Controllers Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2511",
+              "title": "Programmable Logic Controllers Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2250",
+              "title": "Robotics Operations Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2220",
+              "title": "Fundamentals of Electronics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2260",
+              "title": "Infrared Robotic Vision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Automotive Maintenance and General Service, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/automotive-maintenance-general-service-short-term-certificate/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "1101",
+              "title": "Introduction to Automotive Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1400",
+              "title": "Automotive Alignment, Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1450",
+              "title": "Automotive Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1502",
+              "title": "Automotive Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/automotive-technology-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "1101",
+              "title": "Introduction to Automotive Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1400",
+              "title": "Automotive Alignment, Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1450",
+              "title": "Automotive Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1502",
+              "title": "Automotive Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1050",
+              "title": "Numerical Applications in Automotive Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1300",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1510",
+              "title": "Automotive Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/automotive-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "1940",
+              "title": "Automotive Field Experience I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1950",
+              "title": "Automotive Field Experience II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1960",
+              "title": "Automotive Field Experience III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2940",
+              "title": "Automotive Field Experience IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2950",
+              "title": "Automotive Field Experience V",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Bookkeeping, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/bookkeeping-certificate-proficiency/",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1030",
+              "title": "Payroll",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1520",
+              "title": "QuickBooks Immersion",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science with a Concentration in Biology — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/associate-of-science-concentration-biology/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1580",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebraand Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1500",
+              "title": "Principles of Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150H",
+              "title": "Honors Principles of Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1300",
+              "title": "General Chemistry Iand General Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "130H",
+              "title": "Honors General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1510",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1610",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "161H",
+              "title": "Honors Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1310",
+              "title": "General Chemistry IIand General Chemistry Laboratory II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131H",
+              "title": "Honors General Chemistry II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2300",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1020",
+              "title": "The Individual in Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "102H",
+              "title": "Honors Individual in Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2030",
+              "title": "Culture and Belief",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2050",
+              "title": "Bioethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1210",
+              "title": "College Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2310",
+              "title": "General Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Automation Maintenance Technician, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/automation-maintenance-technician-certificate-proficiency/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1410",
+              "title": "Applied Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1420",
+              "title": "Applied Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2250",
+              "title": "Robotics Operations Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2500",
+              "title": "Programmable Logic Controllers Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2240",
+              "title": "Applied National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1340",
+              "title": "Industrial Piping and Tubing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2210",
+              "title": "Commercial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2511",
+              "title": "Programmable Logic Controllers Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management (Human Resources Management), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-management-concentration-human-resources-management-aab/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1470",
+              "title": "Modern Mathematics for Business and Social Science I (Recommended for transfer)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting (Financial Accounting)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2060",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1210",
+              "title": "Labor-Management Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2330",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1460",
+              "title": "Workers' Compensation Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2110",
+              "title": "Production/Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2340",
+              "title": "Human Resources Law and Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2390",
+              "title": "Advanced Human Resources Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management (International Business), Associate of Applied Business — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-management-concentration-international-business-aab/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2601",
+              "title": "Global Commerce and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2780",
+              "title": "Global Marketing and Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1470",
+              "title": "Modern Mathematics for Business and Social Science I (Recommended for transfer)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2110",
+              "title": "Production/Operations Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2162",
+              "title": "Introduction to Supply Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2760",
+              "title": "Global Trade and Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2790",
+              "title": "International Business Strategy and Application",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1010",
+              "title": "World Regional Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, Associate of Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-aa/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1590",
+              "title": "Business Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1610",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1490",
+              "title": "Business Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management (Small Business Management), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-management-concentration-small-business-management-aab/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1470",
+              "title": "Modern Mathematics for Business and Social Science I (Recommended for transfer)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1700",
+              "title": "Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1520",
+              "title": "QuickBooks Immersion",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "1080",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2450",
+              "title": "New Business Development",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2060",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management (Supply Management), Associate of Applied Business — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-management-supply-management-aab/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2162",
+              "title": "Introduction to Supply Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics courses)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1470",
+              "title": "Modern Mathematics for Business and Social Science I (Recommended for transfer)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2110",
+              "title": "Production/Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2060",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2120",
+              "title": "Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2181",
+              "title": "Supply Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2240",
+              "title": "Negotiations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management (Supply Management), Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-management-supply-management-post-degree-certificate/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2120",
+              "title": "Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2162",
+              "title": "Introduction to Supply Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2110",
+              "title": "Production/Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2181",
+              "title": "Supply Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2240",
+              "title": "Negotiations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2601",
+              "title": "Global Commerce and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cancer Registrar, Post-Degree Professional Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/cancer-registrar-post-degree-professional-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Technology, Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-technology-aab/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1150",
+              "title": "Word for Business Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1700",
+              "title": "Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2040",
+              "title": "Emerging Workplace Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2211",
+              "title": "Presentation Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2300",
+              "title": "Business Database Systems (Access)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2411",
+              "title": "Workforce Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2700",
+              "title": "Advanced Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2710",
+              "title": "Microsoft Power BI for Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2990",
+              "title": "Business Technologies Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Captioning and Court Reporting, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/captioning-court-reporting-aab/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1360",
+              "title": "Court Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2200",
+              "title": "Medical Terminology for Captioning and Court Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1010",
+              "title": "Introduction to Humanities",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1331",
+              "title": "Realtime Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1335",
+              "title": "Realtime Theory III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1341",
+              "title": "Realtime Theory IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1451",
+              "title": "Speedbuilding and Transcription at 140 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2401",
+              "title": "Speedbuilding and Transcription at 180 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2361",
+              "title": "Proofreading Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1010",
+              "title": "Cultural Anthropology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2410",
+              "title": "Sociology of Gender",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (Or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2451",
+              "title": "Speedbuilding and Transcription at 225 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2470",
+              "title": "Advanced Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2841",
+              "title": "Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1470",
+              "title": "Transcript Production for Court Reporting and Captioning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Carpentry, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/carpentry-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1310",
+              "title": "Carpentry Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1320",
+              "title": "Introduction to Hand and Power Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1351",
+              "title": "Metal Studs and Dry Walls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1381",
+              "title": "Wood Framing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1331",
+              "title": "Concrete Footers and Walls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1370",
+              "title": "Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1390",
+              "title": "Welding for Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1491",
+              "title": "Residential Steel Framing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1610",
+              "title": "Interior Finish",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2361",
+              "title": "Suspended Ceilings",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2341",
+              "title": "Concrete Specialities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2370",
+              "title": "Interior Systems Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "2560",
+              "title": "Interior Systems III",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cement Masonry, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/cement-masonry-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCM",
+              "number": "1300",
+              "title": "Fundamentals of Concrete Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1321",
+              "title": "Introduction to Plan Reading",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1330",
+              "title": "Concrete Construction Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1341",
+              "title": "OSHA Standards for Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1401",
+              "title": "Concrete Forming and Finishing Basic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "1411",
+              "title": "Commercial and Residential Form and Finish",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2320",
+              "title": "Bluprint Fundamentals - Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2500",
+              "title": "Fundamentals of Concrete Curing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2510",
+              "title": "Fundamentals of Concrete Joints",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2521",
+              "title": "Basic Cement Patching",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2531",
+              "title": "Concrete Restoration",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCM",
+              "number": "2701",
+              "title": "Advanced Concrete Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Captioning and Court Reporting Certified Stenowriting, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/certified-stenowriting-certificate-proficiency/",
+      "total_credits": 44,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1001",
+              "title": "Introduction to Steno Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1101",
+              "title": "Introduction to Voice Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1200",
+              "title": "Voicewriting Iand Voicewriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1301",
+              "title": "Realtime Theory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1360",
+              "title": "Court Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1331",
+              "title": "Realtime Theory IIand Realtime Theory III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1220",
+              "title": "Voicewriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1401",
+              "title": "Speedbuilding and Transcription at 100 WPM",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1451",
+              "title": "Speedbuilding and Transcription at 140 WPM",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2361",
+              "title": "Proofreading Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1602",
+              "title": "Court Reporting Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2470",
+              "title": "Advanced Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2401",
+              "title": "Speedbuilding and Transcription at 180 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1470",
+              "title": "Transcript Production for Court Reporting and Captioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2451",
+              "title": "Speedbuilding and Transcription at 225 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2200",
+              "title": "Medical Terminology for Captioning and Court Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2841",
+              "title": "Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Captioning and Court Reporting Certified Voicewriting, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/certified-voicewriting-certificate-proficiency/",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1101",
+              "title": "Introduction to Voice Writing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1200",
+              "title": "Voicewriting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1210",
+              "title": "Voicewriting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1360",
+              "title": "Court Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1220",
+              "title": "Voicewriting III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1451",
+              "title": "Speedbuilding and Transcription at 140 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2401",
+              "title": "Speedbuilding and Transcription at 180 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2480",
+              "title": "Using Captioning Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2451",
+              "title": "Speedbuilding and Transcription at 225 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2361",
+              "title": "Proofreading Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1470",
+              "title": "Transcript Production for Court Reporting and Captioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2470",
+              "title": "Advanced Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2841",
+              "title": "Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemical Dependency, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/chemical-dependency-short-term-certificate/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HS",
+              "number": "1101",
+              "title": "Foundation of Substance Abuse, Addiction, and Group Work",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1300",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1850",
+              "title": "Introduction to Human Services Principles and Practices",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1200",
+              "title": "Treatment Modalities and Diversity Issues in Chemical Dependency",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2200",
+              "title": "Ethics in Chemical Dependency",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management, Associate of Applied Business — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/business-management-aab/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1470",
+              "title": "Modern Mathematics for Business and Social Science I (recommended for transfer)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1210",
+              "title": "Labor-Management Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2162",
+              "title": "Introduction to Supply Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2060",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2110",
+              "title": "Production/Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2330",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2501",
+              "title": "Business Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Child Care Administration, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/child-care-administration-short-term-certificate/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "1010",
+              "title": "Introduction to Early Childhood Education: Children's Development and Programs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1400",
+              "title": "Administration and Leadership in Early Childhood",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2300",
+              "title": "Child Behavior and Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2401",
+              "title": "Families, Communities, Schools",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cisco, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/cisco-short-term-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1303",
+              "title": "Cisco I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2303",
+              "title": "Cisco II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2313",
+              "title": "Cisco III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2370",
+              "title": "Network Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Classroom Assistant, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/classroom-assistant-short-term-certificate/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "1010",
+              "title": "Introduction to Early Childhood Education: Children's Development and Programs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1301",
+              "title": "Language and Literacy in an Integrated Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1340",
+              "title": "Creative Development in an Integrated Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1860",
+              "title": "Experience with Young Children in Early Childhood Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "1411",
+              "title": "Individuals with Exceptionalities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2601",
+              "title": "Classroom Assistant Professional Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Captioning and Court Reporting (Voice Writing), Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/captioning-court-reporting-concentration-voice-writing-aab/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1101",
+              "title": "Introduction to Voice Writing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1360",
+              "title": "Court Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1200",
+              "title": "Voicewriting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1210",
+              "title": "Voicewriting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1220",
+              "title": "Voicewriting III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1451",
+              "title": "Speedbuilding and Transcription at 140 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1010",
+              "title": "Introduction to Humanities",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2401",
+              "title": "Speedbuilding and Transcription at 180 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2451",
+              "title": "Speedbuilding and Transcription at 225 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2480",
+              "title": "Using Captioning Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2361",
+              "title": "Proofreading Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2470",
+              "title": "Advanced Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2841",
+              "title": "Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1470",
+              "title": "Transcript Production for Court Reporting and Captioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1010",
+              "title": "Cultural Anthropology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2410",
+              "title": "Sociology of Gender",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CNC Machining and Composites Manufacturing, Short-Term Certificate (Pre-Apprenticeship) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/cnc-machining-composites-manufacturing-short-term-certificate/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATMT",
+              "number": "1000",
+              "title": "Mechanical & Spatial Relations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1100",
+              "title": "Manufacturing Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1120",
+              "title": "Machine Operations I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1110",
+              "title": "Manufacturing Skills II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1200",
+              "title": "Machine Tool Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "1300",
+              "title": "Manufacturing Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMT",
+              "number": "2120",
+              "title": "Machine Operations II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Aided Design (CAD) for Professionals — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/computer-aided-design-cad/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZCAD",
+              "number": "1002",
+              "title": "AutoCAD for Professionals - 3D Basics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZCAD",
+              "number": "1011",
+              "title": "SolidWorks Level 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZCAD",
+              "number": "1015",
+              "title": "SolidWorks Level 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZCAD",
+              "number": "1039",
+              "title": "Revit Architecture Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZCAD",
+              "number": "1046",
+              "title": "AutoCAD for Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Integrated Manufacturing (CIM), Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/computer-integrated-manufacturing-cim-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1240",
+              "title": "Machine Tools and Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2140",
+              "title": "Manufacturing Automation and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2422",
+              "title": "Fundamentals of Engineering Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts in Computer Science — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/computer-science-aa/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEN",
+              "number": "1070",
+              "title": "First Year Success Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1051",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1610",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "161H",
+              "title": "Honors Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2651",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1620",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "162H",
+              "title": "Honors Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2660",
+              "title": "Data Structures & Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1300",
+              "title": "General Chemistry Iand General Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "130H",
+              "title": "Honors General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2310",
+              "title": "General Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2352",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2700",
+              "title": "Systems Analysis and Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2410",
+              "title": "Introduction to Linear Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Construction Engineering Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/construction-engineering-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra (or higher)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1411",
+              "title": "CAD Technology in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1210",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2201",
+              "title": "Introduction to Building Information Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2210",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2990",
+              "title": "Construction Estimating & Cost Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1601",
+              "title": "Technical Statics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2610",
+              "title": "Statics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2330",
+              "title": "Construction Scheduling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2631",
+              "title": "Construction Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2200",
+              "title": "Strength of Materials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2630",
+              "title": "Engineering Strength of Materials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Applied Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting ((See Recommended List Below))",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2422",
+              "title": "Fundamentals of Engineering Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1320",
+              "title": "Real Estate Appraisal (and)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1330",
+              "title": "Real Estate Finance",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Conflict Resolution and Peace Studies, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/conflict-resolution-peace-studies-short-term-certificate/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "2020",
+              "title": "Introduction to Conflict and Peace Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2041",
+              "title": "Conflict Resolution and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2140",
+              "title": "Implementing Peace Studies and Conflict Management Theories and Practices with Service Learning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Materials Testing, Short-Term Certificate — diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/construction-materials-testing-short-term-certificate/",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1660",
+              "title": "Material Testing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1670",
+              "title": "Highway Inspection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Aided Drafting (CAD), Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/computer-aided-drafting-cad-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1240",
+              "title": "Machine Tools and Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1300",
+              "title": "Engineering Materials and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2601",
+              "title": "3D Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Operations, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/construction-operations-short-term-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1411",
+              "title": "CAD Technology in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Project Management, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/construction-project-management-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1300",
+              "title": "Real Estate Principles & Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1411",
+              "title": "CAD Technology in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2990",
+              "title": "Construction Estimating & Cost Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra (or higher)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Applied Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2422",
+              "title": "Fundamentals of Engineering Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1320",
+              "title": "Real Estate Appraisal",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1330",
+              "title": "Real Estate Finance",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Tending and Hazardous Material Abatement, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/construction-tending-hazardous-material-abatement-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATLB",
+              "number": "1010",
+              "title": "Craft Orientation for Laborers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "1020",
+              "title": "Measurements and Leveling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "1210",
+              "title": "Concrete Placement",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "1340",
+              "title": "Mason Tending",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "2650",
+              "title": "Demolition Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "2110",
+              "title": "Small Engines & Concrete Saws",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATLB",
+              "number": "2120",
+              "title": "Pneumatic Tools",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Corporate College Leadership Certificate Program (Professional Development) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/corporate-college-leadership-development/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLDR",
+              "number": "8946",
+              "title": "Effective Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8947",
+              "title": "Strengths-Based Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8948",
+              "title": "Decision-Making & Bias",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8949",
+              "title": "Coaching & Performance Enablement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8950",
+              "title": "Time Management & Prioritization",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8951",
+              "title": "Conflict Resolution",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8952",
+              "title": "Adaptability & Change Enablement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8967",
+              "title": "Workplace Culture",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLDR",
+              "number": "8945",
+              "title": "Accelerated Leadership Certificate",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Court Reporting Technologies, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/court-reporting-technologies-short-term-certificate/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1101",
+              "title": "Introduction to Voice Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1001",
+              "title": "Introduction to Steno Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1200",
+              "title": "Voicewriting Iand Voicewriting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1301",
+              "title": "Realtime Theory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1331",
+              "title": "Realtime Theory IIand Realtime Theory III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1220",
+              "title": "Voicewriting III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1401",
+              "title": "Speedbuilding and Transcription at 100 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2200",
+              "title": "Medical Terminology for Captioning and Court Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1451",
+              "title": "Speedbuilding and Transcription at 140 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1602",
+              "title": "Court Reporting Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CPA Prep-Business Component, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/cpa-prep-business-component-post-degree-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communicationsor Honors Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2100",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Creative Art Therapy Facilitator, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/creative-art-therapy-facilitator-certificate-proficiency/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1600",
+              "title": "Introduction to Art Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1610",
+              "title": "Art Therapy II: Methods and Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2300",
+              "title": "Art Therapy III: Approaches and Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2020",
+              "title": "Life Span Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2050",
+              "title": "Painting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1700",
+              "title": "Ceramics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2310",
+              "title": "Art Therapy Studio: Basic Therapeutic Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2081",
+              "title": "Psychopathology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Criminal Justice, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/criminal-justice-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1000",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1120",
+              "title": "Criminal Court Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1130",
+              "title": "Criminal Evidence",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1320",
+              "title": "Ethics in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1111",
+              "title": "Constitutional Law for Police",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1330",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2300",
+              "title": "Juvenile Delinquency",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2390",
+              "title": "The Investigative Process",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "1010",
+              "title": "Introduction to Urban Studies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1010",
+              "title": "Computers in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2360",
+              "title": "Community Oriented Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2990",
+              "title": "Issues in Supervision",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice: Basic Police Academy, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/criminal-justice-basic-police-academy-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1380",
+              "title": "Police Academy I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1390",
+              "title": "Police Academy II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2280",
+              "title": "Police Academy III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2290",
+              "title": "Police Academy IV",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1111",
+              "title": "Constitutional Law for Police",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1120",
+              "title": "Criminal Court Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1130",
+              "title": "Criminal Evidence",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice (Corrections), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/criminal-justice-concentration-corrections-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1070",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1000",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1120",
+              "title": "Criminal Court Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1130",
+              "title": "Criminal Evidence",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1320",
+              "title": "Ethics in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1010",
+              "title": "Computers in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1500",
+              "title": "Community Intervention Resources",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "1010",
+              "title": "Introduction to Urban Studies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2300",
+              "title": "Juvenile Delinquency",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2510",
+              "title": "Community Supervision and Aftercare",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2530",
+              "title": "Correctional Case Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2840",
+              "title": "Corrections: Principles and Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2990",
+              "title": "Issues in Supervision",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice (Basic Police Academy), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/criminal-justice-concentration-basic-police-academy-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1000",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1120",
+              "title": "Criminal Court Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1130",
+              "title": "Criminal Evidence",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1111",
+              "title": "Constitutional Law for Police",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2360",
+              "title": "Community Oriented Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1320",
+              "title": "Ethics in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2300",
+              "title": "Juvenile Delinquency",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "1010",
+              "title": "Introduction to Urban Studies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1380",
+              "title": "Police Academy I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1390",
+              "title": "Police Academy II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2280",
+              "title": "Police Academy III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2290",
+              "title": "Police Academy IV",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2990",
+              "title": "Issues in Supervision",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinarian/Cook, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/culinarian-cook-short-term-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1552",
+              "title": "Introduction to Baking & Pastries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1451",
+              "title": "Contemporary Cuisine",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice (Security Administration), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/criminal-justice-concentration-security-administration-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1000",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1050",
+              "title": "Introduction to Security",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1120",
+              "title": "Criminal Court Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1320",
+              "title": "Ethics in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1010",
+              "title": "Computers in Criminal Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1400",
+              "title": "Assets Protection",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "1010",
+              "title": "Introduction to Urban Studies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2400",
+              "title": "Security Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2410",
+              "title": "Security Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2420",
+              "title": "Legal Aspects of Private Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2440",
+              "title": "Protection Services",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2990",
+              "title": "Issues in Supervision",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Data Analytics, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/data-analytics-post-degree-professional-certificate/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1051",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1490",
+              "title": "Business Probability and Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2070",
+              "title": "Introduction to Data Science and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2352",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2081",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2091",
+              "title": "Data Analytics Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/dental-hygiene-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Biological Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography (Abdomen Extended and Obstetrics Gynecology Sonography), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/diagnostic-medical-sonography-concentration-abdomen-extended-and-obstetrics-gynecology-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1071",
+              "title": "Concepts of Physics in Diagnostic Sonography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1303",
+              "title": "Introduction to Sonography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1320",
+              "title": "Introduction to Sonographic Scanning",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1351",
+              "title": "Patient Care Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/cybersecurity-post-degree-professional-certificate/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2320",
+              "title": "Network Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2370",
+              "title": "Network Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2380",
+              "title": "Linux Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1303",
+              "title": "Cisco I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2303",
+              "title": "Cisco II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2313",
+              "title": "Cisco III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2710",
+              "title": "Advanced Topics in Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2750",
+              "title": "Scripting Fundamentals for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2730",
+              "title": "Intrusion Detection/Prevention Systems Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2720",
+              "title": "Ethical Hacking and Systems Defense",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Diagnostic Medical Sonography, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/diagnostic-medical-sonography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1071",
+              "title": "Concepts of Physics in Diagnostic Sonography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1303",
+              "title": "Introduction to Sonography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1320",
+              "title": "Introduction to Sonographic Scanning",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1351",
+              "title": "Patient Care Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dietary Management, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/dietary-management-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "1200",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "1310",
+              "title": "Introduction to Dietetics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "1320",
+              "title": "Nutrition Applications",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "2301",
+              "title": "Medical Nutrition Therapy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "1940",
+              "title": "Dietary Managers Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Hospitality Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Digital Design & Product Innovation, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/digital-design-product-innovation-short-term-certificate/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1250",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1261",
+              "title": "Product Ideation & Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1270",
+              "title": "Additive Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2601",
+              "title": "3D Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Manufacturing and Product Launch, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/digital-manufacturing-product-launch-short-term-certificate/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "1300",
+              "title": "Engineering Materials and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2151",
+              "title": "3D Digital Design & Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2160",
+              "title": "3D Scanning, Reverse Engineering, and Quality Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2941",
+              "title": "Additive Manufacturing Internship",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2990",
+              "title": "Product Development and Manufacture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Marketing: Online Certificates — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/digital-marketing-manager-professional-certificate-online/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZPDI",
+              "number": "1678",
+              "title": "Advanced AI For Digital Marketing (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1675",
+              "title": "AI for Business and Marketing (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1677",
+              "title": "Social Media Strategy With AI (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0514",
+              "title": "Certified Digital Marketing Associate Essentials (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0502",
+              "title": "Certified Digital Marketing Professional (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0503",
+              "title": "Certified Digital Marketing Specialist in Search Marketing (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0504",
+              "title": "Certified Digital Marketing Specialist in Social Media (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0505",
+              "title": "Certified Digital Marketing Specialist in Digital Strategy and Planning (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Digital Reporting and Transcription, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/digital-reporting-and-transcription-short-term-certificate/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1150",
+              "title": "Introduction to Digital Reporting and Transcription",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1551",
+              "title": "Research and Transcript Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2361",
+              "title": "Proofreading Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1470",
+              "title": "Transcript Production for Court Reporting and Captioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2741",
+              "title": "Digital Reporting Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2751",
+              "title": "Annotation for Digital Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drywall Finishing, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/drywall-finishing-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATDW",
+              "number": "1310",
+              "title": "Tools and Methods of Drywall Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "1330",
+              "title": "Materials and Methods of Drywall Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "1620",
+              "title": "Taping Tools & Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1300",
+              "title": "Introduction to Painting, Drywall Finishing, and Glazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1320",
+              "title": "Safety Standards for Construction (OSHA-10)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1340",
+              "title": "Wall Preparation and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "2310",
+              "title": "Automatic Taping Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "2330",
+              "title": "Finishing Boxes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "2350",
+              "title": "Filling Compounds/Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1650",
+              "title": "Blueprints I: Construction Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1660",
+              "title": "Labor in American Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2320",
+              "title": "Safe Work Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATDW",
+              "number": "2340",
+              "title": "Texturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2340",
+              "title": "Bluepints II: Advanced Reading and Estimating",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2360",
+              "title": "Foreman Training",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical/Electronic Engineering Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electrical-electronic-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1161",
+              "title": "Direct Current Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1180",
+              "title": "Surface Mount Soldering",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1190",
+              "title": "Printed Circuit Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1210",
+              "title": "AC Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1241",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153H",
+              "title": "Honors College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2112",
+              "title": "Industrial Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2120",
+              "title": "Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2242",
+              "title": "C and ASM Programming with Embedded Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1210",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "154H",
+              "title": "Honors Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2170",
+              "title": "Signal Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2220",
+              "title": "Electronics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2290",
+              "title": "Electrical Design Project",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2500",
+              "title": "Instrumentation and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2520",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1220",
+              "title": "College Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical/Electronic Engineering Technology (Bio-Medical), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electrical-electronic-engineering-technology-concentration-bio-medical-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1161",
+              "title": "Direct Current Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1180",
+              "title": "Surface Mount Soldering",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1050",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105L",
+              "title": "Human Biology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1210",
+              "title": "AC Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1241",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153H",
+              "title": "Honors College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2112",
+              "title": "Industrial Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2120",
+              "title": "Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2170",
+              "title": "Signal Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2400",
+              "title": "Biomedical Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "154H",
+              "title": "Honors Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2220",
+              "title": "Electronics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2410",
+              "title": "Biomedical Instrumentation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2490",
+              "title": "Biomedical Design Project",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1210",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2901",
+              "title": "Clinical Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Early Childhood Education, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/early-childhood-education-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "1010",
+              "title": "Introduction to Early Childhood Education: Children's Development and Programs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1050",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105L",
+              "title": "Human Biology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1301",
+              "title": "Language and Literacy in an Integrated Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "1011",
+              "title": "Introduction to Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1340",
+              "title": "Creative Development in an Integrated Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1020",
+              "title": "Introduction to Infant and Toddler Development, Care and Relationships",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "2050",
+              "title": "Human Diversity in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1321",
+              "title": "Math and Science Inquiry in an Integrated Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "1411",
+              "title": "Individuals with Exceptionalities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1860",
+              "title": "Experience with Young Children in Early Childhood Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2200",
+              "title": "Play's Place in an Integrated Early Childhood Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2300",
+              "title": "Child Behavior and Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2401",
+              "title": "Families, Communities, Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2870",
+              "title": "Early Childhood Education Student Teaching Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2990",
+              "title": "Early Childhood Education Student Teaching Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2110",
+              "title": "Educational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical/Electronic Engineering Technology with a concentration in Digital Communications — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electrical-electronic-engineering-technology-concentration-digital-communications-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1161",
+              "title": "Direct Current Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1180",
+              "title": "Surface Mount Soldering",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1190",
+              "title": "Printed Circuit Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1210",
+              "title": "AC Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1241",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1210",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153H",
+              "title": "Honors College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2120",
+              "title": "Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2131",
+              "title": "Digital Communication Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2170",
+              "title": "Signal Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2242",
+              "title": "C and ASM Programming with Embedded Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "154H",
+              "title": "Honors Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2220",
+              "title": "Electronics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2231",
+              "title": "Wired and Wireless Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2591",
+              "title": "Communications Design Project",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1220",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical/Electronic Engineering Technology (Computer Networking Hardware), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electrical-electronic-engineering-technology-concentration-computer-networking-hardware-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1015",
+              "title": "Introduction to Computer Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1035",
+              "title": "Operating Systems and Software for PC Technicians",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1055",
+              "title": "Computer Hardware Support",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2320",
+              "title": "Network Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1303",
+              "title": "Cisco I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2303",
+              "title": "Cisco II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2313",
+              "title": "Cisco III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2990",
+              "title": "Networking Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2370",
+              "title": "Network Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electroneurodiagnostic Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electroneurodiagnostic-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electroneurodiagnostic Technology (Polysomnography), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electroneurodiagnostic-technology-concentration-polysomnography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Engineering Technology, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/electronic-engineering-technician-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1161",
+              "title": "Direct Current Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1180",
+              "title": "Surface Mount Soldering",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1190",
+              "title": "Printed Circuit Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1210",
+              "title": "AC Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1241",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153H",
+              "title": "Honors College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Emergency Medical Technician-Basic, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/emergency-medical-technician-basic-short-term-certificate/",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "1303",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "1401",
+              "title": "Anatomy & Physiology for Paramedics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/emergency-medical-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "1303",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "1010",
+              "title": "Introduction to Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2330",
+              "title": "Paramedic Theory I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2350",
+              "title": "Paramedic Theory III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2340",
+              "title": "Paramedic Theory II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2360",
+              "title": "Paramedic Theory IV",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2020",
+              "title": "Life Span Development",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "202H",
+              "title": "Honors Life Span Development",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2371",
+              "title": "Paramedic Capstone Course",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Enrolled Agent — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/enrolled-agent/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZFIN",
+              "number": "1080",
+              "title": "Enrolled Agent Intensive Exam Prep Boot Camp",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurial Technology, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/entreprenurial-technology-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1150",
+              "title": "Word for Business Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1700",
+              "title": "Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2040",
+              "title": "Emerging Workplace Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2510",
+              "title": "Project Management Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2700",
+              "title": "Advanced Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2300",
+              "title": "Business Database Systems (Access)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2710",
+              "title": "Microsoft Power BI for Data Analysis",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Event Planning, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/event-planning-short-term-certificate/",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1180",
+              "title": "Event Planning Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2180",
+              "title": "Event Planning Workshop",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2380",
+              "title": "Hospitality Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Experienced Project Manager Certificate — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/experienced-project-manager/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLDR",
+              "number": "8947",
+              "title": "Strengths-Based Leadership",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1127",
+              "title": "Certified ScrumMaster (CSM)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1148",
+              "title": "PMI Exam Prep: Project Management Professional (PMP)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1032",
+              "title": "Lean Six Sigma: Yellow Belt",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1033",
+              "title": "Lean Six Sigma: Yellow Belt to Green Belt",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1126",
+              "title": "PMI Agile Certification Exam Prep (PMI-ACP)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film and Media Arts, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/film-and-media-arts-aab/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "1020",
+              "title": "Story: Pre-production Methods and the Art of Story in Motion Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "1040",
+              "title": "Imaging Basics for Film and Media Arts: On Location and in Studio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "1180",
+              "title": "Introduction to Film and Media Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1100",
+              "title": "Sound Recording and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "1120",
+              "title": "Film and Media Arts Colloquium",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2110",
+              "title": "Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2180",
+              "title": "Digital Cinematography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2480",
+              "title": "Motion Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MJS",
+              "number": "1310",
+              "title": "Film Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2280",
+              "title": "Short Films: Exploring Genre & Technique",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2620",
+              "title": "Applied Integrated Media (AIM) I: Real World Pre-production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1081",
+              "title": "2D Design and Color",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1430",
+              "title": "Introduction to Scenery and Stagecrafts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2380",
+              "title": "Visual Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2720",
+              "title": "Applied Integrated Media (AIM) II: Real World Production and Post-Production for Motion Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2990",
+              "title": "Film and Media Arts Professional Prep and Portfolio Review",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2940",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Film and Media Arts (Editing), Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/film-and-media-arts-editing-short-term-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "1180",
+              "title": "Introduction to Film and Media Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "1040",
+              "title": "Imaging Basics for Film and Media Arts: On Location and in Studio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2480",
+              "title": "Motion Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2110",
+              "title": "Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2120",
+              "title": "Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2940",
+              "title": "Field Experience",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2380",
+              "title": "Visual Effects",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2720",
+              "title": "Applied Integrated Media (AIM) II: Real World Production and Post-Production for Motion Media",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2780",
+              "title": "Motion Graphics II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film and Media Arts (Motion Graphics), Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/film-and-media-arts-motion-graphics-short-term-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1081",
+              "title": "2D Design and Color",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "1180",
+              "title": "Introduction to Film and Media Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "1040",
+              "title": "Imaging Basics for Film and Media Arts: On Location and in Studio",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2380",
+              "title": "Visual Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2480",
+              "title": "Motion Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2780",
+              "title": "Motion Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire - Emergency Medical Services, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/fire-emergency-medical-services-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "2330",
+              "title": "Paramedic Theory I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2350",
+              "title": "Paramedic Theory III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2340",
+              "title": "Paramedic Theory II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2360",
+              "title": "Paramedic Theory IV",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2371",
+              "title": "Paramedic Capstone Course",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fitness Specialist, Certificate of Proficiency — diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/fitness-specialist-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SES",
+              "number": "1001",
+              "title": "Introduction to Sport and Exercise Studies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "1040",
+              "title": "Teaching Exercise Training Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "2000",
+              "title": "Essentials of Sports Injury Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "2010",
+              "title": "Exercise and Movement Anatomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1100",
+              "title": "Personal Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1320",
+              "title": "CPR-AED for Healthcare Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "1020",
+              "title": "Weight Training",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "1000",
+              "title": "Personal Fitness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "1010",
+              "title": "Personal Strength Development",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "2300",
+              "title": "Personal Training Certification Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "2310",
+              "title": "Advanced Training Concepts and Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "1300",
+              "title": "Fitness and Wellness Coaching",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SES",
+              "number": "2500",
+              "title": "Health and Wellness Coach Certification Prep",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Floorlaying, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/floorlaying-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1450",
+              "title": "Floorlaying Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1630",
+              "title": "Wood Flooring I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1640",
+              "title": "Sheet Goods Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1300",
+              "title": "Residential Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1600",
+              "title": "Modular Tile",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1610",
+              "title": "Jute & Action Back Carpeting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1620",
+              "title": "Ceramics I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1650",
+              "title": "Sheet Goods - Flash Coving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1720",
+              "title": "Geometric Layout and Inlay",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "1730",
+              "title": "Unitary Back and Enhancer Back Carpeting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "2300",
+              "title": "Ceramics II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATFL",
+              "number": "2400",
+              "title": "Sheet Goods-Specialty Products",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Design, Short-Term Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/game-design-short-term-certificate/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "1640",
+              "title": "3D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1200",
+              "title": "Game Design I: Introduction to Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1400",
+              "title": "Game Design II: Game Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2040",
+              "title": "3D Motion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2271",
+              "title": "2D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2200",
+              "title": "Game Design III: Game Design Studio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2401",
+              "title": "Game Design IV-Game Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food and Beverage Operations, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/food-beverage-operations-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1360",
+              "title": "Fundamentals of Restaurant/Food Service Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1650",
+              "title": "Dining Room Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1680",
+              "title": "Beverage Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1950",
+              "title": "Restaurant/Food Service Management Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2360",
+              "title": "Restaurant Marketing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2371",
+              "title": "Restaurant/Foodservice Entrepreneurship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Garden Center, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/garden-center-short-term-certificate/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PST",
+              "number": "1301",
+              "title": "Horticultural Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1331",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1400",
+              "title": "Garden Center and Nursery Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1351",
+              "title": "Plant Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2321",
+              "title": "Plant Pest Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Glazing, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/glazing-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATGL",
+              "number": "1330",
+              "title": "Hand Tools for Glaziers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "1620",
+              "title": "Glass and Mirror Replacement and Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "1630",
+              "title": "Basic Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1300",
+              "title": "Introduction to Painting, Drywall Finishing, and Glazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1320",
+              "title": "Safety Standards for Construction (OSHA-10)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "1640",
+              "title": "Door Fabrication and Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2330",
+              "title": "Transits, Leveling Instruments, and Lasers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2350",
+              "title": "Curtainwall Fabric & Install",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1650",
+              "title": "Blueprints I: Construction Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2320",
+              "title": "Safe Work Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2340",
+              "title": "Advanced Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1640",
+              "title": "Rigging & Hoisting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Unit Coordinator, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/health-unit-coordinator-short-term-certificate/",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1060",
+              "title": "Health Unit Coordinator",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "2060",
+              "title": "Medical Terminology II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Management Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/health-information-management-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1301",
+              "title": "Introduction to Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1311",
+              "title": "Legal Aspects of Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1401",
+              "title": "Systems in Healthcare Delivery",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1610",
+              "title": "Introduction to Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2600",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1424",
+              "title": "Health Informatics and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1432",
+              "title": "Computer Systems in Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2161",
+              "title": "Coding with ICD-10-CM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2131",
+              "title": "Coding with CPT (Current Procedural Terminology)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2410",
+              "title": "Management Practices in Health Information",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2201",
+              "title": "Project Management for the Health Information Management Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2261",
+              "title": "Coding with ICD-10-PCS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2320",
+              "title": "Quality Improvement & Statistics in Healthcare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2401",
+              "title": "Intermediate Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2430",
+              "title": "Medical Reimbursement Methodologies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2910",
+              "title": "HIM Professional Practice Experiential Learning",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2990",
+              "title": "HIM Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management (Hotel, Destination & Event Management), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/hospitality-management-concentration-hotel-destination-event-management-aab/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1050",
+              "title": "Fundamentals of Food Preparation for Hotel-Lodging",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Applied Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1580",
+              "title": "Front Office Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1482",
+              "title": "Housekeeping Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1180",
+              "title": "Event Planning Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1960",
+              "title": "Lodging/Tourism Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1380",
+              "title": "Dimensions of Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2480",
+              "title": "Hospitality Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2380",
+              "title": "Hospitality Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Hospitality Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2580",
+              "title": "Convention Management and Meeting Planning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2862",
+              "title": "Lodging and Tourism Management Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management (Culinary Art), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/hospitality-management-concentration-culinary-art-aab/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1552",
+              "title": "Introduction to Baking & Pastries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "1200",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1451",
+              "title": "Contemporary Cuisine",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1940",
+              "title": "Culinary Arts/Professional Baking Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1650",
+              "title": "Dining Room Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2330",
+              "title": "Menus and Facilities Planning & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2350",
+              "title": "Restaurant Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Hospitality Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2560",
+              "title": "Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2651",
+              "title": "Banquet Management and Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2992",
+              "title": "Culinary Evaluation and American Regional Cuisine",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management (Restaurant/Food Service Management), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/hospitality-management-concentration-restaurant-food-service-management-aab/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1360",
+              "title": "Fundamentals of Restaurant/Food Service Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1552",
+              "title": "Introduction to Baking & Pastries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1451",
+              "title": "Contemporary Cuisine",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1680",
+              "title": "Beverage Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1950",
+              "title": "Restaurant/Food Service Management Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1650",
+              "title": "Dining Room Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2350",
+              "title": "Restaurant Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2371",
+              "title": "Restaurant/Foodservice Entrepreneurship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Hospitality Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2360",
+              "title": "Restaurant Marketing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2871",
+              "title": "Food and Beverage Management Experience",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Home Inspector Licensure — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/home-inspector-licensure/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZPDI",
+              "number": "1544",
+              "title": "Ohio Home Inspector License: Expert Package",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resources Management, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/human-resources-management-certificate-of-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1210",
+              "title": "Labor-Management Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2330",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1460",
+              "title": "Workers' Compensation Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2340",
+              "title": "Human Resources Law and Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2390",
+              "title": "Advanced Human Resources Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2060",
+              "title": "Business Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Human Services, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/human-services-aas/",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HS",
+              "number": "1101",
+              "title": "Foundation of Substance Abuse, Addiction, and Group Work",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1300",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1850",
+              "title": "Introduction to Human Services Principles and Practices",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1120",
+              "title": "Suicide Prevention & Intervention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1200",
+              "title": "Treatment Modalities and Diversity Issues in Chemical Dependencyand Prevention and Chemical Dependency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1220",
+              "title": "Diagnostic Tools and Legal Considerations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2600",
+              "title": "Systems Approach to Case Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2850",
+              "title": "Human Services Principles and Practices I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2200",
+              "title": "Ethics in Chemical Dependency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1110",
+              "title": "Crisis Intervention and Child Abuse Issuesand Family Theory and Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1050",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105L",
+              "title": "Human Biology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2860",
+              "title": "Human Services Principles and Practices II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2990",
+              "title": "Human Services Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (Recommended for Transfer)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2020",
+              "title": "Life Span Development",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "202H",
+              "title": "Honors Life Span Development",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Humanities and Leadership, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/humanities-and-leadership-certificate-proficiency/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1020",
+              "title": "The Individual in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2020",
+              "title": "Community Engagement Through the Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UST",
+              "number": "1120",
+              "title": "History of Clevelandor Introduction to Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "IATF 16949:2016 Understanding and Internal Quality Auditing — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/iatf-16949-2016-understanding-and-internal-quality-auditing/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZISO",
+              "number": "1801",
+              "title": "IATF 16949:2016 Understanding and Internal Quality Auditing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technician, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/industrial-maintenance-certificate-proficiency/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1410",
+              "title": "Applied Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1450",
+              "title": "Heating Ventilation Air Conditioning/Refrigeration I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1420",
+              "title": "Applied Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2450",
+              "title": "Heating Ventilation Air Conditioning/Refrigeration II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2500",
+              "title": "Programmable Logic Controllers Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2240",
+              "title": "Applied National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1460",
+              "title": "Fundamental Boiler Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1340",
+              "title": "Industrial Piping and Tubing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2210",
+              "title": "Commercial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2460",
+              "title": "Applied Boiler Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/industrial-maintenance-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1410",
+              "title": "Applied Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1420",
+              "title": "Applied Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2240",
+              "title": "Applied National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2210",
+              "title": "Commercial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1340",
+              "title": "Industrial Piping and Tubing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1450",
+              "title": "Heating Ventilation Air Conditioning/Refrigeration I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1460",
+              "title": "Fundamental Boiler Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2450",
+              "title": "Heating Ventilation Air Conditioning/Refrigeration II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2460",
+              "title": "Applied Boiler Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2500",
+              "title": "Programmable Logic Controllers Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2990",
+              "title": "Reliability Centered Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Welding, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/industrial-welding-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1101",
+              "title": "Welding Blue Print Reading (1st 8 Weeks)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1110",
+              "title": "Oxyfuel Processes/Plasma Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2100",
+              "title": "Gas Metal Arc Welding (MIG) (2nd 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety (1st 8 Weeks)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2120",
+              "title": "Shielded Metal Arc Welding (STICK) (1st 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2110",
+              "title": "Gas Tungsten Arc Welding (TIG) (2nd 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2170",
+              "title": "Flux-Cored Arc Welding (FCAW) (1st 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2151",
+              "title": "Robotic Welding (2nd 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2140",
+              "title": "Non-Destructive Testing (1st 8 Weeks)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2160",
+              "title": "Structural Fabrication (2nd 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1300",
+              "title": "Engineering Materials and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Industrial Welding, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/industrial-welding-certificate-proficiency/",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1101",
+              "title": "Welding Blue Print Reading (First 8 week session)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2120",
+              "title": "Shielded Metal Arc Welding (STICK) (First 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1110",
+              "title": "Oxyfuel Processes/Plasma Processes (First 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2100",
+              "title": "Gas Metal Arc Welding (MIG) (Second 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2110",
+              "title": "Gas Tungsten Arc Welding (TIG) (Second 8 week Session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety (First 8 week session)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2170",
+              "title": "Flux-Cored Arc Welding (FCAW) (First 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2140",
+              "title": "Non-Destructive Testing (First 8 week session)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2160",
+              "title": "Structural Fabrication (Second 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2151",
+              "title": "Robotic Welding (2nd 8 Weeks)",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Information Technology - Business Solutions, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-business-solutions-aab/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2070",
+              "title": "Introduction to Data Science and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2700",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2600",
+              "title": "E-Business Programming Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology-Business Solutions, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-business-solutions-post-degree-professional-solutions/",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2680",
+              "title": "Visual C# .NET",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2070",
+              "title": "Introduction to Data Science and Analytics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2600",
+              "title": "E-Business Programming Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2700",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology - Cybersecurity, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-cybersecurity-aab/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1051",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2740",
+              "title": "Fundamentals of Client Operating Systems and Hardware for Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1070",
+              "title": "Introduction to Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2320",
+              "title": "Network Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2370",
+              "title": "Network Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2380",
+              "title": "Linux Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1303",
+              "title": "Cisco I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2303",
+              "title": "Cisco II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2750",
+              "title": "Scripting Fundamentals for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2710",
+              "title": "Advanced Topics in Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology - Programming and Development, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-programming-development-aab/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1051",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2651",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2700",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2321",
+              "title": "Interactive Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2352",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2660",
+              "title": "Data Structures & Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2031",
+              "title": "Server-Side Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology - Network Administration, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-network-administration-aab/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2740",
+              "title": "Fundamentals of Client Operating Systems and Hardware for Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2320",
+              "title": "Network Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2750",
+              "title": "Scripting Fundamentals for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1303",
+              "title": "Cisco I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2303",
+              "title": "Cisco II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2370",
+              "title": "Network Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2313",
+              "title": "Cisco III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1051",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2380",
+              "title": "Linux Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2420",
+              "title": "Network Administration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2990",
+              "title": "Networking Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology–Programming and Development (Quality Assurance), Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-programming-development-concentration-quality-assurance-aab/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1200",
+              "title": "Introduction to Software Quality Assurance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2200",
+              "title": "Software Quality Assurance Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2500",
+              "title": "Software Testing Automation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology-Programming and Development, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/information-technology-programming-development-post-degree-professional-certificate/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1026",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1051",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2321",
+              "title": "Interactive Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2352",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2651",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2031",
+              "title": "Server-Side Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2660",
+              "title": "Data Structures & Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2700",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Insulating Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/insulating-cert-proficiency/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATIN",
+              "number": "1010",
+              "title": "Applied Insulators Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "1020",
+              "title": "Fundamental Insulation I - Insulation Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "1030",
+              "title": "Fundamental Insulation II - Fiberglass Insulation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2000",
+              "title": "Vapor Barriers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2020",
+              "title": "Fundamental Insulation III - Mechanical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2110",
+              "title": "Advanced Metal Jacketing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2130",
+              "title": "Fundamental Insulation IV - Tanks and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2200",
+              "title": "Blueprints and Specifications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2790",
+              "title": "Effective Supervision and Journeyman Certification",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Insulating Technology, Associate of Applied Science  (Apprenticeship program) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/insulating-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "1010",
+              "title": "Applied Insulators Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "1020",
+              "title": "Fundamental Insulation I - Insulation Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "1030",
+              "title": "Fundamental Insulation II - Fiberglass Insulation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2000",
+              "title": "Vapor Barriers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2020",
+              "title": "Fundamental Insulation III - Mechanical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2110",
+              "title": "Advanced Metal Jacketing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2130",
+              "title": "Fundamental Insulation IV - Tanks and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2200",
+              "title": "Blueprints and Specifications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIN",
+              "number": "2790",
+              "title": "Effective Supervision and Journeyman Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interior Design, Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/interior-design-aab/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTD",
+              "number": "1101",
+              "title": "Hand Drafting and Sketching for Interiors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1111",
+              "title": "Introduction to Interior Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2020",
+              "title": "Art History Survey: Prehistoric to Renaissance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2030",
+              "title": "Art History Survey: Late Renaissance to Present",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1120",
+              "title": "Architectural Drafting for Interiors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2320",
+              "title": "History of Interiors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2330",
+              "title": "Interior Design Materials and Sources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2430",
+              "title": "Architectural Materials and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1130",
+              "title": "Architectural Drafting for Interiors II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2300",
+              "title": "Interior Design Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2380",
+              "title": "Fundamentals of Lighting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1140",
+              "title": "Digital Presentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1150",
+              "title": "Color and Textile Studio",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1081",
+              "title": "2D Design and Color",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2400",
+              "title": "Interior Design Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2460",
+              "title": "Interior Design Presentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2471",
+              "title": "Professional Practice of Interior Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2851",
+              "title": "Interior Design Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Introductory Welding, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/introductory-welding-short-term-certificate/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1101",
+              "title": "Welding Blue Print Reading (1st 8 Weeks)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1110",
+              "title": "Oxyfuel Processes/Plasma Processes (FIrst 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2120",
+              "title": "Shielded Metal Arc Welding (STICK) (FIrst 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2100",
+              "title": "Gas Metal Arc Welding (MIG) (Second 8 Week Session)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2110",
+              "title": "Gas Tungsten Arc Welding (TIG) (Second 8 week session)",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Ironworking, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/ironworking-certificate-proficiency/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATIW",
+              "number": "1300",
+              "title": "Structural Steel Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1310",
+              "title": "Safety for Ironworkers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1320",
+              "title": "Steel Construction Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1330",
+              "title": "Erection Concepts & Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1400",
+              "title": "Principle of Reinforcing Steel",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1410",
+              "title": "Practical Applications of Reinforcing Steel",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "1600",
+              "title": "Welding Fundamentals for Ironworkers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2300",
+              "title": "Shielded Metal Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2310",
+              "title": "Welding Specialties",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2320",
+              "title": "Welding Blueprints and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2330",
+              "title": "Pre-Construction Planning of Specialty Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2340",
+              "title": "Specialty Installation Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2350",
+              "title": "Ornamental Systems & Railings",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2360",
+              "title": "Ornamental Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATIW",
+              "number": "2500",
+              "title": "Rigging and Hoisting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bachelor of Applied Science in Integrated Digital Manufacturing Engineering Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/integrated-digital-manufacturing-engineering-technology-bas/",
+      "total_credits": 124,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 124,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1220",
+              "title": "Circuits and Electronics for Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1640",
+              "title": "Robotics and Programmable Logic Controllers in Process Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1020",
+              "title": "The Individual in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1340",
+              "title": "Introduction to Industry 4.0 and Vision Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2601",
+              "title": "3D Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1600",
+              "title": "Industrial Routers, Switches, and Operating Systems for Smart Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1620",
+              "title": "Industrial Protocols and Machine Connectivity for Smart Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2450",
+              "title": "Robotics and Automation in Smart Manufacturing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2460",
+              "title": "Applied Programmable Logic Controllers and Mechatronic Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1010",
+              "title": "Introduction to Inorganic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "3830",
+              "title": "Smart Manufacturing Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "3100",
+              "title": "Electrical and Mechanical Systems for Smart Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "3100",
+              "title": "Applied Smart Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "3100",
+              "title": "Manufacturing Network Devices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "3200",
+              "title": "Industrial IoT Fundamentals and Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "3210",
+              "title": "CyberOps for Manufacturing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "202H",
+              "title": "Honors Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "3840",
+              "title": "Smart Manufacturing Internship II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "4200",
+              "title": "Cloud Security for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "3300",
+              "title": "Applications Programming for Smart Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "3310",
+              "title": "Industrial Software Applications Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "4100",
+              "title": "Network Security for Manufacturing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "4210",
+              "title": "Smart Manufacturing ERP Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "4990",
+              "title": "Integrated Digital Manufacturing Project",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "4210",
+              "title": "Big Data Analytics for Smart Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "IT Support Professional, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/it-support-professional-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2300",
+              "title": "Networking Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2740",
+              "title": "Fundamentals of Client Operating Systems and Hardware for Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1050",
+              "title": "Professional Success Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2320",
+              "title": "Network Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITNT",
+              "number": "2370",
+              "title": "Network Security Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1303",
+              "title": "Cisco I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Laboratory Phlebotomy, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/laboratory-phlebotomy-short-term-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1050",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1120",
+              "title": "Critical Thinking in Healthcare",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "1310",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LP",
+              "number": "1300",
+              "title": "Introduction to Blood Collection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LP",
+              "number": "1850",
+              "title": "Laboratory Phlebotomy Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LP",
+              "number": "2970",
+              "title": "Advanced Phlebotomy Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Landscape Contracting, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/landscape-contracting-short-term-certificate/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1411",
+              "title": "Equipment Operations and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1510",
+              "title": "Landscape Contracting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1420",
+              "title": "Landscape Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1600",
+              "title": "Irrigation and Drainage",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2370",
+              "title": "Introduction to Turfgrass",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Land Surveying Fundamentals, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/land-surveying-fundamentals-certificate-proficiency/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1411",
+              "title": "CAD Technology in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2110",
+              "title": "Basic Survey Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1740",
+              "title": "Fundamentals of Geographic Information Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2520",
+              "title": "Aerial Surveying",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2550",
+              "title": "3D Laser Scanning for Land Surveying",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2500",
+              "title": "Construction Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2560",
+              "title": "Land Development Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2535",
+              "title": "Legal Principles in Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2540",
+              "title": "Ohio Lands",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2590",
+              "title": "Professional Aspects of Land Surveying",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2570",
+              "title": "Geodetic Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Landscape Design, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/landscape-design-short-term-certificate/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1441",
+              "title": "Introduction to Landscape Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1510",
+              "title": "Landscape Contracting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1450",
+              "title": "Landscape Design - CAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2431",
+              "title": "Planting Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Landscape Horticulture, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/landscape-horticulture-short-term-certificate/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1301",
+              "title": "Horticultural Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1000",
+              "title": "Everyday Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100L",
+              "title": "Everyday Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1060",
+              "title": "Environment, Ecology, and Evolution",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106L",
+              "title": "Environment, Ecology, & Evolution Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2310",
+              "title": "Soil Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2370",
+              "title": "Introduction to Turfgrass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2321",
+              "title": "Plant Pest Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Lean Six Sigma for Health Care: Yellow Belt and Green Belt — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/lean-six-sigma-green-belt-health-care/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLSS",
+              "number": "1073",
+              "title": "Lean Six Sigma Yellow Belt for Health Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1027",
+              "title": "Lean Six Sigma Green Belt for Health Care - Comprehensive",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1150",
+              "title": "Lean Six Sigma Yellow Belt to Green Belt for Health Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1096",
+              "title": "Lean Essentials for Healthcare: Foundational Skills (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Lean Six Sigma for Education: Yellow Belt and Green Belt — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/lean-six-sigma-yellow-belt-education/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLSS",
+              "number": "1090",
+              "title": "Lean Six Sigma Yellow Belt for Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1530",
+              "title": "Lean Six Sigma Green Belt for Education - Comprehensive",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1033",
+              "title": "Lean Six Sigma: Yellow Belt to Green Belt",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1078",
+              "title": "Lean for Education: Comprehensive (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "LeanOhio Boot Camp: Transforming the Public Sector — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/leanohio-boot-camp-transforming-public-sector/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLEN",
+              "number": "1037",
+              "title": "LeanOhio Boot Camp: Transforming the Public Sector (Four days)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Lean Six Sigma: Yellow Belt, Green Belt, Black Belt — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/lean-six-sigma-yellow-green-black-belt/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLSS",
+              "number": "1032",
+              "title": "Lean Six Sigma: Yellow Belt",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1033",
+              "title": "Lean Six Sigma: Yellow Belt to Green Belt",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1524",
+              "title": "Lean Six Sigma: Green Belt Certification - Comprehensive",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1003",
+              "title": "Lean Six Sigma: Green Belt to Black Belt",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1090",
+              "title": "Lean Six Sigma Yellow Belt for Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1531",
+              "title": "Lean Six Sigma Yellow Belt to Green Belt for Education",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1530",
+              "title": "Lean Six Sigma Green Belt for Education - Comprehensive",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1073",
+              "title": "Lean Six Sigma Yellow Belt for Health Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1150",
+              "title": "Lean Six Sigma Yellow Belt to Green Belt for Health Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1027",
+              "title": "Lean Six Sigma Green Belt for Health Care - Comprehensive",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "8917",
+              "title": "Lean Six Sigma Yellow Belt (Online)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1078",
+              "title": "Lean for Education: Comprehensive (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1096",
+              "title": "Lean Essentials for Healthcare: Foundational Skills (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1112",
+              "title": "Lean Essentials for Manufacturing: Foundational Skills (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "8910",
+              "title": "Problem-Solving Essentials — Go 4 It 4-Step PS (Online)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Administrative Specialist, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/legal-administrative-specialist-certificate-proficiency/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1150",
+              "title": "Word for Business Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1502",
+              "title": "Law Office Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2200",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2040",
+              "title": "Emerging Workplace Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2361",
+              "title": "Proofreading Skill Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Lodging Rooms Division, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/lodging-rooms-division-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1180",
+              "title": "Event Planning Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1482",
+              "title": "Housekeeping Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1580",
+              "title": "Front Office Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1960",
+              "title": "Lodging/Tourism Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2480",
+              "title": "Hospitality Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tools Operation, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/machine-tools-operation-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1240",
+              "title": "Machine Tools and Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1300",
+              "title": "Engineering Materials and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2422",
+              "title": "Fundamentals of Engineering Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mammography, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/mammography-short-term-certificate/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "2610",
+              "title": "Introduction to Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2620",
+              "title": "Anatomy and Pathology of the Breast",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2630",
+              "title": "Positioning Techniques for Breast Imaging",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2640",
+              "title": "Physics of Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2670",
+              "title": "Mammography Quality Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2650",
+              "title": "Interventional and Special Imaging Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2660",
+              "title": "MQSA and ACR Regulatory Standards",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2930",
+              "title": "Mammography Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing, Associate of Applied Business — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/marketing-aab/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "1080",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1122",
+              "title": "Principles of Management and Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2261",
+              "title": "Integrated Marketing Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2270",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1341",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2081",
+              "title": "Social Media Content Strategies and Analytics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2090",
+              "title": "Digital Marketing Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2060",
+              "title": "Business Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2020",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Massage Therapy, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/massage-therapy-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "0995",
+              "title": "Applied College Literacies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "0915",
+              "title": "Basic Arithmetic and Pre-Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Industrial Engineering Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/manufacturing-industrial-engineering-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1240",
+              "title": "Machine Tools and Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1300",
+              "title": "Engineering Materials and Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1250",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2601",
+              "title": "3D Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1261",
+              "title": "Product Ideation & Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1270",
+              "title": "Additive Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2160",
+              "title": "3D Scanning, Reverse Engineering, and Quality Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1210",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2422",
+              "title": "Fundamentals of Engineering Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2410",
+              "title": "Quality Control and Lean Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2990",
+              "title": "Product Development and Manufacture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2151",
+              "title": "3D Digital Design & Printing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1220",
+              "title": "College Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Medical Administrative Specialist, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/medical-administrative-specialist-certificate-proficiency/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1150",
+              "title": "Word for Business Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2040",
+              "title": "Emerging Workplace Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1700",
+              "title": "Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1113",
+              "title": "Physician Office Coding with Current Procedural Terminology (CPT) Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1114",
+              "title": "Medical Office Coding with ICD-10-CM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1122",
+              "title": "Medical Billing Practices for Healthcare Providers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "2060",
+              "title": "Medical Terminology II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy, Post-Degree Professional Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/massage-therapy-post-degree-professional-certificate/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MT",
+              "number": "1242",
+              "title": "Somatic Studies I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "1302",
+              "title": "Massage Therapy I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "1312",
+              "title": "Applied Musculo-Skeletal Anatomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2301",
+              "title": "Pathology for Massage Therapists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "1272",
+              "title": "Somatic Studies II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "1321",
+              "title": "Functional Assessment in Massage Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "1331",
+              "title": "Massage Therapy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2351",
+              "title": "Ethics for Massage Therapists",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "235L",
+              "title": "Massage Therapy Clinic I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "1280",
+              "title": "Somatic Studies III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2202",
+              "title": "Massage Modalities and Career Paths",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2361",
+              "title": "Business Practices for Massage Therapists",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "236L",
+              "title": "Massage Therapy Clinic II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2701",
+              "title": "Comprehensive Somatic Studies for Massage Therapists",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "2991",
+              "title": "Comprehensive Massage Therapy",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/massage-therapy-certificate-proficiency/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "0995",
+              "title": "Applied College Literacies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "0915",
+              "title": "Basic Arithmetic and Pre-Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Engineering Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/mechanical-engineering-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "0965",
+              "title": "Intermediate Algebra (or appropriate score on Math Placement Test)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Medical Assisting, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/medical-assisting-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "0955",
+              "title": "Beginning Algebra (or eligibility for MATH-1190 or higher)",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Billing Specialist, Short-Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/medical-billing-specialist-short-term-certificate/",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1114",
+              "title": "Medical Office Coding with ICD-10-CM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1311",
+              "title": "Legal Aspects of Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1122",
+              "title": "Medical Billing Practices for Healthcare Providers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2131",
+              "title": "Coding with CPT (Current Procedural Terminology)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "2060",
+              "title": "Medical Terminology II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/medical-assisting-certificate-proficiency/",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "1200",
+              "title": "Introduction to Medical Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "1100",
+              "title": "Body Systems for Medical Assistants",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "1430",
+              "title": "Basic Medical Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "143L",
+              "title": "Basic Medical Assisting Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "1504",
+              "title": "Administrative Procedures for the Medical Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "150L",
+              "title": "Administrative Procedures Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "1601",
+              "title": "EKG - Electrocardiogram Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "1310",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1120",
+              "title": "Critical Thinking in Healthcare",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "2400",
+              "title": "Advanced Procedures for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "240L",
+              "title": "Advanced Procedures for the Medical Assistant Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "2420",
+              "title": "Medical Assisting Certification Exam Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "2861",
+              "title": "Medical Assisting Practicum and Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Microsoft Office Application Specialist, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/microsoft-office-application-specialist-short-term-certificate/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1150",
+              "title": "Word for Business Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "1700",
+              "title": "Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2040",
+              "title": "Emerging Workplace Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2211",
+              "title": "Presentation Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2200",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BT",
+              "number": "2700",
+              "title": "Advanced Business Spreadsheets (Excel)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting (Patient Advocate), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/medical-assisting-concentration-patient-navigator-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/medical-laboratory-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1500",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "1001",
+              "title": "Introduction to Medical Laboratory Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Millwrighting, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/millwrighting-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1320",
+              "title": "Introduction to Millwrighting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1330",
+              "title": "Print Reading for Millwrights",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1350",
+              "title": "Hydraulics/Centrifugal Pumps",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1450",
+              "title": "Heavy Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1490",
+              "title": "Millwright Pile Driver Weld I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1310",
+              "title": "Carpentry Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1720",
+              "title": "Machinery Installation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2120",
+              "title": "Shaft Alignment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2230",
+              "title": "Millwright Pile Driver Weld II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2350",
+              "title": "Floor Conveyor",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2130",
+              "title": "Shaft Alignment II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2520",
+              "title": "Millwright PileDriver Weld III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2700",
+              "title": "Millwright-Pile Driver Weld IV",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": ".Net Programming, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/net-programming-post-degree-professional-certificate/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/nuclear-medicine-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1300",
+              "title": "General Chemistry Iand General Chemistry Laboratory I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "130H",
+              "title": "Honors General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1050",
+              "title": "Everyday Physics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra (or higher)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/nursing-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I (must be completed with a grade of \"B\" or higher)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1000",
+              "title": "Introduction to Healthcare Concepts (5 week hybrid course)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1010",
+              "title": "Introduction to Patient Care Concepts (8 week lab/clinical course)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing (Access LPN to RN Track), Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/nursing-access-lpn-rn-track-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I (Must be completed with a grade of \"B\" or higher)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1250",
+              "title": "LPN to RN Transitions I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Ohio Transfer 36, Certificate of Proficiency — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/ohio-transfer-36-certificate-proficiency/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Painting, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/painting-certificate-proficiency/",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATPT",
+              "number": "1300",
+              "title": "Introduction to Painting, Drywall Finishing, and Glazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1320",
+              "title": "Safety Standards for Construction (OSHA-10)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1330",
+              "title": "Filling Compounds and Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1340",
+              "title": "Wall Preparation and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1620",
+              "title": "Wood Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1650",
+              "title": "Blueprints I: Construction Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATGL",
+              "number": "2400",
+              "title": "Advanced Rigging & Hoisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1640",
+              "title": "Rigging & Hoisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "1660",
+              "title": "Labor in American Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2320",
+              "title": "Safe Work Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2330",
+              "title": "Spray & Industrial Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2370",
+              "title": "Abrasives Blasting Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2380",
+              "title": "Special Coating and Decorative Finishes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2340",
+              "title": "Bluepints II: Advanced Reading and Estimating",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2350",
+              "title": "Advanced Spray and Industrial Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPT",
+              "number": "2360",
+              "title": "Foreman Training",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/occupational-therapy-assistant-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I (or BIO-2330)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Operating Engineers, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/operating-engineers-certificate-proficiency/",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATOE",
+              "number": "1100",
+              "title": "Operating Engineering Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "1200",
+              "title": "Basic Mechanical Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "1650",
+              "title": "Graders and Plans",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "1700",
+              "title": "Paving, Tractor, Backhoe Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2100",
+              "title": "Mobile Crane",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2200",
+              "title": "Mechanical Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2600",
+              "title": "Bulldozer Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2620",
+              "title": "Backhoe Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2640",
+              "title": "Advanced Grader Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATOE",
+              "number": "2660",
+              "title": "Grader Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies,  Post-Degree Professional Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/paralegal-studies-post-degree-professional-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PL",
+              "number": "1001",
+              "title": "Introduction to the Paralegal Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1300",
+              "title": "Civil Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1401",
+              "title": "Legal Research and Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1502",
+              "title": "Law Office Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2301",
+              "title": "Torts and Evidence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2401",
+              "title": "Legal Research and Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2440",
+              "title": "Business Transactions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2851",
+              "title": "Paralegal Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2991",
+              "title": "Paralegal Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/paramedic-certificate-proficiency/",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "1303",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "1401",
+              "title": "Anatomy & Physiology for Paramedics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2330",
+              "title": "Paramedic Theory I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2350",
+              "title": "Paramedic Theory III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2340",
+              "title": "Paramedic Theory II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2360",
+              "title": "Paramedic Theory IV",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "2371",
+              "title": "Paramedic Capstone Course",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies, Associate of Applied Business — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/paralegal-studies-aab/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Applied Accounting (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1001",
+              "title": "Introduction to the Paralegal Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1000",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100H",
+              "title": "Honors American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1300",
+              "title": "Civil Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1401",
+              "title": "Legal Research and Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "1502",
+              "title": "Law Office Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1020",
+              "title": "Introduction to Logic",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2301",
+              "title": "Torts and Evidence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2401",
+              "title": "Legal Research and Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2440",
+              "title": "Business Transactions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2851",
+              "title": "Paralegal Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PL",
+              "number": "2991",
+              "title": "Paralegal Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1020",
+              "title": "State & Local Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "2100",
+              "title": "Constitutional Law",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Patient Advocate, Short Term Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/patient-navigator-short-term-certificate/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "2601",
+              "title": "Patient Advocate Fundamentals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "2610",
+              "title": "Advanced Health Care Delivery Coordination",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "2620",
+              "title": "Patient-Centered Medical Home",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "2841",
+              "title": "Patient Navigator Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Payroll, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/payroll-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1041",
+              "title": "Individual Taxation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1030",
+              "title": "Payroll",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1520",
+              "title": "QuickBooks Immersion",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Personal Chef, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/personal-chef-certificate-proficiency/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1180",
+              "title": "Event Planning Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1552",
+              "title": "Introduction to Baking & Pastries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1451",
+              "title": "Contemporary Cuisine",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1710",
+              "title": "Doing Business as a Personal Chef",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2330",
+              "title": "Menus and Facilities Planning & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Hospitality Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pile Driving, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/pile-driving-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCT",
+              "number": "1301",
+              "title": "Introduction to Carpentry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATCT",
+              "number": "1310",
+              "title": "Carpentry Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1340",
+              "title": "Introduction to Pile Driving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1450",
+              "title": "Heavy Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "1490",
+              "title": "Millwright Pile Driver Weld I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "1330",
+              "title": "Print Reading for Pile Driving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2230",
+              "title": "Millwright Pile Driver Weld II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "1310",
+              "title": "Technical Measurements, Hand & Power Tool Use in Pile Driving",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "1370",
+              "title": "Pile Driving on Land and Water",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2020",
+              "title": "Pile Driving Technologies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2220",
+              "title": "False Work and Heavy Timber",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2370",
+              "title": "Advanced Pile Driving on Land",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2380",
+              "title": "Advanced Pile Driving on Water",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMW",
+              "number": "2520",
+              "title": "Millwright PileDriver Weld III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2700",
+              "title": "Millwright-Pile Driver Weld IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPD",
+              "number": "2710",
+              "title": "Millwright-Pile Driver Weld V",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pipefitting, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/pipefitting-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATCM",
+              "number": "1341",
+              "title": "OSHA Standards for Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "1070",
+              "title": "Soldering, Brazing, and Pipefitting Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "1210",
+              "title": "Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "1220",
+              "title": "Basic Pipefitting Layout",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1000",
+              "title": "Care and Use of Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "1360",
+              "title": "Hydronic Heating and Cooling",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPF",
+              "number": "2340",
+              "title": "Steam Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2560",
+              "title": "Foreman Certification",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assisting Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/physical-therapist-assisting-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I (or BIO-2330)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "1000",
+              "title": "Introduction to Physical Therapy Patient Care",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plant and Pest Identification, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plant-and-pest-identification-short-term-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2321",
+              "title": "Plant Pest Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plant Science and Landscape Technology (Landscape Technician), Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plant-science-technology-landscape-technician-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1301",
+              "title": "Horticultural Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1411",
+              "title": "Equipment Operations and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1420",
+              "title": "Landscape Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1600",
+              "title": "Irrigation and Drainage",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1441",
+              "title": "Introduction to Landscape Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1380",
+              "title": "Introduction to Tree Care",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2370",
+              "title": "Introduction to Turfgrass",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1510",
+              "title": "Landscape Contracting",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plant Science and Landscape Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plant-science-landscape-technology-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PST",
+              "number": "1301",
+              "title": "Horticultural Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1411",
+              "title": "Equipment Operations and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (Or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1420",
+              "title": "Landscape Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1441",
+              "title": "Introduction to Landscape Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1380",
+              "title": "Introduction to Tree Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2950",
+              "title": "Field Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2321",
+              "title": "Plant Pest Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1010",
+              "title": "Art Appreciation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2030",
+              "title": "Environmental Geography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Critical Thinking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1010",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101H",
+              "title": "Honors Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1060",
+              "title": "Environment, Ecology, and Evolution",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106L",
+              "title": "Environment, Ecology, & Evolution Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1000",
+              "title": "Everyday Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100L",
+              "title": "Everyday Chemistry Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1400",
+              "title": "Garden Center and Nursery Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1510",
+              "title": "Landscape Contracting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1331",
+              "title": "Plant Propagation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2431",
+              "title": "Planting Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2381",
+              "title": "Arboriculture",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1600",
+              "title": "Irrigation and Drainage",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2310",
+              "title": "Soil Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2370",
+              "title": "Introduction to Turfgrass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1351",
+              "title": "Plant Production",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1450",
+              "title": "Landscape Design - CAD",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2480",
+              "title": "Arboriculture Practices",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plexus: ISO 45001:2018 Internal Auditor Training for Occupational Health and Safety — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plexus-iso-45001-2018-internal-auditor-training-for-occupational-health-and-safety/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZISO",
+              "number": "1181",
+              "title": "Plexus: ISO 45001:2018 Internal Auditor Training for Occupational Health and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "8915",
+              "title": "Understanding ISO 45001:2018 Occupational Health & Safety Management System Requirements",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plexus: ISO 9001:2015 Understanding and Internal Auditor Training — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plexus-iso-9001-2015-understanding-and-internal-auditior-training/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZISO",
+              "number": "1800",
+              "title": "Plexus ISO 9001:2015 Understanding and Internal Auditing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "1801",
+              "title": "IATF 16949:2016 Understanding and Internal Quality Auditing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "1039",
+              "title": "Certified Quality Auditor (CQA) Refresher",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plexus: Understanding and Internal Auditing for ISO 14001:2015 — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plexus-understanding-and-internal-auditing-for-iso-14001-2015/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZISO",
+              "number": "1130",
+              "title": "Plexus: Understanding and Internal Auditing for ISO 14001:2015",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "8915",
+              "title": "Understanding ISO 45001:2018 Occupational Health & Safety Management System Requirements",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plexus Understanding and Internal Auditing for ISO 14001:2015 — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plexus-understanding-iso-14001-2015-internal-auditing-iso-14001/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZISO",
+              "number": "1130",
+              "title": "Plexus: Understanding and Internal Auditing for ISO 14001:2015",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/plumbing-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATPL",
+              "number": "1000",
+              "title": "Care and Use of Tools",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1010",
+              "title": "Soldering and Brazing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1030",
+              "title": "State of Ohio Plumbing Code I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1070",
+              "title": "Pipe Fittings, Valves, and Supports",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1220",
+              "title": "Gas Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "1230",
+              "title": "Water Supply",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2320",
+              "title": "State of Ohio Plumbing Code III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2350",
+              "title": "Electricity for Plumbers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATPL",
+              "number": "2410",
+              "title": "City & State Backflow Cert",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/practical-nursing-certificate-proficiency/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1000",
+              "title": "Introduction to Healthcare Concepts",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1010",
+              "title": "Introduction to Patient Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Professional Baking, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/professional-baking-certificate-proficiency/",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1552",
+              "title": "Introduction to Baking & Pastries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "1200",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1451",
+              "title": "Contemporary Cuisine",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2550",
+              "title": "Baking Production and Sales II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1940",
+              "title": "Culinary Arts/Professional Baking Field Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Culinarian/Cook, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/professional-culinarian-cook-certificate-proficiency/",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1010",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1552",
+              "title": "Introduction to Baking & Pastries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "1200",
+              "title": "Basic Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1040",
+              "title": "Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1451",
+              "title": "Contemporary Cuisine",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Hospitality Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2700",
+              "title": "Hospitality Purchasing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1940",
+              "title": "Culinary Arts/Professional Baking Field Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Project Management Professional (PMP) — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/project-management-professional-pmp-find/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLSS",
+              "number": "1148",
+              "title": "PMI Exam Prep: Project Management Professional (PMP)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1133",
+              "title": "Project Management Professional (PMP) Exam Prep (Online)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Project Manager Entry-Level Certificate — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/project-manager-entry-level/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLDR",
+              "number": "0294",
+              "title": "Moving From Peer to Boss",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1152",
+              "title": "Introduction to Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "8911",
+              "title": "Principles of Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1144",
+              "title": "PMI Exam Prep: Certified Associate in Project Management (CAPM)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1127",
+              "title": "Certified ScrumMaster (CSM)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1032",
+              "title": "Lean Six Sigma: Yellow Belt",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Quality/Continuous Improvement Supervisor Entry-Level Certificate — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/quality-continuous-improvement-supervisor-entry-level/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZLDR",
+              "number": "0294",
+              "title": "Moving From Peer to Boss",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1113",
+              "title": "Practical Problem-Solving",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "1161",
+              "title": "Plexus: Understanding ISO 9001:2015",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZLSS",
+              "number": "1032",
+              "title": "Lean Six Sigma: Yellow Belt",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "1064",
+              "title": "Certified Quality Improvement Associate (CQIA) Refresher",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "1044",
+              "title": "Certified Quality Technician (CQT) Refresher",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZISO",
+              "number": "1800",
+              "title": "Plexus ISO 9001:2015 Understanding and Internal Auditing",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Quality Control, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/quality-control-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra (or higher)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1100",
+              "title": "Technology Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1240",
+              "title": "Machine Tools and Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2410",
+              "title": "Quality Control and Lean Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2422",
+              "title": "Fundamentals of Engineering Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2990",
+              "title": "Product Development and Manufacture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Real Estate Pre-Licensure Education & Exam Prep Course — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/real-estate-pre-licensure/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZPDI",
+              "number": "0785",
+              "title": "Ohio Real Estate Pre-Licensure Education and Exam Prep: National and State (Online)",
+              "credits": 12,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0795",
+              "title": "Ohio Real Estate Pre-Licensure Education and Exam Prep: National and State (Online) With Coach",
+              "credits": 13,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/radiography-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1221",
+              "title": "Anatomy and Physiology for Diagnostic Medical Imaging",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "1351",
+              "title": "Patient Care Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1050",
+              "title": "Introduction to Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101H",
+              "title": "Honors General Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Recording Arts and Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/recording-arts-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "1010",
+              "title": "Survey of European Classical Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1020",
+              "title": "Survey of Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1030",
+              "title": "Survey of Rock and Roll",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1040",
+              "title": "Survey of African-American Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1050",
+              "title": "Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Restaurant Entrepreneurship, Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/restaurant-entrepreneurship-certificate-proficiency/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "1020",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1301",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1031",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1360",
+              "title": "Fundamentals of Restaurant/Food Service Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2450",
+              "title": "New Business Development",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2371",
+              "title": "Restaurant/Foodservice Entrepreneurship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2330",
+              "title": "Human Resource Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Hospitality Management and Supervision",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2360",
+              "title": "Restaurant Marketing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "1080",
+              "title": "Social Media Marketing",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care, Associate of Applied Science — associate of applied science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/respiratory-care-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I (or BIO-2330)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1100",
+              "title": "Introduction to Respiratory Care",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Biological Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1010",
+              "title": "Introduction to Inorganic Chemistryand Introduction to Organic Chemistry and Biochemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science in Roofing Technology (Apprenticeship) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/roofing-technology-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATRF",
+              "number": "1020",
+              "title": "Introduction to Roofing Tools, Materials, and Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1050",
+              "title": "Single Ply Roofing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1070",
+              "title": "Roofer's Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1030",
+              "title": "Steep Slope Roofing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1080",
+              "title": "Applied Roofer's Math",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2020",
+              "title": "Built Up Roofing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2040",
+              "title": "Built Up Roofing II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2050",
+              "title": "Single Ply Roofing II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2790",
+              "title": "Journeyman's Review and Certification",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "2990",
+              "title": "Contracting in a Diverse World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sheet Metal Service, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/sheet-metal-service-certificate-proficiency/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATSM",
+              "number": "1010",
+              "title": "Benefits Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1020",
+              "title": "Trade History",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1030",
+              "title": "Layout and Fabrication I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1060",
+              "title": "Sheet Metal OSHA 30",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1080",
+              "title": "New EPA 608",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1070",
+              "title": "Sheet Metal Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1090",
+              "title": "HVAC Cleaning",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1220",
+              "title": "Layout and Fabrication II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1230",
+              "title": "Field Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2310",
+              "title": "Refrigeration I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2350",
+              "title": "Duct Design and Testing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2360",
+              "title": "Load Calculations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2410",
+              "title": "Residential Heating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2420",
+              "title": "Refrigeration II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2530",
+              "title": "Direct Digital Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2540",
+              "title": "SMART ICRA",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2780",
+              "title": "NATE Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2790",
+              "title": "Sheet Metal Foreman Training",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Semiconductor Fundamentals, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/semiconductor-fundamentals-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "1041",
+              "title": "Foundations of Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1060",
+              "title": "Semiconductor Manufacturing Processes and Cleanrooms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1220",
+              "title": "Circuits and Electronics for Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1060",
+              "title": "General Industry Safety Awareness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1070",
+              "title": "Vacuum Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1640",
+              "title": "Robotics and Programmable Logic Controllers in Process Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sheet Metal Working, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/sheet-metal-working-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATSM",
+              "number": "1010",
+              "title": "Benefits Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1020",
+              "title": "Trade History",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1030",
+              "title": "Layout and Fabrication I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1050",
+              "title": "Fire Life Safety Tech I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1060",
+              "title": "Sheet Metal OSHA 30",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1230",
+              "title": "Field Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2540",
+              "title": "SMART ICRA",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "1220",
+              "title": "Layout and Fabrication II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2310",
+              "title": "Refrigeration I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2330",
+              "title": "Layout and Fabrication III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2340",
+              "title": "Advanced Field Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2420",
+              "title": "Refrigeration II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2520",
+              "title": "Project Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATSM",
+              "number": "2790",
+              "title": "Sheet Metal Foreman Training",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Smart Manufacturing - Mechatronics, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/smart-manufacturing-mechatronics-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1220",
+              "title": "Circuits and Electronics for Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1120",
+              "title": "Computer Applications and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1230",
+              "title": "Drawing & AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1640",
+              "title": "Robotics and Programmable Logic Controllers in Process Automation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra (or higher Approved Ohio Transfer 36 Mathematics course.)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1340",
+              "title": "Introduction to Industry 4.0 and Vision Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2601",
+              "title": "3D Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1020",
+              "title": "The Individual in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1600",
+              "title": "Industrial Routers, Switches, and Operating Systems for Smart Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1410",
+              "title": "Computer Aided Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1050",
+              "title": "Introduction to Industrial/Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1620",
+              "title": "Industrial Protocols and Machine Connectivity for Smart Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2450",
+              "title": "Robotics and Automation in Smart Manufacturing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2460",
+              "title": "Applied Programmable Logic Controllers and Mechatronic Systems",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Media Influencer, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/social-media-influencer/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MJS",
+              "number": "1320",
+              "title": "Social Media Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "1080",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MJS",
+              "number": "2000",
+              "title": "Digital Media Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Media Marketing, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/social-media-marketing-short-term-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MARK",
+              "number": "1080",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2261",
+              "title": "Integrated Marketing Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2270",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2090",
+              "title": "Digital Marketing Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "2081",
+              "title": "Social Media Content Strategies and Analytics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Software Quality Assurance, Post-Degree Professional Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/software-quality-assurance-post-degree-certificate/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "1200",
+              "title": "Introduction to Software Quality Assurance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2200",
+              "title": "Software Quality Assurance Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2500",
+              "title": "Software Testing Automation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sport and Exercise Studies, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/sport-exercise-studies-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1500",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2341",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Elementary Probability and Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Steelworker for the Future – Electrical Technology, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/steelworker-future-electrical-technology-certificate-of-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1410",
+              "title": "Applied Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1420",
+              "title": "Applied Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2990",
+              "title": "Reliability Centered Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1000",
+              "title": "Numerical Applications in Electrical and Mechanical Maintenance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2200",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2240",
+              "title": "Applied National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2220",
+              "title": "Fundamentals of Electronics and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2500",
+              "title": "Programmable Logic Controllers Maintenance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2511",
+              "title": "Programmable Logic Controllers Maintenance II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Roofing, Short-Term Certificate (Apprenticeship) — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/roofing-short-term-certificate/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATRF",
+              "number": "1020",
+              "title": "Introduction to Roofing Tools, Materials, and Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1050",
+              "title": "Single Ply Roofing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1070",
+              "title": "Roofer's Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2020",
+              "title": "Built Up Roofing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1080",
+              "title": "Applied Roofer's Math",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2050",
+              "title": "Single Ply Roofing II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "1030",
+              "title": "Steep Slope Roofing I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2040",
+              "title": "Built Up Roofing II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATRF",
+              "number": "2790",
+              "title": "Journeyman's Review and Certification",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Steelworker for the Future- Mechanical Technology, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/steelworker-future-mechanical-technology-certificate-of-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISET",
+              "number": "1101",
+              "title": "Welding Blue Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1110",
+              "title": "Oxyfuel Processes/Plasma Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1301",
+              "title": "Mechanical/Electrical Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1340",
+              "title": "Industrial Piping and Tubing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1410",
+              "title": "Applied Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1000",
+              "title": "Numerical Applications in Electrical and Mechanical Maintenance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or higher approved Ohio Transfer 36 Mathematics course)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1240",
+              "title": "Machine Tools and Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1310",
+              "title": "Mechanical Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "1320",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2120",
+              "title": "Shielded Metal Arc Welding (STICK)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISET",
+              "number": "2990",
+              "title": "Reliability Centered Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sterile Processing and Distribution Technology, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/sterile-processing-distribution-technology-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1700",
+              "title": "Sterile Processing Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1720",
+              "title": "Introduction to Hospital Administration",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1050",
+              "title": "Human Biology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Biological Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1500",
+              "title": "Principles of Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2500",
+              "title": "Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1710",
+              "title": "Sterile Processing Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1861",
+              "title": "Clinical Experience: Sterile Processing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "1110",
+              "title": "Ethics for Health Care Professionals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2050",
+              "title": "Bioethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "205H",
+              "title": "Honors Bioethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/surgical-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTEC",
+              "number": "1060",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2331",
+              "title": "Anatomy and Physiology I (or BIO-2330)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1000",
+              "title": "Survey of Surgical Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tax Preparation, Certificate of Proficiency — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/tax-preparation-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1041",
+              "title": "Individual Taxation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "1020",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1030",
+              "title": "Payroll",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2041",
+              "title": "Business Taxation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2151",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "2010",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201H",
+              "title": "Honors Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "The Center for Entrepreneurs: Entrepreneurial Courses — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/the-center-for-entrepreneurs-entrepreneurial-courses/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZPDI",
+              "number": "0901",
+              "title": "The Discovery Track for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0905",
+              "title": "The Foundation Track for Entrepreneurs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0904",
+              "title": "The Acceleration Track for Entrepreneurs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0903",
+              "title": "The Expansion Track for Entrepreneurs",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "The Center for Entrepreneurs: Podcasting — Certificate of Completion",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/the-center-for-entrepreneurs-podcasting/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZPDI",
+              "number": "1490",
+              "title": "Launching a Successful Podcast: Podcasting 101, 102 and 103",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1491",
+              "title": "Podcasting 101 - Pre-Production: Planning for Success",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1492",
+              "title": "Podcasting 102 - Production: Gearing Up for Your Podcast",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1493",
+              "title": "Podcasting 103 - Post-Production: Getting Your Podcast Heard and Seen",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Transportation Construction Inspection Level II, Certificate of Proficiency — diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/transportation-construction-inspection-level-ii-certificate-proficiency/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1660",
+              "title": "Material Testing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1670",
+              "title": "Highway Inspection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1540",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "109H",
+              "title": "Honors Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2110",
+              "title": "Basic Survey Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2140",
+              "title": "Advanced Material Testing & Inspection",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "The Center for Entrepreneurs",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/the-center-for-entrepreneurs/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZPDI",
+              "number": "0901",
+              "title": "The Discovery Track for Entrepreneurs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0905",
+              "title": "The Foundation Track for Entrepreneurs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0904",
+              "title": "The Acceleration Track for Entrepreneurs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "0903",
+              "title": "The Expansion Track for Entrepreneurs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1490",
+              "title": "Launching a Successful Podcast: Podcasting 101, 102 and 103",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1491",
+              "title": "Podcasting 101 - Pre-Production: Planning for Success",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1492",
+              "title": "Podcasting 102 - Production: Gearing Up for Your Podcast",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZPDI",
+              "number": "1493",
+              "title": "Podcasting 103 - Post-Production: Getting Your Podcast Heard and Seen",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tree Care, Short-Term Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/tree-care-short-term-certificate/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PST",
+              "number": "1411",
+              "title": "Equipment Operations and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1311",
+              "title": "Deciduous Woody Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1230",
+              "title": "Standard First Aid and Personal Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1380",
+              "title": "Introduction to Tree Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "1321",
+              "title": "Evergreens, Groundcovers, and Herbaceous Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2321",
+              "title": "Plant Pest Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2381",
+              "title": "Arboriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PST",
+              "number": "2480",
+              "title": "Arboriculture Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "User Experience Design, Post-Degree Certificate — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/user-experience-design-post-degree-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2700",
+              "title": "User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2372",
+              "title": "Interactive Media I - Design Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2380",
+              "title": "Interactive Media II - App Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2572",
+              "title": "User Experience Studio",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Utilities Safety and Operations Fundamentals, Certificate of Proficiency — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/utilities-safety-operations-fundamentals-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1640",
+              "title": "Utility Locating and Traffic Flagging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2220",
+              "title": "Telecommunication Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1220",
+              "title": "Circuits and Electronics for Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2050",
+              "title": "Advanced Construction Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2000",
+              "title": "Equipment Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2100",
+              "title": "Aerial Construction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Utilities Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/utilities-technology-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1281",
+              "title": "Construction Engineering Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1290",
+              "title": "Construction Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1751",
+              "title": "Construction Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1640",
+              "title": "Utility Locating and Traffic Flagging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "1090",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2050",
+              "title": "Advanced Construction Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2131",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2220",
+              "title": "Telecommunication Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2000",
+              "title": "Equipment Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2830",
+              "title": "Cooperative Field Experience",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2100",
+              "title": "Aerial Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2200",
+              "title": "Underground Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2230",
+              "title": "Gas Pipeline Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "2240",
+              "title": "Water and Wastewater Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1311",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1220",
+              "title": "Circuits and Electronics for Automation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1061",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1020",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "Honors College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2151",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESCI",
+              "number": "1410",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESCI",
+              "number": "141L",
+              "title": "Lab in Physical Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2010",
+              "title": "Equipment Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UT",
+              "number": "2210",
+              "title": "Underground Construction II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/veterinary-technology-aas/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VT",
+              "number": "1120",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Biological Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1010",
+              "title": "Introduction to Inorganic Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communication & Design (Graphic Design), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/visual-communication-design-concentration-graphic-design-aab/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1061",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1201",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (Or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "1500",
+              "title": "Advertising and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2301",
+              "title": "Graphic Design and Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2331",
+              "title": "Brand Identity Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2232",
+              "title": "Typography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2400",
+              "title": "Information Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2431",
+              "title": "Package Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2631",
+              "title": "Graphic Design Studio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2700",
+              "title": "User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Visual Communication & Design (Illustration), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/visual-communication-design-concentration-illustration-aab/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "1142",
+              "title": "Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (Or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "1640",
+              "title": "3D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2142",
+              "title": "Illustration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2301",
+              "title": "Graphic Design and Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2040",
+              "title": "3D Motion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2271",
+              "title": "2D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2341",
+              "title": "Illustration for Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2000",
+              "title": "Life Drawing I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1200",
+              "title": "Game Design I: Introduction to Game Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2540",
+              "title": "3D Studio",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "2641",
+              "title": "Illustration Studio",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Visual Communication & Design (Photography), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/visual-communication-design-concentration-photography-aab/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1150",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1261",
+              "title": "Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2050",
+              "title": "Commercial Studio Techniques I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2260",
+              "title": "Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2450",
+              "title": "Digital Imaging II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2030",
+              "title": "Art History Survey: Late Renaissance to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1201",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2160",
+              "title": "Digital Video for Photographers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2550",
+              "title": "Commercial Studio Techniques II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2541",
+              "title": "Individual Projects in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2660",
+              "title": "Photography III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2761",
+              "title": "Photography for Media Publication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2770",
+              "title": "Commercial Studio Techniques III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "2991",
+              "title": "Professional Business Practices and Portfolio Prep for Photographers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Fundamentals of Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101H",
+              "title": "Honors Speech Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101H",
+              "title": "Honors Introductory Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Visual Communication & Design (Graphic Design), Certificate of Proficiency — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/visual-communication-design-graphic-design-certificate-proficiency/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1061",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1201",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101H",
+              "title": "Honors College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2301",
+              "title": "Graphic Design and Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "1500",
+              "title": "Advertising and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2232",
+              "title": "Typography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2700",
+              "title": "User Experience Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2331",
+              "title": "Brand Identity Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2431",
+              "title": "Package Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCGD",
+              "number": "2400",
+              "title": "Information Graphic Design",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication & Design (Web and Interactive Media), Associate of Applied Business — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/visual-communication-design-concentration-web-interactive-media-aab/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1010",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Algebraic and Quantitative Reasoning (or Any Approved Ohio Transfer 36 Mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1570",
+              "title": "Web Publishing I: HTML (Option A)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1200",
+              "title": "Game Design I: Introduction to Game Design (Option B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1201",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIL",
+              "number": "1640",
+              "title": "3D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1770",
+              "title": "Web Publishing II: Site Theory & Construction (Option A)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1400",
+              "title": "Game Design II: Game Engines (Option B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2271",
+              "title": "2D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2372",
+              "title": "Interactive Media I - Design Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2700",
+              "title": "User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2281",
+              "title": "Web Publishing III: JavaScript (Web Publishing III: JavaScript (Option A))",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2200",
+              "title": "Game Design III: Game Design Studio (Option B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2072",
+              "title": "Service Learning: Real World Experience in Web, Game Design, and Interactive Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2380",
+              "title": "Interactive Media II - App Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2291",
+              "title": "Web Publishing IV: Data-Driven Sites",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2401",
+              "title": "Game Design IV-Game Publishing",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Voicewriting, Short-Term Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/voicewriting-short-term-certificate/",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCR",
+              "number": "1101",
+              "title": "Introduction to Voice Writing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1200",
+              "title": "Voicewriting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1210",
+              "title": "Voicewriting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1350",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1470",
+              "title": "Transcript Production for Court Reporting and Captioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2351",
+              "title": "Editing Legal Documents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "1220",
+              "title": "Voicewriting III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2401",
+              "title": "Speedbuilding and Transcription at 180 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2480",
+              "title": "Using Captioning Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2451",
+              "title": "Speedbuilding and Transcription at 225 WPM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCR",
+              "number": "2841",
+              "title": "Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Application Development, Short-Term Certificate — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/web-application-development-short-term-certificate/",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IT",
+              "number": "2310",
+              "title": "Web Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IT",
+              "number": "2600",
+              "title": "E-Business Programming Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Design & Development, Certificate of Proficiency — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.tri-c.edu/programs/web-design-development-certificate-proficiency/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCIM",
+              "number": "1570",
+              "title": "Web Publishing I: HTML",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1000",
+              "title": "Visual Communication Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1201",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCPH",
+              "number": "1450",
+              "title": "Digital Imaging I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2281",
+              "title": "Web Publishing III: JavaScript",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2271",
+              "title": "2D Animation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "1431",
+              "title": "Vector Graphics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "1770",
+              "title": "Web Publishing II: Site Theory & Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2291",
+              "title": "Web Publishing IV: Data-Driven Sites",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2700",
+              "title": "User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VC",
+              "number": "2991",
+              "title": "Portfolio Preparation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCIM",
+              "number": "2072",
+              "title": "Service Learning: Real World Experience in Web, Game Design, and Interactive Media",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/oh/programs/james-a-rhodes-state-college.json
+++ b/data/oh/programs/james-a-rhodes-state-college.json
@@ -1,0 +1,8963 @@
+{
+  "college_slug": "james-a-rhodes-state-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.rhodesstate.edu/programs/",
+  "scraped_at": "2026-06-06T17:58:10.646Z",
+  "programs": [
+    {
+      "title": "Advanced EMT Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/advanced-emt-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "1120",
+              "title": "Advanced EMT",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Addiction Services Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/addiction-services-certificate/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "1710",
+              "title": "Substance-Related and Addictive Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2710",
+              "title": "Addictions Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Clerk Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/accounting-clerk-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience or Customer Service or Microeconomics or Macroeconomics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1020",
+              "title": "Managerial Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1050",
+              "title": "Accounting Software (QuickBooks)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1121",
+              "title": "Payroll Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Artificial Intelligence and Machine Learning (AAS) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/aas_artificial-intelligence/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIM",
+              "number": "1000",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1110",
+              "title": "Introduction to Programming Logic and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology or American Government and Civic Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "1300",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "1100",
+              "title": "Introduction to Machine Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2350",
+              "title": "Database Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "1010",
+              "title": "Maths for AI",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2200",
+              "title": "Natural Language Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2220",
+              "title": "Artificial Intelligence for Computer Vision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I or Introductory General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2130",
+              "title": "JavaScript Programming or Introduction to Java Programming or Linux Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2970",
+              "title": "AIM Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2991",
+              "title": "AIM Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1620",
+              "title": "Linux Administration I or Linux Administration II or C# Programming and .NET5 or Ethical Hacking I or Ethical Hacking II or Virtualization I or Virtualization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1625",
+              "title": "Linux Administration II or C# Programming and .NET5 or Ethical Hacking I or Ethical Hacking II or Virtualization I or Virtualization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology or Physics II or Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/accounting/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1020",
+              "title": "Managerial Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1050",
+              "title": "Accounting Software (QuickBooks)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1121",
+              "title": "Payroll Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2251",
+              "title": "Federal Income Tax",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1000",
+              "title": "Power Skills for Business Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2010",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2111",
+              "title": "Cost Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics or Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2020",
+              "title": "Intermediate Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2300",
+              "title": "Auditing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2401",
+              "title": "Applications in Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2100",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2901",
+              "title": "Field Experience (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior or Principles of Marketing or Business Communications or Project Management Principles or Small Business and the Entrepreneur",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Electro-Mechanical Engineering Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/advanced-mfg-technology/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1130",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2991",
+              "title": "Field Experience or Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1130",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1130",
+              "title": "Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2210",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2970",
+              "title": "MET Department Capstone or Electronic Engineering Technology Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Agricultural Data Analytics Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agriculturaldataanalytics/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1515",
+              "title": "Introduction to GPS in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1501",
+              "title": "Prescription Mapping in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1540",
+              "title": "Introduction to GIS in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agricultural Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agricultural-technology/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1000",
+              "title": "Introduction to Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1402",
+              "title": "Principles of Crop Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1404",
+              "title": "Introduction to Integrated Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1100",
+              "title": "Principles of Agricultural Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1401",
+              "title": "Introduction to Soils for Agronomic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1403",
+              "title": "Principles of Nutrient Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVI",
+              "number": "1000",
+              "title": "Unmanned Aerial Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "2991",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1300",
+              "title": "Principles of Agricultural Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1110",
+              "title": "Introductory General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1310",
+              "title": "Environmental Science I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "2970",
+              "title": "Agriculture Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agricultural Entrepreneur Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agriculture-robotics-intelligence-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1000",
+              "title": "Introduction to Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1300",
+              "title": "Principles of Agricultural Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1402",
+              "title": "Principles of Crop Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1100",
+              "title": "Principles of Agricultural Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1401",
+              "title": "Introduction to Soils for Agronomic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Nursing Assistant Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/advanced-nursing-assistant-certificate/",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I (ADN or BSN Concentration) or Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2120",
+              "title": "Introduction to Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Agronomic Prescription Mapping Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agronomicprescriptionmapping/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1402",
+              "title": "Principles of Crop Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1401",
+              "title": "Introduction to Soils for Agronomic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1403",
+              "title": "Principles of Nutrient Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1501",
+              "title": "Prescription Mapping in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agronomy Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agronomy/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1402",
+              "title": "Principles of Crop Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1404",
+              "title": "Introduction to Integrated Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1401",
+              "title": "Introduction to Soils for Agronomic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1403",
+              "title": "Principles of Nutrient Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Allied Health Profession to Paramedic Certification — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/allied-health-profession-paramedic-certification/",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2310",
+              "title": "Allied Health Professional to Medic",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2320",
+              "title": "Allied Health Professional to Medic Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agricultural Precision Equipment Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agriculturalprecisionequipment/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1500",
+              "title": "Precision Agriculture Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1515",
+              "title": "Introduction to GPS in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1502",
+              "title": "Agricultural Mechanics and Systems Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/american-sign-language-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1010",
+              "title": "American Sign Language I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology or Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1020",
+              "title": "American Sign Language II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2010",
+              "title": "American Sign Language III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2020",
+              "title": "American Sign Language IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Artificial Intelligence and Machine Learning (AS) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/artificial-intelligence/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1050",
+              "title": "Technology Basics for IT Pro",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "1000",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1610",
+              "title": "American History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1711",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1010",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1110",
+              "title": "Introduction to Programming Logic and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2350",
+              "title": "Database Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1721",
+              "title": "Calculus II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "1100",
+              "title": "Introduction to Machine Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2991",
+              "title": "AIM Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2210",
+              "title": "Introduction to Literature or Native American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2200",
+              "title": "Natural Language Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2220",
+              "title": "Artificial Intelligence for Computer Vision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "2970",
+              "title": "AIM Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1130",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts Degree — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/associate-arts-degree/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2820",
+              "title": "Directed Research for Capstone Project",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "RN to BSN Completion Program — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/bsnsg/",
+      "total_credits": 53,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "3010",
+              "title": "Evolving Roles in Professional Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "3020",
+              "title": "Healthcare Research in Evidence-Based Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "3030",
+              "title": "Nursing Informatics in Technological Healthcare Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "3040",
+              "title": "Nursing Leadership and Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology or Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1115",
+              "title": "Introductory General, Organic, and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "4010",
+              "title": "Advanced Health Assessment for Individuals and Families",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "4020",
+              "title": "Birth to Middle Age Nursing Care in a Global Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "4011",
+              "title": "Advanced Health Assessment for Complex Health Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "4021",
+              "title": "Gerontological Nursing Care in a Global Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1020",
+              "title": "American Government and Civic Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "4030",
+              "title": "Capstone in Professional Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1730",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Business Management Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/business-management-certificate/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1410",
+              "title": "Macroeconomics or Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1010",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1160",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2000",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/business-administration/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1010",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1000",
+              "title": "Power Skills for Business Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics or Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2000",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1160",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2100",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2901",
+              "title": "Field Experience (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2490",
+              "title": "Applications in Business Administration",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Fundamentals Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/business-administration-certificate/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1020",
+              "title": "Managerial Accounting Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1160",
+              "title": "Business Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1410",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1010",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Agricultural Business Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/agricultural-business-certificate/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1000",
+              "title": "Introduction to Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1300",
+              "title": "Principles of Agricultural Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1100",
+              "title": "Principles of Agricultural Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1200",
+              "title": "Sustainable Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cardiographic Technician Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/cardiographic-technician/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function or Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1530",
+              "title": "12 Lead ECG Interpretation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1540",
+              "title": "Advanced Cardiac Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science Degree — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/associate-science-degree/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2820",
+              "title": "Associate of Science Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development Associate Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/cda-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "1080",
+              "title": "Classroom Management and Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1300",
+              "title": "Curriculum, Observation, and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2040",
+              "title": "Administration and Health Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Cisco CCNA Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/cisco-ccna-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1706",
+              "title": "Cisco CCNA Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1716",
+              "title": "Cisco CCNA Switching, Routing, and Wireless Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2706",
+              "title": "Cisco CCNA Enterprise Networking Security and Automation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Numerical Control (CNC) Machining Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/cncmachining/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "1020",
+              "title": "Preventive Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1910",
+              "title": "OSHA 10-hr General Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1010",
+              "title": "Mechanical and Electrical Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2320",
+              "title": "Manual Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2340",
+              "title": "Numerical Control Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Peace Officer Academy - OPOTC Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/basic-peace-officer-training-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "2900",
+              "title": "Basic Police Academy",
+              "credits": 30,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computed Tomography (CT) Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/computed-tomography/",
+      "total_credits": 4,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "2620",
+              "title": "Principles of Computed Tomography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "2622",
+              "title": "Computed Tomography Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "2631",
+              "title": "Clinical Education I - CT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "2632",
+              "title": "Clinical Education II - CT",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Numerical Control Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/computer-numerical-control-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1130",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2210",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2440",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/cyber-security-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1705",
+              "title": "Cisco I - CCNA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2540",
+              "title": "Computer and Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2545",
+              "title": "Scripting for Cybersecurity Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2550",
+              "title": "Cryptography and Encryption",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2555",
+              "title": "Network Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1940",
+              "title": "Introduction to Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1945",
+              "title": "Introduction to the Internet of Things",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1950",
+              "title": "Security Awareness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1955",
+              "title": "Firewall Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1715",
+              "title": "Cisco II - CCNA",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media Technology Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/digital-media-technology-certificate/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1210",
+              "title": "Introduction to Digital and Emerging Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1580",
+              "title": "Introduction to Graphic Design and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2755",
+              "title": "Web Content Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2670",
+              "title": "Graphics Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2760",
+              "title": "Animation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2650",
+              "title": "Creating and Editing Digital Images",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2700",
+              "title": "Digital Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2770",
+              "title": "Animation II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/dental-hygiene/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drone Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/dronecertificate/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVI",
+              "number": "1000",
+              "title": "Unmanned Aerial Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVI",
+              "number": "1200",
+              "title": "Unmanned Aerial Systems Basic Operation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Semiconductors Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/electrical-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMC",
+              "number": "1000",
+              "title": "Semiconductors 101",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMC",
+              "number": "1200",
+              "title": "Introduction to Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMC",
+              "number": "1100",
+              "title": "Vacuum and Gases",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro-Mechanical Systems Technology Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/electro-mechanical-systems-technology-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1100",
+              "title": "Welding and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1130",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2210",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2200",
+              "title": "Panel Wiring and Arc Flash Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2900",
+              "title": "Electric Codes and Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2340",
+              "title": "Numerical Control Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2170",
+              "title": "Industrial Motor Drives",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2260",
+              "title": "Industrial Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2440",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Systems Technology Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/electronic-systems-technology-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1921",
+              "title": "Technical Math II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2320",
+              "title": "C# Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1130",
+              "title": "Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2200",
+              "title": "Panel Wiring and Arc Flash Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2310",
+              "title": "Microcontroller Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2900",
+              "title": "Electric Codes and Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2170",
+              "title": "Industrial Motor Drives",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2260",
+              "title": "Industrial Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Engineering Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/electronic-engineering-technology/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1130",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo or Conversational German or Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2991",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1130",
+              "title": "Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2311",
+              "title": "Microcontroller Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2900",
+              "title": "Electric Codes and Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2970",
+              "title": "Electronic Engineering Technology Capstone or MET Department Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Health Safety Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/environmental-health-safety-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "1100",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1000",
+              "title": "Introduction to EHS Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1210",
+              "title": "Environmental Laws and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "1110",
+              "title": "Introduction to Operations Excellence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "2970",
+              "title": "Troubleshooting Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Forensic Mental Health Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/forensic-mental-health-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "2022",
+              "title": "Criminal Minds or Criminal Minds",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2400",
+              "title": "Crisis Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "2010",
+              "title": "Psychology and the Legal System or Psychology and the Legal System",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1980",
+              "title": "The Color of Justice or The Color of Justice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2170",
+              "title": "Dynamics of Mental Health and Substance Use",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2230",
+              "title": "Issues and Ethics in Helping or Ethics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/emergency-medical-services/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Volunteer Firefighter",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1160",
+              "title": "Level I Transition Firefighter",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1170",
+              "title": "Level I Firefighter",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1180",
+              "title": "Level II Firefighter",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1190",
+              "title": "Fire Safety Inspector",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Care Administration  (Northwest Ohio Allied Health Education Consortium) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/health-care-administration/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2400",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "1300",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Care Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/health-care-technology/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1160",
+              "title": "Medical Law-Ethics Healthcare",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "2500",
+              "title": "Health Care Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/general-education-requirements/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1160",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1200",
+              "title": "Writing in the Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2400",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1011",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1012",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1610",
+              "title": "American History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "2300",
+              "title": "Technology and Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2210",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2215",
+              "title": "Native American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2260",
+              "title": "Fantasy Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2227",
+              "title": "Literature of Graphic Novels",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2228",
+              "title": "African-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2241",
+              "title": "World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2242",
+              "title": "World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2250",
+              "title": "The American Short Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2301",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2310",
+              "title": "Literature and the Holocaust",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2450",
+              "title": "Themes in Literature and Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1010",
+              "title": "Music Appreciation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "1010",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1611",
+              "title": "Business Calculus",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1711",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1721",
+              "title": "Calculus II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "2660",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "2670",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "2680",
+              "title": "Elementary Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "2510",
+              "title": "History of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1730",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2150",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2200",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2301",
+              "title": "Educational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1200",
+              "title": "Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1210",
+              "title": "Family Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1320",
+              "title": "American Cultural Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2211",
+              "title": "World Religions: History, Belief, and Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2300",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "1010",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2121",
+              "title": "Introduction to Human Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1110",
+              "title": "Introductory General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1130",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Family Services Worker Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/family-services-worker-certificate/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "1150",
+              "title": "Interviewing Techniques in Addictions, Mental Health and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2100",
+              "title": "Case Management in Addictions, Mental Health and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2230",
+              "title": "Issues and Ethics in Helping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2310",
+              "title": "Group Dynamics/Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resource Specialist Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/human-resource-management-certificate/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "2000",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2060",
+              "title": "Employee and Labor Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2435",
+              "title": "Benefits and Compensation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2440",
+              "title": "Training, Development and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2410",
+              "title": "Employee Selection and Placement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2500",
+              "title": "Human Resource Analytics and Strategic Management",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resource — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/human-resource/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2000",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1000",
+              "title": "Power Skills for Business Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2410",
+              "title": "Employee Selection and Placement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2440",
+              "title": "Training, Development and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics or Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2060",
+              "title": "Employee and Labor Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2435",
+              "title": "Benefits and Compensation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2100",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2901",
+              "title": "Field Experience (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2500",
+              "title": "Human Resource Analytics and Strategic Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2530",
+              "title": "Applications in Human Resources",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing or Payroll Accounting or Team Building or Business Communications or Project Management Principles",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industry 4.0 Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/industry4-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1080",
+              "title": "Mechanical Drive Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Security Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/it-network-security-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1620",
+              "title": "Linux Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1706",
+              "title": "Cisco CCNA Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1716",
+              "title": "Cisco CCNA Switching, Routing, and Wireless Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2706",
+              "title": "Cisco CCNA Enterprise Networking Security and Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2930",
+              "title": "Ethical Hacking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2935",
+              "title": "Ethical Hacking II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Laboratory Science Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/laboratory-science-technology/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1210",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1310",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LST",
+              "number": "1210",
+              "title": "Experimental Design",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1011",
+              "title": "Western Civilization I or Western Civilization II or History of Latin America or Women in World History or Literature and the Holocaust",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2820",
+              "title": "Associate of Science Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2400",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LST",
+              "number": "1220",
+              "title": "Internship Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1010",
+              "title": "Music Appreciation I or Introduction to Film or Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1320",
+              "title": "American Cultural Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Addictions, Mental Health, and Social Work Assistant — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/human-service/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1111",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1150",
+              "title": "Interviewing Techniques in Addictions, Mental Health and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1900",
+              "title": "Professional Preparation and Engagement",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2100",
+              "title": "Case Management in Addictions, Mental Health and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2230",
+              "title": "Issues and Ethics in Helping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1730",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1710",
+              "title": "Substance-Related and Addictive Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2400",
+              "title": "Crisis Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2991",
+              "title": "Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2170",
+              "title": "Dynamics of Mental Health and Substance Use",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2310",
+              "title": "Group Dynamics/Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2710",
+              "title": "Addictions Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2150",
+              "title": "Lifespan Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "2992",
+              "title": "Practicum II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/liberal-arts-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1010",
+              "title": "Music Appreciation I or Introduction to Film or Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2241",
+              "title": "World Literature I or World Literature II or British Literature I or Literature and the Holocaust",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2400",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1011",
+              "title": "Western Civilization I or Western Civilization II or Women in World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1320",
+              "title": "American Cultural Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2211",
+              "title": "World Religions: History, Belief, and Practice or Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Mammography Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/mammography/",
+      "total_credits": 4,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "2721",
+              "title": "Principles of Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "2722",
+              "title": "Mammographic Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "2731",
+              "title": "Clinical Education I - Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "2732",
+              "title": "Clinical Education II - Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "LPN to ADN Transition Program — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/lpn-adn-transition-program/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Manufacturing Engineering Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/manufacturing-engineering-technology/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra or Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2991",
+              "title": "Field Experience or Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2970",
+              "title": "MET Department Capstone or Electronic Engineering Technology Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Digital Marketing and Media — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/marketing/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1210",
+              "title": "Introduction to Digital and Emerging Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics or Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1000",
+              "title": "Power Skills for Business Professionals",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2650",
+              "title": "Creating and Editing Digital Images",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2000",
+              "title": "Digital Marketing and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1580",
+              "title": "Introduction to Graphic Design and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2670",
+              "title": "Graphics Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2300",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2901",
+              "title": "Field Experience (Internship)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2490",
+              "title": "Applications in Digital Marketing and Media",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mechanical Engineering Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/mechanical-engineering-technology/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1120",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1130",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1130",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo or Conversational German or Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2991",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2210",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2440",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2970",
+              "title": "MET Department Capstone or Electronic Engineering Technology Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Marketing Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/marketing-certificate/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "1430",
+              "title": "Microeconomics or Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1610",
+              "title": "Customer Service",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1620",
+              "title": "Public Relations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2000",
+              "title": "Digital Marketing and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2700",
+              "title": "Digital Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2650",
+              "title": "Creating and Editing Digital Images",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2210",
+              "title": "Comprehensive Sales Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2300",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1580",
+              "title": "Introduction to Graphic Design and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Billing and Coding Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/medical-billing-coding-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Microcontrollers Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/microcontrollers-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2320",
+              "title": "C# Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2310",
+              "title": "Microcontroller Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2900",
+              "title": "Electric Codes and Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2260",
+              "title": "Industrial Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2820",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1130",
+              "title": "Statics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2210",
+              "title": "Strength of Materials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2440",
+              "title": "Computer Aided Design",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equipment Service Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/minor-maintenance-certificate/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "1080",
+              "title": "Mechanical Drive Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2400",
+              "title": "Introduction to Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2080",
+              "title": "Introduction to Electricity or Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nurse Assistant Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/nurse-assistant-certificate/",
+      "total_credits": 5,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1140",
+              "title": "Certified Nurse Aide Training",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Laboratory Technology (Northwest Ohio Allied Health Education Consortium) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/medical-laboratory-technology/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2400",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Security — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/networking-security/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1605",
+              "title": "IT Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1411",
+              "title": "Microsoft Azure Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1416",
+              "title": "Microsoft Azure Administrator",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1620",
+              "title": "Linux Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1706",
+              "title": "Cisco CCNA Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1716",
+              "title": "Cisco CCNA Switching, Routing, and Wireless Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2930",
+              "title": "Ethical Hacking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2935",
+              "title": "Ethical Hacking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1625",
+              "title": "Linux Administration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2706",
+              "title": "Cisco CCNA Enterprise Networking Security and Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2940",
+              "title": "Virtualization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2991",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2965",
+              "title": "Applications of Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2742",
+              "title": "Cisco CCNP Enterprise: Core Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2743",
+              "title": "Cisco CCNP Enterprise: Advanced Routing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1421",
+              "title": "Microsoft Azure Security Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Scribe (Northwest Ohio Allied Health Education Consortium) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/medical-scribe/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2310",
+              "title": "Healthcare Reimbursement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2430",
+              "title": "Electronic Health Records and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/nursing/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Operations Excellence Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/operations-excellence-certificate/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OET",
+              "number": "1100",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "1110",
+              "title": "Introduction to Operations Excellence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "1120",
+              "title": "Tools of Operations Excellence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2015",
+              "title": "Statistics for SPC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2021",
+              "title": "Advanced Tools of Operations Excellence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2120",
+              "title": "Quality Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2210",
+              "title": "Logistics and Supply Chain",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2510",
+              "title": "Lean Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2970",
+              "title": "Cost Analysis and Estimating",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OET",
+              "number": "2980",
+              "title": "OET Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "One-Year Maintenance Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/one-year-maintenance-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IMT",
+              "number": "1921",
+              "title": "Technical Math II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1130",
+              "title": "Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2200",
+              "title": "Panel Wiring and Arc Flash Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2310",
+              "title": "Microcontroller Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2900",
+              "title": "Electric Codes and Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2080",
+              "title": "Introduction to Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2260",
+              "title": "Industrial Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1050",
+              "title": "CAD for Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2320",
+              "title": "Manual Machining I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2810",
+              "title": "Millwright Tools and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2820",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1100",
+              "title": "Welding and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1080",
+              "title": "Mechanical Drive Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "2970",
+              "title": "Troubleshooting Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "2550",
+              "title": "Fundamentals of Plumbing and Pipefitting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2400",
+              "title": "Introduction to Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2170",
+              "title": "Industrial Motor Drives",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2710",
+              "title": "Fundamentals of Refrigeration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2740",
+              "title": "Advanced Refrigeration and HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2750",
+              "title": "Wastewater Treatment and Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2850",
+              "title": "Power Plant Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/paramedic-certificate/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2210",
+              "title": "Paramedic I",
+              "credits": 13,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2215",
+              "title": "Paramedic Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2220",
+              "title": "Paramedic II",
+              "credits": 13,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2225",
+              "title": "Paramedic Field Experience",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/occupational-therapy-assistant/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Patient Care Technician Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/patient-care-technician-certificate/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function or Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1000",
+              "title": "Introduction to Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1160",
+              "title": "Medical Law-Ethics Healthcare",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2000",
+              "title": "Advanced Patient Care",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/phlebotomy-certificate/",
+      "total_credits": 3,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1845",
+              "title": "Phlebotomy Principles and Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1850",
+              "title": "Phlebotomy Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Systems Technology Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/mechanical-systems-technology-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1110",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1130",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2210",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2440",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Transfer Module Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/ohio-transfer-module-certificate/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1151",
+              "title": "Quantitative Reasoning or Statistics or College Algebra or Trigonometry or Business Calculus or Calculus I or Calculus II or Calculus III or Differential Equations or Elementary Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2210",
+              "title": "Introduction to Literature or Native American Literature or Literature of Graphic Novels or African-American Literature or World Literature I or World Literature II or The American Short Story or Fantasy Literature or British Literature I or Literature and the Holocaust or Themes in Literature and Film or Music Appreciation I or Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or History of Latin America or American Government or Death and Dying or Family Sociology or American Cultural Diversity or World Religions: History, Belief, and Practice or Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1210",
+              "title": "Biology I or Anatomy and Physiology I or Introductory General Chemistry or Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2400",
+              "title": "English Composition II or Technical Writing or Business Communications or Writing in the Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877 or Western Civilization I or Western Civilization II or American History to 1877 or Women in World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology or Abnormal Psychology or Lifespan Psychology or Social Psychology or Educational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking or Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II or Microbiology or Introduction to Human Genetics or Introductory Organic and Biochemistry or Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/physical-therapist-assistant/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programmable Controller Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/programmable-controllers-certificate/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/practical-nursing-certificate/",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "2120",
+              "title": "Introduction to Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function (or BIO 1110 & BIO 1120)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNS",
+              "number": "1200",
+              "title": "Foundations of Practical Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNS",
+              "number": "1202",
+              "title": "Adult Medical-Surgical Nursing",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNS",
+              "number": "1203",
+              "title": "PN-Issues and Trends",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNS",
+              "number": "1204",
+              "title": "Maternal Child Nursing",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Programmable Logic Controllers Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/programmable-logic-controllers-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1070",
+              "title": "Basic Electricity and Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1040",
+              "title": "Blueprint Reading and Schematics or Engineering Graphics with AutoCAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2920",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1020",
+              "title": "Preventive Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Project Management Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/project-management-certificate/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PGM",
+              "number": "2000",
+              "title": "Project Management Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGM",
+              "number": "2010",
+              "title": "Project Management Techniques",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Power Skills for Business and Industry Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/power-skills-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1010",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1250",
+              "title": "Team Building",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1610",
+              "title": "Customer Service",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1320",
+              "title": "American Cultural Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Radiographic Imaging (Radiography) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/radiographic-imaging-radiography/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Production Associate Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/production-associate/",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1020",
+              "title": "Preventive Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1040",
+              "title": "Blueprint Reading and Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1910",
+              "title": "OSHA 10-hr General Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1020",
+              "title": "Manufacturing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Robotics Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/robotics-certificate/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "1020",
+              "title": "Preventive Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1040",
+              "title": "Blueprint Reading and Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1070",
+              "title": "Basic Electricity and Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "2050",
+              "title": "Robot Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "2970",
+              "title": "Troubleshooting Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Red Hat Systems Administrator Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/red-hat-systems-administrator/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1620",
+              "title": "Linux Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1625",
+              "title": "Linux Administration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1706",
+              "title": "Cisco CCNA Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1716",
+              "title": "Cisco CCNA Switching, Routing, and Wireless Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sterile Processing Technician Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/sterile-processing-technician-certificate/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STP",
+              "number": "1000",
+              "title": "Sterile Processing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STP",
+              "number": "1200",
+              "title": "Sterile Processing II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STP",
+              "number": "1207",
+              "title": "Directed Practice For Sterile Processing",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/supply-chain-management/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AOT",
+              "number": "2640",
+              "title": "Spreadsheet Software and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PGM",
+              "number": "2000",
+              "title": "Project Management Principles or Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCM",
+              "number": "1100",
+              "title": "Supply Chain Management Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2440",
+              "title": "Training, Development and Safety or OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCM",
+              "number": "1200",
+              "title": "Logistics and Transportation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCM",
+              "number": "1300",
+              "title": "Purchasing and Negotiation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Respiratory Care — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/respiratory-care/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "1150",
+              "title": "Applied Functional Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "2110",
+              "title": "Growth and Development: Lifespan",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1000",
+              "title": "Basic Human Structure and Function",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1120",
+              "title": "Introductory Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTN",
+              "number": "1220",
+              "title": "Principles of Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1721",
+              "title": "Pharmacology for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tax Preparer Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/tax-preparer-certificate/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1010",
+              "title": "Corporate Accounting Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1050",
+              "title": "Accounting Software (QuickBooks)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2251",
+              "title": "Federal Income Tax",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/surgical-technology/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SRG",
+              "number": "1050",
+              "title": "Introduction to Sterile Processing for the Surgical Technologist",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1110",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "1000",
+              "title": "Theory and Fundamentals",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1120",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "1200",
+              "title": "Pharmacology for Surgical Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "1700",
+              "title": "Surgical Procedures I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "1510",
+              "title": "Directed Practice for Surgical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "2100",
+              "title": "Surgical Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "2110",
+              "title": "Directed Practice for Surgical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "2500",
+              "title": "Surgical Procedures III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "2610",
+              "title": "Surgical Technology Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Troubleshooting Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/troubleshooting-certificate/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "1370",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1430",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1911",
+              "title": "Technical Math I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1921",
+              "title": "Technical Math II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2320",
+              "title": "C# Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1120",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1130",
+              "title": "Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1330",
+              "title": "Digital Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2030",
+              "title": "Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2200",
+              "title": "Panel Wiring and Arc Flash Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2310",
+              "title": "Microcontroller Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2900",
+              "title": "Electric Codes and Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2911",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "1300",
+              "title": "OSHA Regulations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2110",
+              "title": "Basic Robotics and Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2130",
+              "title": "Industrial Mechatronics and Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2170",
+              "title": "Industrial Motor Drives",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "2260",
+              "title": "Industrial Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Marketing Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/social-media-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "1010",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2300",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2650",
+              "title": "Creating and Editing Digital Images",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2700",
+              "title": "Digital Video Editing or Web Content Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "2000",
+              "title": "Digital Marketing and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Pre-Veterinary Technology/Nursing — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/vet-tech/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "1390",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1210",
+              "title": "Biology I or Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology or Macroeconomics or Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1110",
+              "title": "Introductory General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2110",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Developer Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/web-developer-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1110",
+              "title": "Introduction to Programming Logic and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2130",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2650",
+              "title": "Creating and Editing Digital Images",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1820",
+              "title": "ASP.NET Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2350",
+              "title": "Database Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2750",
+              "title": "HTML and CSS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Team Leadership Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/team-leadership-certificate/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "1010",
+              "title": "Principles of Management or Project Management Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1250",
+              "title": "Computer Applications in the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1250",
+              "title": "Team Building",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2010",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2213",
+              "title": "Verbal Judo",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tool and Die Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/tool-and-die-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "1091",
+              "title": "Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2210",
+              "title": "CAM/CNC Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1000",
+              "title": "Engineering Graphics with AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1010",
+              "title": "Blueprint Reading and Sketching",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2310",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "1100",
+              "title": "Welding and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMS",
+              "number": "2220",
+              "title": "CAM/CNC Machining II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1190",
+              "title": "Tool and Die Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IMT",
+              "number": "1195",
+              "title": "Tool and Die Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1020",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Programming/Computer Programming Certificate — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/web-programing-computer-programing-certificate/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPT",
+              "number": "1050",
+              "title": "Technology Basics for IT Pro",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1110",
+              "title": "Introduction to Programming Logic and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2321",
+              "title": "C# Programming and .NET5",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2750",
+              "title": "HTML and CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2130",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2210",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2350",
+              "title": "Database Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2400",
+              "title": "Special Topics in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2500",
+              "title": "iOS Mobile Applications Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Programming/Computer Programming — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.rhodesstate.edu/programs/web-programming-computer-programming/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "1110",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1110",
+              "title": "Introduction to Programming Logic and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1580",
+              "title": "Introduction to Graphic Design and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1120",
+              "title": "Introduction to VB Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1411",
+              "title": "Microsoft Azure Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDE",
+              "number": "1010",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Sociology or General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "1260",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "1620",
+              "title": "Linux Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2130",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2750",
+              "title": "HTML and CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2350",
+              "title": "Database Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "1000",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2321",
+              "title": "C# Programming and .NET5",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "1140",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HST",
+              "number": "1620",
+              "title": "American History Since 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2210",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2400",
+              "title": "Special Topics in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2450",
+              "title": "Introduction to Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2500",
+              "title": "iOS Mobile Applications Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPT",
+              "number": "2991",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "1100",
+              "title": "Introduction to Machine Learning or Maths for AI",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/oh/programs/lakeland-community-college.json
+++ b/data/oh/programs/lakeland-community-college.json
@@ -1,0 +1,14914 @@
+{
+  "college_slug": "lakeland-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/",
+  "scraped_at": "2026-06-06T17:58:05.773Z",
+  "programs": [
+    {
+      "title": "General Accounting Certificate (2101) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/acct/2101/",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1200",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2110",
+              "title": "Managerial Accounting: Cost",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2200",
+              "title": "Intermediate Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2210",
+              "title": "Managerial Accounting: Finance",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Family Financial Planning Certificate (2104) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/acct/2104/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FINN",
+              "number": "1100",
+              "title": "Personal and Family Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1200",
+              "title": "Fundamentals of Investing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1300",
+              "title": "Financial Management for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Financial Accounting Certificate (2102) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/acct/2102/",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1200",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2110",
+              "title": "Managerial Accounting: Cost",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2120",
+              "title": "Auditing Theory and Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2130",
+              "title": "Advanced Topics in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2140",
+              "title": "Ethics and Professional Standards for Accounting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2200",
+              "title": "Intermediate Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2210",
+              "title": "Managerial Accounting: Finance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2390",
+              "title": "Taxation of Individuals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Small Business Accounting Certificate (2103) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/acct/2103/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1200",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2110",
+              "title": "Managerial Accounting: Cost",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2210",
+              "title": "Managerial Accounting: Finance",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2390",
+              "title": "Taxation of Individuals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1300",
+              "title": "Financial Management for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting  (9210) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/acct/9210/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1100",
+              "title": "Personal and Family Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1200",
+              "title": "Introduction to Managerial Accounting ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Accounting Information Systems ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomicsor Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Intermediate Accounting I ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2110",
+              "title": "Managerial Accounting: Cost ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2390",
+              "title": "Taxation of Individuals ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2200",
+              "title": "Intermediate Accounting II ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2210",
+              "title": "Managerial Accounting: Finance ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2130",
+              "title": "Business Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Applied American Sign Language Studies (9312) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/asli/9312/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLI",
+              "number": "1100",
+              "title": "Introduction to American Sign Language I ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "1550",
+              "title": "Deaf History and Culture ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "1200",
+              "title": "Introduction to American Sign Language II ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "2700",
+              "title": "Resources Concerning the Deaf Community ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1150",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "1700",
+              "title": "Deaf Literature ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "1800",
+              "title": "American Sign Language I ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "1830",
+              "title": "American Sign Language: Discourse ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "1850",
+              "title": "American Sign Language II ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLI",
+              "number": "2750",
+              "title": "Applied Issues Concerning the Deaf Community ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Technical Studies — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/ats/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Science Certificate (3751) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/bios/3751/",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOS",
+              "number": "1050",
+              "title": "Introduction to Biotechnology Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1200",
+              "title": "Biotechnology Science Lab Skills",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1500",
+              "title": "Introduction to Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1600",
+              "title": "Advanced Molecular Separations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2100",
+              "title": "Applied Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2400",
+              "title": "Tissue Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2500",
+              "title": "Recombinant DNA Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2550",
+              "title": "Introduction to Bioinformatics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2600",
+              "title": "Bioscience Manufacturing Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2700",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2800",
+              "title": "Biotechnology Science Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business Management Certificate (2201) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2201/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1500",
+              "title": "International Business in a Global Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2250",
+              "title": "Leadership Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2570",
+              "title": "Principles of Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Ohio Real Estate Salesperson Certificate (2072) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2072/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "REST",
+              "number": "1100",
+              "title": "Real Estate Principles and Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1200",
+              "title": "Real Estate Finance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1300",
+              "title": "Real Estate Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1400",
+              "title": "Real Estate Appraisal",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bioinformatics Concentration (9376) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/bios/9376/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1510",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "General Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1500",
+              "title": "Introduction to Biochemistry ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1520",
+              "title": "Microsoft Office Excel: Skills and Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2500",
+              "title": "Recombinant DNA Technology ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1405",
+              "title": "Oracle PL/SQL Programming ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2400",
+              "title": "Tissue Culture ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2550",
+              "title": "Introduction to Bioinformatics ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2700",
+              "title": "Internship ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2800",
+              "title": "Biotechnology Science Seminar ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resources Management Certificate (2251) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2251/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2330",
+              "title": "Employment Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2380",
+              "title": "Training Skills and Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Leadership Certificate (2262) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2262/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2250",
+              "title": "Leadership Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2380",
+              "title": "Training Skills and Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Information Management Certificate (2221) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2221/",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing Certificate (2271) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2271/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1400",
+              "title": "Professional Personal Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1700",
+              "title": "Principles of E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2530",
+              "title": "Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Ohio Real Estate Broker Certificate (2280) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2280/",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "1150",
+              "title": "Basic Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1300",
+              "title": "Financial Management for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1500",
+              "title": "Applied Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1100",
+              "title": "Real Estate Principles and Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1200",
+              "title": "Real Estate Finance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1300",
+              "title": "Real Estate Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REST",
+              "number": "1400",
+              "title": "Real Estate Appraisal",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship Certificate (2291) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2291/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1620",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2250",
+              "title": "Leadership Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2640",
+              "title": "Managing Entrepreneurial Ventures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1300",
+              "title": "Financial Management for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Communications Certificate (2610) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2610/",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skillsor Computer Essentials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Science (9375) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/bios/9375/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOS",
+              "number": "1050",
+              "title": "Introduction to Biotechnology Science ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1200",
+              "title": "Biotechnology Science Lab Skills ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1510",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "General Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1500",
+              "title": "Introduction to Biochemistry ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1600",
+              "title": "General Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "1600",
+              "title": "Advanced Molecular Separations ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2100",
+              "title": "Applied Microbiology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2500",
+              "title": "Recombinant DNA Technology ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2600",
+              "title": "Bioscience Manufacturing Processes ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2550",
+              "title": "Introduction to Bioinformatics ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2800",
+              "title": "Biotechnology Science Seminar ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1050",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2400",
+              "title": "Tissue Culture ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2700",
+              "title": "Internship ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Associate of Arts Degree in Business (9010) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/9010/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1200",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2400",
+              "title": "Calculus for Business, Social, and Life Sciences",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2130",
+              "title": "Business Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "E-Business Certificate (2202) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/2202/",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1700",
+              "title": "Principles of E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2550",
+              "title": "Direct and Digital Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Information Management Concentration (9222) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/9222/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentials or Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1520",
+              "title": "Microsoft Office Excel: Skills and Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management or Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1435",
+              "title": "Introductory Data Analytics ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2700",
+              "title": "Management Philosophy and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1450",
+              "title": "Visualization Tools for Data Analytics ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship Concentration (9215) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/9215/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1620",
+              "title": "Introduction to Entrepreneurship ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skills or Computer Essentials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets  or Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2250",
+              "title": "Leadership Development ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2640",
+              "title": "Managing Entrepreneurial Ventures ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINN",
+              "number": "1300",
+              "title": "Financial Management for the Small Business ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2700",
+              "title": "Management Philosophy and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Management Concentration (9224) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/9224/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skills or Computer Essentials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1500",
+              "title": "International Business in a Global Environment ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2250",
+              "title": "Leadership Development ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets  or Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2570",
+              "title": "Principles of Supply Chain Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2700",
+              "title": "Management Philosophy and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Human Resources Management Concentration (9225) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/9225/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skills or Computer Essentials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2300",
+              "title": "Human Resource Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2330",
+              "title": "Employment Practices ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2380",
+              "title": "Training Skills and Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets  or Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2700",
+              "title": "Management Philosophy and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing Concentration (9227) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/busm/9227/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skills or Computer Essentials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Applied Business Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "Mathematics of Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1400",
+              "title": "Professional Personal Selling ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1700",
+              "title": "Principles of E-Business ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2530",
+              "title": "Advertising ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1270",
+              "title": "Financial Analysis Using Spreadsheets  or Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2700",
+              "title": "Management Philosophy and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemical Technician Certificate (3701) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/chem/3701/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "General Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1700",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1600",
+              "title": "General Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2500",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2000",
+              "title": "Quantitative Analysis",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2600",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2800",
+              "title": "Internship and Seminar in Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro-Mechanical Fundamentals Certificate (4203) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4203/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1120",
+              "title": "DC Circuits with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "Applied Physics Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Computer Hardware Technician Certificate (4241) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4241/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1100",
+              "title": "Cisco Networking Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPET",
+              "number": "1050",
+              "title": "Managing Computers: Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPET",
+              "number": "1120",
+              "title": "C Prog for Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "2080",
+              "title": "Supporting Client Operating Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Repair Technology Certificate (4303) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4303/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1420",
+              "title": "Computer Numerical Control Part Programming (CNC)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1430",
+              "title": "Introduction to Computer Assisted Part Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1450",
+              "title": "Programming CNC Lathes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1460",
+              "title": "Programming CNC Machining Centers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2240",
+              "title": "Jig and Fixture Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2370",
+              "title": "Materials Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1040",
+              "title": "Introduction to Metal Fabrication and Mechanized Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Repair Electrician Certificate (4310) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4310/",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1020",
+              "title": "Industrial Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1220",
+              "title": "AC Circuits with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1330",
+              "title": "Digital Electronics with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2120",
+              "title": "Electronics with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2300",
+              "title": "Sensors, Actuators, and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2700",
+              "title": "Motor Control and Servo Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2821",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2150",
+              "title": "Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Repair Mechanic Certificate (4311) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4311/",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1420",
+              "title": "Computer Numerical Control Part Programming (CNC)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1430",
+              "title": "Introduction to Computer Assisted Part Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2390",
+              "title": "Fluid Power Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2150",
+              "title": "Power Transmission",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2370",
+              "title": "Materials Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1040",
+              "title": "Introduction to Metal Fabrication and Mechanized Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Operator Mini Certificate (4315) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4315/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1420",
+              "title": "Computer Numerical Control Part Programming (CNC)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1450",
+              "title": "Programming CNC Lathes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1460",
+              "title": "Programming CNC Machining Centers",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Set-Up and Programming Technology Certificate (4312) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4312/",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2500",
+              "title": "Advanced SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1420",
+              "title": "Computer Numerical Control Part Programming (CNC)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1430",
+              "title": "Introduction to Computer Assisted Part Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1450",
+              "title": "Programming CNC Lathes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1460",
+              "title": "Programming CNC Machining Centers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGS",
+              "number": "1000",
+              "title": "Introduction to Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Production Shift Leader/Manufacturing Management Certificate (4351) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4351/",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1210",
+              "title": "Materials Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2190",
+              "title": "Manufacturing Methods and Costs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGS",
+              "number": "1000",
+              "title": "Introduction to Engineering",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Tool Room/Maintenance Machinist Certificate (4302) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/4302/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technologyor Introduction to Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1210",
+              "title": "Materials Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1420",
+              "title": "Computer Numerical Control Part Programming (CNC)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1450",
+              "title": "Programming CNC Lathes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1460",
+              "title": "Programming CNC Machining Centers",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Maintenance and Repair Concentration (9439) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/9439/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1160",
+              "title": "Applied Electricity ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1210",
+              "title": "Materials Processing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition IIor Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1550",
+              "title": "Everyday Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Businessor Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2150",
+              "title": "Power Transmission ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2390",
+              "title": "Fluid Power Technology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2840",
+              "title": "Repair and Maintenance Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QENT",
+              "number": "1200",
+              "title": "Quality Concepts and Techniques ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management Certificate (4131) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/civt/4131/",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1011",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1012",
+              "title": "Reading Construction Drawings",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1016",
+              "title": "Civil Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1019",
+              "title": "Architectural Building Codes and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1021",
+              "title": "Construction Materials Testing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2016",
+              "title": "Scheduling and Building Information Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2018",
+              "title": "Construction Estimating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2020",
+              "title": "Green Building and LEED (R) Rating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2024",
+              "title": "Construction Administration and Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2025",
+              "title": "Safety in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2800",
+              "title": "Engineering Co-Op Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1180",
+              "title": "Technical Mathematics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "Applied Physics Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Facility Management Certificate (4141) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/civt/4141/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1011",
+              "title": "Construction Methods and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1012",
+              "title": "Reading Construction Drawings",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1016",
+              "title": "Civil Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1019",
+              "title": "Architectural Building Codes and Standards",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1028",
+              "title": "Mechanical and Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2017",
+              "title": "Construction Estimating and Scheduling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2024",
+              "title": "Construction Administration and Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2025",
+              "title": "Safety in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2800",
+              "title": "Engineering Co-Op Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1180",
+              "title": "Technical Mathematics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "General Manufacturing Major (9430) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cimn/9430/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technologyor Introduction to Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1420",
+              "title": "Computer Numerical Control Part Programming (CNC) ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1430",
+              "title": "Introduction to Computer Assisted Part Programming ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1210",
+              "title": "Materials Processing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1450",
+              "title": "Programming CNC Lathes ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1460",
+              "title": "Programming CNC Machining Centers ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition IIor Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2500",
+              "title": "Advanced SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2190",
+              "title": "Manufacturing Methods and Costs ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2240",
+              "title": "Jig and Fixture Design ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1550",
+              "title": "Everyday Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Businessor Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2875",
+              "title": "Design and Manufacturing Capstone ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QENT",
+              "number": "1200",
+              "title": "Quality Concepts and Techniques ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management (9413) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/civt/9413/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIVT",
+              "number": "1011",
+              "title": "Construction Methods and Materials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1180",
+              "title": "Technical Mathematics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1012",
+              "title": "Reading Construction Drawings ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1019",
+              "title": "Architectural Building Codes and Standards ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1016",
+              "title": "Civil Drafting ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1021",
+              "title": "Construction Materials Testing ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "Applied Physics Mechanics or General Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1620",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1410",
+              "title": "Building Construction I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2018",
+              "title": "Construction Estimating ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2025",
+              "title": "Safety in Construction ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1400",
+              "title": "Professional Personal Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2016",
+              "title": "Scheduling and Building Information Modeling ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2020",
+              "title": "Green Building and LEED (R) Rating System ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2024",
+              "title": "Construction Administration and Inspection ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cisco Network Security Certificate (4254) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cnet/4254/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNET",
+              "number": "1100",
+              "title": "Cisco Networking Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1200",
+              "title": "Cisco Networking Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1300",
+              "title": "Cisco Networking Technology III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1735",
+              "title": "Cisco Cyber Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2720",
+              "title": "Cisco Network Security: Managing Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1011",
+              "title": "History of Computing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2355",
+              "title": "Security Investigation and Penetration Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cisco Network Security (9438) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/cnet/9438/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology or Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1100",
+              "title": "Cisco Networking Technology I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1200",
+              "title": "Cisco Networking Technology II ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1310",
+              "title": "Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1735",
+              "title": "Cisco Cyber Operations ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1050",
+              "title": "Fundamentals of Public Speaking or Fundamentals of Interpersonal Communications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1758",
+              "title": "Linux Administration II ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1610",
+              "title": "General Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2720",
+              "title": "Cisco Network Security: Managing Security ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1300",
+              "title": "Cisco Networking Technology III ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene (9310) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/dnhy/9310/",
+      "total_credits": 75,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 75,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1110",
+              "title": "Introduction to Preventive Oral Hygiene ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1111",
+              "title": "Anatomy of Orofacial Structures ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1112",
+              "title": "Dental Radiology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1122",
+              "title": "Nutrition and Preventive Oral Hygiene Concepts ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1123",
+              "title": "General and Oral Pathology ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1124",
+              "title": "Periodontics I ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1125",
+              "title": "Dental Hygiene Practice-Clinic I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1126",
+              "title": "Dental Hygiene Practice-Seminar I ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "1127",
+              "title": "Current Concepts in Dental Materials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "Elementary Chemistry I: Intro to Inorganic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2005",
+              "title": "Pain Management for Dental Hygienists ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2110",
+              "title": "Periodontics II ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2111",
+              "title": "Dental Pharmacology and Pain Control ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2112",
+              "title": "Community Dental Health ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2113",
+              "title": "Dental Specialties and Extended Dental Hygiene Functions ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2114",
+              "title": "Dental Hygiene Practice-Clinic II ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2115",
+              "title": "Dental Hygiene Practice-Seminar II ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1150",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1050",
+              "title": "Fundamentals of Public Speakingor Fundamentals of Interpersonal Communications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2126",
+              "title": "Practice Management ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2128",
+              "title": "Dental Hygiene Practice-Clinic III ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNHY",
+              "number": "2129",
+              "title": "Dental Hygiene Practice-Seminar III ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice (9620) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/crmj/9620/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communicationsor Conflict Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1110",
+              "title": "Introduction to Criminal Justice ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMX",
+              "number": "1100",
+              "title": "Introduction to Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1117",
+              "title": "Community Policing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2244",
+              "title": "Criminology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2210",
+              "title": "Ethics in Criminal Justice ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2212",
+              "title": "Criminal Law ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2260",
+              "title": "Interview and Interrogation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1300",
+              "title": "U.S. National Governmentor State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2216",
+              "title": "Criminal Procedure ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2231",
+              "title": "Juvenile Delinquency ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2250",
+              "title": "Current Issues in Criminal Justice ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Early Childhood Education (9610) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/eced/9610/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1130",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1120",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1650",
+              "title": "The Developing Child ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "1800",
+              "title": "Early Childhood Foundations of Learning ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2220",
+              "title": "Early Care and Education: The First Three Years of Life ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2110",
+              "title": "Working with Families ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2140",
+              "title": "Early Childhood Curriculum - Integrated Learning ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2150",
+              "title": "Language and Literacy Experiences ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "2180",
+              "title": "Practicum in the Educational Setting ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2120",
+              "title": "Music and Movement in Early Childhood Education ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "2800",
+              "title": "Student Teaching Practicum and Seminar ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "2010",
+              "title": "Promoting Wellness for Young Children ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical Construction Technology (9712) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/ecta/9712/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECTA",
+              "number": "1000",
+              "title": "Electrical Construction Technology IA ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "1010",
+              "title": "Electrical Construction Technology 1B ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1080",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "1200",
+              "title": "Electrical Construction Technology IIA ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1180",
+              "title": "Technical Mathematics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "1210",
+              "title": "Electrical Construction Technology IIB ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1280",
+              "title": "Technical Mathematics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2300",
+              "title": "Advanced Electrical Construction Technology IA ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2310",
+              "title": "Advanced Electrical Construction Technology IB ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "Applied Physics Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2400",
+              "title": "Advanced Electrical Construction Technology IIA ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "1150",
+              "title": "Basic Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2410",
+              "title": "Advanced Electrical Construction Technology IIB ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMX",
+              "number": "1100",
+              "title": "Introduction to Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2500",
+              "title": "Instrumentation and Testing A ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2510",
+              "title": "Instrumentation and Testing B ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Electrical Systems Certificate (4201) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/elec/4201/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "2300",
+              "title": "Sensors, Actuators, and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2420",
+              "title": "Microcontrollers with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2610",
+              "title": "Embedded Systems Project Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2700",
+              "title": "Motor Control and Servo Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2850",
+              "title": "Advanced Programmable Logic Controller Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2821",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Civil Engineering Technology (9410) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/civt/9410/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIVT",
+              "number": "1011",
+              "title": "Construction Methods and Materials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1012",
+              "title": "Reading Construction Drawings ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1016",
+              "title": "Civil Drafting ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1019",
+              "title": "Architectural Building Codes and Standards ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2111",
+              "title": "Surveying I ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1700",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1610",
+              "title": "General Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "1021",
+              "title": "Construction Materials Testing ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2017",
+              "title": "Construction Estimating and Scheduling ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2400",
+              "title": "Calculus for Business, Social, and Life Sciencesor Calculus and Analytical Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2110",
+              "title": "Engineering Mechanics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2112",
+              "title": "Surveying II ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2750",
+              "title": "Engineering Technology Capstone Course ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2230",
+              "title": "Strength of Materials ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical Systems Fundamentals Certificate (4220) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/elec/4220/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "1120",
+              "title": "DC Circuits with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1220",
+              "title": "AC Circuits with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1330",
+              "title": "Digital Electronics with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2120",
+              "title": "Electronics with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "A+ Computer Maintenance and Repair Certificate (4252) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/elec/4252/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPET",
+              "number": "1050",
+              "title": "Managing Computers: Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPET",
+              "number": "1051",
+              "title": "Managing Computers: Software",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction Certificate (4222) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/ecta/4222/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECTA",
+              "number": "1000",
+              "title": "Electrical Construction Technology IA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "1010",
+              "title": "Electrical Construction Technology 1B",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "1200",
+              "title": "Electrical Construction Technology IIA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "1210",
+              "title": "Electrical Construction Technology IIB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2300",
+              "title": "Advanced Electrical Construction Technology IA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2310",
+              "title": "Advanced Electrical Construction Technology IB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2400",
+              "title": "Advanced Electrical Construction Technology IIA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2410",
+              "title": "Advanced Electrical Construction Technology IIB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2500",
+              "title": "Instrumentation and Testing A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECTA",
+              "number": "2510",
+              "title": "Instrumentation and Testing B",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro-Mechanical Engineering Technology Concentration (9417) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/elec/9417/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIMN",
+              "number": "1050",
+              "title": "Blueprint Reading and Shop Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1120",
+              "title": "DC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technologyor Introduction to Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1220",
+              "title": "AC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1260",
+              "title": "Direct Current and Alternating Current Laboratory ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1330",
+              "title": "Digital Electronics with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1550",
+              "title": "Everyday Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communicationor English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1210",
+              "title": "Materials Processing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2821",
+              "title": "Programmable Logic Controllers ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2390",
+              "title": "Fluid Power Technology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2300",
+              "title": "Sensors, Actuators, and Control ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2700",
+              "title": "Motor Control and Servo Systems ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2850",
+              "title": "Advanced Programmable Logic Controller Applications ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical Instrumentation Technology (9418) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/elec/9418/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "1120",
+              "title": "DC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1330",
+              "title": "Digital Electronics with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPET",
+              "number": "1120",
+              "title": "C Prog for Technicians ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1220",
+              "title": "AC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "Applied Physics Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1620",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2120",
+              "title": "Electronics with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2300",
+              "title": "Sensors, Actuators, and Control ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2821",
+              "title": "Programmable Logic Controllers ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1640",
+              "title": "Entrepreneurial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communicationsor English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2420",
+              "title": "Microcontrollers with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Management Planning and Administration Certificate (6701) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/emgt/6701/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMGT",
+              "number": "1000",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1120",
+              "title": "Emergency Management Administration and Policy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1140",
+              "title": "Incident Command System",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1220",
+              "title": "Emergency Planning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1240",
+              "title": "Developing Volunteer Resources",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1260",
+              "title": "Mitigation for Emergency Managers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1280",
+              "title": "Emergency Operations Center Management and Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1350",
+              "title": "Public Sector Community Relations and Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2160",
+              "title": "Exercise Design and Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2210",
+              "title": "Public Sector Supervision and Leadership",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2340",
+              "title": "Hazardous Materials Operations and Command",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2360",
+              "title": "Disaster Response and Recovery",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Electrical Engineering Technology (9420) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/elec/9420/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "1120",
+              "title": "DC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1330",
+              "title": "Digital Electronics with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPET",
+              "number": "1120",
+              "title": "C Prog for Technicians ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1220",
+              "title": "AC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1610",
+              "title": "General Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2120",
+              "title": "Electronics with Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2821",
+              "title": "Programmable Logic Controllers ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2400",
+              "title": "Calculus for Business, Social, and Life Sciencesor Calculus and Analytical Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1620",
+              "title": "General Physics II ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2300",
+              "title": "Sensors, Actuators, and Control ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2420",
+              "title": "Microcontrollers with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1150",
+              "title": "Technical Communications ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2750",
+              "title": "Engineering Technology Capstone Course ",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Fire Science Technology Certificate (6401) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/fire/6401/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "1100",
+              "title": "Introduction to Fire and Emergency Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1120",
+              "title": "Fire Organization and Administration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1170",
+              "title": "Fire Protection and Detection Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1260",
+              "title": "Fire Prevention Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1290",
+              "title": "Building Construction for Fire and Life Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1350",
+              "title": "Public Sector Community Relations and Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2200",
+              "title": "Fire Investigation Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2205",
+              "title": "Fire Service Hydraulics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2210",
+              "title": "Public Sector Supervision and Leadership",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2280",
+              "title": "Fireground Strategy and Tactics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2330",
+              "title": "Combustion Processes and Fire Behavior",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2340",
+              "title": "Hazardous Materials Operations and Command",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Management Planning and Administration (9670) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/emgt/9670/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1050",
+              "title": "Chemistry in the Everyday Worldor Introduction to Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1000",
+              "title": "Introduction to Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1120",
+              "title": "Emergency Management Administration and Policy ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1140",
+              "title": "Incident Command System ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1220",
+              "title": "Emergency Planning ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1240",
+              "title": "Developing Volunteer Resources ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1260",
+              "title": "Mitigation for Emergency Managers ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1280",
+              "title": "Emergency Operations Center Management and Operation ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2100",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1050",
+              "title": "Fundamentals of Public Speaking or Fundamentals of Interpersonal Communications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "1350",
+              "title": "Public Sector Community Relations and Customer Service ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2160",
+              "title": "Exercise Design and Evaluation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2210",
+              "title": "Public Sector Supervision and Leadership ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2380",
+              "title": "Continuity of Operations ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2340",
+              "title": "Hazardous Materials Operations and Command ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2390",
+              "title": "Emergency Management Field Service Seminar or Emergency Management Problem Analysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMGT",
+              "number": "2360",
+              "title": "Disaster Response and Recovery ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1100",
+              "title": "Basic Photography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1105",
+              "title": "Basic Photography - Digital",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Fire Science Technology (9640) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/fire/9640/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1050",
+              "title": "Chemistry in the Everyday Worldor Introduction to Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1100",
+              "title": "Introduction to Fire and Emergency Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1260",
+              "title": "Fire Prevention Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1350",
+              "title": "Public Sector Community Relations and Customer Service ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1120",
+              "title": "Fire Organization and Administration ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1290",
+              "title": "Building Construction for Fire and Life Safety ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2330",
+              "title": "Combustion Processes and Fire Behavior ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2100",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1050",
+              "title": "Fundamentals of Public Speaking or Fundamentals of Interpersonal Communications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "1170",
+              "title": "Fire Protection and Detection Systems ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2205",
+              "title": "Fire Service Hydraulics ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2280",
+              "title": "Fireground Strategy and Tactics ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2200",
+              "title": "Fire Investigation Methods ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2340",
+              "title": "Hazardous Materials Operations and Command ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2390",
+              "title": "Fire Field Service Seminar or Fire Service Problem Analysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "2380",
+              "title": "Emergency Services Safety and Survival ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1400",
+              "title": "Mapping Technologies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Map Design and Interpretation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1100",
+              "title": "Basic Photography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1105",
+              "title": "Basic Photography - Digital",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geospatial Technology Certificate (6801) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/geog/6801/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Map Design and Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2700",
+              "title": "Geographic Information Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2730",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2710",
+              "title": "Spatial Data Acquisition and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2750",
+              "title": "Spatial Analysis and Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2780",
+              "title": "Internship and Seminar in Geospatial Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geospatial Technology Skills Certificate (6802) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/geog/6802/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "1400",
+              "title": "Mapping Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Map Design and Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2700",
+              "title": "Geographic Information Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2730",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "sUAS Applications in Geospatial Technology Certificate (6803) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/geog/6803/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Map Design and Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1740",
+              "title": "Uncrewed Aircraft Systems (UAS)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2700",
+              "title": "Geographic Information Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2740",
+              "title": "sUAS Flight and Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2730",
+              "title": "Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2781",
+              "title": "Internship and Seminar in sUAS Applications in Geospatial Technologies",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geospatial Technology (9680) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/geog/9680/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1400",
+              "title": "Mapping Technologies ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1500",
+              "title": "Introduction to Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Map Design and Interpretation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition IIor English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1600",
+              "title": "World Regional Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2700",
+              "title": "Geographic Information Science ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1520",
+              "title": "Microsoft Office Excel: Skills and Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communicationsor Technical Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1550",
+              "title": "Physical and Environmental Geographyor Earth Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2710",
+              "title": "Spatial Data Acquisition and Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2730",
+              "title": "Remote Sensing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2780",
+              "title": "Internship and Seminar in Geospatial Technology ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1300",
+              "title": "U.S. National Governmentor State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts Degree in Information Technology (9025) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/gnst/9025/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1102",
+              "title": "Internet: Services, Tools, and Web Page Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1105",
+              "title": "Web Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate of Arts Degree in Business (9010) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/gnst/9010/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1200",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2400",
+              "title": "Calculus for Business, Social, and Life Sciences",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2500",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2130",
+              "title": "Business Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2100",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate of Arts Degree in Information Systems (9030) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/gnst/9030/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2010",
+              "title": "Systems Analysis and Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science Degree in Computer Science (9110) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/gnst/9110/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2500",
+              "title": "Calculus and Analytical Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2600",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "General Chemistry Ior Science and Engineering Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2870",
+              "title": "Data Structures ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2873",
+              "title": "Python Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2600",
+              "title": "Calculus and Analytical Geometry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2012",
+              "title": "Discrete Structures ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2875",
+              "title": "Computer Architecture and Organization ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Graphic Design for the Web Certificate (2513) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/grds/2513/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITIS",
+              "number": "1102",
+              "title": "Internet: Services, Tools, and Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1015",
+              "title": "Introduction to Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1375",
+              "title": "Computer Graphics AI, ID and PS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1800",
+              "title": "Introduction to User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1105",
+              "title": "Web Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1105",
+              "title": "Basic Photography - Digital",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of Arts Degree  (9000) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/gnst/9000/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science Degree (9100) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/gnst/9100/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Photography Certificate (2514) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/grds/2514/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GRDS",
+              "number": "1375",
+              "title": "Computer Graphics AI, ID and PS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1105",
+              "title": "Basic Photography - Digital",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "2300",
+              "title": "Introduction to Digital Photo Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1620",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2110",
+              "title": "Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1400",
+              "title": "Commercial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1500",
+              "title": "Portrait Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1700",
+              "title": "Color Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "2350",
+              "title": "Advanced Digital Photo Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "2650",
+              "title": "Professional Practices in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Print Production Certificate (2515) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/grds/2515/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GRDS",
+              "number": "1015",
+              "title": "Introduction to Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1375",
+              "title": "Computer Graphics AI, ID and PS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1450",
+              "title": "Introduction to Digital Print Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2110",
+              "title": "Graphic Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1550",
+              "title": "Using Microsoft Office: Word and Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "2300",
+              "title": "Introduction to Digital Photo Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design (9250) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/grds/9250/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1130",
+              "title": "Art Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1010",
+              "title": "Visual Organization ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1015",
+              "title": "Introduction to Typography ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1375",
+              "title": "Computer Graphics AI, ID and PS ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1020",
+              "title": "Graphic Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1500",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2110",
+              "title": "Graphic Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1105",
+              "title": "Basic Photography - Digital",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2015",
+              "title": "Advanced Typography ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2230",
+              "title": "Advertising Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2330",
+              "title": "Corporate Identity ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "2500",
+              "title": "Graphic Design Portfolio ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1105",
+              "title": "Web Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Personal Trainer Certificate/Area of Specialization (0201) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/0201/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1238",
+              "title": "Structure, Function, Disease, and Therapeutics of the Human Body",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1620",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1250",
+              "title": "First Aid",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1550",
+              "title": "Introduction to Personal Training",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1600",
+              "title": "Exercise Physiology I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1660",
+              "title": "Diet and Weight Management Strategies for Sport and Fitness",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1670",
+              "title": "Instructional Techniques: Strength and Cardio Fitness Training",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1750",
+              "title": "Personal Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "2500",
+              "title": "Athletic Training",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "2750",
+              "title": "Personal Trainer Internship/Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Management Technology (9345) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/himt/9345/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "1100",
+              "title": "Introduction to Health Information Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "1200",
+              "title": "Healthcare Records and Documentation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "1300",
+              "title": "Healthcare Applied Information Systems and Services ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1520",
+              "title": "Microsoft Office Excel: Skills and Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychologyor Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "2100",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "1225",
+              "title": "Outpatient Procedure Coding ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2070",
+              "title": "Inpatient and Outpatient Diagnostic Coding ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2080",
+              "title": "Inpatient Procedure Coding ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2160",
+              "title": "Analyzing Heathcare Data ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2350",
+              "title": "Health Information Management: Ethics, Legal Issues, and Compliance ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communicationor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2300",
+              "title": "Performance Improvement and HIM Leadership ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2535",
+              "title": "Reimbursement Methodologies ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2540",
+              "title": "Advanced Coding ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2550",
+              "title": "Clinical Practicum ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2600",
+              "title": "Seminar ",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Electrocardiography Certificate/Area of Specialization  (3251) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3251/",
+      "total_credits": 5,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1700",
+              "title": "Basic Electrocardiography",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technology-Paramedic Certificate/Area of Specialization (3254) — Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3254/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTS",
+              "number": "2011",
+              "title": "Paramedic Beginner ",
+              "credits": 13,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTS",
+              "number": "2021",
+              "title": "Paramedic Intermediate A ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTS",
+              "number": "2031",
+              "title": "Paramedic Intermediate B ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTS",
+              "number": "2041",
+              "title": "Paramedic Clinical and Capstone ",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health and Wellness Certificate/Area of Specialization (3252) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3252/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1300",
+              "title": "Nutrition and Family Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1250",
+              "title": "First Aid",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "1750",
+              "title": "Personal Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEHR",
+              "number": "2500",
+              "title": "Athletic Training",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding Certificate/Area of Specialization (3261) — A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3261/",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1238",
+              "title": "Structure, Function, Disease, and Therapeutics of the Human Body or Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "1225",
+              "title": "Outpatient Procedure Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2070",
+              "title": "Inpatient and Outpatient Diagnostic Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2080",
+              "title": "Inpatient Procedure Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1150",
+              "title": "Introduction to Electronic Health Records",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2535",
+              "title": "Reimbursement Methodologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2540",
+              "title": "Advanced Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIMT",
+              "number": "2547",
+              "title": "Medical Coding Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Coach Certificate/Area of Specialization (3300) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3300/",
+      "total_credits": 3,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1160",
+              "title": "Health Coach I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1170",
+              "title": "Health Coach Externship",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting Certificate/Area of Specialization (3265) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3265/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAST",
+              "number": "1100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1120",
+              "title": "Dental Science and Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1130",
+              "title": "Chairside I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1150",
+              "title": "Infection Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1160",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1200",
+              "title": "Radiography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1210",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1230",
+              "title": "Chairside II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1310",
+              "title": "Dental Assisting Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "1320",
+              "title": "Dental Assisting Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Assistant Certificate/Area of Specialization (3310) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3310/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1350",
+              "title": "Nursing Assistant",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1400",
+              "title": "Customer Service and Healthcare",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Emergency Medical Technology-Basic Certificate/Area of Specialization (3501) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3501/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTS",
+              "number": "1010",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Medical Office Assistant Certificate/Area of Specialization (3549) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3549/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1150",
+              "title": "Introduction to Electronic Health Records",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1110",
+              "title": "Administrative Procedures for the Medical Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1150",
+              "title": "Medical Office Insurance and Reimbursements",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1550",
+              "title": "Using Microsoft Office: Word and Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1238",
+              "title": "Structure, Function, Disease, and Therapeutics of the Human Body",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1600",
+              "title": "Basic Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Certificate/Area of Specialization (3601) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3601/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1238",
+              "title": "Structure, Function, Disease, and Therapeutics of the Human Body",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1400",
+              "title": "Customer Service and Healthcare",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1150",
+              "title": "Introduction to Electronic Health Records",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1240",
+              "title": "Phlebotomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1260",
+              "title": "Phlebotomy Clinical Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1265",
+              "title": "Phlebotomy Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Case Management Certificate (3262) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hmsv/3262/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1115",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1118",
+              "title": "Principles of Case Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1120",
+              "title": "Fundamentals of the Helping Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1300",
+              "title": "Thinking Critically",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Assisting Certificate/Area of Specialization (3550) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/3550/",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1238",
+              "title": "Structure, Function, Disease, and Therapeutics of the Human Body",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1110",
+              "title": "Administrative Procedures for the Medical Office ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1150",
+              "title": "Medical Office Insurance and Reimbursements ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1250",
+              "title": "Medical Office Surgical Procedures ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1600",
+              "title": "Basic Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1210",
+              "title": "Basic Patient Skills ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1220",
+              "title": "Specialty Medical Assisting ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1300",
+              "title": "Physician Office Laboratory ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1700",
+              "title": "Medical Assisting Practicum ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDAS",
+              "number": "1800",
+              "title": "Medical Assisting Seminar ",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multi-Skilled Health Technology (9325) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hlth/9325/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences (or other college-level mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1150",
+              "title": "Principles of Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemical Dependency Certificate (3263) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hmsv/3263/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMSV",
+              "number": "2200",
+              "title": "Motivational Interviewing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2230",
+              "title": "Fundamentals of Addiction Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1190",
+              "title": "Drug Use and U.S. Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services (9660) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hmsv/9660/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1115",
+              "title": "Introduction to Human Services ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1215",
+              "title": "Dealing with Diversity ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1300",
+              "title": "Thinking Critically",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1118",
+              "title": "Principles of Case Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1120",
+              "title": "Fundamentals of the Helping Process ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1150",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1190",
+              "title": "Drug Use and U.S. Society ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1300",
+              "title": "U.S. National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1140",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2200",
+              "title": "Motivational Interviewing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2230",
+              "title": "Fundamentals of Addiction Counseling ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2284",
+              "title": "Human Services Internship Preparation ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "2250",
+              "title": "Introduction to Social Work ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2116",
+              "title": "Social Welfare ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2285",
+              "title": "Human Services Internship and Seminar ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2700",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Social Work Bridge Certificate (3264) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hmsv/3264/",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1140",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1115",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "1120",
+              "title": "Fundamentals of the Helping Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMSV",
+              "number": "2116",
+              "title": "Social Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1300",
+              "title": "Thinking Critically",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2700",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1300",
+              "title": "U.S. National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1150",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "2250",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "IT Foundations Certificate  (2401) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/2401/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1030",
+              "title": "Security Awareness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Histotechnology (9395) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/hsty/9395/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "Elementary Chemistry I: Intro to Inorganic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "1100",
+              "title": "Introduction to Histotechnology ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2100",
+              "title": "Histology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1150",
+              "title": "Introduction to Electronic Health Records",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2050",
+              "title": "Histochemistry ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2250",
+              "title": "Histotechnique ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOS",
+              "number": "2901",
+              "title": "Clinical Molecular Diagnostics ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2151",
+              "title": "Specialty Areas in Histotechnology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2220",
+              "title": "Theory and Practice of Immunohistochemistry ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1050",
+              "title": "Fundamentals of Public Speaking or Fundamentals of Interpersonal Communications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2300",
+              "title": "Histotechnician Clinical Directed Practice ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSTY",
+              "number": "2400",
+              "title": "Histotechnician Seminar ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychologyor Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer User Certificate  (2402) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/2402/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentials",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1030",
+              "title": "Security Awareness",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design for the Web Certificate (2513) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/2513/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITIS",
+              "number": "1102",
+              "title": "Internet: Services, Tools, and Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1015",
+              "title": "Introduction to Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1375",
+              "title": "Computer Graphics AI, ID and PS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1800",
+              "title": "Introduction to User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1105",
+              "title": "Web Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "1105",
+              "title": "Basic Photography - Digital",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of Arts Degree in Information Technology (9025) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9025/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1102",
+              "title": "Internet: Services, Tools, and Web Page Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1105",
+              "title": "Web Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate of Arts Degree in Information Systems (9030) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9030/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2500",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2010",
+              "title": "Systems Analysis and Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Introduction to Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Application Programming and Web Development (9246) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9246/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1005",
+              "title": "Computer Essentialsor Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1102",
+              "title": "Internet: Services, Tools, and Web Page Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRDS",
+              "number": "1800",
+              "title": "Introduction to User Experience Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1105",
+              "title": "Web Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1820",
+              "title": "Java Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2120",
+              "title": "JavaScript Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2820",
+              "title": "Java/Android Programming II ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1008",
+              "title": "Ethics in Information Technology ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1700",
+              "title": "Principles of E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2155",
+              "title": "PHP Programming ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1030",
+              "title": "Security Awareness ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science Degree in Computer Science (9110) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9110/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2500",
+              "title": "Calculus and Analytical Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2600",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "General Chemistry Ior Science and Engineering Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2870",
+              "title": "Data Structures ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2873",
+              "title": "Python Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2600",
+              "title": "Calculus and Analytical Geometry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2012",
+              "title": "Discrete Structures ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2875",
+              "title": "Computer Architecture and Organization ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "IT Support Analyst Major (9243) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9243/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1027",
+              "title": "Information Technology Support Fundamentals I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1028",
+              "title": "Information Technology Support Fundamentals II ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1030",
+              "title": "Security Awareness ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1050",
+              "title": "Managing Computers: Hardware ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1520",
+              "title": "Microsoft Office Excel: Skills and Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1051",
+              "title": "Managing Computers: Software ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "2080",
+              "title": "Supporting Client Operating Systems ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1310",
+              "title": "Cloud Computing ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity Concentration (9247) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9247/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1100",
+              "title": "Cisco Networking Technology I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1310",
+              "title": "Cloud Computing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1110",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1360",
+              "title": "Cyber/Computer Forensics and Counterterrorism ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1735",
+              "title": "Cisco Cyber Operations ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2720",
+              "title": "Cisco Network Security: Managing Security ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2355",
+              "title": "Security Investigation and Penetration Studies ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Operating Systems/Networking Concentration  (9249) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9249/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1100",
+              "title": "Cisco Networking Technology I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1310",
+              "title": "Cloud Computing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1758",
+              "title": "Linux Administration II ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "2080",
+              "title": "Supporting Client Operating Systems ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1050",
+              "title": "Managing Computers: Hardware ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "2769",
+              "title": "Linux Administration III: Automation ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Technology (9720) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9720/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1070",
+              "title": "Operating Systems: Skills and Techniques ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2010",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2015",
+              "title": "Information Technology Project Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1100",
+              "title": "Cisco Networking Technology I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Data Analytics Concentration  (9258) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9258/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1435",
+              "title": "Introductory Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1550",
+              "title": "Statistics (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1520",
+              "title": "Microsoft Office Excel: Skills and Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1405",
+              "title": "Oracle PL/SQL Programming ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1407",
+              "title": "Analysis and Design of Database Systems ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1450",
+              "title": "Visualization Tools for Data Analytics ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1355",
+              "title": "Security+ and Security Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "2435",
+              "title": "Advanced Data Analytics ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2010",
+              "title": "Systems Analysis and Design or Information Technology Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1748",
+              "title": "Linux Administration I ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science/Software Engineering Concentration  (9259) — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/isys/9259/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1010",
+              "title": "Programming Logic ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1011",
+              "title": "History of Computing ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1007",
+              "title": "Principles of Information Technology and Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1700",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPET",
+              "number": "1120",
+              "title": "C Prog for Technicians ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1820",
+              "title": "Java Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "1870",
+              "title": "Python Programming I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2500",
+              "title": "Calculus and Analytical Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "General Chemistry I or Science and Engineering Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2080",
+              "title": "Fundamentals of Software Engineering ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2870",
+              "title": "Data Structures ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2600",
+              "title": "Calculus and Analytical Geometry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2012",
+              "title": "Discrete Structures ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITCS",
+              "number": "2875",
+              "title": "Computer Architecture and Organization ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITDB",
+              "number": "1401",
+              "title": "SQL Programming and Database Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "2890",
+              "title": "Information Technology and Computer Science Capstone ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITON",
+              "number": "1205",
+              "title": "Network+ and Networking Essentials ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Interactive Media Certificate (2501) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/2501/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1505",
+              "title": "Interactive Media II: Interactive Production Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1540",
+              "title": "Interactive Media Design Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1600",
+              "title": "Animation I: Introduction to Two and Three-Dimensional Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2500",
+              "title": "Interactive Media III: Multiple Media Integration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2505",
+              "title": "Interactive Media IV: Advanced Interactive Presentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2560",
+              "title": "Interactive Educational Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Production and Broadcast Certificate (2502) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/2502/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1045",
+              "title": "Writing for Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1060",
+              "title": "Vocalization and Diction for Broadcast Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1205",
+              "title": "Video II: Action Videography and Video Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2200",
+              "title": "Video III: Electronic News Gathering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2205",
+              "title": "Video IV: Independent Commercial Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2260",
+              "title": "Video Compositing and Special Effects",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2265",
+              "title": "Sports Reporting, Commentary and Videography",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Audio Engineering and Production Certificate (2503) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/2503/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1300",
+              "title": "Radio I: Introduction to Radio Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1405",
+              "title": "Audio II: Recording and Studio Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1420",
+              "title": "Basics of Sound Reinforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2400",
+              "title": "Audio III: Sound Shaping and Advanced Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2405",
+              "title": "Audio IV: Advanced Recording and Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2420",
+              "title": "Foley Sound Design and Recording",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2650",
+              "title": "Electronic Music I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animation and Cartoon Arts Certificate (2504) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/2504/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1600",
+              "title": "Animation I: Introduction to Two and Three-Dimensional Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1605",
+              "title": "Animation II: Two Dimensional Animation and Cartooning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1640",
+              "title": "Cartoon Animation Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1700",
+              "title": "Interactive Entertainment I: Introduction to Entertainment Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2600",
+              "title": "Animation III: Three Dimensional Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2605",
+              "title": "Animation IV: Advanced Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2660",
+              "title": "Virtual Set and World Design",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interactive Entertainment Technology Certificate (2505) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/2505/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1600",
+              "title": "Animation I: Introduction to Two and Three-Dimensional Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1640",
+              "title": "Cartoon Animation Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1700",
+              "title": "Interactive Entertainment I: Introduction to Entertainment Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1705",
+              "title": "Interactive Entertainment II: Interactive Game Design Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1740",
+              "title": "Interactive Entertainment Design Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2700",
+              "title": "Interactive Entertainment III: Applied Game Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2705",
+              "title": "Interactive Entertainment IV: Advanced Game Design and Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radio Production and Broadcast Certificate (2506) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/2506/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1045",
+              "title": "Writing for Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1060",
+              "title": "Vocalization and Diction for Broadcast Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1300",
+              "title": "Radio I: Introduction to Radio Production and Broadcast",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1305",
+              "title": "Radio II: Advanced Radio Technique",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1320",
+              "title": "Live Radio Performance and Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2300",
+              "title": "Radio III: Electronic News Gathering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2305",
+              "title": "Radio IV: Commercial Radio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2340",
+              "title": "Radio Business Techniques and Broadcast Direction",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Audio Recording and Production Technical Major (9275) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/9275/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1300",
+              "title": "Radio I: Introduction to Radio Production and Broadcast ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1045",
+              "title": "Writing for Broadcast and Interactive Media ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1405",
+              "title": "Audio II: Recording and Studio Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1420",
+              "title": "Basics of Sound Reinforcement ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2400",
+              "title": "Audio III: Sound Shaping and Advanced Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2420",
+              "title": "Foley Sound Design and Recording ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2405",
+              "title": "Audio IV: Advanced Recording and Editing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2650",
+              "title": "Electronic Music I ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Production and Broadcast Technical Major (9278) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/9278/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1060",
+              "title": "Vocalization and Diction for Broadcast Media ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1045",
+              "title": "Writing for Broadcast and Interactive Media ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1205",
+              "title": "Video II: Action Videography and Video Techniques ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1600",
+              "title": "Animation I: Introduction to Two and Three-Dimensional Animation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2200",
+              "title": "Video III: Electronic News Gathering ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2260",
+              "title": "Video Compositing and Special Effects ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2205",
+              "title": "Video IV: Independent Commercial Video Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2265",
+              "title": "Sports Reporting, Commentary and Videography ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interactive Media Design and Delivery Technical Major (9276) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/9276/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1045",
+              "title": "Writing for Broadcast and Interactive Media ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1505",
+              "title": "Interactive Media II: Interactive Production Technology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1540",
+              "title": "Interactive Media Design Theory ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1600",
+              "title": "Animation I: Introduction to Two and Three-Dimensional Animation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1700",
+              "title": "Interactive Entertainment I: Introduction to Entertainment Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2500",
+              "title": "Interactive Media III: Multiple Media Integration ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2505",
+              "title": "Interactive Media IV: Advanced Interactive Presentation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2560",
+              "title": "Interactive Educational Design ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radio Production and Broadcast Technical Major (9277) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdia/9277/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1003",
+              "title": "Introduction to the Multimedia Computer",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1010",
+              "title": "The Business and History of Broadcast and Interactive Media",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1060",
+              "title": "Vocalization and Diction for Broadcast Media ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1300",
+              "title": "Radio I: Introduction to Radio Production and Broadcast ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1400",
+              "title": "Audio I: Introduction to Audio Production and Recording ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1045",
+              "title": "Writing for Broadcast and Interactive Media ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1080",
+              "title": "Staff Practice I ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1305",
+              "title": "Radio II: Advanced Radio Technique ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1200",
+              "title": "Video I: Introduction to Video Production and Broadcast ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1320",
+              "title": "Live Radio Performance and Engineering ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "1500",
+              "title": "Interactive Media I: Introduction to Interactive Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2300",
+              "title": "Radio III: Electronic News Gathering ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Survey of College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2080",
+              "title": "Staff Practice II ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2305",
+              "title": "Radio IV: Commercial Radio Production ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "2340",
+              "title": "Radio Business Techniques and Broadcast Direction ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology (9320) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mdlt/9320/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "Elementary Chemistry I: Intro to Inorganic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2150",
+              "title": "Hematology and Coagulation ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2151",
+              "title": "Blood Collection Techniques ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2152",
+              "title": "Urinalysis ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2153",
+              "title": "Body Fluid Analysis ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2250",
+              "title": "Clinical Immunology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2350",
+              "title": "Immunohematology ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1150",
+              "title": "Elementary Chemistry II: Intro to Organic and Biochemistry or Clinical Molecular Diagnostics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychologyor Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1150",
+              "title": "Fundamentals of Interpersonal Communications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2550",
+              "title": "Clinical Chemistry ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2650",
+              "title": "Clinical Microbiology ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences (or other college-level mathematics course)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2750",
+              "title": "Clinical Directed Practicum ",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDLT",
+              "number": "2850",
+              "title": "Medical Laboratory Technology Seminar ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CAD Design Certificate (4442) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mect/4442/",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "1100",
+              "title": "Introduction to AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "1500",
+              "title": "Advanced AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2500",
+              "title": "Advanced SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AutoCAD Operator Certificate (4443) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mect/4443/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "1100",
+              "title": "Introduction to AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "1500",
+              "title": "Advanced AutoCAD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology Foundations Certificate (4444) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mect/4444/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1111",
+              "title": "English Composition I (B)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1700",
+              "title": "Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical and Manufacturing Technology Specialist Certificate (4445) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mect/4445/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2500",
+              "title": "Advanced SolidWorks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1160",
+              "title": "Applied Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1600",
+              "title": "Geometric Dimensioning and Tolerancing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2370",
+              "title": "Materials Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1550",
+              "title": "Everyday Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1610",
+              "title": "General Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Engineering Technology (9440) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mect/9440/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A) or Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2500",
+              "title": "Advanced SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speaking or Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1600",
+              "title": "Geometric Dimensioning and Tolerancing ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2370",
+              "title": "Materials Technology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1610",
+              "title": "General Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2400",
+              "title": "Calculus for Business, Social, and Life Sciencesor Calculus and Analytical Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2110",
+              "title": "Engineering Mechanics I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1620",
+              "title": "General Physics II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2390",
+              "title": "Fluid Power Technology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2600",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2230",
+              "title": "Strength of Materials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2700",
+              "title": "Mechanical Technology Design Capstone ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QENT",
+              "number": "1200",
+              "title": "Quality Concepts and Techniques ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Aided Design Concentration (9444) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/mect/9444/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADT",
+              "number": "2100",
+              "title": "Introduction to SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1110",
+              "title": "Machining Processes ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2500",
+              "title": "Advanced SolidWorks ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "1160",
+              "title": "Applied Electricity ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "1600",
+              "title": "Geometric Dimensioning and Tolerancing ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2370",
+              "title": "Materials Technology or Materials Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1550",
+              "title": "Everyday Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADT",
+              "number": "2600",
+              "title": "SolidWorks Design Productivity ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2240",
+              "title": "Jig and Fixture Design ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1121",
+              "title": "English Composition II-Technical Focus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECT",
+              "number": "2250",
+              "title": "Mechanism Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2400",
+              "title": "Business Communicationor English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2390",
+              "title": "Fluid Power Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIMN",
+              "number": "2875",
+              "title": "Design and Manufacturing Capstone ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QENT",
+              "number": "1200",
+              "title": "Quality Concepts and Techniques ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Engineering Technology (9416) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/nuet/9416/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1000",
+              "title": "Introduction to Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1650",
+              "title": "College Algebra (A)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "1000",
+              "title": "Nuclear Industry Fundamental Concepts ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "1100",
+              "title": "Radiation Detection and Protection ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "Elementary Chemistry I: Intro to Inorganic Chemistry or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1120",
+              "title": "DC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1700",
+              "title": "Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "1200",
+              "title": "Plant Drawings ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "1300",
+              "title": "Power Plant Components ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1220",
+              "title": "AC Circuits with Lab ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1260",
+              "title": "Direct Current and Alternating Current Laboratory ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "2000",
+              "title": "Reactor Plant Materials ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "2250",
+              "title": "Reactor Theory, Safety and Design ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1610",
+              "title": "General Physics I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "1150",
+              "title": "Basic Economicsor Principles of Macroeconomicsor Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2300",
+              "title": "Sensors, Actuators, and Control ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMX",
+              "number": "1100",
+              "title": "Introduction to Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "2300",
+              "title": "Thermo-Fluid Sciences ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUET",
+              "number": "2400",
+              "title": "Capstone and Case Studies in Nuclear Engineering Technology ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Nursing (RN) (9330) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/nurs/9330/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1020",
+              "title": "Introduction to Nursing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1060",
+              "title": "Pharmacology Fundamentals and Drug Dosage Calculations ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1090",
+              "title": "Nursing Care of Adults I ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1250",
+              "title": "Nursing Care of Adults II ",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1310",
+              "title": "Nutrition and Diet Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2100",
+              "title": "Lifespan Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2160",
+              "title": "Nursing Care of Chronic and Vulnerable Populations ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2210",
+              "title": "Nursing Care of Childbearing Families ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2260",
+              "title": "Nursing Care of Children and Families ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "1150",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2360",
+              "title": "Nursing Care of Adults III ",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paralegal Studies (9290) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/parl/9290/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1000",
+              "title": "Basic Computer Skillsor Computer Essentials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1100",
+              "title": "Introduction to Paralegal Studies ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1300",
+              "title": "U.S. National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1120",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1200",
+              "title": "Introduction to Legal Research and Writing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1400",
+              "title": "Business Issues in the Law ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1500",
+              "title": "Civil Law and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2600",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1600",
+              "title": "World Regional Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1550",
+              "title": "Using Microsoft Office: Word and Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1250",
+              "title": "Advanced Legal Research Writing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2050",
+              "title": "The Legal Workplace ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2200",
+              "title": "Employment Law and the Administrative Process or Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMX",
+              "number": "1100",
+              "title": "Introduction to Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2199",
+              "title": "Business Law I (Contract Law) or Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2700",
+              "title": "Legal Internship/Seminar I ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant (9365) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/ptas/9365/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "1200",
+              "title": "Introduction to Physical Therapist Assisting ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "1210",
+              "title": "Functional Anatomy and Kinesiology for the PTA ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "1220",
+              "title": "PTA Interventions I ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "2100",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "1300",
+              "title": "PTA Interventions II ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1600",
+              "title": "Basic Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2700",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2110",
+              "title": "PTA Interventions III ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2120",
+              "title": "Pediatric and Geriatric Physical Therapy ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2130",
+              "title": "Rehabilitation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2140",
+              "title": "Clinical Education I ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2200",
+              "title": "PTA Seminar ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2210",
+              "title": "Clinical Education II ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAS",
+              "number": "2220",
+              "title": "Clinical Education III ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Magnetic Resonance Imaging Certificate (3821) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/radt/3821/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "2600",
+              "title": "Introduction to Computerized Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2620",
+              "title": "Sectional Anatomy and Pathophysiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2820",
+              "title": "MRI Clinical Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2640",
+              "title": "Sectional Anatomy and Pathophysiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2810",
+              "title": "MRI Physics and Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology (9380) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/radt/9380/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "1100",
+              "title": "Introduction to Radiography and Imaging Principles ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "1210",
+              "title": "Radiographic Procedures I ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "1300",
+              "title": "Patient Care in Radiography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "1150",
+              "title": "Principles of Imaging II ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "1220",
+              "title": "Radiographic Procedure II ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "1320",
+              "title": "Clinical Experience I ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences (or any mathematics course from MATH 1550 or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2310",
+              "title": "Clinical Experience II ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2100",
+              "title": "Special Imaging Modalities ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2150",
+              "title": "Radiation Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2200",
+              "title": "Principles of Imaging III ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2320",
+              "title": "Clinical Experience III ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2280",
+              "title": "Radiographic Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2330",
+              "title": "Clinical Experience IV ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2410",
+              "title": "Radiation Protection and Biology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2340",
+              "title": "Clinical Experience V ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2450",
+              "title": "Seminar II ",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computed Tomography Certificate (3811) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/radt/3811/",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "2600",
+              "title": "Introduction to Computerized Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2620",
+              "title": "Sectional Anatomy and Pathophysiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2720",
+              "title": "CT Clinical Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2640",
+              "title": "Sectional Anatomy and Pathophysiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "2710",
+              "title": "CT Physics and Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy (9340) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/resp/9340/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1100",
+              "title": "Fundamentals of Respiratory Therapy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1200",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1300",
+              "title": "Cardiopulmonary Therapeutics ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1400",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1500",
+              "title": "Cardiopulmonary Pathology ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1600",
+              "title": "Advanced Diagnostics ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1800",
+              "title": "Introduction to Pediatric Respiratory Therapy ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2100",
+              "title": "Mechanical Ventilation ",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2200",
+              "title": "Hemodynamics and Electrocardiography ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2300",
+              "title": "Long Term Care and Rehabilitation ",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2400",
+              "title": "Advanced Therapeutics ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant (9355) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/otas/9355/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "1100",
+              "title": "Foundations of Occupational Therapy ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "1130",
+              "title": "Activities and Occupation as OT Intervention ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "1230",
+              "title": "Functional Anatomy and Kinesiology for the OTA ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "1140",
+              "title": "Documentation for the OTA Professional ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "1205",
+              "title": "Pediatric Foundations and Interventions for the OTA ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "1220",
+              "title": "Level I Fieldwork and Seminar: Pediatrics and Developmental Disabilities ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2100",
+              "title": "Lifespan Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2105",
+              "title": "Physical Dysfunction Foundations and Interventions for the OTA ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2130",
+              "title": "Foundations and Interventions in Neurological Rehabilitation ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2700",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2120",
+              "title": "Level I Fieldwork and Seminar: Physical Dysfunction ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2200",
+              "title": "Foundations of Psychosocial Dysfunction ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2210",
+              "title": "Techniques and Fieldwork in Psychosocial Dysfunction ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2230",
+              "title": "Professional Development and Management in Rehabilitation Practice ",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2250",
+              "title": "Level IIA Fieldwork ",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTAS",
+              "number": "2350",
+              "title": "Level IIB Fieldwork ",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies Certificate (2901) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/parl/2901/",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PARL",
+              "number": "1100",
+              "title": "Introduction to Paralegal Studies ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1200",
+              "title": "Introduction to Legal Research and Writing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1400",
+              "title": "Business Issues in the Law ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1500",
+              "title": "Civil Law and Practice ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2050",
+              "title": "The Legal Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITIS",
+              "number": "1550",
+              "title": "Using Microsoft Office: Word and Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1250",
+              "title": "Advanced Legal Research Writing ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2200",
+              "title": "Employment Law and the Administrative Process or Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2700",
+              "title": "Legal Internship/Seminar I ",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "SMAW (Stick) Welding Certificate (4326) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4326/",
+      "total_credits": 5,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1320",
+              "title": "Basic SMAW (Stick) Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2320",
+              "title": "Advanced SMAW (Stick) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "GTAW (TIG) Welding Certificate (4330) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4330/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1330",
+              "title": "Basic GTAW (TIG)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2330",
+              "title": "Advanced GTAW (TIG)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Pipe Welding Certificate (4331) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4331/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1370",
+              "title": "Basic Pipe Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2370",
+              "title": "Advanced Pipe Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "FCAW (Flux Cored) Welding Certificate (4333) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4333/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1340",
+              "title": "Basic FCAW (Flux Cored) and GMAW (MIG/MAG) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2340",
+              "title": "Advanced FCAW (Flux Cored) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Surgical Technology (9335) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/surg/9335/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1215",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1100",
+              "title": "Surgical Technology I ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1330",
+              "title": "Statistics for the Health Sciences (or any mathematics course from MATH 1330 or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1300",
+              "title": "Surgical Technology II ",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1500",
+              "title": "Surgical Pharmacology ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1100",
+              "title": "Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2100",
+              "title": "Surgical Technology III ",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2700",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2300",
+              "title": "Surgical Technology IV ",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2500",
+              "title": "Surgical Technology V ",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2600",
+              "title": "Surgical Technology Seminar ",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding and Fabrication Technology I Certificate (4336) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4336/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1300",
+              "title": "Thermal Cutting, Gouging, Brazing, and Soldering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1320",
+              "title": "Basic SMAW (Stick) Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1330",
+              "title": "Basic GTAW (TIG)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1340",
+              "title": "Basic FCAW (Flux Cored) and GMAW (MIG/MAG) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1370",
+              "title": "Basic Pipe Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1030",
+              "title": "Arc Welding Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1040",
+              "title": "Introduction to Metal Fabrication and Mechanized Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2025",
+              "title": "Safety in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding and Fabrication Technology II Certificate (4337) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4337/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "2320",
+              "title": "Advanced SMAW (Stick) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2330",
+              "title": "Advanced GTAW (TIG)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2340",
+              "title": "Advanced FCAW (Flux Cored) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2350",
+              "title": "Advanced GMAW (MIG/MAG) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2370",
+              "title": "Advanced Pipe Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2380",
+              "title": "GTAW (TIG) Pipe Welding Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2400",
+              "title": "Welding Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2410",
+              "title": "Welding Economics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding and Fabrication Technology (9414) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/9414/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYEX",
+              "number": "1000",
+              "title": "First Year Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "2025",
+              "title": "Safety in Construction",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1030",
+              "title": "Arc Welding Fundamentals ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1040",
+              "title": "Introduction to Metal Fabrication and Mechanized Welding ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1300",
+              "title": "Thermal Cutting, Gouging, Brazing, and Soldering ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1320",
+              "title": "Basic SMAW (Stick) Welding ",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1340",
+              "title": "Basic FCAW (Flux Cored) and GMAW (MIG/MAG) Welding ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1300",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1330",
+              "title": "Basic GTAW (TIG) ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1370",
+              "title": "Basic Pipe Welding ",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1000",
+              "title": "Effective Public Speakingor Effective Interpersonal Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1110",
+              "title": "English Composition I (A) or English Composition I (B)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1080",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "1330",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "2000",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1550",
+              "title": "Everyday Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1500",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Thermal Cutting, Gouging, Brazing, and Soldering Certificate (4335) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4335/",
+      "total_credits": 2,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1300",
+              "title": "Thermal Cutting, Gouging, Brazing, and Soldering",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "GMAW (MIG/MAG) Welding Certificate (4334) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.lakelandcc.edu/degree-certificate-programs/weld/4334/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1340",
+              "title": "Basic FCAW (Flux Cored) and GMAW (MIG/MAG) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2350",
+              "title": "Advanced GMAW (MIG/MAG) Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/oh/programs/owens-community-college.json
+++ b/data/oh/programs/owens-community-college.json
@@ -1,0 +1,31885 @@
+{
+  "college_slug": "owens-community-college",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.owens.edu",
+  "scraped_at": "2026-06-06T17:57:49.217Z",
+  "programs": [
+    {
+      "title": "Associate of Technical Study, ATS (Owens Code: ATSD)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6173",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Core",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education Transfer Certificate (Owens Code: ZGEN)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6216",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts, General Arts Concentration, AA (Owens Code: AGEN)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6089",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Transfer Pathway, AA (Owens Code: CMTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6103",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Individualized Study, AIS (Owens Code: AIND)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6215",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Literature Transfer Pathway, AA (Owens Code: LTTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6119",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - English Literature Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History Transfer Pathway, AA (Owens Code: HSTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6129",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 5(Lec: 3 to 5 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Foreign Language II Elective (Lec: 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "history"
+    },
+    {
+      "title": "Powerskills Certificate (Owens Code: ZPSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6249",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "120",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Course Electives",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6172",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Arts and Humanities",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARB",
+              "number": "111",
+              "title": "Beginning Arabic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "112",
+              "title": "Beginning Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Art Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "History of Western Art  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "His of Art I:Ancnt to Medieval",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Hist of Art II:Ren to Contemp",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "211",
+              "title": "Inter American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "212",
+              "title": "Int. American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "History of Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "120",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Introduction to Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Introduction to Fiction  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "Introduction to Poetry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Women in Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "American Literature I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "267",
+              "title": "American Literature II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "111",
+              "title": "Beginning German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "112",
+              "title": "German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "250",
+              "title": "World War II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "270",
+              "title": "History of Women in America  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Intro to the Humanities  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "275",
+              "title": "World Religions  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Survey of Jazz Styles  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "History of Popular Music  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music of World Cultures  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "152",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "The Profession of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "Music History I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "Music History II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "121",
+              "title": "Darkroom Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "123",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "130",
+              "title": "Intro to Visual Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "202",
+              "title": "History of Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "221",
+              "title": "Black &amp; White Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "223",
+              "title": "Digital Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "241",
+              "title": "Portrait &amp; Event Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "245",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPC",
+              "number": "200",
+              "title": "Intro to Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "110",
+              "title": "Intro to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "201",
+              "title": "Intro to Communication Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "100",
+              "title": "Introduction to Theater",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversity",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Cultural Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Women in Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "108",
+              "title": "Geography of the US and Canada  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Survey of Jazz Styles  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Arts and Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Cultural Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Physical Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Art Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "History of Western Art  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Foundations In 2D Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Foundations of 3D Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Oil Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "135",
+              "title": "Printmaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "145",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "His of Art I:Ancnt to Medieval",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Hist of Art II:Ren to Contemp",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "211",
+              "title": "Inter American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "212",
+              "title": "Int. American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Astronomy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "Life-An Intro to Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "125",
+              "title": "The Science of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "203",
+              "title": "Introduction to Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "General Biology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "105",
+              "title": "Chemistry for Biol Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "Basic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "115",
+              "title": "Inorganic &amp; Organic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "122",
+              "title": "General Chemistry II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "202",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "History of Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "245",
+              "title": "Intro to Package Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "255",
+              "title": "Digital Imaging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "295",
+              "title": "Portfolio Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "111",
+              "title": "Principles of Economics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Educational Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "120",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Introduction to Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Introduction to Fiction  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "Introduction to Poetry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Women in Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "American Literature I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "267",
+              "title": "American Literature II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Intro to Environmental Science  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "102",
+              "title": "Lab Intro to Environmental Sci  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "111",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "112",
+              "title": "German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "100",
+              "title": "Intro to Comparative Politics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "207",
+              "title": "Contemporary Global Issues  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "106",
+              "title": "Human Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "108",
+              "title": "Geography of the US and Canada  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "110",
+              "title": "Physical Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "206",
+              "title": "World Regional Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "250",
+              "title": "World War II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Intro to the Humanities  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "275",
+              "title": "World Religions  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LTM",
+              "number": "174",
+              "title": "Greenhouse Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "173",
+              "title": "College Trigonometry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "233",
+              "title": "Calculus III  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "234",
+              "title": "Differential Equations  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "100",
+              "title": "Fundamentals of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Survey of Jazz Styles  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "History of Popular Music  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music of World Cultures  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Survey of Recording History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "120",
+              "title": "Chorus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "123",
+              "title": "String Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "124",
+              "title": "Small Group Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "126",
+              "title": "Jazz Express",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "127",
+              "title": "Pep Band",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "128",
+              "title": "Concert Band I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "129",
+              "title": "Percussion Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "130",
+              "title": "Voice Class",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Guitar Class",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Piano for Non-Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "133",
+              "title": "Piano for Non-Majors II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "135",
+              "title": "Guitar Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Guitar Class II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "137",
+              "title": "Pop Music Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Aural Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Aural Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "143",
+              "title": "Diction for Singers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "152",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "The Profession of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "170",
+              "title": "Applied Lessons",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Applied Lessons II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "175",
+              "title": "Music Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "176",
+              "title": "Music Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Audio Recording I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Audio Recording II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "Music History I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "Music History II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "232",
+              "title": "Piano for Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "233",
+              "title": "Piano for Majors II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Music Business I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "241",
+              "title": "Music Business II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "270",
+              "title": "Applied Lessons III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "271",
+              "title": "Applied Lessons IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "275",
+              "title": "Sound Reinforcement &amp; Prod",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "276",
+              "title": "Digital Music Composition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "280",
+              "title": "Advanced Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "121",
+              "title": "Darkroom Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "123",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "130",
+              "title": "Intro to Visual Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "140",
+              "title": "Studio Lighting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "150",
+              "title": "Large Format I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "160",
+              "title": "Mixed Media I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "202",
+              "title": "History of Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "221",
+              "title": "Black &amp; White Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "223",
+              "title": "Digital Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "240",
+              "title": "Studio Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "241",
+              "title": "Portrait &amp; Event Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "245",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "250",
+              "title": "Large Format Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "Tech Physics I - Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "Tech Physics II-Heat Light Ele",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Physical Science for Tech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Industrial Physics-Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Industrial Physics-Ht Li Sound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "Radiologic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Calculus Based Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Calculus Based Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPC",
+              "number": "200",
+              "title": "Intro to Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Childhood  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Social Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Intro to Human Sexuality  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Intro to Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage and the Family  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Criminology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "110",
+              "title": "Intro to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "201",
+              "title": "Intro to Communication Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "201",
+              "title": "Intro to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "220",
+              "title": "Social Welfare Institutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "250",
+              "title": "Social Work Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "100",
+              "title": "Introduction to Theater",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "131",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "132",
+              "title": "Acting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "151",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Global Perspectives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARB",
+              "number": "111",
+              "title": "Beginning Arabic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "112",
+              "title": "Beginning Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Cultural Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Physical Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "207",
+              "title": "Contemporary Global Issues  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "106",
+              "title": "Human Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "206",
+              "title": "World Regional Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "275",
+              "title": "World Religions  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music of World Cultures  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Introduction to Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Introduction to Fiction  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "Introduction to Poetry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Women in Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "American Literature I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "267",
+              "title": "American Literature II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "250",
+              "title": "World War II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "270",
+              "title": "History of Women in America  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Intro to the Humanities  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "275",
+              "title": "World Religions  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "173",
+              "title": "College Trigonometry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "233",
+              "title": "Calculus III  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "234",
+              "title": "Differential Equations  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music and Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Art Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "History of Western Art  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Survey of Jazz Styles  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "History of Popular Music  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music of World Cultures  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "Music History I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "Music History II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ohio Transfer 36 Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Cultural Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Art Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "History of Western Art  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Astronomy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "General Biology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "122",
+              "title": "General Chemistry II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLW",
+              "number": "105",
+              "title": "Climate &amp; Weather  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "111",
+              "title": "Principles of Economics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Introduction to Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Introduction to Fiction  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "Introduction to Poetry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Women in Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "American Literature I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "267",
+              "title": "American Literature II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Intro to Environmental Science  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "102",
+              "title": "Lab Intro to Environmental Sci  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "100",
+              "title": "Intro to Comparative Politics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "207",
+              "title": "Contemporary Global Issues  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "106",
+              "title": "Human Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "108",
+              "title": "Geography of the US and Canada  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "110",
+              "title": "Physical Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "206",
+              "title": "World Regional Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "250",
+              "title": "World War II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "270",
+              "title": "History of Women in America  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Intro to the Humanities  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "275",
+              "title": "World Religions  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "173",
+              "title": "College Trigonometry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "178",
+              "title": "Business Calculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "233",
+              "title": "Calculus III  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "234",
+              "title": "Differential Equations  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Survey of Jazz Styles  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "History of Popular Music  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music of World Cultures  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "Music History I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "Music History II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Calculus Based Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Calculus Based Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Childhood  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Social Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Intro to Human Sexuality  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage and the Family  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Criminology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Courses With Laboratory Component",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "Life-An Intro to Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "General Biology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "105",
+              "title": "Chemistry for Biol Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "Basic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "115",
+              "title": "Inorganic &amp; Organic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "122",
+              "title": "General Chemistry II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "202",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "102",
+              "title": "Lab Intro to Environmental Sci  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "111",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LTM",
+              "number": "174",
+              "title": "Greenhouse Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "Tech Physics I - Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "Tech Physics II-Heat Light Ele",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Physical Science for Tech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "Radiologic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Calculus Based Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Calculus Based Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Courses With No Laboratory Component",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Astronomy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "125",
+              "title": "The Science of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "203",
+              "title": "Introduction to Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLW",
+              "number": "105",
+              "title": "Climate &amp; Weather  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Industrial Physics-Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "Industrial Physics-Ht Li Sound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Intro to Environmental Science  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social and Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Cultural Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Physical Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "111",
+              "title": "Principles of Economics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "100",
+              "title": "Intro to Comparative Politics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "207",
+              "title": "Contemporary Global Issues  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "106",
+              "title": "Human Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "108",
+              "title": "Geography of the US and Canada  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "110",
+              "title": "Physical Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "206",
+              "title": "World Regional Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Childhood  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Social Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Intro to Human Sexuality  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Intro to Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage and the Family  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Criminology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Speech",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "110",
+              "title": "Intro to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Studio Art",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Foundations In 2D Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Foundations of 3D Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Oil Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "135",
+              "title": "Printmaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "145",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "295",
+              "title": "Portfolio Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "121",
+              "title": "Darkroom Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "123",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "130",
+              "title": "Intro to Visual Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "140",
+              "title": "Studio Lighting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "150",
+              "title": "Large Format I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "160",
+              "title": "Mixed Media I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "221",
+              "title": "Black &amp; White Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "223",
+              "title": "Digital Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "240",
+              "title": "Studio Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "241",
+              "title": "Portrait &amp; Event Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "245",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "250",
+              "title": "Large Format Photography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Transfer Assurance Guide Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Introductory Managerial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Cultural Anthropology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Physical Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "111",
+              "title": "Beginning Arabic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "112",
+              "title": "Beginning Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Oil Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "135",
+              "title": "Printmaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "145",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "His of Art I:Ancnt to Medieval",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Hist of Art II:Ren to Contemp",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "211",
+              "title": "Inter American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "212",
+              "title": "Int. American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "General Biology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "135",
+              "title": "Introduction to Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "210",
+              "title": "Intro to 3D Modeling-CAD 1A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "120",
+              "title": "Modern Manufacturing Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "122",
+              "title": "General Chemistry II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "110",
+              "title": "Construction Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "101",
+              "title": "Intro to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "100",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Early Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Individuals w/Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "Family,Communities &amp; Schools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Educational Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "101",
+              "title": "Circuit Analysis I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "102",
+              "title": "Circuit Analysis II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "160",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "205",
+              "title": "Advanced Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "120",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Introduction to Literature  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "American Multicultural Lit  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "American Literature I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "267",
+              "title": "American Literature II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "121",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "126",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "270",
+              "title": "Techniques of Healthy Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "111",
+              "title": "Beginning German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "112",
+              "title": "German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "100",
+              "title": "Intro to Comparative Politics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "207",
+              "title": "Contemporary Global Issues  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "106",
+              "title": "Human Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "110",
+              "title": "Physical Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "206",
+              "title": "World Regional Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "World Civilization I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "152",
+              "title": "World Civilization II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "223",
+              "title": "Legal Concepts in Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "236",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "130",
+              "title": "Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "135",
+              "title": "Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "136",
+              "title": "Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "245",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "233",
+              "title": "Calculus III  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "234",
+              "title": "Differential Equations  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Audio Recording I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "232",
+              "title": "Piano for Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "233",
+              "title": "Piano for Majors II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "121",
+              "title": "Darkroom Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "123",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "245",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Calculus Based Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Calculus Based Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Childhood  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Social Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Intro to Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage and the Family  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Criminology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "110",
+              "title": "Intro to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "201",
+              "title": "Intro to Communication Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "230",
+              "title": "Land and Route Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "201",
+              "title": "Intro to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "220",
+              "title": "Social Welfare Institutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "110",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "131",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "151",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "World Languages",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARB",
+              "number": "111",
+              "title": "Beginning Arabic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "112",
+              "title": "Beginning Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "211",
+              "title": "Inter American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "212",
+              "title": "Int. American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "111",
+              "title": "Beginning German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "112",
+              "title": "German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Philosophy Transfer Pathway, AA (Owens Code: PHTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6234",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social And Behavioral Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Intro to Philosophy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Foreign Language II Elective (Lec: 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language Certificate (Owens Code: ZASL)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6251",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "113",
+              "title": "Fingerspelling &amp; Numerical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "211",
+              "title": "Inter American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "212",
+              "title": "Int. American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "213",
+              "title": "Receptive Skills in ASL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "214",
+              "title": "Practical Applications to ASL in the Worksplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "101",
+              "title": "Orientation to Deaf Culture",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Influencer Certificate (Owens Code: ZMIC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6252",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "126",
+              "title": "Introduction to HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "110",
+              "title": "Intro to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "135",
+              "title": "Introduction to Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMT",
+              "number": "111",
+              "title": "Media Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "245",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "228",
+              "title": "Web Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "267",
+              "title": "Web Development Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "101",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "270",
+              "title": "Media Influencer Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fine Art Concentration, AA (Owens Code: FINA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6123",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Foundations In 2D Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Studio Art Elective (Lec: 2 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "His of Art I:Ancnt to Medieval",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Studio Art Elective (Lec: 2 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Foundations of 3D Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Studio Art Elective (Lec: 2 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Hist of Art II:Ren to Contemp",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "295",
+              "title": "Portfolio Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Communication Technology, AAS (Owens Code: VCMT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6101",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCT",
+              "number": "100",
+              "title": "Careers in Visual Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Vector Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "123",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "110",
+              "title": "Graphic Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "125",
+              "title": "Electronic Page Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "210",
+              "title": "Digital Design and Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "225",
+              "title": "World Wide Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "235",
+              "title": "Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "History of Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "130",
+              "title": "Intro to Visual Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "210",
+              "title": "Creative Arts/Media Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "295",
+              "title": "Portfolio Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Foundations In 2D Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "245",
+              "title": "Intro to Package Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Business Technology, AAS (Owens Code: MUBT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6166",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "175",
+              "title": "Music Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Audio Recording I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Music Business I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "107",
+              "title": "Musicianship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "241",
+              "title": "Music Business II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "176",
+              "title": "Music Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Audio Recording II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "The Profession of Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "276",
+              "title": "Digital Music Composition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Survey of Recording History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "280",
+              "title": "Advanced Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "286",
+              "title": "Recording Tech Portfolio I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "108",
+              "title": "Songwriting Workshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "210",
+              "title": "Creative Arts/Media Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "275",
+              "title": "Sound Reinforcement &amp; Prod",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Education/Performance Concentration, AA (Owens Code: MEPC)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6139",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "107",
+              "title": "Musicianship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "The Profession of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "170",
+              "title": "Applied Lessons",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "120",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUS ___ - Ensemble Elective (Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "232",
+              "title": "Piano for Majors I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Aural Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Applied Lessons II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "120",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUS ___ - Ensemble Elective (Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "233",
+              "title": "Piano for Majors II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Aural Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "152",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "Music History I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "270",
+              "title": "Applied Lessons III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "120",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUS ___ - Ensemble Elective (Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "Music History II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "271",
+              "title": "Applied Lessons IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "120",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUS ___ - Ensemble Elective (Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Broadcast Media Technology, AAS (Owens Code: BRMT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6188",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "110",
+              "title": "Intro to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Audio Recording I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "160",
+              "title": "Broadcast Operations &amp; Career",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "135",
+              "title": "Introduction to Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMT",
+              "number": "111",
+              "title": "Media Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "171",
+              "title": "TV Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "245",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "181",
+              "title": "Broadcast Audio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "201",
+              "title": "Intro to Communication Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "172",
+              "title": "TV Production II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "211",
+              "title": "Radio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "210",
+              "title": "Creative Arts/Media Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animation Major, AAS (Owens Code: ANIM )",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6247",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCT",
+              "number": "100",
+              "title": "Careers in Visual Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Vector Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "123",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "101",
+              "title": "Evolution of Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "110",
+              "title": "Fundamentals of Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "115",
+              "title": "Digital Media for Animation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "235",
+              "title": "Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "220",
+              "title": "2D Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "225",
+              "title": "Character Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHO",
+              "number": "130",
+              "title": "Intro to Visual Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "210",
+              "title": "Creative Arts/Media Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "295",
+              "title": "Demo Reel Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General-Ed Non-Tech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "History of Western Art  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Certificate (Owens Code: ZTHC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6222",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "100",
+              "title": "Introduction to Theater",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "131",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "151",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "110",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animation Certificate (Owens Code: ZANM)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6230",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Vector Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "101",
+              "title": "Evolution of Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "History of Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCT",
+              "number": "100",
+              "title": "Careers in Visual Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANM",
+              "number": "110",
+              "title": "Fundamentals of Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "115",
+              "title": "Digital Media for Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "235",
+              "title": "Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "220",
+              "title": "2D Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "225",
+              "title": "Character Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANM",
+              "number": "295",
+              "title": "Demo Reel Presentation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design Certificate (Owens Code: ZGDC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6231",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Vector Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "110",
+              "title": "Graphic Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "125",
+              "title": "Electronic Page Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCT",
+              "number": "100",
+              "title": "Careers in Visual Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "235",
+              "title": "Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "225",
+              "title": "World Wide Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "History of Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "245",
+              "title": "Intro to Package Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "295",
+              "title": "Portfolio Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "210",
+              "title": "Digital Design and Typography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Theatre Transfer Pathway, AA (Owens Code: THEP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6221",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "100",
+              "title": "Introduction to Theater",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "131",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "151",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "110",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Lab Science Elective to 5(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "285",
+              "title": "Acting Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "286",
+              "title": "Technology Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Recording Production Certificate (Owens Code: ZRPC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6248",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "100",
+              "title": "Fundamentals of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Piano for Non-Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "175",
+              "title": "Music Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Audio Recording I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Music Business I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "The Profession of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "176",
+              "title": "Music Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Audio Recording II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "280",
+              "title": "Advanced Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "135",
+              "title": "Introduction to Digital Video",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology Concentration, AS (Owens Code: BIOL)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6093",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "General Biology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "173",
+              "title": "College Trigonometry  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Chemistry Concentration, AS (Owens Code: CHMC)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6099",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "122",
+              "title": "General Chemistry II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "202",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Theatre Certificate (Owens Code: ZTTC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6250",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THE",
+              "number": "100",
+              "title": "Introduction to Theater",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "110",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "105",
+              "title": "Micro Concepts &amp; Apps for Mac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Audio Recording I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Fundamentals of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "261",
+              "title": "Introduction to Film  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THE",
+              "number": "151",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Intro to Board &amp; CAD Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Audio Recording II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "275",
+              "title": "Sound Reinforcement &amp; Prod",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "286",
+              "title": "Technology Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Concentration, AS (Owens Code: EGRC)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6154",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Physics Elective (Lec: 4 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Physics Elective (Lec: 4 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Concentration, AS (Owens Code: ENST)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6186",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Intro to Environmental Science  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "102",
+              "title": "Lab Intro to Environmental Sci  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "232",
+              "title": "Environmental Laws and Regs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "124",
+              "title": "Environmental Sampling Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "203",
+              "title": "Introduction to Ecology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "236",
+              "title": "Water Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics Concentration, AS (Owens Code: MATH)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6134",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "233",
+              "title": "Calculus III  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Calculus Based Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "234",
+              "title": "Differential Equations  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Calculus Based Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Lab Science Elective to 5(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Geography Transfer Pathway, AA (Owens Code: GETP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6125",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "106",
+              "title": "Human Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "206",
+              "title": "World Regional Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "110",
+              "title": "Physical Geography  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective with Lab to 5(Lec: 4 to 5 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Foreign Language II Elective (Lec: 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Veterinary Technician Certificate (Owens Code: PVET)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6254",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "105",
+              "title": "Chemistry for Biol Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "Life-An Intro to Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "General Biology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology Transfer Pathway, AA (Owens Code: PSTA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6156",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ -Science Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Social Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective with Lab to 5(Lec: 4 to 5 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Intro to Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Foreign Language II Elective (Lec: 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Economics Transfer Pathway, AA (Owens Code: ECTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6171",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "178",
+              "title": "Business Calculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science Transfer Pathway, AA (Owens Code: POTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6170",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "100",
+              "title": "Intro to Comparative Politics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "​________ - Science Elective with Lab to 5(Lec: 4 to 5 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOV",
+              "number": "207",
+              "title": "Contemporary Global Issues  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Foreign Language II Elective (Lec: 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Law Concentration, AA (Owens Code: PLWC)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6174",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Amer History I (Begin to 1877)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Amer Hist II (1877 - Present)  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective with Lab to 5(Lec: 3 to 4 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology Transfer Pathway, AA (Owens Code: SOTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6219",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage and the Family  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective with Lab to 5(Lec: 4 to 5 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Foreign Language II Elective (Lec: 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education Transfer Concentration, AA (Owens Code: EDTC)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6114",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "100",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*This course meets the TAG requirements for transfer. Check your major for specific requirements with your transfer institution.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Early Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*This course meets the TAG requirements for transfer. Check your major for specific requirements with your transfer institution.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "Educational Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*This course meets the TAG requirements for transfer. Check your major for specific requirements with your transfer institution.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Individuals w/Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*This course meets the TAG requirements for transfer. Check your major for specific requirements with your transfer institution.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Educational Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*This course meets the TAG requirements for transfer. Check your major for specific course requirements.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Technology, AAS (Owens Code: ECET)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6115",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Intro Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Early Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "Life-An Intro to Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "104",
+              "title": "Science of Reading &amp; Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "201",
+              "title": "Teaching Infants and Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "109",
+              "title": "Play, Learning &amp; Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "106",
+              "title": "Assessment &amp; Observation in Ed",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "203",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "202",
+              "title": "Teaching Preschoolers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Individuals w/Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "Family,Communities &amp; Schools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "216",
+              "title": "Child and Youth Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "221",
+              "title": "Professional Leadership Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "298",
+              "title": "Practicum and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Educational Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Social Work Transfer Pathway, AA (Owens Code: SWTP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6160",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "101",
+              "title": "CDCA I - Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "201",
+              "title": "Intro to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "102",
+              "title": "Addiction Service Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "102",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "220",
+              "title": "Social Welfare Institutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ -Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "103",
+              "title": "CDCA II - Renewable",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "102",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "Life-An Intro to Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ -Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "250",
+              "title": "Social Work Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ -Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Astronomy  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Intro to Environmental Science  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage and the Family  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "260",
+              "title": "Field Experience and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Community & Family Service, AAS (Owens Code: CFSC)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6195",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "125",
+              "title": "The Science of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Intro Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Early Child Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "106",
+              "title": "Assessment &amp; Observation in Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "201",
+              "title": "Intro to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "201",
+              "title": "Teaching Infants and Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "111",
+              "title": "Beginning American Sign Lang I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "203",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Individuals w/Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "Family,Communities &amp; Schools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "220",
+              "title": "Social Welfare Institutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "112",
+              "title": "Beginning American Sign LangII",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "250",
+              "title": "Social Work Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "298",
+              "title": "Practicum and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ASL Interpreter Preparation Program, AAS (Owens Code: ASLI)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6253",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "103",
+              "title": "Preparation for Education and Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "102",
+              "title": "Introduction to the ASL Interpreting Profession",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "211",
+              "title": "Inter American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "101",
+              "title": "Orientation to Deaf Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "103",
+              "title": "Introduction to Transliterating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "212",
+              "title": "Int. American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Science Elective with Lab to 5(Lec: 4 to 5 Lab: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "201",
+              "title": "Interpreting from Sign (ASL) to Voice (ENG)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "202",
+              "title": "Interpreting from Voice (ENG) to Sign (ASL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "113",
+              "title": "Fingerspelling &amp; Numerical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "203",
+              "title": "Legal and Ethical Considerations for ASL Interpreters",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "204",
+              "title": "ASL Interpreter Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "205",
+              "title": "Specialized ASL Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "213",
+              "title": "Receptive Skills in ASL",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Addiction Services Certificate (Owens Code: ZADD)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6264",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SWK",
+              "number": "101",
+              "title": "CDCA I - Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SWK",
+              "number": "102",
+              "title": "Addiction Service Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "103",
+              "title": "CDCA II - Renewable",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology, AAB (Owens Code: ACCT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6087",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Introductory Managerial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "140",
+              "title": "Federal Tax Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "239",
+              "title": "Quickbooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Cost and Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business (BUS) Course Elective or 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "240",
+              "title": "Governmental Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Entrepreneurship Major, AAB (Owens Code: ESHP)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6120",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Introduction to Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Accounting for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "239",
+              "title": "Quickbooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "231",
+              "title": "Entrepreneurial Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "232",
+              "title": "Case Apps in Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "111",
+              "title": "Principles of Economics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "233",
+              "title": "Entrepreneurial Business Plan",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business Course Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship Certificate (Owens Code: ZENT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6121",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Accounting for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Introduction to Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "239",
+              "title": "Quickbooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "231",
+              "title": "Entrepreneurial Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "232",
+              "title": "Case Apps in Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "233",
+              "title": "Entrepreneurial Business Plan",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CPA Qualifying Certificate (Owens Code: ZCPA)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6107",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "140",
+              "title": "Federal Tax Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Cost and Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "141",
+              "title": "Federal Tax Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "240",
+              "title": "Governmental Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "230",
+              "title": "Auditing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "280",
+              "title": "Forensic Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management Technology, AAB (Owens Code: BUMT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6095",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Data Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Critical Think &amp; Problem Solve",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Contemporary Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Introductory Managerial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business (BUS) Course Elective or 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "296",
+              "title": "Business Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing and Sales Technology, AAB (Owens Code: MKTS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6133",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "125",
+              "title": "Personal Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Data Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "225",
+              "title": "Sales Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "230",
+              "title": "Mkt of Service Businesses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business (BUS) Course Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "242",
+              "title": "Marketing on the Web",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "210",
+              "title": "Marketing Planning &amp; Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Office Support Certificate (Owens Code: ZMOS)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6138",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "100",
+              "title": "Beginning Keyboarding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "135",
+              "title": "Intro to Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "102",
+              "title": "Word Processing Apps--Word",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "150",
+              "title": "Medical Scribe Introduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "264",
+              "title": "Medical Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Office Professional, AAB (Owens Code: BUOP)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6143",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "100",
+              "title": "Beginning Keyboarding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "135",
+              "title": "Intro to Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "132",
+              "title": "Data Mgmt Using Excel &amp; Access",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "102",
+              "title": "Word Processing Apps--Word",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "150",
+              "title": "Medical Scribe Introduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "264",
+              "title": "Medical Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Accounting for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "140",
+              "title": "Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "270",
+              "title": "Presentation Mgmt-Power Point",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "293",
+              "title": "Office Admin Internship Work Exp",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Logistics/Supply Chain Major, AAB (Owens Code: LGSC)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6176",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Data Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Continuous Improvement &amp; TQM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Supply Chain Mgt Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "243",
+              "title": "Logistics Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective to 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Logistics/Supply Chain Certificate (Owens Code: ZLSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6177",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Data Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Continuous Improvement &amp; TQM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Supply Chain Mgt Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "243",
+              "title": "Logistics Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "QuickBooks Certificate (Owens Code: ZQBK)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6187",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Accounting for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "239",
+              "title": "Quickbooks",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Insurance Studies, AAB (Owens Code: INSS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6179",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Intro to Insurance &amp; Risk Mgt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Insurance for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Critical Think &amp; Problem Solve",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "125",
+              "title": "Personal Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Risk Finance/Risk Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Insurance Certificate (Owens Code: ZINS)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6189",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Intro to Insurance &amp; Risk Mgt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "125",
+              "title": "Personal Selling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bookkeeping Certificate (Owens Code: ZBKC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6196",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "239",
+              "title": "Quickbooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management Certificate (Owens Code: ZMGT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6210",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Contemporary Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Introductory Managerial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Payroll Certificate (Owens Code: ZPAY)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6178",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "239",
+              "title": "Quickbooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Transfer Concentration, AA (Owens Code: PARA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6233",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "132",
+              "title": "Data Mgmt Using Excel &amp; Access",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Transfer Pathway, AS (Owens Code: BUTP)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6218",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective with No Lab to 4(Lec: 3 to 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Macroeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "120",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science with Lab Elective to 5(Lec: 4 to 5 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Introductory Managerial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "178",
+              "title": "Business Calculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Sales Certificate (Owens Code: ZSAL)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6211",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "125",
+              "title": "Personal Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Microeconomics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "101",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "235",
+              "title": "Spreadsheet Applications-Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Data Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKT",
+              "number": "210",
+              "title": "Marketing Planning &amp; Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "225",
+              "title": "Sales Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "242",
+              "title": "Marketing on the Web",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Assistant Technology Program, AAB (Owens Code: LAST)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6237",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "College &amp; Career Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "100",
+              "title": "Beginning Keyboarding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "135",
+              "title": "Intro to Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "The Legal Environment of Bus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "102",
+              "title": "Word Processing Apps--Word",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "132",
+              "title": "Data Mgmt Using Excel &amp; Access",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "1720",
+              "title": "(UT Course) - Law Practice Management (UT-Synchronous) (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Bus &amp; Profession Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "140",
+              "title": "Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "270",
+              "title": "Presentation Mgmt-Power Point",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "1160",
+              "title": "(UT Course) - Legal Research, Writing & Case Analysis (UT-Synchronous) (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "293",
+              "title": "Office Admin Internship Work Exp",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baking and Pastry Certificate (Owens Code: ZBPD)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6092",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "101",
+              "title": "Intro to Hosp &amp; Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "112",
+              "title": "Fundamental of Food Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "114",
+              "title": "Recipe Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "121",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "150",
+              "title": "Baking &amp; Pastry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "212",
+              "title": "Essentials of Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "213",
+              "title": "Hospitality Facilities Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "230",
+              "title": "Purchasing &amp; Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "250",
+              "title": "Baking &amp; Pastry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "251",
+              "title": "Baking &amp; Pastry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "292",
+              "title": "Culinary Arts Capstone Practic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts Certificate (Owens Code: ZCAB)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6108",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "101",
+              "title": "Intro to Hosp &amp; Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "112",
+              "title": "Fundamental of Food Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "114",
+              "title": "Recipe Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "121",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "130",
+              "title": "Dining Room &amp; Bev Mgt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "150",
+              "title": "Baking &amp; Pastry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "170",
+              "title": "American Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "213",
+              "title": "Hospitality Facilities Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "270",
+              "title": "Techniques of Healthy Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "271",
+              "title": "Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "292",
+              "title": "Culinary Arts Capstone Practic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts Program, AAS (Owens Code: CAPP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6109",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "101",
+              "title": "Intro to Hosp &amp; Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "114",
+              "title": "Recipe Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "112",
+              "title": "Fundamental of Food Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "150",
+              "title": "Baking &amp; Pastry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "121",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "130",
+              "title": "Dining Room &amp; Bev Mgt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "170",
+              "title": "American Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "160",
+              "title": "Menu Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "271",
+              "title": "Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "213",
+              "title": "Hospitality Facilities Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "230",
+              "title": "Purchasing &amp; Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "241",
+              "title": "Catering &amp; Banquet Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "272",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ -Science Elective without Lab to 4(Lec: 2 to 4)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "212",
+              "title": "Essentials of Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "220",
+              "title": "Beer, Wine and Spirits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "270",
+              "title": "Techniques of Healthy Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "292",
+              "title": "Culinary Arts Capstone Practic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "293",
+              "title": "Internship for Culinary &amp; Hosp Prof",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Craft Beverage Certificate (Owens Code: ZCBC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6228",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "General Biology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "115",
+              "title": "Introduction to Craft Beverages",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Accounting for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "115",
+              "title": "Inorganic &amp; Organic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "210",
+              "title": "Hospitality Marketing &amp; Sales",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "220",
+              "title": "Beer, Wine and Spirits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "280",
+              "title": "Craft Brewing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "293",
+              "title": "Internship for Culinary &amp; Hosp Prof",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dietary Manager Certificate (Owens Code: ZCDM)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6200",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "121",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "112",
+              "title": "Fundamental of Food Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "212",
+              "title": "Essentials of Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "230",
+              "title": "Purchasing &amp; Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "102",
+              "title": "Applied Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "270",
+              "title": "Techniques of Healthy Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "190",
+              "title": "Nutrition App Clinical Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "289",
+              "title": "Systems Mgt Clinical Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nutrition Concentration, AS (Owens Code: NTRC)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6199",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "126",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "112",
+              "title": "Fundamental of Food Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "216",
+              "title": "Foodservice Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "122",
+              "title": "General Chemistry II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "102",
+              "title": "Applied Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "270",
+              "title": "Techniques of Healthy Cooking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Event Planning Certificate (Owens Code: ZEVP)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6229",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "101",
+              "title": "Intro to Hosp &amp; Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "112",
+              "title": "Fundamental of Food Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "135",
+              "title": "ServSafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "220",
+              "title": "Beer, Wine and Spirits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "240",
+              "title": "Convention, Meeting and Event Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Introductory Financial Acct",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "210",
+              "title": "Hospitality Marketing &amp; Sales",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "241",
+              "title": "Catering &amp; Banquet Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "213",
+              "title": "Hospitality Facilities Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "293",
+              "title": "Internship for Culinary &amp; Hosp Prof",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Programming & Development Program, AAS (Owens Code: CPRD)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6105",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "133",
+              "title": "Computer Hardware and Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "126",
+              "title": "Introduction to HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "140",
+              "title": "Introduction to C# Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "269",
+              "title": "Programming Mobile Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "264",
+              "title": "JavaScript &amp; jQuery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "Intro Database Design &amp; SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "267",
+              "title": "Web Development Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Networking & Systems Administration Program, AAS (Owens Code: CNSA)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6140",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "133",
+              "title": "Computer Hardware and Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "176",
+              "title": "Intro to Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "240",
+              "title": "Microsoft Net Admin I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "241",
+              "title": "Linux Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "205",
+              "title": "Advanced Networking Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "Intro Database Design &amp; SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer WAN & Cloud Tech Program, AAS (Owens Code: WANT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6165",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "176",
+              "title": "Intro to Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4 (Lec: 3 to 4 Lab 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "205",
+              "title": "Advanced Networking Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "240",
+              "title": "Microsoft Net Admin I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "241",
+              "title": "Linux Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "242",
+              "title": "Microsoft Net Admin II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "274",
+              "title": "Cyber Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Program, AAS (Owens Code: CSCI)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6106",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "126",
+              "title": "Introduction to HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "135",
+              "title": "Visual Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 5(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "264",
+              "title": "JavaScript &amp; jQuery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "121",
+              "title": "General Chemistry I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Calculus Based Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Systems Technologies & Support Program, AAS (Owens Code: CSTS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6213",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "133",
+              "title": "Computer Hardware and Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "Intro Database Design &amp; SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "288",
+              "title": "Project Mgmt/Microsoft Proj",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "Microsoft Op System Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Contemporary Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "176",
+              "title": "Intro to Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science, General Science Concentration, AS (Owens Code: SGEN)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6090",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Programming - Developer II Certificate (Owens Code: ZCDV)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6240",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "267",
+              "title": "Web Development Tools",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "Intro Database Design &amp; SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "269",
+              "title": "Programming Mobile Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security Program, AAS (Owens Code: CYSP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6238",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "Microsoft Op System Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "Intro Database Design &amp; SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 5(Lec: 4 to 5 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "205",
+              "title": "Advanced Networking Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "240",
+              "title": "Microsoft Net Admin I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "241",
+              "title": "Linux Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "273",
+              "title": "Ethical Hacker",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "274",
+              "title": "Cyber Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Programming - Developer I Certificate (Owens Code: ZCDI)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6239",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "126",
+              "title": "Introduction to HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "140",
+              "title": "Introduction to C# Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Support Tech. Certificate (Owens Code: ZCSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6241",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "133",
+              "title": "Computer Hardware and Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Contemporary Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "Microsoft Op System Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "176",
+              "title": "Intro to Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Tech I Certificate (Owens Code: ZNTI)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6242",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "133",
+              "title": "Computer Hardware and Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "176",
+              "title": "Intro to Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Security Tech Certificate (Owens Code: ZSTC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6245",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "Microsoft Op System Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "241",
+              "title": "Linux Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "273",
+              "title": "Ethical Hacker",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "274",
+              "title": "Cyber Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Tech II Certificate (Owens Code: ZNII)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6243",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "240",
+              "title": "Microsoft Net Admin I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "241",
+              "title": "Linux Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "205",
+              "title": "Advanced Networking Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "IT Project Management Certificate (Owens Code: ZPMC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6244",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "Microsoft Op System Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "288",
+              "title": "Project Mgmt/Microsoft Proj",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Web Developer Front-End Certificate (Owens Code: ZWFC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6246",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "126",
+              "title": "Introduction to HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "Intro Database Design &amp; SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "269",
+              "title": "Programming Mobile Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "267",
+              "title": "Web Development Tools",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Tech II Certificate (Owens Code: ZCS2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6262",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "265",
+              "title": "Introduction to Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "264",
+              "title": "JavaScript &amp; jQuery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "232",
+              "title": "Calculus II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "235",
+              "title": "Linear Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "293",
+              "title": "Info Systems Coop Wk Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer WAN Cloud Tech I Certificate (Owens Code: ZCW1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6260",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "175",
+              "title": "Networking Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "176",
+              "title": "Intro to Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPH",
+              "number": "220",
+              "title": "Intro to Geograph Info Sys-GIS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer WAN Cloud Tech II Certificate (Owens Code: ZCW2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6261",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "181",
+              "title": "Intro to Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "205",
+              "title": "Advanced Networking Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "240",
+              "title": "Microsoft Net Admin I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "241",
+              "title": "Linux Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "242",
+              "title": "Microsoft Net Admin II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "274",
+              "title": "Cyber Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "289",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Tech I Certificate (Owens Code: ZCS1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6263",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "101",
+              "title": "IT Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "124",
+              "title": "Internet Research Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "126",
+              "title": "Introduction to HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "135",
+              "title": "Visual Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "180",
+              "title": "Calculus I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Automotive Technology, AAS (Owens Code: AUTO)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6091",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Automotive Service Fundamental",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "113",
+              "title": "Automotive Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Vehicle Electric &amp; Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Anti-Lock Brake System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "133",
+              "title": "Automotive Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Automotive Engine Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "212",
+              "title": "Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "214",
+              "title": "Wheel Alignment &amp; Suspensions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "232",
+              "title": "Vehicle Accessory Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "248",
+              "title": "Engine Perform &amp; Drivability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Standard Transmission",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "213",
+              "title": "Fund of Automatic Transmission",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "215",
+              "title": "Auto Trans Diagnosis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "249",
+              "title": "Hybrid Elect &amp; Fuel Cell Veh",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "General Motors Corporation Automotive Service Education Program, AAS (Owens Code: ASEP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6124",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Automotive Service Fundamental",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "113",
+              "title": "Automotive Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Vehicle Electric &amp; Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Anti-Lock Brake System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "133",
+              "title": "Automotive Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Automotive Engine Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "212",
+              "title": "Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "248",
+              "title": "Engine Perform &amp; Drivability",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "214",
+              "title": "Wheel Alignment &amp; Suspensions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "232",
+              "title": "Vehicle Accessory Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Standard Transmission",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "213",
+              "title": "Fund of Automatic Transmission",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291",
+              "title": "Automotive Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "215",
+              "title": "Auto Trans Diagnosis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "249",
+              "title": "Hybrid Elect &amp; Fuel Cell Veh",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Caterpillar Dealer Service Technician, AAS (Owens Code: CATP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6098",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAT",
+              "number": "110",
+              "title": "CAT Engine Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "111",
+              "title": "Intro to CAT Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "291",
+              "title": "CAT Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAT",
+              "number": "112",
+              "title": "Fundamentals of Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "113",
+              "title": "CAT Engine Fuel System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "114",
+              "title": "Fund of Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "291",
+              "title": "CAT Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAT",
+              "number": "115",
+              "title": "Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "116",
+              "title": "Fund of Trans &amp; Tor Con",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "117",
+              "title": "Machine Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAT",
+              "number": "200",
+              "title": "Undercarriage &amp; Final Drive",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "201",
+              "title": "Machine Electronic System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "291",
+              "title": "CAT Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAT",
+              "number": "202",
+              "title": "CAT Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "203",
+              "title": "Diagnostic Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "204",
+              "title": "Machine Specific Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "291",
+              "title": "CAT Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "John Deere Tech Major, AAS (Owens Code: JDEM)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6130",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "101",
+              "title": "Hydraulic Theory &amp; Oper",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "130",
+              "title": "Vehicle Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "182",
+              "title": "Preventive Maint. &amp; Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "110",
+              "title": "Info Resource Systems for JD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "111",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "117",
+              "title": "Combine Maintenance &amp; Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "133",
+              "title": "Vehicle Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "241",
+              "title": "Fundamentals of Engines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "102",
+              "title": "Tractor Drivelines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "203",
+              "title": "Advanced Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "218",
+              "title": "Seeding &amp; Tillage Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "245",
+              "title": "Diesel Eng Perf-Anal &amp; Tune",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "212",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "257",
+              "title": "Advanced Drivelines Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology, AAS (Owens Code: DSLT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6113",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "101",
+              "title": "Hydraulic Theory &amp; Oper",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "182",
+              "title": "Preventive Maint. &amp; Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "254",
+              "title": "Truck Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "112",
+              "title": "Drive Lines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "130",
+              "title": "Vehicle Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "241",
+              "title": "Fundamentals of Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "212",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "133",
+              "title": "Vehicle Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "268",
+              "title": "Computer Ctrld Diesel Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "253",
+              "title": "Shop Truck Operation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "245",
+              "title": "Diesel Eng Perf-Anal &amp; Tune",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "261",
+              "title": "Truck Susp/Steering/Chassis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "215",
+              "title": "Transmission &amp; Torque Conv.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "291",
+              "title": "Diesel Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Service Certificate (Owens Code: ZDSL)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6183",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "130",
+              "title": "Vehicle Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "133",
+              "title": "Vehicle Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "182",
+              "title": "Preventive Maint. &amp; Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "241",
+              "title": "Fundamentals of Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "245",
+              "title": "Diesel Eng Perf-Anal &amp; Tune",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "254",
+              "title": "Truck Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "261",
+              "title": "Truck Susp/Steering/Chassis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "112",
+              "title": "Drive Lines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "212",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "253",
+              "title": "Shop Truck Operation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "190",
+              "title": "Welding: Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "193",
+              "title": "SMAW (Vertical and Overhead)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "262",
+              "title": "GMAW Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Service Certificate (Owens Code: ZSER)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6185",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Automotive Service Fundamental",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Standard Transmission",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "113",
+              "title": "Automotive Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Anti-Lock Brake System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Vehicle Electric &amp; Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "133",
+              "title": "Automotive Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Automotive Engine Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "213",
+              "title": "Fund of Automatic Transmission",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "214",
+              "title": "Wheel Alignment &amp; Suspensions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "215",
+              "title": "Auto Trans Diagnosis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "232",
+              "title": "Vehicle Accessory Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "248",
+              "title": "Engine Perform &amp; Drivability",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "GTAW Welding Certificate (Owens Code: ZGTW)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6127",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "266",
+              "title": "GTAW Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Electrical Major, AAS (Owens Code: SKTE)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6116",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "171",
+              "title": "Electricity: DC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "132",
+              "title": "Electrical Prints: Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "133",
+              "title": "Electrical Prints: Industrial",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "174",
+              "title": "Electricity: AC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "181",
+              "title": "Motor Control Systems: I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "184",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "281",
+              "title": "Electronics: Princ/Applicat",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "182",
+              "title": "Motor Control Systems: II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "165",
+              "title": "Automation Control: PLC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business (BUS) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "166",
+              "title": "Automation Control: PLC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "254",
+              "title": "Motor Control/Syst: Adv",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "175",
+              "title": "Electricity: Electric Applicat",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "172",
+              "title": "Electricity: Mag/DC Motors/Gen",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "286",
+              "title": "Electronics: Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Maintenance Major, AAS (Owens Code: SKTB)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6094",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "237",
+              "title": "Maintenance Tools/Equipment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "170",
+              "title": "Maintenance Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "145",
+              "title": "Building Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "150",
+              "title": "Piping Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "177",
+              "title": "Wood/Metal Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business (BUS) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "176",
+              "title": "Electricity: HVACR Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "158",
+              "title": "Refrigeration - A/C Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "165",
+              "title": "Gas Heating Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "115",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "OSHA 30 hour Const Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "128",
+              "title": "Building Energy Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "GMAW Welding Certificate (Owens Code: ZGMW)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6126",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "262",
+              "title": "GMAW Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Mechanical Major, AAS (Owens Code: SKTM)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6135",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "142",
+              "title": "Mechanical Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "170",
+              "title": "Maintenance Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUP",
+              "number": "102",
+              "title": "Managing Yourself",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "150",
+              "title": "Piping Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "151",
+              "title": "Fluid Power: Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "157",
+              "title": "Plant Equipment: Gear/Bearings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Business (BUS) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "153",
+              "title": "Fluid Power: Pneumatics/Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "239",
+              "title": "Mechanical Power Trans System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "OSHA General Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Arts and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Major, AAS (Owens Code: WELD)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6164",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIM",
+              "number": "105",
+              "title": "Sys of Eng &amp; Int Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "142",
+              "title": "Mechanical Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "190",
+              "title": "Welding: Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAM",
+              "number": "161",
+              "title": "Machining II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "OSHA General Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "262",
+              "title": "GMAW Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "130",
+              "title": "Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "193",
+              "title": "SMAW (Vertical and Overhead)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "261",
+              "title": "Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "266",
+              "title": "GTAW Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Data Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "264",
+              "title": "Welding: Plate Pre-Cert &amp; Test",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "265",
+              "title": "Pipe Welding Pre-Cert &amp; Test",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_________ - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Tool and Die/Mold Maker Certificate (Owens Code: ZTLD)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6163",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "143",
+              "title": "Machining Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "161",
+              "title": "Machining II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "122",
+              "title": "CNC Mill Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "124",
+              "title": "CNC Lathe Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "120",
+              "title": "Modern Manufacturing Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAM",
+              "number": "126",
+              "title": "Advanced CNC Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "216",
+              "title": "Basic CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "218",
+              "title": "Advanced CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "130",
+              "title": "Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "OSHA General Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pipe Welding Certificate (Owens Code: ZPWL)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6180",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "193",
+              "title": "SMAW (Vertical and Overhead)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "261",
+              "title": "Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "265",
+              "title": "Pipe Welding Pre-Cert &amp; Test",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Machining Certificate (Owens Code: ZMCC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6184",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "143",
+              "title": "Machining Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "161",
+              "title": "Machining II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "122",
+              "title": "CNC Mill Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "124",
+              "title": "CNC Lathe Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "144",
+              "title": "GD &amp; T",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "160",
+              "title": "Machinery Handbook",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "125",
+              "title": "Metallurgy: Ferrous",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "126",
+              "title": "Metallurgy: Non-Ferrous",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAM",
+              "number": "126",
+              "title": "Advanced CNC Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "216",
+              "title": "Basic CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "218",
+              "title": "Advanced CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "150",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "216",
+              "title": "Drftg/Bluprnt Read:Die Detail",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "266",
+              "title": "GTAW Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plate Welding Certificate (Owens Code: ZPLW)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6181",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "193",
+              "title": "SMAW (Vertical and Overhead)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "264",
+              "title": "Welding: Plate Pre-Cert &amp; Test",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "HVAC Certificate (Owens Code: ZVCC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6191",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "170",
+              "title": "Maintenance Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "176",
+              "title": "Electricity: HVACR Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "158",
+              "title": "Refrigeration - A/C Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "165",
+              "title": "Gas Heating Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "167",
+              "title": "HVAC Design &amp; Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "197",
+              "title": "Sheet Metal Fabric/Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "206",
+              "title": "HVACR: Service Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "244",
+              "title": "HVACR System Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "145",
+              "title": "Building Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "240",
+              "title": "Light Commercial Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "211",
+              "title": "Chiller Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "242",
+              "title": "HVACR Control Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "128",
+              "title": "Building Energy Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Mechanic Certificate (Owens Code: ZINM)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6192",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "170",
+              "title": "Maintenance Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "142",
+              "title": "Mechanical Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "150",
+              "title": "Piping Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "151",
+              "title": "Fluid Power: Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "153",
+              "title": "Fluid Power: Pneumatics/Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "157",
+              "title": "Plant Equipment: Gear/Bearings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "239",
+              "title": "Mechanical Power Trans System",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "152",
+              "title": "Fluid Power: Pumps/Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "156",
+              "title": "Conveyors/Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "238",
+              "title": "Machine Moving and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "161",
+              "title": "Machining II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "193",
+              "title": "SMAW (Vertical and Overhead)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Maintenance Certificate (Owens Code: ZBLD)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6190",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "170",
+              "title": "Maintenance Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "128",
+              "title": "Building Energy Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "115",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "145",
+              "title": "Building Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "150",
+              "title": "Piping Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "177",
+              "title": "Wood/Metal Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "237",
+              "title": "Maintenance Tools/Equipment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "158",
+              "title": "Refrigeration - A/C Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "159",
+              "title": "Pipefitting/Plumbing Con",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "165",
+              "title": "Gas Heating Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "176",
+              "title": "Electricity: HVACR Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "187",
+              "title": "Resid &amp; Comm Mech Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "195",
+              "title": "Low/High Pressure Boiler",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "OSHA 30 hour Const Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "211",
+              "title": "Chiller Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Certificate (Owens Code: ZECT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6194",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "171",
+              "title": "Electricity: DC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "132",
+              "title": "Electrical Prints: Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "174",
+              "title": "Electricity: AC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "181",
+              "title": "Motor Control Systems: I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "175",
+              "title": "Electricity: Electric Applicat",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "184",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "133",
+              "title": "Electrical Prints: Industrial",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "182",
+              "title": "Motor Control Systems: II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "165",
+              "title": "Automation Control: PLC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "166",
+              "title": "Automation Control: PLC II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "172",
+              "title": "Electricity: Mag/DC Motors/Gen",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "281",
+              "title": "Electronics: Princ/Applicat",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "254",
+              "title": "Motor Control/Syst: Adv",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pipefitting/Plumbing Certificate (Owens Code: ZPPC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6193",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "145",
+              "title": "Building Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "237",
+              "title": "Maintenance Tools/Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "150",
+              "title": "Piping Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "159",
+              "title": "Pipefitting/Plumbing Con",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "139",
+              "title": "Plumbing Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "188",
+              "title": "Piping Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "151",
+              "title": "Fluid Power: Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "153",
+              "title": "Fluid Power: Pneumatics/Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "195",
+              "title": "Low/High Pressure Boiler",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "SMAW Welding Certificate (Owens Code: ZSMW)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6159",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "193",
+              "title": "SMAW (Vertical and Overhead)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Dana Mechatronics Maintenance Certificate (Owens Code: ZDMM)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6226",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "OSHA 30 hour Const Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "157",
+              "title": "Plant Equipment: Gear/Bearings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "132",
+              "title": "Electrical Prints: Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "171",
+              "title": "Electricity: DC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "142",
+              "title": "Mechanical Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "174",
+              "title": "Electricity: AC Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "153",
+              "title": "Fluid Power: Pneumatics/Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "151",
+              "title": "Fluid Power: Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "281",
+              "title": "Electronics: Princ/Applicat",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dana Mechatronics Engineering Certificate (Owens Code: ZDME)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6225",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "OSHA 30 hour Const Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "157",
+              "title": "Plant Equipment: Gear/Bearings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "132",
+              "title": "Electrical Prints: Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "171",
+              "title": "Electricity: DC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "142",
+              "title": "Mechanical Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "181",
+              "title": "Motor Control Systems: I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "153",
+              "title": "Fluid Power: Pneumatics/Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "151",
+              "title": "Fluid Power: Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "165",
+              "title": "Automation Control: PLC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "125",
+              "title": "Production Drawing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Dana Mechatronics Controls Certificate (Owens Code: ZDMC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6227",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "OSHA 30 hour Const Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "157",
+              "title": "Plant Equipment: Gear/Bearings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "131",
+              "title": "Electrical Prints",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SKT",
+              "number": "132",
+              "title": "Electrical Prints: Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "171",
+              "title": "Electricity: DC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "181",
+              "title": "Motor Control Systems: I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "174",
+              "title": "Electricity: AC Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "150",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "165",
+              "title": "Automation Control: PLC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "281",
+              "title": "Electronics: Princ/Applicat",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "182",
+              "title": "Motor Control Systems: II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "166",
+              "title": "Automation Control: PLC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "254",
+              "title": "Motor Control/Syst: Adv",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Law Enforcement Certificate (Owens Code: ZOPA)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6214",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "171",
+              "title": "Basic Academy 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "172",
+              "title": "Basic Academy 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "173",
+              "title": "Basic Academy 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "174",
+              "title": "Basic Academy 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Professional Law Enforcement Officer, AAS (Owens Code: PLEO)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6144",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Speech (SPE) Course Listing (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Criminology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics (MTH) Course Listing to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "205",
+              "title": "State and Local Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "171",
+              "title": "Basic Academy 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "172",
+              "title": "Basic Academy 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "173",
+              "title": "Basic Academy 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "174",
+              "title": "Basic Academy 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Transfer Pathway, AA (Owens Code: CJPP)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6220",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "101",
+              "title": "Intro to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Mathematics Elective to 5(Lec: 3 to 5)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Criminology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "105",
+              "title": "Community Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Criminal Justice Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Abnormal Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Ohio Transfer 36 (OH36) Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Advanced Manufacturing, AAS (Owens Code: APET)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6088",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "157",
+              "title": "Plant Equipment: Gear/Bearings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "191",
+              "title": "Intro to the Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Intro to Board &amp; CAD Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAM",
+              "number": "161",
+              "title": "Machining II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Fundamental DC Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "OSHA General Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "165",
+              "title": "Automation Control: PLC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "151",
+              "title": "Fluid Power: Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "122",
+              "title": "CNC Mill Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "192",
+              "title": "SMAW (Flat &amp; Horizontal)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "166",
+              "title": "Automation Control: PLC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "153",
+              "title": "Fluid Power: Pneumatics/Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CAD Certificate (Owens Code: ZCDC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6096",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Intro to Board &amp; CAD Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "130",
+              "title": "3D Modeling for Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "210",
+              "title": "Intro to 3D Modeling-CAD 1A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "144",
+              "title": "GD &amp; T",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Foundations Certificate (Owens Code: ZMFC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6217",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Intro to Board &amp; CAD Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "130",
+              "title": "Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "291",
+              "title": "CAD Tech Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical/Electronics Engineering Technology, AAS (Owens Code: EETT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6117",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "101",
+              "title": "Circuit Analysis I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "113",
+              "title": "Intro to Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "175",
+              "title": "Precalculus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "102",
+              "title": "Circuit Analysis II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "110",
+              "title": "Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General Physics I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Intro to Board &amp; CAD Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General Physics II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "201",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "211",
+              "title": "Electronics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "165",
+              "title": "Automation Control: PLC I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "205",
+              "title": "Advanced Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "212",
+              "title": "Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "166",
+              "title": "Automation Control: PLC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Social and Behavioral Science Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "CAD Technology, AAS (Owens Code: CADT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6097",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Intro to Board &amp; CAD Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "130",
+              "title": "3D Modeling for Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "143",
+              "title": "Applied Industrial Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "105",
+              "title": "Technology in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "132",
+              "title": "CAD Drafting &amp; Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "144",
+              "title": "GD &amp; T",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "210",
+              "title": "Intro to 3D Modeling-CAD 1A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "230",
+              "title": "Industrial CAD I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "160",
+              "title": "Machining I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "235",
+              "title": "Construction and Surveying CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "130",
+              "title": "Intro to Technical Comm",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "280",
+              "title": "Intro to 3D Modeling-CAD 1B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "130",
+              "title": "Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "161",
+              "title": "Machining II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "143",
+              "title": "Applied Industrial Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "287",
+              "title": "Capstone Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "111",
+              "title": "Indust/Organization Psych",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Treatment Professions (Owens Code: ZWAT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6255",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st 8 weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Intro to Environmental Science  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "103",
+              "title": "Intro to Water Treatment Profession",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "124",
+              "title": "Environmental Sampling Methods",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd 8 weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "OSHA General Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "230",
+              "title": "Waste Water Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "235",
+              "title": "Water Treatment Operation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Semiconductor Technician Certificate (Owens Code: ZSCD)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6265",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "101",
+              "title": "Circuit Analysis I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "108",
+              "title": "Introduction to Semiconductors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "109",
+              "title": "Introduction to Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "102",
+              "title": "Circuit Analysis II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SKT",
+              "number": "239",
+              "title": "Mechanical Power Trans System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STM",
+              "number": "110",
+              "title": "Introduction to Vacuum Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Vascular Sonography Cert (Owens Code: ZVSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6205",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "102",
+              "title": "Ind Delivery MIT Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "205",
+              "title": "Vascular Ultrasound IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "209",
+              "title": "Vascular Ultrasound V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "213",
+              "title": "Vascular Ultrasound Dir Prac I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "215",
+              "title": "Vascular Ultrasound Dir Pra II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Vascular Sonography Major, AAS (Owens Code: VSTM)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6167",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "106",
+              "title": "Intro to Basic Physics for Sonographers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "105",
+              "title": "Ultrasound Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "101",
+              "title": "Ultrasound Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "103",
+              "title": "Vascular Ultrasound I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "201",
+              "title": "Sect Anatomy for Med Imagers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "104",
+              "title": "Foundations for Clinical Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "105",
+              "title": "Vascular Ultrasound II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "107",
+              "title": "Vascular Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Informatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "213",
+              "title": "Vascular Ultrasound Dir Prac I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "205",
+              "title": "Vascular Ultrasound IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "215",
+              "title": "Vascular Ultrasound Dir Pra II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Vascular Ultrasound Dir Pr III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "209",
+              "title": "Vascular Ultrasound V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "219",
+              "title": "Vascular Ultrasound Dir Pr IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "221",
+              "title": "Vascular Ultrasound Dir Pr V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Capstone Seminar I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Sonography Cert (Owens Code: ZGSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6204",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "102",
+              "title": "Ind Delivery MIT Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "204",
+              "title": "General Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "208",
+              "title": "General Ultrasound IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "212",
+              "title": "General Ultrasound Dir Prac I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "214",
+              "title": "General Ultrasound Dir Prac II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Effective Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Diagnostic Medical Sonography Concentration, AS (Owens Code: PDMS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6208",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Vascular Sonography Concentration, AS (Owens Code: PVST)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6209",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cardiac Sonography (Owens Code: CARD)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6259",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "106",
+              "title": "Intro to Basic Physics for Sonographers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "105",
+              "title": "Ultrasound Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "107",
+              "title": "Cardiac Testing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "101",
+              "title": "Ultrasound Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "113",
+              "title": "Cardiac Ultrasound I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "104",
+              "title": "Foundations for Clinical Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "115",
+              "title": "Cardiac Ultrasound II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Informatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "222",
+              "title": "Cardiac US Dir Practice I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "Cardia Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Cardiac Ultrasound for Peds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "223",
+              "title": "Cardiac US Dir Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "224",
+              "title": "Cardiac US Dir Practice III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Cardiac Ultrasound IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "225",
+              "title": "Cardiac US Dir Practice IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "226",
+              "title": "Cardiac US Dir Practice V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Capstone Seminar I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene Program, AAS (Owens Code: DHYP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6111",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "121",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "122",
+              "title": "Tooth Morphology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "115",
+              "title": "Inorganic &amp; Organic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "100",
+              "title": "Clinical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "101",
+              "title": "Preclinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "110",
+              "title": "Preventive Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "120",
+              "title": "Oral Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "138",
+              "title": "Dental Radiographic Imaging",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "102",
+              "title": "Preventive Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "103",
+              "title": "Preventive Practice I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "107",
+              "title": "Intro to Periodontology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "150",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "131",
+              "title": "Local Anesthesia &amp; Pain Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "204",
+              "title": "Preventive Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "205",
+              "title": "Preventive Practice II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "207",
+              "title": "Periodontology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "226",
+              "title": "General &amp; Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "230",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "250",
+              "title": "Community Dental Health I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "210",
+              "title": "Preventive Pract III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "211",
+              "title": "Preventive Practice III Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "251",
+              "title": "Community Dental Health II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "255",
+              "title": "Trends in Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Technology, AAS (Owens Code: HINF)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6128",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "102",
+              "title": "Hlth Info Mgmt &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "131",
+              "title": "Pathopharmacology for HIT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "131",
+              "title": "Computer Concepts and Apps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "233",
+              "title": "Clin Classification Syst I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "132",
+              "title": "Data Mgmt Using Excel &amp; Access",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "223",
+              "title": "Legal Concepts in Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Ancillary Health Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "235",
+              "title": "Healthcare Stats &amp; Registries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "241",
+              "title": "Clin Classifcation Syst II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "242",
+              "title": "Healthcare Quality Improvement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "226",
+              "title": "HIT Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "234",
+              "title": "Prof Directed Practice Exper",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "237",
+              "title": "Health Care Information System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "243",
+              "title": "Reimbursement Methodologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "246",
+              "title": "Management of Health Info Svcs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "248",
+              "title": "Clin Classification Sys III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "296",
+              "title": "HIT Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Assisting Certificate (Owens Code: ZDAC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6110",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAS",
+              "number": "101",
+              "title": "Intro to Dental Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "102",
+              "title": "Dental Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "103",
+              "title": "Chairside Assisting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "104",
+              "title": "Dental Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "105",
+              "title": "Infection Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAS",
+              "number": "106",
+              "title": "Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "107",
+              "title": "Dental Materials II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "108",
+              "title": "Chairside Assisting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "109",
+              "title": "Dental Radiography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAS",
+              "number": "201",
+              "title": "Dental Assisting Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "202",
+              "title": "Dental Assisting Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Dental Hygiene Concentration, AS (Owens Code: PDHT)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6148",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding Certificate (Owens Code: ZMED)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6137",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "102",
+              "title": "Hlth Info Mgmt &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "131",
+              "title": "Pathopharmacology for HIT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "233",
+              "title": "Clin Classification Syst I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "241",
+              "title": "Clin Classifcation Syst II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "249",
+              "title": "Concepts in Med Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography Technology, AAS (Owens Code: SONO)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6112",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "106",
+              "title": "Intro to Basic Physics for Sonographers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "105",
+              "title": "Ultrasound Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "101",
+              "title": "Ultrasound Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "102",
+              "title": "General Ultrasound I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "201",
+              "title": "Sect Anatomy for Med Imagers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "104",
+              "title": "Foundations for Clinical Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "106",
+              "title": "General Ultrasound II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Informatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "212",
+              "title": "General Ultrasound Dir Prac I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "204",
+              "title": "General Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "214",
+              "title": "General Ultrasound Dir Prac II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "216",
+              "title": "General Ultrasound Dir Pra III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "108",
+              "title": "Pediatric Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "110",
+              "title": "Breast Sonography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "208",
+              "title": "General Ultrasound IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "218",
+              "title": "General Ultrasound Dir Pr IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "220",
+              "title": "General Ultrasound Dir Pr V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Capstone Seminar I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Magnetic Resonance Imaging Program, AAS (Owens Code: MRIT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6168",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "100",
+              "title": "Introductions to MR Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "101",
+              "title": "MRI Patient Care and Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "201",
+              "title": "Sect Anatomy for Med Imagers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "103",
+              "title": "MRI Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "104",
+              "title": "MRI Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRI",
+              "number": "203",
+              "title": "MRI Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "204",
+              "title": "MRI Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Informatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRI",
+              "number": "211",
+              "title": "MRI Directed Practice I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRI",
+              "number": "212",
+              "title": "MRI Directed Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "213",
+              "title": "MRI Directed Practice III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "205",
+              "title": "Pathophysiology I for MRI",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRI",
+              "number": "214",
+              "title": "MRI Directed Practice IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "215",
+              "title": "MRI Directed Practice V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "221",
+              "title": "MRI Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "220",
+              "title": "MR Registry Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Health Information Concentration, AS (Owens Code: PHIT)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6149",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Magnetic Resonance Concentration, AS (Owens Code: PMAG)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6206",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Program, AAS (Owens Code: MDAP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6136",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "105",
+              "title": "Med Assist Law &amp; Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "110",
+              "title": "Basic Med Assisting Clin Proce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "120",
+              "title": "Med Asst Admin Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "210",
+              "title": "Adv Med Asst Clinical Proc",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAP",
+              "number": "130",
+              "title": "Med Asst Specialty Exam/Proc",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "140",
+              "title": "Emergency Preparedness(Med As)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "230",
+              "title": "Coding and Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "240",
+              "title": "Med Asst Lab Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "264",
+              "title": "Medical Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAP",
+              "number": "250",
+              "title": "Med Asst Directed Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "260",
+              "title": "Med Asst Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "131",
+              "title": "Pathopharmacology for HIT",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Certificate (Owens Code: ZMDA)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6212",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "105",
+              "title": "Med Assist Law &amp; Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "110",
+              "title": "Basic Med Assisting Clin Proce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "120",
+              "title": "Med Asst Admin Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "210",
+              "title": "Adv Med Asst Clinical Proc",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAP",
+              "number": "130",
+              "title": "Med Asst Specialty Exam/Proc",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "140",
+              "title": "Emergency Preparedness(Med As)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "230",
+              "title": "Coding and Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "240",
+              "title": "Med Asst Lab Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "264",
+              "title": "Medical Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAP",
+              "number": "250",
+              "title": "Med Asst Directed Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "260",
+              "title": "Med Asst Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Licensed Practical Nurse/Associate Degree Nursing Progression Program, AAS (Owens Code: NRSL)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6132",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "100",
+              "title": "Fundamentals of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "LPN-RN Transitional Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "201",
+              "title": "Adult Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "202",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "203",
+              "title": "Applied Concepts for Nrs Pract",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nurse Assistant Training/Home Health Aide Certificate (Owens Code: ZSTN)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6141",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Pre-Cardiac Sonography Concentration, AS (Owens Code: PCAR)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6257",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Nursing Concentration, AS (Owens Code: PNTC)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6151",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing Certificate (Owens Code: LPNP)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6147",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "126",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRP",
+              "number": "120",
+              "title": "Practical Nursing Roles &amp; Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRP",
+              "number": "121",
+              "title": "Practical Nursing Care of the Adult",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRP",
+              "number": "122",
+              "title": "Nursing Concepts Lifespan PN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRP",
+              "number": "123",
+              "title": "Applied Concepts for the Practical Nurse",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Pre-LPN to RN Concentration, AS (Owens Code: PLRT)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6150",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Computed Tomography Certificate (Owens Code: ZCTC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6104",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "251",
+              "title": "Fundamental Principles of CT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "252",
+              "title": "Sectional Anatomy for CT",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "253",
+              "title": "Safety &amp; Patient Care in CT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "254",
+              "title": "Pathology &amp; Protocols in CT",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bachelor of Science in Nursing, BSN (Owens Code: BSNP)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6266",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "300",
+              "title": "Transition to Professional Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "310",
+              "title": "Nursing Information &amp; Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "320",
+              "title": "Community &amp; Public Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Education Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "330",
+              "title": "Nursing and Collab.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "360",
+              "title": "Nursing Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "380",
+              "title": "Patient-Centered Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "400",
+              "title": "System Based Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Sociology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "410",
+              "title": "Professionalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "420",
+              "title": "Healthcare Quality &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "450",
+              "title": "Nursing Leadership &amp; Manage.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Education Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Registered Nurse Program, AAS (Owens Code: NRSP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6158",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNH",
+              "number": "126",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "101",
+              "title": "Intro to Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "102",
+              "title": "Nursing Concepts Across Lifespan",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "201",
+              "title": "Adult Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "202",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "203",
+              "title": "Applied Concepts for Nrs Pract",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Radiologic Technology, AAS (Owens Code: RDTT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6157",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "211",
+              "title": "Introduction to Radiologic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Radiologic Technology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "101",
+              "title": "Rad Directed Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "102",
+              "title": "Rad Directed Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiologic Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "Radiologic Technology III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "103",
+              "title": "Rad Directed Practice III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "104",
+              "title": "Rad Directed Practice IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "Radiologic Technology IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "201",
+              "title": "Sect Anatomy for Med Imagers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "201",
+              "title": "Rad Directed Practice V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "104",
+              "title": "Medical Informatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "250",
+              "title": "Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "202",
+              "title": "Rad Directed Practice VI",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "203",
+              "title": "Rad Directed Practice VII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "212",
+              "title": "Radiologic Technology V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "213",
+              "title": "Radiologic Technology VI",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "204",
+              "title": "Rad Directed Practice VIII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "205",
+              "title": "Rad Directed Practice IX",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "Radiologic Technology VII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "215",
+              "title": "Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant Program, AAS (Owens Code: PTAP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6146",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "130",
+              "title": "Intro to Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "101",
+              "title": "Intro to the Phys Therap Asst",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "210",
+              "title": "Pathological Dysfunction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "102",
+              "title": "Funct Anat &amp; Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "214",
+              "title": "Neurological Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "108",
+              "title": "Physical Agents Theory &amp; Pract",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "110",
+              "title": "Musculoskeletal Dysfunctions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "PTA Evidence Based Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "211",
+              "title": "Directed Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "213",
+              "title": "PTA Directed Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "215",
+              "title": "PTA Directed Practice III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Radiologic Technology Concentration, AS (Owens Code: PRAG)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6207",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mammography Certificate (Owens Code: ZMAM)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6256",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIT",
+              "number": "256",
+              "title": "Principles of Mammography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIT",
+              "number": "257",
+              "title": "Mammography clinical applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Physical Therapist Assistant Concentration, AS (Owens Code: PPTT)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6153",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Surgical Concentration, AS (Owens Code: PSTC)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6155",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, AAS (Owens Code: SURT)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6162",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "101",
+              "title": "Surgical Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "102",
+              "title": "Surgical Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPD",
+              "number": "100",
+              "title": "Intro to Sterile Processing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "103",
+              "title": "Surgical Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "104",
+              "title": "The Surgical Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "105",
+              "title": "BioMed and MIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPD",
+              "number": "101",
+              "title": "Sterile Processing Field Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SRG",
+              "number": "201",
+              "title": "Surgical Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "202",
+              "title": "Surgical Technology DP I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "221",
+              "title": "Surgical Technology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "222",
+              "title": "Surgical Technology DP II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Social Problems  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "231",
+              "title": "Surgical Technology IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "232",
+              "title": "Surgical Technology DP III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "233",
+              "title": "Career Prep I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRG",
+              "number": "234",
+              "title": "Career Prep II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant Program, AAS (Owens Code: OTAP)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6142",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "110",
+              "title": "Intro to OT Domain &amp; Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "111",
+              "title": "OTA Professional Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "130",
+              "title": "Intro to Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "120",
+              "title": "Domain and Process II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "121",
+              "title": "Contexts &amp; Client Factors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "122",
+              "title": "Contexts &amp; Client Factors II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "200",
+              "title": "Contexts &amp; Client Factors III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "211",
+              "title": "Domain &amp; Process III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "223",
+              "title": "OTA Professional Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "222",
+              "title": "Contexts &amp; Client Factors IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "242",
+              "title": "OTA Professional Practicum II-A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "244",
+              "title": "OTA Professional Prac II-B",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Occupational Therapy Concentration, AS (Owens Code: POTT)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6152",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPE",
+              "number": "101",
+              "title": "Introduction to Health Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Quantitative Reasoning  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170",
+              "title": "College Algebra  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "170P",
+              "title": "College Algebra Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_______ - Sociology Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "101",
+              "title": "Public Speaking  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "102",
+              "title": "Principles of Ethics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STN",
+              "number": "110",
+              "title": "Certified Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "_________- General Arts and Sciences Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "231",
+              "title": "Microbiology &amp; Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Science Elective to 4(Lec: 3 to 4 Lab: 0 to 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician - Basic Certificate (Owens Code: ZEMT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6118",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMM",
+              "number": "270",
+              "title": "Emergency Medical Technician-B",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician - Intermediate Certificate (Owens Code: ZEIC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6202",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMM",
+              "number": "271",
+              "title": "Emerg Med Technician-Intermed",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician - Paramedic Certificate (Owens Code: ZPAR)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6201",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMM",
+              "number": "270",
+              "title": "Emergency Medical Technician-B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMM",
+              "number": "274",
+              "title": "Anat &amp; Phys for Paramedics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMM",
+              "number": "277",
+              "title": "Paramedic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMM",
+              "number": "279",
+              "title": "Paramedic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMM",
+              "number": "281",
+              "title": "Paramedic III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Exercise Science Concentration, AS (Owens Code: EXSC)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6122",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*If transfer path is followed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "101",
+              "title": "Intro to Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "132",
+              "title": "Weight Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "130",
+              "title": "Intro to Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EXS",
+              "number": "205",
+              "title": "Exercise Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Composition II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "201",
+              "title": "Interpretations Seminar  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Life Span Psychology  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "102",
+              "title": "Athletic Strength and Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Interpersonal Commun",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Intro to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*If transfer path is followed",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "125",
+              "title": "The Science of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNH",
+              "number": "126",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*If transfer path is followed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "201",
+              "title": "Health Promo &amp; Fitness Assess",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "260",
+              "title": "Personal Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "209",
+              "title": "Exercise Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EXS",
+              "number": "280",
+              "title": "Exercise Science Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "281",
+              "title": "Exercise Science Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213",
+              "title": "Introductory Statistics  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "213P",
+              "title": "Introductory Statistics Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Multicultural Diversity in US",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "________ - Art and Humanities Elective (Lec: 3)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Anatomy and Physiology II  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "​*ONLY taken if transfer path is followed",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sterile Processing Certificate (Owens Code: ZSPC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6161",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Language of Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Composition I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111P",
+              "title": "Composition I Plus  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Critical Thinking Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "211",
+              "title": "Anatomy and Physiology I  *Ohio Transfer 36 Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPD",
+              "number": "100",
+              "title": "Intro to Sterile Processing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPD",
+              "number": "101",
+              "title": "Sterile Processing Field Exp",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Exercise Science Certified Personal Trainer Certificate (Owens Code: ZEPT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.owens.edu/preview_program.php?catoid=21&poid=6203",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPE",
+              "number": "132",
+              "title": "Weight Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "101",
+              "title": "Intro to Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "201",
+              "title": "Health Promo &amp; Fitness Assess",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "260",
+              "title": "Personal Wellness",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EXS",
+              "number": "102",
+              "title": "Athletic Strength and Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "205",
+              "title": "Exercise Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "280",
+              "title": "Exercise Science Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "281",
+              "title": "Exercise Science Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/oh/programs/sinclair-community-college.json
+++ b/data/oh/programs/sinclair-community-college.json
@@ -1,0 +1,17790 @@
+{
+  "college_slug": "sinclair-community-college",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.sinclair.edu",
+  "scraped_at": "2026-06-06T17:57:23.717Z",
+  "programs": [
+    {
+      "title": "Ohio Transfer 36",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5444",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "OT36 Arts and Humanities",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5449",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1110",
+              "title": "Visual Literacy - Introduction to Art &amp; Art Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2230",
+              "title": "Art History: Ancient through Medieval Periods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2231",
+              "title": "Art History: Renaissance through Contemporary Periods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2235",
+              "title": "History of Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2236",
+              "title": "History of Women Artists",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2237",
+              "title": "History of American Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2238",
+              "title": "History of African Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2239",
+              "title": "History of Asian Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1101",
+              "title": "United States History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1102",
+              "title": "United States History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1105",
+              "title": "African-American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1111",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1112",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "2215",
+              "title": "Survey of African History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "2216",
+              "title": "Survey of Latin American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "2217",
+              "title": "Survey of East Asian History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "2218",
+              "title": "History of Ohio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1125",
+              "title": "Introduction to the Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1131",
+              "title": "The Search for Utopia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1142",
+              "title": "Native American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2201",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2202",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2211",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2212",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2217",
+              "title": "Images of Women in Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2220",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2230",
+              "title": "Great Books of the Western World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2234",
+              "title": "Literature of Africa, Asia, &amp; Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2236",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2400",
+              "title": "Children&#039;s &amp; Adolescent Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1121",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1123",
+              "title": "World Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2117",
+              "title": "Survey of Musical Styles I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2118",
+              "title": "Survey of Musical Styles II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "2205",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "2206",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "1111",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "1112",
+              "title": "Western Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "2204",
+              "title": "Great Books: The Bible &amp; Western Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "2255",
+              "title": "People &amp; Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "1101",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "1105",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "2201",
+              "title": "History of Theatre I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "2202",
+              "title": "History of Theatre II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "OT36 Mathematics, Statistics, and Logic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5446",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "1445",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1455",
+              "title": "Introduction to Data Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1450",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1470",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1570",
+              "title": "Analytic Geometry &amp; Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1580",
+              "title": "Precalculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2160",
+              "title": "Calculus for Business &amp; Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2240",
+              "title": "Calculus for the Life Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2270",
+              "title": "Calculus &amp; Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2280",
+              "title": "Calculus &amp; Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2290",
+              "title": "Calculus &amp; Analytic Geometry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2310",
+              "title": "Elementary Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2320",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2330",
+              "title": "Differential Equations &amp; Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2415",
+              "title": "Mathematics for Elementary Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2435",
+              "title": "Mathematics for Elementary Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2570",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "OT36 Social and Behavioral Sciences",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5448",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "1100",
+              "title": "Introduction to Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1101",
+              "title": "Global Forces, Local Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1201",
+              "title": "World Regional Geography: People, Places &amp; Globalization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "1121",
+              "title": "US Federal Government &amp; Civics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "1232",
+              "title": "State &amp; Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "1301",
+              "title": "Public Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "1302",
+              "title": "Public Policy &amp; Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "2220",
+              "title": "International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2200",
+              "title": "Lifespan Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2217",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2220",
+              "title": "Personality Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2225",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2228",
+              "title": "Industrial Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2242",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1115",
+              "title": "Sociology of Marriage &amp; Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1117",
+              "title": "Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1160",
+              "title": "Sociology of Aging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2205",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2215",
+              "title": "Race &amp; Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2226",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English/Oral Communication",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5445",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1201",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "OT36 Natural Sciences",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5447",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "1111",
+              "title": "The Solar System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "1112",
+              "title": "Stars, Galaxies &amp; the Universe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "1117",
+              "title": "Lab for the Solar System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "1118",
+              "title": "Lab for Stars, Galaxies &amp; the Universe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1133",
+              "title": "Introduction to Environmental Science &amp; Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1121",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1141",
+              "title": "Principles of Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1171",
+              "title": "Principles of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1211",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1222",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1242",
+              "title": "Principles of Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1272",
+              "title": "Principles of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2222",
+              "title": "Evolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2225",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1011",
+              "title": "Chemistry in Modern Life for General Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1211",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1221",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2111",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2121",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1102",
+              "title": "Earth&#039;s Physical Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1300",
+              "title": "Introduction to Weather &amp; Climate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1101",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1201",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1401",
+              "title": "Environmental Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1100",
+              "title": "Introduction to Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1141",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1142",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "2201",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "2202",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Transfer Assurance Guides (TAGs)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5450",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2220",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1101",
+              "title": "2-D Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1102",
+              "title": "3-D Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1111",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1121",
+              "title": "Beginning Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1131",
+              "title": "Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1141",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1161",
+              "title": "Black &amp; White Darkroom Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2216",
+              "title": "Life Drawing &amp; Anatomy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2230",
+              "title": "Art History: Ancient through Medieval Periods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2231",
+              "title": "Art History: Renaissance through Contemporary Periods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2265",
+              "title": "Digital Color Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2269",
+              "title": "Printmaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1111",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1228",
+              "title": "Intermediate American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1171",
+              "title": "Principles of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1272",
+              "title": "Principles of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2235",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1221",
+              "title": "Specialized Computer Applications for Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1201",
+              "title": "Construction Methods &amp; Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1211",
+              "title": "Construction Materials Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1501",
+              "title": "Fundamentals of Surveying &amp; Mapping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "2421",
+              "title": "Soil Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1211",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1221",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2111",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2121",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1101",
+              "title": "Elementary Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1102",
+              "title": "Elementary Chinese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2510",
+              "title": "Microsoft Windows Server Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2550",
+              "title": "Linux Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1125",
+              "title": "Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2201",
+              "title": "Introduction to Mass Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2220",
+              "title": "Introduction to Communication Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2286",
+              "title": "Public Relations Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1111",
+              "title": "Introduction to Problem Solving &amp; Computer Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1350",
+              "title": "Web Site Development with HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1202",
+              "title": "C++ Software Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2165",
+              "title": "Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2212",
+              "title": "Java Software Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1525",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2510",
+              "title": "Institutional Food Safety &amp; Quantity Food Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2515",
+              "title": "Foodservice Systems Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2735",
+              "title": "Foodservice Retail Business Management &amp; Mid-Program Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "2200",
+              "title": "Families, Communities &amp; Schools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1100",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1105",
+              "title": "Individuals with Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1131",
+              "title": "Digital Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1150",
+              "title": "DC Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1155",
+              "title": "AC Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2201",
+              "title": "Electronic Devices &amp; Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2261",
+              "title": "Microprocessors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2281",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "1128",
+              "title": "Robotics in Computer Integrated Manufacturing (CIM) Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2252",
+              "title": "Teach Pendant Robot Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2205",
+              "title": "Integrated Circuit (IC) Fabrication Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1101",
+              "title": "Global Forces, Local Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1102",
+              "title": "Earth&#039;s Physical Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1107",
+              "title": "Introduction to Geographic Information Systems (GIS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1201",
+              "title": "World Regional Geography: People, Places &amp; Globalization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1209",
+              "title": "Map Design &amp; Visualization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1101",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1201",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1204",
+              "title": "Medicolegal &amp; Ethics in Healthcare Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1101",
+              "title": "United States History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1102",
+              "title": "United States History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1111",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1112",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISE",
+              "number": "1207",
+              "title": "Introduction to Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2201",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2202",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2211",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2212",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2220",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2236",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2170",
+              "title": "Business Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2290",
+              "title": "Calculus &amp; Analytic Geometry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2310",
+              "title": "Elementary Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2320",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEE",
+              "number": "2101",
+              "title": "Statics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEE",
+              "number": "2401",
+              "title": "Dynamics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1231",
+              "title": "Introduction to Engineering Design Using 3D CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2151",
+              "title": "Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2201",
+              "title": "Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2251",
+              "title": "Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "2301",
+              "title": "Fluid Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2102",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1111",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1112",
+              "title": "Aural Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1113",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1114",
+              "title": "Aural Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1115",
+              "title": "Piano for Music Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1116",
+              "title": "Piano for Music Majors II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1131",
+              "title": "Chorale",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1141",
+              "title": "Wind Symphony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1143",
+              "title": "Concert Band",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1145",
+              "title": "Classical Guitar Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2111",
+              "title": "Music Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2112",
+              "title": "Aural Skills III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2113",
+              "title": "Music Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "2114",
+              "title": "Aural Skills IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "2205",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "2206",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "1232",
+              "title": "State &amp; Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "2200",
+              "title": "Political Life, Systems &amp; Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "2220",
+              "title": "International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2200",
+              "title": "Lifespan Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2205",
+              "title": "Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2206",
+              "title": "Adolescent &amp; Adult Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2217",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2220",
+              "title": "Personality Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2225",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1115",
+              "title": "Sociology of Marriage &amp; Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2205",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2215",
+              "title": "Race &amp; Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2226",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "1206",
+              "title": "Introduction to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "1213",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "1106",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "1107",
+              "title": "Lab for Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "1111",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "1194",
+              "title": "Applied Theatre Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "2206",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industry Recognized Credential Transfer Assurance Guides (ITAGs)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5452",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "1102",
+              "title": "Introduction to Automotive Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1108",
+              "title": "Automotive Engine Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1114",
+              "title": "Automotive Electrical/Electronic Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1115",
+              "title": "Automotive Engine Performance I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1116",
+              "title": "Automotive Steering &amp; Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1142",
+              "title": "Automotive Manual Transmission &amp; Driveline",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1146",
+              "title": "Automotive Heating Ventilation &amp; Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1165",
+              "title": "Automotive Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "2241",
+              "title": "Automatic Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1101",
+              "title": "Introduction to Unmanned Aerial Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1103",
+              "title": "Remote Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1110",
+              "title": "Private Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1124",
+              "title": "Private Pilot Flight Lab - Airplane Single Engine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "1116",
+              "title": "Fundamentals of Computer Numerical Control Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1411",
+              "title": "Introduction to Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1500",
+              "title": "A+ Hardware &amp; Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2416",
+              "title": "Routing &amp; Switching Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2421",
+              "title": "Scaling Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2640",
+              "title": "Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2650",
+              "title": "Ethical Hacker",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "1100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "1202",
+              "title": "Healthy &amp; Safe Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2281",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "1128",
+              "title": "Robotics in Computer Integrated Manufacturing (CIM) Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2252",
+              "title": "Teach Pendant Robot Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGV",
+              "number": "2101",
+              "title": "Solar Photovoltaic Design &amp; Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Emergency Medical Technician: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1155",
+              "title": "Laboratory for Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2100",
+              "title": "Applied Anatomy, Physiology &amp; Pathophysiology for Emergency Medical Services Provider",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2105",
+              "title": "Paramedic 1: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2110",
+              "title": "Paramedic 1: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2125",
+              "title": "Paramedic 2: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2130",
+              "title": "Paramedic 2: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2135",
+              "title": "Paramedic 2: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2150",
+              "title": "Paramedic 3: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2155",
+              "title": "Paramedic 3: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2160",
+              "title": "Paramedic 3: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2175",
+              "title": "Paramedic 4: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2180",
+              "title": "Paramedic 4: Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2200",
+              "title": "Paramedic 5: Integration / Refresher Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2205",
+              "title": "Paramedic 5: Integration / Refresher Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1102",
+              "title": "Firefighter I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1103",
+              "title": "Firefighter II Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1231",
+              "title": "Introduction to Engineering Design Using 3D CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multicultural Electives",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5453",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "2236",
+              "title": "History of Women Artists",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2238",
+              "title": "History of African Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2239",
+              "title": "History of Asian Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1101",
+              "title": "Global Forces, Local Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1201",
+              "title": "World Regional Geography: People, Places &amp; Globalization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1105",
+              "title": "African-American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1111",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1112",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "2215",
+              "title": "Survey of African History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1125",
+              "title": "Introduction to the Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1142",
+              "title": "Native American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2217",
+              "title": "Images of Women in Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2234",
+              "title": "Literature of Africa, Asia, &amp; Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "2236",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1123",
+              "title": "World Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "2220",
+              "title": "International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2225",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "1111",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "1112",
+              "title": "Western Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2215",
+              "title": "Race &amp; Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "2201",
+              "title": "History of Theatre I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "2202",
+              "title": "History of Theatre II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Military Transfer Assurance Guides (MTAGs)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5451",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "1119",
+              "title": "Aviation Meteorology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1201",
+              "title": "Construction Methods &amp; Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1501",
+              "title": "Fundamentals of Surveying &amp; Mapping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "2421",
+              "title": "Soil Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1411",
+              "title": "Introduction to Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1510",
+              "title": "Windows Client Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2416",
+              "title": "Routing &amp; Switching Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2510",
+              "title": "Microsoft Windows Server Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2640",
+              "title": "Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1500",
+              "title": "A+ Hardware &amp; Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2711",
+              "title": "Enterprise Desktop Support Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2510",
+              "title": "Institutional Food Safety &amp; Quantity Food Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2515",
+              "title": "Foodservice Systems Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2735",
+              "title": "Foodservice Retail Business Management &amp; Mid-Program Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1131",
+              "title": "Digital Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1150",
+              "title": "DC Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1155",
+              "title": "AC Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2201",
+              "title": "Electronic Devices &amp; Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2261",
+              "title": "Microprocessors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2281",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Emergency Medical Technician: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1155",
+              "title": "Laboratory for Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1209",
+              "title": "Map Design &amp; Visualization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1131",
+              "title": "Chorale",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1141",
+              "title": "Wind Symphony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1143",
+              "title": "Concert Band",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "1145",
+              "title": "Classical Guitar Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1141",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1142",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Second-year Foreign Language Electives",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5785",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Choose a second-year language sequence from:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHN",
+              "number": "2201",
+              "title": "Intermediate Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "2202",
+              "title": "Intermediate Chinese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "2201",
+              "title": "Intermediate French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "2202",
+              "title": "Intermediate French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "2201",
+              "title": "Intermediate Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "2202",
+              "title": "Intermediate Japanese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "2201",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "2202",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "First-year Modern Language Electives",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5783",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Choose a first-year language sequence from:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1111",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1112",
+              "title": "Beginning American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1101",
+              "title": "Elementary Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1102",
+              "title": "Elementary Chinese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1102",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1101",
+              "title": "Elementary German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1102",
+              "title": "Elementary German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1101",
+              "title": "Elementary Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1102",
+              "title": "Elementary Japanese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Career-Technical Assurance Guides (CTAGs)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5561",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Approved Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1110",
+              "title": "Introduction to Large Animal Sciences: Handling &amp; Husbandry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "1102",
+              "title": "Introduction to Automotive Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1101",
+              "title": "Introduction to Unmanned Aerial Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1103",
+              "title": "Remote Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1105",
+              "title": "Orientation to Aviation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "1119",
+              "title": "Aviation Meteorology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "2146",
+              "title": "Introduction to Airline Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2180",
+              "title": "Medical Office Simulation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "1110",
+              "title": "Biotechnology &amp; Bioethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAM",
+              "number": "1116",
+              "title": "Fundamentals of Computer Numerical Control Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1141",
+              "title": "Reading Architectural Drawings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1201",
+              "title": "Construction Methods &amp; Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "1431",
+              "title": "OSHA Construction Standards 10 Hour",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "2431",
+              "title": "OSHA Construction Standards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1107",
+              "title": "Introduction to Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1411",
+              "title": "Introduction to Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1500",
+              "title": "A+ Hardware &amp; Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1510",
+              "title": "Windows Client Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2416",
+              "title": "Routing &amp; Switching Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2421",
+              "title": "Scaling Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2510",
+              "title": "Microsoft Windows Server Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2550",
+              "title": "Linux Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2640",
+              "title": "Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "2711",
+              "title": "Enterprise Desktop Support Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1200",
+              "title": "Introduction to Clinical Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1111",
+              "title": "Introduction to Problem Solving &amp; Computer Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1202",
+              "title": "C++ Software Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1350",
+              "title": "Web Site Development with HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2165",
+              "title": "Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2212",
+              "title": "Java Software Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1206",
+              "title": "Dental Assisting Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1207",
+              "title": "Lab Dental Assisting Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "1100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "1202",
+              "title": "Healthy &amp; Safe Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "2302",
+              "title": "Infant &amp; Toddler Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1100",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1131",
+              "title": "Digital Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1150",
+              "title": "DC Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "2103",
+              "title": "Introduction to Vacuum System Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2205",
+              "title": "Integrated Circuit (IC) Fabrication Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGV",
+              "number": "1101",
+              "title": "Alternate &amp; Renewable Energy Sources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGV",
+              "number": "2101",
+              "title": "Solar Photovoltaic Design &amp; Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1100",
+              "title": "Emergency Medical Responder Lecture &amp; Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Emergency Medical Technician: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1155",
+              "title": "Laboratory for Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2100",
+              "title": "Applied Anatomy, Physiology &amp; Pathophysiology for Emergency Medical Services Provider",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2105",
+              "title": "Paramedic 1: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2110",
+              "title": "Paramedic 1: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2125",
+              "title": "Paramedic 2: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2130",
+              "title": "Paramedic 2: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2135",
+              "title": "Paramedic 2: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2150",
+              "title": "Paramedic 3: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2155",
+              "title": "Paramedic 3: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2160",
+              "title": "Paramedic 3: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2175",
+              "title": "Paramedic 4: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2180",
+              "title": "Paramedic 4: Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2200",
+              "title": "Paramedic 5: Integration / Refresher Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2205",
+              "title": "Paramedic 5: Integration / Refresher Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENS",
+              "number": "1118",
+              "title": "Lifetime Physical Fitness &amp; Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2450",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1102",
+              "title": "Firefighter I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1103",
+              "title": "Firefighter II Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1110",
+              "title": "Health Information Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1204",
+              "title": "Medicolegal &amp; Ethics in Healthcare Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1129",
+              "title": "Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1136",
+              "title": "Front Office Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1139",
+              "title": "Housekeeping Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1137",
+              "title": "Hospitality Industry Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2226",
+              "title": "Hospitality Purchasing &amp; Negotiations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISE",
+              "number": "1207",
+              "title": "Introduction to Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "1231",
+              "title": "Introduction to Engineering Design Using 3D CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1101",
+              "title": "Introduction to Mental Health Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2102",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VIS",
+              "number": "1150",
+              "title": "Design Processes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VIS",
+              "number": "1420",
+              "title": "Video Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "First-year Foreign Language Electives",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5784",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Choose a first-year language sequence from:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHN",
+              "number": "1101",
+              "title": "Elementary Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1102",
+              "title": "Elementary Chinese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1102",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1101",
+              "title": "Elementary German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1102",
+              "title": "Elementary German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1101",
+              "title": "Elementary Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1102",
+              "title": "Elementary Japanese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tax Practitioner, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5622",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1510",
+              "title": "Computerized Accounting Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2321",
+              "title": "Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2322",
+              "title": "Advanced Taxation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences AAS Technical Electives",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5797",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Health Sciences AAS Technical Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1103",
+              "title": "Test Taking Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1105",
+              "title": "Overview of Holistic Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1107",
+              "title": "Core Concepts of Public Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1110",
+              "title": "Principles of Electrocardiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1120",
+              "title": "Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1121",
+              "title": "Patient Care Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1122",
+              "title": "Pharmacy Technician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1123",
+              "title": "Pharmacy Technician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1124",
+              "title": "Pharmacy Technician Directed Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1125",
+              "title": "Pharmacy Technician Directed Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1130",
+              "title": "Basic Life Support Training for Healthcare Provider",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1132",
+              "title": "Heartsaver First Aid, CPR &amp; AED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1140",
+              "title": "Fundamentals of Disease Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1182",
+              "title": "Pharmacy Technician Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1183",
+              "title": "Pharmacy Technician Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2201",
+              "title": "Survey of Drug Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2202",
+              "title": "General Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2220",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1107",
+              "title": "Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1108",
+              "title": "Lab for Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1117",
+              "title": "Lab for General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1121",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1141",
+              "title": "Principles of Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1147",
+              "title": "Lab for Principles of Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1171",
+              "title": "Principles of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1211",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1217",
+              "title": "Lab for General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1222",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1242",
+              "title": "Principles of Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1248",
+              "title": "Lab for Principles of Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1272",
+              "title": "Principles of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1221",
+              "title": "Specialized Computer Applications for Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "1120",
+              "title": "Laboratory Safety &amp; Regulatory Compliance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1111",
+              "title": "Introduction to Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1121",
+              "title": "Introduction to Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1151",
+              "title": "Lab for Introduction to Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1161",
+              "title": "Lab for Introduction to Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1211",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1221",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1251",
+              "title": "Lab for General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1261",
+              "title": "Lab for General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2111",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2151",
+              "title": "Lab for Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1111",
+              "title": "Introduction to Problem Solving &amp; Computer Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2165",
+              "title": "Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2269",
+              "title": "Data Analytics Theory &amp; Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1113",
+              "title": "Clinical Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1114",
+              "title": "Clinical Phlebotomy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1200",
+              "title": "Introduction to Clinical Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2720",
+              "title": "Histology Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2723",
+              "title": "Lab for Histology Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2730",
+              "title": "Special Staining in Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2733",
+              "title": "Lab for Special Staining in Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2910",
+              "title": "Histology Topics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2913",
+              "title": "Lab for Histology Topics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2740",
+              "title": "Histology Topics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2743",
+              "title": "Lab for Histology Topics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2990",
+              "title": "Histology Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2245",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1102",
+              "title": "Introduction to Dental Assisting Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1104",
+              "title": "Dental Assisting Techniques &amp; Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1108",
+              "title": "Dental Assisting Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1204",
+              "title": "Dental Assisting Techniques &amp; Materials II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1206",
+              "title": "Dental Assisting Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1102",
+              "title": "Introduction to Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1105",
+              "title": "Exploration of the Nutrition &amp; Dietetics Profession",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1111",
+              "title": "Nutrition &amp; Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1210",
+              "title": "Medical Terminology for Dietetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1525",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1630",
+              "title": "Nutrition Through the Lifecycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1635",
+              "title": "Community Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1825",
+              "title": "Nutrition for Exercise &amp; Sport Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2101",
+              "title": "Dining Assistant Dietary Aide",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2180",
+              "title": "Medical Nutrition Therapy for Dietary Managers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2240",
+              "title": "Motivational Interviewing, Nutrition Counseling &amp; Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2305",
+              "title": "Food, Culture &amp; Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2310",
+              "title": "Lab for Food, Culture &amp; Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2505",
+              "title": "Food Science Introductory Foods Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2510",
+              "title": "Institutional Food Safety &amp; Quantity Food Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2515",
+              "title": "Foodservice Systems Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2520",
+              "title": "Advanced Food Science Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2735",
+              "title": "Foodservice Retail Business Management &amp; Mid-Program Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2740",
+              "title": "Retail Business Management Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1102",
+              "title": "Dental Anatomy for Dental Auxiliaries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1202",
+              "title": "Expanded Functions for Dental Auxiliaries I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1203",
+              "title": "Lab for Expanded Functions for Dental Auxiliaries I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1302",
+              "title": "Expanded Functions for Dental Auxiliaries II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1303",
+              "title": "Lab for Expanded Functions for Dental Auxiliaries II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Emergency Medical Technician: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1155",
+              "title": "Laboratory for Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2100",
+              "title": "Applied Anatomy, Physiology &amp; Pathophysiology for Emergency Medical Services Provider",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2105",
+              "title": "Paramedic 1: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2110",
+              "title": "Paramedic 1: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2125",
+              "title": "Paramedic 2: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2130",
+              "title": "Paramedic 2: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2135",
+              "title": "Paramedic 2: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2136",
+              "title": "Paramedic 2a: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2137",
+              "title": "Paramedic 2b: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2150",
+              "title": "Paramedic 3: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2155",
+              "title": "Paramedic 3: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2160",
+              "title": "Paramedic 3: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2175",
+              "title": "Paramedic 4: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2180",
+              "title": "Paramedic 4: Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2200",
+              "title": "Paramedic 5: Integration / Refresher Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2205",
+              "title": "Paramedic 5: Integration / Refresher Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2300",
+              "title": "Critical Care Paramedic 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2305",
+              "title": "Critical Care Paramedic 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENS",
+              "number": "1118",
+              "title": "Lifetime Physical Fitness &amp; Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1102",
+              "title": "Firefighter I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1103",
+              "title": "Firefighter II Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1110",
+              "title": "Health Information Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1160",
+              "title": "Medical Office Coding Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1165",
+              "title": "Drug Classification for Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1201",
+              "title": "Introductory Medical Office Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1204",
+              "title": "Medicolegal &amp; Ethics in Healthcare Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1217",
+              "title": "Alternative Health Records &amp; Registries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2145",
+              "title": "Health Information Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2165",
+              "title": "Healthcare Data in Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2233",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2262",
+              "title": "Advanced Medical Office Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1130",
+              "title": "Humanity &amp; the Challenge of Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1131",
+              "title": "The Search for Utopia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1102",
+              "title": "Clinical Medical Assisting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1103",
+              "title": "Clinical Medical Assisting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1110",
+              "title": "Administrative Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1130",
+              "title": "Reimbursement Specialist Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1192",
+              "title": "Lab for MAS 1102",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1193",
+              "title": "Lab for MAS 1103",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2201",
+              "title": "Clinical Medical Assisting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2210",
+              "title": "Medical Billing Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2291",
+              "title": "Lab for MAS 2201",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1130",
+              "title": "Mathematics in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1445",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1450",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1460",
+              "title": "Mathematics for Business Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1470",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1101",
+              "title": "Introduction to Mental Health Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1120",
+              "title": "Trauma-Informed Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1202",
+              "title": "Motivational Interviewing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1236",
+              "title": "Assessment &amp; Diagnosis of Substance Use Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2130",
+              "title": "Fundamentals of Addiction Counseling CDCA Renewable",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2137",
+              "title": "Treatment Techniques in Substance Use Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2138",
+              "title": "Ethical Issues in the Helping Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2235",
+              "title": "Family Dynamics of Addiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2250",
+              "title": "Child &amp; Adolescent Mental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1200",
+              "title": "Introduction to Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1101",
+              "title": "Introduction to Neurodiagnostic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1421",
+              "title": "Intermediate Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1425",
+              "title": "Lab for Intermediate Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1430",
+              "title": "Advanced Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1435",
+              "title": "Lab for Advanced Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1801",
+              "title": "Seminar for Polysomnography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1891",
+              "title": "Polysomnography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2460",
+              "title": "Neurophysiology of Electroencephalography/Sleep Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2550",
+              "title": "Fundamentals of Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2585",
+              "title": "Lab for Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1111",
+              "title": "Introduction to Occupational Therapy Assistant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "2206",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1106",
+              "title": "Physics for Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1141",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "1121",
+              "title": "US Federal Government &amp; Civics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1160",
+              "title": "Black Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2126",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2200",
+              "title": "Lifespan Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2217",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1000",
+              "title": "Introduction to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1005",
+              "title": "Musculoskeletal Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1101",
+              "title": "Introduction to Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2640",
+              "title": "Computed Tomography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2641",
+              "title": "Principles of Computed Tomography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2643",
+              "title": "Principles of Magnetic Resonance Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2645",
+              "title": "Magnetic Resonance Imaging Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2647",
+              "title": "Principles of Mammography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2649",
+              "title": "Mammography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1100",
+              "title": "Introduction to Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2205",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2215",
+              "title": "Race &amp; Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1100",
+              "title": "Sterile Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1200",
+              "title": "Sterile Processing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1207",
+              "title": "Practicum for Sterile Processing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "2207",
+              "title": "Anti-Oppressive Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1000",
+              "title": "Introduction to Veterinary Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1102",
+              "title": "Topics in Veterinary Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1107",
+              "title": "Topics in Veterinary Medicine Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1202",
+              "title": "Introduction to Veterinary Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1205",
+              "title": "Clinical Practice I: Hospital Practices &amp; Professionalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2005",
+              "title": "Veterinary Terminology &amp; Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2008",
+              "title": "Veterinary Assisting Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2108",
+              "title": "Veterinary Technical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CPA Exam Eligibility: Business Component, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5573",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Accounting Elective 6 Cr. Hr(s). (options listed below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Accounting Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1107",
+              "title": "Introduction to Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1111",
+              "title": "Introduction to Problem Solving &amp; Computer Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1350",
+              "title": "Web Site Development with HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2450",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2225",
+              "title": "Sales Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Health Sciences BAS Technical Electives",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5798",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Health Sciences BAS Technical Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1103",
+              "title": "Test Taking Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1105",
+              "title": "Overview of Holistic Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1107",
+              "title": "Core Concepts of Public Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1110",
+              "title": "Principles of Electrocardiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1120",
+              "title": "Nurse Aide Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1121",
+              "title": "Patient Care Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1122",
+              "title": "Pharmacy Technician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1123",
+              "title": "Pharmacy Technician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1124",
+              "title": "Pharmacy Technician Directed Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1125",
+              "title": "Pharmacy Technician Directed Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1130",
+              "title": "Basic Life Support Training for Healthcare Provider",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1132",
+              "title": "Heartsaver First Aid, CPR &amp; AED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1140",
+              "title": "Fundamentals of Disease Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1182",
+              "title": "Pharmacy Technician Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1183",
+              "title": "Pharmacy Technician Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2201",
+              "title": "Survey of Drug Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2202",
+              "title": "General Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "2220",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1107",
+              "title": "Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1108",
+              "title": "Lab for Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1117",
+              "title": "Lab for General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1121",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1141",
+              "title": "Principles of Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1147",
+              "title": "Lab for Principles of Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1171",
+              "title": "Principles of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1211",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1217",
+              "title": "Lab for General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1222",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1242",
+              "title": "Principles of Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1248",
+              "title": "Lab for Principles of Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1272",
+              "title": "Principles of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1221",
+              "title": "Specialized Computer Applications for Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "1120",
+              "title": "Laboratory Safety &amp; Regulatory Compliance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1111",
+              "title": "Introduction to Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1121",
+              "title": "Introduction to Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1151",
+              "title": "Lab for Introduction to Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1161",
+              "title": "Lab for Introduction to Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1211",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1221",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1251",
+              "title": "Lab for General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "1261",
+              "title": "Lab for General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2111",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2151",
+              "title": "Lab for Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1111",
+              "title": "Introduction to Problem Solving &amp; Computer Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2165",
+              "title": "Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2269",
+              "title": "Data Analytics Theory &amp; Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1113",
+              "title": "Clinical Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1114",
+              "title": "Clinical Phlebotomy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "1200",
+              "title": "Introduction to Clinical Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2110",
+              "title": "Urine &amp; Body Fluid Analysis/Immunology/Serology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2113",
+              "title": "Lab for Urine &amp; Body Fluid Analysis/Immunology/Serology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2210",
+              "title": "Hematology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2213",
+              "title": "Lab for Hematology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2310",
+              "title": "Clinical Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2313",
+              "title": "Lab for Clinical Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2410",
+              "title": "Clinical Microbiology/Parasitology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2413",
+              "title": "Lab for Clinical Microbiology/Parasitology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2510",
+              "title": "Immunohematology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2513",
+              "title": "Lab for Immunohematology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2810",
+              "title": "CLT Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2720",
+              "title": "Histology Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2723",
+              "title": "Lab for Histology Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2730",
+              "title": "Special Staining in Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2733",
+              "title": "Lab for Special Staining in Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2740",
+              "title": "Histology Topics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2743",
+              "title": "Lab for Histology Topics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2910",
+              "title": "Histology Topics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2913",
+              "title": "Lab for Histology Topics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLT",
+              "number": "2990",
+              "title": "Histology Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1102",
+              "title": "Introduction to Dental Assisting Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1104",
+              "title": "Dental Assisting Techniques &amp; Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1108",
+              "title": "Dental Assisting Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1204",
+              "title": "Dental Assisting Techniques &amp; Materials II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "1206",
+              "title": "Dental Assisting Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1102",
+              "title": "Introduction to Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1202",
+              "title": "Head, Neck &amp; Dental Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1203",
+              "title": "Lab for Head, Neck &amp; Dental Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1204",
+              "title": "Preclinical Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1205",
+              "title": "Lab for Preclinical Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1206",
+              "title": "Nutrition &amp; Oral Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1302",
+              "title": "Preclinical Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1303",
+              "title": "Lab for Preclinical Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1304",
+              "title": "Oral Histology &amp; Embryology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1305",
+              "title": "Medical Emergencies in Dental Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1306",
+              "title": "General &amp; Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1308",
+              "title": "Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1309",
+              "title": "Lab for Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2402",
+              "title": "Clinical Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2403",
+              "title": "Dental Hygiene Clinic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2502",
+              "title": "Pharmacology in the Dental Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2503",
+              "title": "Pain Control in the Dental Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2504",
+              "title": "Dental Hygiene Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2506",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2507",
+              "title": "Lab for Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2508",
+              "title": "Clinical Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2509",
+              "title": "Dental Hygiene Clinic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2601",
+              "title": "Community Dental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2602",
+              "title": "Clinical Dental Hygiene III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2603",
+              "title": "Dental Hygiene Clinic III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2604",
+              "title": "Dental Hygiene Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1105",
+              "title": "Exploration of the Nutrition &amp; Dietetics Profession",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1111",
+              "title": "Nutrition &amp; Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1210",
+              "title": "Medical Terminology for Dietetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1525",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1630",
+              "title": "Nutrition Through the Lifecycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1635",
+              "title": "Community Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1825",
+              "title": "Nutrition for Exercise &amp; Sport Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2101",
+              "title": "Dining Assistant Dietary Aide",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2180",
+              "title": "Medical Nutrition Therapy for Dietary Managers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2240",
+              "title": "Motivational Interviewing, Nutrition Counseling &amp; Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2305",
+              "title": "Food, Culture &amp; Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2310",
+              "title": "Lab for Food, Culture &amp; Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2505",
+              "title": "Food Science Introductory Foods Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2510",
+              "title": "Institutional Food Safety &amp; Quantity Food Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2515",
+              "title": "Foodservice Systems Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2520",
+              "title": "Advanced Food Science Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2625",
+              "title": "Medical Nutrition Therapy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2630",
+              "title": "Medical Nutrition Therapy Clinical I Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2735",
+              "title": "Foodservice Retail Business Management &amp; Mid-Program Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2740",
+              "title": "Retail Business Management Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2845",
+              "title": "Medical Nutrition Therapy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2850",
+              "title": "Medical Nutrition Therapy Clinical II Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "2855",
+              "title": "Nutrition &amp; Dietetics Program Assessment Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1102",
+              "title": "Dental Anatomy for Dental Auxiliaries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1202",
+              "title": "Expanded Functions for Dental Auxiliaries I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1203",
+              "title": "Lab for Expanded Functions for Dental Auxiliaries I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1302",
+              "title": "Expanded Functions for Dental Auxiliaries II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EFD",
+              "number": "1303",
+              "title": "Lab for Expanded Functions for Dental Auxiliaries II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Emergency Medical Technician: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1155",
+              "title": "Laboratory for Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2100",
+              "title": "Applied Anatomy, Physiology &amp; Pathophysiology for Emergency Medical Services Provider",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2105",
+              "title": "Paramedic 1: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2110",
+              "title": "Paramedic 1: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2125",
+              "title": "Paramedic 2: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2130",
+              "title": "Paramedic 2: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2135",
+              "title": "Paramedic 2: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2136",
+              "title": "Paramedic 2a: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2137",
+              "title": "Paramedic 2b: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2150",
+              "title": "Paramedic 3: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2155",
+              "title": "Paramedic 3: Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2160",
+              "title": "Paramedic 3: Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2175",
+              "title": "Paramedic 4: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2180",
+              "title": "Paramedic 4: Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2200",
+              "title": "Paramedic 5: Integration / Refresher Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2205",
+              "title": "Paramedic 5: Integration / Refresher Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2300",
+              "title": "Critical Care Paramedic 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2305",
+              "title": "Critical Care Paramedic 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENS",
+              "number": "1118",
+              "title": "Lifetime Physical Fitness &amp; Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1102",
+              "title": "Firefighter I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1103",
+              "title": "Firefighter II Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1110",
+              "title": "Health Information Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1160",
+              "title": "Medical Office Coding Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1165",
+              "title": "Drug Classification for Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1201",
+              "title": "Introductory Medical Office Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1204",
+              "title": "Medicolegal &amp; Ethics in Healthcare Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1217",
+              "title": "Alternative Health Records &amp; Registries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2110",
+              "title": "Ambulatory Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2144",
+              "title": "Quality Improvement, Statistics &amp; Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2145",
+              "title": "Health Information Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2165",
+              "title": "Healthcare Data in Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2211",
+              "title": "Inpatient Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2233",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2252",
+              "title": "Professional Practice Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2262",
+              "title": "Advanced Medical Office Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2278",
+              "title": "Health Information Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1130",
+              "title": "Humanity &amp; the Challenge of Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1131",
+              "title": "The Search for Utopia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1102",
+              "title": "Clinical Medical Assisting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1103",
+              "title": "Clinical Medical Assisting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1110",
+              "title": "Administrative Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1130",
+              "title": "Reimbursement Specialist Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1192",
+              "title": "Lab for MAS 1102",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1193",
+              "title": "Lab for MAS 1103",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2201",
+              "title": "Clinical Medical Assisting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2210",
+              "title": "Medical Billing Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2220",
+              "title": "MAS Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "2291",
+              "title": "Lab for MAS 2201",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1130",
+              "title": "Mathematics in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1445",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1450",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1460",
+              "title": "Mathematics for Business Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1470",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1101",
+              "title": "Introduction to Mental Health Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1120",
+              "title": "Trauma-Informed Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1202",
+              "title": "Motivational Interviewing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1203",
+              "title": "Professional Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1236",
+              "title": "Assessment &amp; Diagnosis of Substance Use Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2105",
+              "title": "Mental Health Treatment Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2111",
+              "title": "Group Dynamics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2121",
+              "title": "Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2130",
+              "title": "Fundamentals of Addiction Counseling CDCA Renewable",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2137",
+              "title": "Treatment Techniques in Substance Use Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2138",
+              "title": "Ethical Issues in the Helping Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2211",
+              "title": "Group Dynamics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2222",
+              "title": "Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2235",
+              "title": "Family Dynamics of Addiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2245",
+              "title": "Mental Health &amp; the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2250",
+              "title": "Child &amp; Adolescent Mental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1101",
+              "title": "Introduction to Neurodiagnostic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1102",
+              "title": "Introduction to Electroencephalography (EEG)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1182",
+              "title": "Lab for Introduction to Electroencephalography (EEG)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1250",
+              "title": "Intermediate Electroencephalography (EEG)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1260",
+              "title": "Basic Evoked Potentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1285",
+              "title": "Lab for Intermediate EEG",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1286",
+              "title": "Lab for Basic Evoked Potentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1421",
+              "title": "Intermediate Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1425",
+              "title": "Lab for Intermediate Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1430",
+              "title": "Advanced Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1435",
+              "title": "Lab for Advanced Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1801",
+              "title": "Seminar for Polysomnography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1891",
+              "title": "Polysomnography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1901",
+              "title": "Seminar for NDT Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1991",
+              "title": "Practicum Experience I for NDT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2350",
+              "title": "Intraoperative Monitoring for Neurodiagnostic Technologists",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2360",
+              "title": "Neonatal/Pediatric Electroencephalography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2386",
+              "title": "Lab for Neonatal/Pediatric EEG",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2450",
+              "title": "Nerve Conduction Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2460",
+              "title": "Neurophysiology of Electroencephalography/Sleep Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2485",
+              "title": "Lab for Nerve Conduction Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2550",
+              "title": "Fundamentals of Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2585",
+              "title": "Lab for Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2902",
+              "title": "Seminar for NDT Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2903",
+              "title": "Seminar for NDT Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2990",
+              "title": "Neurodiagnostic Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2992",
+              "title": "NDT Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "2993",
+              "title": "Neurodiagnostic Technology Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1200",
+              "title": "Introduction to Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1400",
+              "title": "Health &amp; Illness I: Foundational Concepts in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1450",
+              "title": "Professional Nursing I: Introduction to the Role of the Professional Nurse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1600",
+              "title": "Health &amp; Illness II: Health &amp; Wellness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1650",
+              "title": "Professional Nursing II: Healthcare System Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1700",
+              "title": "Health &amp; Illness Concepts I &amp; II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1750",
+              "title": "Professional Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "2400",
+              "title": "Health &amp; Illness III: Health &amp; Wellness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "2450",
+              "title": "Professional Nursing III: Leadership &amp; Management of Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "2600",
+              "title": "Concept Synthesis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1111",
+              "title": "Introduction to Occupational Therapy Assistant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1211",
+              "title": "Occupational Therapy Assistant Foundations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1212",
+              "title": "Functional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1213",
+              "title": "Occupational Therapy &amp; Adults with Physical Dysfunction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1214",
+              "title": "Occupational Therapy &amp; Adults with Physical Dysfunction Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1311",
+              "title": "Occupational Therapy Assistant Foundations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1312",
+              "title": "Occupational Therapy &amp; Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1313",
+              "title": "Occupational Therapy &amp; Adults with Neurological Dysfunction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1314",
+              "title": "Occupational Therapy &amp; Neurological Dysfunction Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1315",
+              "title": "Therapeutic Use of Self",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2412",
+              "title": "Occupational Therapy Assistant &amp; Pediatrics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2413",
+              "title": "Occupational Therapy Assistant &amp; Pediatrics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2414",
+              "title": "Occupational Therapy Assistant &amp; Psychosocial Dysfunction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2415",
+              "title": "Occupational Therapy Assistant &amp; Psychosocial Dysfunction Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2416",
+              "title": "Occupational Therapy Assistant Level 1 Fieldwork",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2511",
+              "title": "Occupational Therapy Assistant Level 2 Fieldwork A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2512",
+              "title": "Occupational Therapy Assistant Level 2 Fieldwork B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2523",
+              "title": "Occupational Therapy Assistant Clinical Issues A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2524",
+              "title": "Occupational Therapy Assistant Clinical Issues B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "2206",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1106",
+              "title": "Physics for Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1141",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1160",
+              "title": "Black Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2126",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2200",
+              "title": "Lifespan Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2217",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1000",
+              "title": "Introduction to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1005",
+              "title": "Musculoskeletal Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1100",
+              "title": "Professional Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1105",
+              "title": "Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1165",
+              "title": "Manual Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1215",
+              "title": "Functional Mobility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1300",
+              "title": "Pathophysiology for the PTA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1325",
+              "title": "Neuropathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1350",
+              "title": "Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1375",
+              "title": "Professional Issues II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2305",
+              "title": "Neuromuscular Rehabilitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2315",
+              "title": "The Medically Complex Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2330",
+              "title": "Seminar for Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2335",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2355",
+              "title": "Physical Agents",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2365",
+              "title": "Orthopedics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2430",
+              "title": "Seminar for Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2435",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1101",
+              "title": "Introduction to Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1111",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1121",
+              "title": "Radiographic Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1127",
+              "title": "Lab for Radiographic Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1131",
+              "title": "Patient Care in Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1137",
+              "title": "Lab for Patient Care in Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1212",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1222",
+              "title": "Radiographic Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1228",
+              "title": "Lab for Radiographic Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "1241",
+              "title": "Radiologic Sciences I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2413",
+              "title": "Clinical Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2415",
+              "title": "Radiographic Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2423",
+              "title": "Radiographic Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2429",
+              "title": "Lab for Radiographic Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2442",
+              "title": "Radiologic Sciences II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2448",
+              "title": "Lab for Radiologic Sciences II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2514",
+              "title": "Clinical Practicum IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2526",
+              "title": "Capstone in Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2543",
+              "title": "Radiologic Sciences III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2640",
+              "title": "Computed Tomography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2641",
+              "title": "Principles of Computed Tomography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2643",
+              "title": "Principles of Magnetic Resonance Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2645",
+              "title": "Magnetic Resonance Imaging Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2647",
+              "title": "Principles of Mammography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAT",
+              "number": "2649",
+              "title": "Mammography Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1100",
+              "title": "Introduction to Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1101",
+              "title": "Respiratory Care Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1102",
+              "title": "Lab for Respiratory Care Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1124",
+              "title": "Cardiopulmonary Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1125",
+              "title": "Respiratory Care Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1201",
+              "title": "Respiratory Care Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1202",
+              "title": "Lab for Respiratory Care Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1203",
+              "title": "Respiratory Care Clinic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1205",
+              "title": "Cardiopulmonary Disease Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1301",
+              "title": "Respiratory Care Fundamentals III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "1303",
+              "title": "Respiratory Care Clinic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2101",
+              "title": "Critical Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2102",
+              "title": "Lab for Critical Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2103",
+              "title": "Respiratory Care Clinic III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2124",
+              "title": "Cardiopulmonary Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2201",
+              "title": "Critical Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2202",
+              "title": "Lab for Critical Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2203",
+              "title": "Respiratory Care Clinic IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2204",
+              "title": "Respiratory Care Clinic V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2220",
+              "title": "Respiratory Care Emergency Preparedness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2222",
+              "title": "Lab for Respiratory Care Emergency Preparedness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RET",
+              "number": "2250",
+              "title": "Pediatrics &amp; Neonatology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2205",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2215",
+              "title": "Race &amp; Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1100",
+              "title": "Sterile Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1110",
+              "title": "Theory &amp; Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1117",
+              "title": "Laboratory for Theory &amp; Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1120",
+              "title": "The Surgical Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1127",
+              "title": "Lab for the Surgical Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1200",
+              "title": "Sterile Processing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "1207",
+              "title": "Practicum for Sterile Processing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2110",
+              "title": "Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2117",
+              "title": "Directed Practice for Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2120",
+              "title": "Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2127",
+              "title": "Directed Practice for Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2200",
+              "title": "Surgical Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2207",
+              "title": "Directed Practice for Surgical Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUT",
+              "number": "2300",
+              "title": "Surgical Technology Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWK",
+              "number": "2207",
+              "title": "Anti-Oppressive Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1000",
+              "title": "Introduction to Veterinary Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1102",
+              "title": "Topics in Veterinary Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1107",
+              "title": "Topics in Veterinary Medicine Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1202",
+              "title": "Introduction to Veterinary Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "1205",
+              "title": "Clinical Practice I: Hospital Practices &amp; Professionalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2005",
+              "title": "Veterinary Terminology &amp; Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2008",
+              "title": "Veterinary Assisting Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2104",
+              "title": "Animal Husbandry &amp; Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2106",
+              "title": "Comparative Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2107",
+              "title": "Veterinary Technical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2108",
+              "title": "Veterinary Technical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2110",
+              "title": "Veterinary Parasitology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2111",
+              "title": "Large Animal Husbandry &amp; Veterinary Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2113",
+              "title": "Laboratory for Comparative Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2114",
+              "title": "Exotic &amp; Pocket Pet Health &amp; Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2115",
+              "title": "Veterinary Anesthesia &amp; Surgical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2116",
+              "title": "Large Animal Husbandry &amp; Disease Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2117",
+              "title": "Laboratory for Veterinary Anesthesia &amp; Surgical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2205",
+              "title": "Veterinary Dentistry, Advanced Radiology &amp; Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2207",
+              "title": "Veterinary Technical Practice III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2211",
+              "title": "Veterinary Case Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2250",
+              "title": "Veterinary Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2300",
+              "title": "Preceptorship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "2301",
+              "title": "Veterinary Technician National Exam Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5479",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1510",
+              "title": "Computerized Accounting Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2101",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2102",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2211",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2212",
+              "title": "Managerial Accounting &amp; Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2321",
+              "title": "Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2435",
+              "title": "Auditing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ACC Accounting Elective 3 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1460",
+              "title": "Mathematics for Business Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1470",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2170",
+              "title": "Business Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Accounting Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "2270",
+              "title": "Accounting Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2322",
+              "title": "Advanced Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2510",
+              "title": "Advanced Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1111",
+              "title": "Introduction to Problem Solving &amp; Computer Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1102",
+              "title": "Consumer Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1110",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2145",
+              "title": "Principles of Retailing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "CPA Exam Eligibility: Accounting Component, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5707",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1510",
+              "title": "Computerized Accounting Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2101",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2102",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2211",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2212",
+              "title": "Managerial Accounting &amp; Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2321",
+              "title": "Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2435",
+              "title": "Auditing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2322",
+              "title": "Advanced Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2510",
+              "title": "Advanced Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Agribusiness Greenhouse Management, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5545",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1201",
+              "title": "Horticulture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1202",
+              "title": "Science of Soil",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1203",
+              "title": "Trees &amp; Shrubs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1204",
+              "title": "Plant Propagation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1205",
+              "title": "Greenhouse Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1206",
+              "title": "Horticulture II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1208",
+              "title": "Sustainable Landscape Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1209",
+              "title": "Greenhouse Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1504",
+              "title": "Management &amp; Supervision in Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1500",
+              "title": "Foundations of Agricultural Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1501",
+              "title": "Agricultural Finance for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting_AAS_MAP",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5958",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester (First Year)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1460",
+              "title": "Mathematics for Business Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester (First Year)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1510",
+              "title": "Computerized Accounting Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2170",
+              "title": "Business Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester (First Year)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1111",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester (Second Year)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "2101",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2211",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2321",
+              "title": "Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester (Second Year)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "2102",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2212",
+              "title": "Managerial Accounting &amp; Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2322",
+              "title": "Advanced Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2435",
+              "title": "Auditing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Large Animal Care & Handling, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5665",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1110",
+              "title": "Introduction to Large Animal Sciences: Handling &amp; Husbandry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1111",
+              "title": "Principles of Large Animal Reproduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1112",
+              "title": "Principles of Large Animal Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1113",
+              "title": "Animal Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1401",
+              "title": "Food Science &amp; Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1505",
+              "title": "Foundations of Agricultural Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agricultural Technology, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5546",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1300",
+              "title": "Agronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1110",
+              "title": "Introduction to Large Animal Sciences: Handling &amp; Husbandry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities Elective 3 Cr. Hr(s). OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Natural and Physical Sciences Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1111",
+              "title": "Principles of Large Animal Reproduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1112",
+              "title": "Principles of Large Animal Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Urban and Community Agriculture, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5604",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1201",
+              "title": "Horticulture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1202",
+              "title": "Science of Soil",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1203",
+              "title": "Trees &amp; Shrubs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1204",
+              "title": "Plant Propagation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1205",
+              "title": "Greenhouse Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1206",
+              "title": "Horticulture II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1207",
+              "title": "Greenhouse Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1208",
+              "title": "Sustainable Landscape Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1209",
+              "title": "Greenhouse Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agribusiness, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5740",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1300",
+              "title": "Agronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Greenhouse Technician, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5677",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "1160",
+              "title": "Introduction to Agriculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1201",
+              "title": "Horticulture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1205",
+              "title": "Greenhouse Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1206",
+              "title": "Horticulture II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1207",
+              "title": "Greenhouse Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "1208",
+              "title": "Sustainable Landscape Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Information Systems, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5489",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1220",
+              "title": "Word Processing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2170",
+              "title": "BIS Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose one of the following concentrations – 18 - 19 Cr. Hr(s). (see options below) Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Software Applications Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1240",
+              "title": "Presentation Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1250",
+              "title": "Specialized Business Software Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2270",
+              "title": "Business Information Systems Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "BIS or MAN/MRK Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Natural & Physical Sciences Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business Data Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "1140",
+              "title": "Information Systems Analysis &amp; Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1160",
+              "title": "Introduction to Data Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2165",
+              "title": "Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2265",
+              "title": "Data Visualization with Tableau",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2269",
+              "title": "Data Analytics Theory &amp; Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Natural & Physical Sciences Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Medical Office Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1121",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2180",
+              "title": "Medical Office Simulation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2270",
+              "title": "Business Information Systems Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1201",
+              "title": "Introductory Medical Office Coding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Support Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2270",
+              "title": "Business Information Systems Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1107",
+              "title": "Introduction to Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1500",
+              "title": "A+ Hardware &amp; Software",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Information Systems/Information Processing, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5554",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1220",
+              "title": "Word Processing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1240",
+              "title": "Presentation Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1250",
+              "title": "Specialized Business Software Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Information Systems/Medical Office Specialist, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5555",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1220",
+              "title": "Word Processing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2180",
+              "title": "Medical Office Simulation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Personal Computers in Business, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5556",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1220",
+              "title": "Word Processing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1107",
+              "title": "Introduction to Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Software Applications for the Professional, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5627",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1220",
+              "title": "Word Processing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1240",
+              "title": "Presentation Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1250",
+              "title": "Specialized Business Software Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Support Technician, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5559",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1107",
+              "title": "Introduction to Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1500",
+              "title": "A+ Hardware &amp; Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data and Information Management, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5705",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1160",
+              "title": "Introduction to Data Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "2265",
+              "title": "Data Visualization with Tableau",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Customer Service Specialist, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5762",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Call Center/Customer Service, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5725",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1201",
+              "title": "Keyboarding &amp; Document Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "2180",
+              "title": "Medical Office Simulation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "1102",
+              "title": "Basic Healthcare Practices &amp; Medical Scribe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "1110",
+              "title": "Administrative Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1107",
+              "title": "Introduction to Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "1130",
+              "title": "Network Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1260",
+              "title": "Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice Science/Law Enforcement, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5505",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1107",
+              "title": "Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Natural & Physical Sciences Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Traditional Law Enforcement – 30 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1103",
+              "title": "Constitutional Law &amp; Evidentiary Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1125",
+              "title": "Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1155",
+              "title": "Homeland Security Issues &amp; Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2205",
+              "title": "Introduction to Criminal Investigation &amp; Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2209",
+              "title": "Computer Crime",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2270",
+              "title": "Criminal Justice Science Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2295",
+              "title": "Criminal Justice Science Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Ohio Peace Officer Basic Training Academy (OPOTA) – 29 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2280",
+              "title": "Basic Peace Officer Training I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2281",
+              "title": "Basic Peace Officer Training II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose one additional CJS courses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2245",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2226",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Science/Corrections, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5504",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1107",
+              "title": "Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Natural & Physical Sciences Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1103",
+              "title": "Constitutional Law &amp; Evidentiary Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1197",
+              "title": "Corrections Full Service Jails/Basic Correction Officer Academy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2145",
+              "title": "Correctional Case Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2270",
+              "title": "Criminal Justice Science Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2295",
+              "title": "Criminal Justice Science Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2245",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1201",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2226",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Corrections, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5560",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1103",
+              "title": "Constitutional Law &amp; Evidentiary Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1197",
+              "title": "Corrections Full Service Jails/Basic Correction Officer Academy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Law Enforcement, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5588",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1103",
+              "title": "Constitutional Law &amp; Evidentiary Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1125",
+              "title": "Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Ohio Peace Officer Basic Training Academy Professional, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5594",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "2280",
+              "title": "Basic Peace Officer Training I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2281",
+              "title": "Basic Peace Officer Training II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ohio Peace Officer Basic Training Academy, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5650",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "2280",
+              "title": "Basic Peace Officer Training I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2281",
+              "title": "Basic Peace Officer Training II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Services Assistant, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5767",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2205",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2130",
+              "title": "Sociology of Family Violence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2145",
+              "title": "Correctional Case Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "2138",
+              "title": "Ethical Issues in the Helping Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5664",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1103",
+              "title": "Constitutional Law &amp; Evidentiary Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1125",
+              "title": "Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Corrections Officer, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5708",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1197",
+              "title": "Corrections Full Service Jails/Basic Correction Officer Academy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Community and Public Services Specialist, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5759",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2145",
+              "title": "Correctional Case Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2130",
+              "title": "Sociology of Family Violence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2205",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2226",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Re-Entry Preparation, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5768",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Correctional Rehabilitation, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5777",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1101",
+              "title": "Introduction to Criminal Justice Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1103",
+              "title": "Constitutional Law &amp; Evidentiary Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1110",
+              "title": "Interrogation, Documentation &amp; Testimony",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1165",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2111",
+              "title": "Ethics &amp; Professionalism in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2145",
+              "title": "Correctional Case Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "2200",
+              "title": "Human Relations, Mediation &amp; Conflict Resolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective - 3 Cr. Hr.(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1130",
+              "title": "Fundamentals of Addiction Counseling CDCA Preliminary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2226",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities 3 Cr. Hr.(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Social & Behavioral Sciences Elective 3 Cr. Hr.(s)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Workforce Readiness, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5772",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Firefighter, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5639",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FST",
+              "number": "1102",
+              "title": "Firefighter I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1103",
+              "title": "Firefighter II Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1104",
+              "title": "Firefighter II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Department Executive Officer, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5685",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FST",
+              "number": "2253",
+              "title": "Fire Officer III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "2254",
+              "title": "Fire Officer IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Firefighter EMT, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5684",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "1150",
+              "title": "Emergency Medical Technician: Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1155",
+              "title": "Laboratory for Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1102",
+              "title": "Firefighter I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1103",
+              "title": "Firefighter II Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1104",
+              "title": "Firefighter II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "1442",
+              "title": "Emergency Vehicle Operator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Department Company Officer, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5686",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FST",
+              "number": "2251",
+              "title": "Fire Officer I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "2252",
+              "title": "Fire Officer II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Management & Tourism/Bakery & Pastry Arts, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5521",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1108",
+              "title": "Nutrition for the Culinary Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1126",
+              "title": "Baking I, II, &amp; Barista Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2110",
+              "title": "Pastry &amp; Confectionary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2118",
+              "title": "Artisan Breads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2126",
+              "title": "Cake Production &amp; Cake Decoration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2200",
+              "title": "Baking &amp; Culinary Fundamentals &amp; Commercial Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2218",
+              "title": "Advanced Pastry Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2226",
+              "title": "Hospitality Purchasing &amp; Negotiations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2227",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2230",
+              "title": "Risk &amp; Prevention Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2293",
+              "title": "Baking &amp; Pastry Arts Option Cooperative Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1125",
+              "title": "Math for the Culinary Arts &amp; Baking &amp; Pastry Arts Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management & Tourism, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5520",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1110",
+              "title": "Menu Planning &amp; Table Service Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1125",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1136",
+              "title": "Front Office Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1137",
+              "title": "Hospitality Industry Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1139",
+              "title": "Housekeeping Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1143",
+              "title": "Organization of the Travel Product",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1148",
+              "title": "Meeting &amp; Events Contracts &amp; Obligations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1149",
+              "title": "Meeting &amp; Events Set-up &amp; Breakdown",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2226",
+              "title": "Hospitality Purchasing &amp; Negotiations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2227",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2230",
+              "title": "Risk &amp; Prevention Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2291",
+              "title": "Hospitality Management &amp; Tourism Cooperative Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2295",
+              "title": "Hospitality Management &amp; Tourism Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective 3 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Language Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1111",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1100",
+              "title": "Conversational Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1101",
+              "title": "Elementary Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1100",
+              "title": "Conversational French",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1100",
+              "title": "Conversational German",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1101",
+              "title": "Elementary German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1100",
+              "title": "Conversational Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1101",
+              "title": "Elementary Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1100",
+              "title": "Conversational Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Bakery Operations and Pastry Skills, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5551",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1126",
+              "title": "Baking I, II, &amp; Barista Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2110",
+              "title": "Pastry &amp; Confectionary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2118",
+              "title": "Artisan Breads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1125",
+              "title": "Math for the Culinary Arts &amp; Baking &amp; Pastry Arts Professional",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Management & Tourism/Meeting & Event Planning, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5523",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1110",
+              "title": "Menu Planning &amp; Table Service Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1125",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1141",
+              "title": "Destination Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1143",
+              "title": "Organization of the Travel Product",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1148",
+              "title": "Meeting &amp; Events Contracts &amp; Obligations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1149",
+              "title": "Meeting &amp; Events Set-up &amp; Breakdown",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1150",
+              "title": "Meeting &amp; Event Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1151",
+              "title": "Special Events, Expositions &amp; Festivals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2226",
+              "title": "Hospitality Purchasing &amp; Negotiations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2227",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2230",
+              "title": "Risk &amp; Prevention Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2291",
+              "title": "Hospitality Management &amp; Tourism Cooperative Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2295",
+              "title": "Hospitality Management &amp; Tourism Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective &nbsp;3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective 3 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Language Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1111",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1100",
+              "title": "Conversational Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHN",
+              "number": "1101",
+              "title": "Elementary Chinese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1100",
+              "title": "Conversational French",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "1101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1100",
+              "title": "Conversational German",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "1101",
+              "title": "Elementary German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1100",
+              "title": "Conversational Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "1101",
+              "title": "Elementary Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1100",
+              "title": "Conversational Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "1101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management & Tourism/Culinary Arts, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5522",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "1108",
+              "title": "Nutrition for the Culinary Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1110",
+              "title": "Menu Planning &amp; Table Service Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1125",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1129",
+              "title": "Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2200",
+              "title": "Baking &amp; Culinary Fundamentals &amp; Commercial Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2206",
+              "title": "Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2207",
+              "title": "Butchery &amp; Fish Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2208",
+              "title": "Advanced Culinary &amp; Competition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2209",
+              "title": "Advanced Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2226",
+              "title": "Hospitality Purchasing &amp; Negotiations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2227",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2230",
+              "title": "Risk &amp; Prevention Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2292",
+              "title": "Culinary Arts Option Cooperative Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1125",
+              "title": "Math for the Culinary Arts &amp; Baking &amp; Pastry Arts Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Skills and Food and Beverage Operations, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5574",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1110",
+              "title": "Menu Planning &amp; Table Service Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1125",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1129",
+              "title": "Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2207",
+              "title": "Butchery &amp; Fish Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1125",
+              "title": "Math for the Culinary Arts &amp; Baking &amp; Pastry Arts Professional",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Leadership and Administration, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5584",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1110",
+              "title": "Menu Planning &amp; Table Service Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1125",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Service Management, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5581",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisite(s)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1110",
+              "title": "Menu Planning &amp; Table Service Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2225",
+              "title": "Hospitality &amp; Tourism Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2226",
+              "title": "Hospitality Purchasing &amp; Negotiations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1125",
+              "title": "Math for the Culinary Arts &amp; Baking &amp; Pastry Arts Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Food Truck and Street Foods, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5683",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisite(s)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1129",
+              "title": "Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2203",
+              "title": "Street Foods &amp; Food Trucks",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Reception and Service Specialist, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5674",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Baking and Fundamentals, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5731",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1126",
+              "title": "Baking I, II, &amp; Barista Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Preparation of Food, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5729",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2201",
+              "title": "Food Service Equipment, Design &amp; Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2207",
+              "title": "Butchery &amp; Fish Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Entrepreneurship, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5746",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2160",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1129",
+              "title": "Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2203",
+              "title": "Street Foods &amp; Food Trucks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1125",
+              "title": "Math for the Culinary Arts &amp; Baking &amp; Pastry Arts Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Social & Behavioral Sciences Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bakery Specialist, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5732",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1126",
+              "title": "Baking I, II, &amp; Barista Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2110",
+              "title": "Pastry &amp; Confectionary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2126",
+              "title": "Cake Production &amp; Cake Decoration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Management, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5761",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Food Production Specialist, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5764",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1101",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1112",
+              "title": "Food Principles &amp; Basic Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2215",
+              "title": "Hospitality Cost Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pastry Specialist, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5765",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMT",
+              "number": "1102",
+              "title": "Kitchen Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1105",
+              "title": "Introduction to the Hospitality &amp; Tourism Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1107",
+              "title": "Sanitation &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "1126",
+              "title": "Baking I, II, &amp; Barista Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2110",
+              "title": "Pastry &amp; Confectionary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2126",
+              "title": "Cake Production &amp; Cake Decoration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMT",
+              "number": "2218",
+              "title": "Advanced Pastry Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5527",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1199",
+              "title": "Textual Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1201",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1101",
+              "title": "Introduction to Legal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1102",
+              "title": "Legal Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1103",
+              "title": "Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1201",
+              "title": "Legal Research &amp; Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1202",
+              "title": "Advanced Legal Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1203",
+              "title": "Advanced Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2301",
+              "title": "Advanced Legal Research &amp; Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2302",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2303",
+              "title": "Probate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2401",
+              "title": "Legal Studies Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Legal Studies Electives 6 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "1201",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Legal Studies Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1102",
+              "title": "Consumer Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1104",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Nurse Consultant, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5589",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "1101",
+              "title": "Introduction to Legal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1102",
+              "title": "Legal Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1103",
+              "title": "Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1201",
+              "title": "Legal Research &amp; Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1202",
+              "title": "Advanced Legal Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1203",
+              "title": "Advanced Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2301",
+              "title": "Advanced Legal Research &amp; Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2401",
+              "title": "Legal Studies Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1101",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1160",
+              "title": "Medical Office Coding Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1221",
+              "title": "Specialized Computer Applications for Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1204",
+              "title": "Medicolegal &amp; Ethics in Healthcare Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Legal Studies Elective 6 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Legal Studies Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1102",
+              "title": "Consumer Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1104",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHT",
+              "number": "1101",
+              "title": "Introduction to Mental Health Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2302",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2303",
+              "title": "Probate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "1201",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Sport and Recreation Education, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5467",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "1132",
+              "title": "Heartsaver First Aid, CPR &amp; AED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1201",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENS",
+              "number": "1118",
+              "title": "Lifetime Physical Fitness &amp; Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENS",
+              "number": "2419",
+              "title": "Health Promotion, Fitness &amp; Sport Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1101",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "1201",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1111",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "1112",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1114",
+              "title": "Introduction to Sports Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2414",
+              "title": "Foundations of Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2415",
+              "title": "Coaching &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2270",
+              "title": "Management Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective (at least two disciplines) 6 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Social & Behavioral Sciences Elective (may not be PSY course) 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Studies Post Baccalaureate Certificate, CRT",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5590",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "1101",
+              "title": "Introduction to Legal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1102",
+              "title": "Legal Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1103",
+              "title": "Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1201",
+              "title": "Legal Research &amp; Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1202",
+              "title": "Advanced Legal Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "1203",
+              "title": "Advanced Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2301",
+              "title": "Advanced Legal Research &amp; Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2302",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2303",
+              "title": "Probate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "2401",
+              "title": "Legal Studies Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "1201",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Legal Studies Elective 6 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Legal Studies Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "1105",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1102",
+              "title": "Consumer Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1104",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5493",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1230",
+              "title": "Spreadsheet Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "1130",
+              "title": "Humanity &amp; the Challenge of Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISE",
+              "number": "1101",
+              "title": "Introduction to Industrial &amp; Systems Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISE",
+              "number": "1130",
+              "title": "Lean Operations &amp; Continuous Improvement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISE",
+              "number": "2240",
+              "title": "Six Sigma: Green Belt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1102",
+              "title": "Consumer Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1104",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1157",
+              "title": "Management Applications of Radio Frequency Identification Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2270",
+              "title": "Management Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2279",
+              "title": "Business Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5472",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1201",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2160",
+              "title": "Calculus for Business &amp; Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2170",
+              "title": "Business Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts & Humanities Elective (at least two disciplines) 6 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Natural & Physical Sciences Elective 7 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Social & Behavioral Sciences Elective (May not be ECO course) 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5490",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1100",
+              "title": "Introduction to Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1110",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2270",
+              "title": "Management Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2275",
+              "title": "Retail Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2279",
+              "title": "Business Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities Elective 3 Cr. Hr(s). OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Electives 18 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management/Entrepreneurship, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5492",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2286",
+              "title": "Public Relations Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2160",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Entrepreneurship Elective 3 Cr. Hr(s). (see options below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Entrepreneurship Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1157",
+              "title": "Management Applications of Radio Frequency Identification Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2102",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2145",
+              "title": "Principles of Retailing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2225",
+              "title": "Sales Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5557",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1100",
+              "title": "Introduction to Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1110",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Management Elective 3 Cr. Hr(s). (options list below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business Management Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2160",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1157",
+              "title": "Management Applications of Radio Frequency Identification Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2102",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2145",
+              "title": "Principles of Retailing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2225",
+              "title": "Sales Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Transfer, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5558",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1220",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Social and Behavioral Sciences Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5580",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2286",
+              "title": "Public Relations Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2160",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sports Management, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5600",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2286",
+              "title": "Public Relations Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1114",
+              "title": "Introduction to Sports Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2414",
+              "title": "Foundations of Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2415",
+              "title": "Coaching &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Supervisory Skills, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5624",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1100",
+              "title": "Introduction to Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supply Chain Management, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5601",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISE",
+              "number": "1101",
+              "title": "Introduction to Industrial &amp; Systems Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1157",
+              "title": "Management Applications of Radio Frequency Identification Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Retail Management, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5631",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2275",
+              "title": "Retail Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Supervision Foundations, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5625",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Small Business Management, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5629",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Human Resource Management, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5673",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2450",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Retail Business, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5632",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "International Business, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5668",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEO",
+              "number": "1201",
+              "title": "World Regional Geography: People, Places &amp; Globalization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1110",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1145",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Management Elective 3 Cr. Hr(s). (options listed below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business Management Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAN",
+              "number": "2110",
+              "title": "Introduction to Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2270",
+              "title": "Management Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2279",
+              "title": "Business Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Digital Marketing Analytics, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5698",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2230",
+              "title": "Social Media &amp; Consumer Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2236",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2250",
+              "title": "Digital Marketing Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1350",
+              "title": "Web Site Development with HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VIS",
+              "number": "1310",
+              "title": "History &amp; Theory of Web Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Coaching, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5718",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAN",
+              "number": "2414",
+              "title": "Foundations of Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2415",
+              "title": "Coaching &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Retail Manager, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5770",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2275",
+              "title": "Retail Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Foundations Specialist, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5758",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2160",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship and Business Foundations, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5763",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2140",
+              "title": "Small Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2160",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2220",
+              "title": "Small Business Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Supply Chain Manager, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5771",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1400",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2140",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Organizational Leadership in Business, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5800",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAN",
+              "number": "1050",
+              "title": "Organizational Leadership I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2050",
+              "title": "Organizational Leadership II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Digital Marketing, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5491",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1210",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "1120",
+              "title": "Introduction to Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "1350",
+              "title": "Web Site Development with HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VIS",
+              "number": "1310",
+              "title": "History &amp; Theory of Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1100",
+              "title": "Introduction to Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2160",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2180",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "1101",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2270",
+              "title": "Management Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Mathematics Elective 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2230",
+              "title": "Social Media &amp; Consumer Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2236",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2250",
+              "title": "Digital Marketing Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OT36 Arts and Humanities 3 Cr. Hr(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VIS",
+              "number": "1140",
+              "title": "Design Processes I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose one marketing elective from:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2102",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2145",
+              "title": "Principles of Retailing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2225",
+              "title": "Sales Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2201",
+              "title": "Introduction to Mass Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2286",
+              "title": "Public Relations Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Supply Chain Technician, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5954",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJS",
+              "number": "1106",
+              "title": "Transition Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2150",
+              "title": "Management &amp; Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1106",
+              "title": "Introduction to Radio Frequency Identification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2101",
+              "title": "Introduction to Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2144",
+              "title": "Negotiation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "2159",
+              "title": "Supply Chain Management Concepts &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1120",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Marketing, CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.sinclair.edu/preview_program.php?catoid=13&poid=5577",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "1350",
+              "title": "Web Site Development with HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VIS",
+              "number": "1310",
+              "title": "History &amp; Theory of Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2206",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2211",
+              "title": "Effective Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2225",
+              "title": "Small Group Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "1131",
+              "title": "Business Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "1107",
+              "title": "Foundations of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2100",
+              "title": "Foundations of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2101",
+              "title": "Principles of Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2135",
+              "title": "Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2230",
+              "title": "Social Media &amp; Consumer Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2236",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2250",
+              "title": "Digital Marketing Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose one marketing elective from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2102",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2145",
+              "title": "Principles of Retailing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRK",
+              "number": "2225",
+              "title": "Sales Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2201",
+              "title": "Introduction to Mass Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "2286",
+              "title": "Public Relations Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    }
+  ]
+}

--- a/lib/states/oh/config.ts
+++ b/lib/states/oh/config.ts
@@ -59,7 +59,12 @@ const ohConfig: StateConfig = {
       { scripts: ["scripts/oh/scrape-transfer-osu.ts"], runner: "http" },
     ],
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: programs — Phase 5+.
+    // Acalog (Sinclair, Owens) via search_advanced + CourseLeaf (Cuyahoga/Tri-C,
+    // Lakeland, Rhodes State). Columbus State + Cincinnati State (CourseLeaf,
+    // program index path TBD) and the other colleges are deferred.
+    programs: [
+      { scripts: ["scripts/oh/scrape-programs.ts"], runner: "http" },
+    ],
   },
 };
 

--- a/scripts/oh/scrape-programs.ts
+++ b/scripts/oh/scrape-programs.ts
@@ -1,0 +1,84 @@
+/**
+ * scrape-programs.ts — degree/program requirements for OH.
+ *
+ * Ohio community colleges with a scrapeable templated catalog:
+ *   Acalog (search_advanced discovery): Sinclair, Owens
+ *   CourseLeaf (per-college program index path — none use the default
+ *     /programs-study/): Cuyahoga (Tri-C, /programs/), Lakeland
+ *     (/degree-certificate-programs/), Rhodes State (/programs/)
+ * Deferred: Columbus State + Cincinnati State are CourseLeaf but neither
+ * /programs/ nor /azindex/ yields program detail links (structure differs,
+ * needs investigation); Stark State is AWS-WAF gated (202); the rest use
+ * custom / non-templated catalogs.
+ *
+ * Usage:
+ *   npx tsx scripts/oh/scrape-programs.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import { scrapeAcalogPrograms } from "../lib/scrape-acalog-programs.js";
+import { scrapeCourseleafPrograms } from "../lib/scrape-courseleaf-programs.js";
+
+async function run(
+  slug: string,
+  scrape: () => Promise<{ programs: unknown[]; catalog_year: string; catalog_url: string; college_slug: string; scraped_at: string }>,
+): Promise<void> {
+  console.log(`\n=== ${slug} ===`);
+  try {
+    const data = await scrape();
+    if (data.programs.length === 0) {
+      console.log(`  No programs found for ${slug}.`);
+      return;
+    }
+    const { matched, unmatched } = applyProgramMatching(data.programs as never);
+    console.log(`  Matcher: ${matched} matched / ${unmatched} unmatched`);
+    const outDir = path.join(process.cwd(), "data", "oh", "programs");
+    fs.mkdirSync(outDir, { recursive: true });
+    const outPath = path.join(outDir, `${slug}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+    console.log(`  ✓ Wrote ${data.programs.length} programs → ${outPath}`);
+  } catch (e) {
+    console.error(`  ✗ ${slug} failed: ${e}`);
+  }
+}
+
+const ACALOG: { collegeSlug: string; baseUrl: string }[] = [
+  { collegeSlug: "sinclair-community-college", baseUrl: "https://catalog.sinclair.edu" },
+  { collegeSlug: "owens-community-college", baseUrl: "https://catalog.owens.edu" },
+];
+
+const COURSELEAF: { collegeSlug: string; baseUrl: string; programIndexPath: string }[] = [
+  { collegeSlug: "cuyahoga-community-college-district", baseUrl: "https://catalog.tri-c.edu", programIndexPath: "/programs/" },
+  { collegeSlug: "lakeland-community-college", baseUrl: "https://catalog.lakelandcc.edu", programIndexPath: "/degree-certificate-programs/" },
+  { collegeSlug: "james-a-rhodes-state-college", baseUrl: "https://catalog.rhodesstate.edu", programIndexPath: "/programs/" },
+];
+
+async function main() {
+  console.log("OH program scraper");
+
+  for (const c of ACALOG) {
+    await run(c.collegeSlug, () =>
+      scrapeAcalogPrograms({
+        collegeSlug: c.collegeSlug,
+        baseUrl: c.baseUrl,
+        catoidFallback: 0,
+        programNavoids: [],
+        autoDiscoverCatoid: true,
+        useSearchDiscovery: true,
+      }),
+    );
+  }
+
+  for (const c of COURSELEAF) {
+    await run(c.collegeSlug, () =>
+      scrapeCourseleafPrograms({ collegeSlug: c.collegeSlug, baseUrl: c.baseUrl, programIndexPath: c.programIndexPath }),
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for a student

Ohio had **zero** program data, so the degree planner was effectively dead there despite OH having transfers + prerequisites. This adds **746 programs** (648 with full course requirements) across OH's **5 templated-catalog colleges**, including the three biggest: Cuyahoga/Tri-C (242), Owens (165), Lakeland (142), Sinclair (100), Rhodes State (97). Students can now browse Ohio majors, see required courses, and get a transfer-validated plan. This is the largest of the recent state unlocks.

## How it works

New bespoke scraper in the now-proven playbook (probe each college's real catalog platform, use the matching template):

- **Acalog** (Sinclair, Owens): JS-rendered lists → `search_advanced.php` discovery.
- **CourseLeaf** (Cuyahoga, Lakeland, Rhodes): each uses a different program-index path — Cuyahoga/Rhodes at `/programs/`, Lakeland at `/degree-certificate-programs/` (none use CourseLeaf's default `/programs-study/`).

Validated: real codes that align with section data (Cuyahoga "Accounting" → ACCT 1011–1041; Cuyahoga has 283 ENG sections). Wired to the monthly programs cron; `check:scrapers` passes.

**Deferred, named honestly:** Columbus State + Cincinnati State are CourseLeaf too, but neither `/programs/` nor `/azindex/` yields program detail links (their structure differs — needs a closer look). Stark State is behind an AWS-WAF challenge (HTTP 202, would need the Playwright path). So this covers 5 of 22 colleges — but the largest.

## Test plan
- Scraper run: 746 programs / 648 with ≥5 real courses; `tsc --noEmit` clean; `check:scrapers` OK.
- Data validated (codes align with section data); slug-align checked (all 5 files match institution slugs).
- **Plan page:** same architecture as NM/OR/AZ — renders on prod once `import-on-merge` syncs the files. **Post-merge check:** load `/oh/college/cuyahoga-community-college-district/program/<slug>` on prod.

**DO NOT MERGE — opened for review.**
