### PR TITLE
hi: degree-program data for Kauai + Windward (planner now works); document HI/ME program ceilings

### DIFF
--- a/data/hi/programs/kauai-community-college.json
+++ b/data/hi/programs/kauai-community-college.json
@@ -1,0 +1,14381 @@
+{
+  "college_slug": "kauai-community-college",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.kauai.hawaii.edu/degrees-and-certificates",
+  "scraped_at": "2026-06-06T17:55:32.709Z",
+  "programs": [
+    {
+      "title": "Accounting: Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-associate-in-applied-science-degree",
+      "total_credits": 127,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Payroll and Hawai‘i General Excise Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "185",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "231",
+              "title": "Performance of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "185",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "231",
+              "title": "Performance of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "126",
+              "title": "Principles of Accounting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "134",
+              "title": "Individual Income Tax Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLAW",
+              "number": "200",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Environment (A.A.S. Core Options): Refer to \"General Education/Skills Core Options Courses\" under the \"Programs (Certificates and Degrees)\" section for a list of courses that will fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "137",
+              "title": "Business Income Tax Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "193V",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any ENG course higher than ENG 200 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Environment (A.A.S. Core Options): Refer to \"General Education/Skills Core Options Courses\" under the \"Programs (Certificates and Degrees)\" section for a list of courses that will fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting: Certificate of Achievement (Tax Preparer)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-certificate-of-achievement-tax-preparer",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "134",
+              "title": "Individual Income Tax Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "137",
+              "title": "Business Income Tax Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting: Certificate of Achievement (Payroll Preparer)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-certificate-of-achievement-payroll-preparer",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Payroll and Hawai‘i General Excise Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting: Certificate of Achievement (Small Business Accounting)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-certificate-of-achievement-small-business-accounting",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Payroll and Hawai‘i General Excise Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting: Certificate of Competence (Basic Accounting)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-certificate-of-competence-basic-accounting",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-certificate-of-achievement",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Payroll and Hawai‘i General Excise Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "134",
+              "title": "Individual Income Tax Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Environment (A.A.S. Core Options): Refer to \"General Education/Skills Core Options Courses\" under the \"Programs (Certificates and Degrees)\" section for a list of courses that will fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Automotive Technology: Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-associate-in-applied-science-degree",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "152",
+              "title": "Brake Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "154",
+              "title": "Suspension and Steering Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "145",
+              "title": "Manual Drive Trains and Axles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Electrical/Electronic Systems II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Career and Technical Education Physics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "149",
+              "title": "Automatic Transmission and Transaxle",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "240",
+              "title": "Fuel and Emission Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Engine Performance I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "144",
+              "title": "Heating and Air Conditioning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Engine Performance II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "260",
+              "title": "Diagnostic and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Accounting: Certificate of Achievement (Accounting Assistant)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/accounting/accounting-certificate-of-achievement-accounting-assistant",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Using Spreadsheets in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "252",
+              "title": "Using Quickbooks in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Achievement (Driveability Technician)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-achievement-driveability-technician",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Electrical/Electronic Systems II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "240",
+              "title": "Fuel and Emission Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Engine Performance I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Engine Performance II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "260",
+              "title": "Diagnostic and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Achievement (Automotive Green Technology)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-achievement-automotive-green-technology",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "171",
+              "title": "HEV I - Introduction to Hybrid and Electric Vehicle Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "172",
+              "title": "HEV II - Preventive Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "173",
+              "title": "HEV III – Diagnostic and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Engine Performance II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Achievement (Heavy Line Technician)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-achievement-heavy-line-technician",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "152",
+              "title": "Brake Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "154",
+              "title": "Suspension and Steering Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "145",
+              "title": "Manual Drive Trains and Axles",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "149",
+              "title": "Automatic Transmission and Transaxle",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Achievement (Electronics/Computer Control Technician)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-achievement-electronicscomputer-control",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Electrical/Electronic Systems II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "240",
+              "title": "Fuel and Emission Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Engine Performance I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "144",
+              "title": "Heating and Air Conditioning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Engine Performance II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Competence (Engine Specialist)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-competence-engine-specialist",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Achievement (Non-Structural Analysis and Damage Repair)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-achievement-nonstructural-analysis-and",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "120B",
+              "title": "Auto Metal Work and Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "126B",
+              "title": "Non-Structural Analysis and Repair I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "134B",
+              "title": "Paint Prep and Refinishing I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "136B",
+              "title": "Non-Structural Analysis and Repair II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "144B",
+              "title": "Paint Prep and Refinish II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Achievement (Master Automobile Service Technology)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-achievement-master-automobile-service",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "152",
+              "title": "Brake Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "154",
+              "title": "Suspension and Steering Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "145",
+              "title": "Manual Drive Trains and Axles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Electrical/Electronic Systems II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "149",
+              "title": "Automatic Transmission and Transaxle",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "240",
+              "title": "Fuel and Emission Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Engine Performance I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "144",
+              "title": "Heating and Air Conditioning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Engine Performance II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "260",
+              "title": "Diagnostic and Repair",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Competence (Drive Train Specialist)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-competence-drive-train-specialist",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "145",
+              "title": "Manual Drive Trains and Axles",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Competence (HEV Diagnostic and Repair)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-competence-hev-diagnostic-and-repair",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "171",
+              "title": "HEV I - Introduction to Hybrid and Electric Vehicle Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "173",
+              "title": "HEV III – Diagnostic and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Engine Performance II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Competence (Undercar Specialist)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-competence-undercar-specialist",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "100",
+              "title": "Introduction to Automotive Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "152",
+              "title": "Brake Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "154",
+              "title": "Suspension and Steering Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Certificate of Competence (HEV Preventive Maintenance and Repair)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/automotive-technology/automotive-technology-certificate-of-competence-hev-preventive-maintenance",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "141",
+              "title": "Electrical/Electronic Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "129",
+              "title": "Engine Repair",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "171",
+              "title": "HEV I - Introduction to Hybrid and Electric Vehicle Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "172",
+              "title": "HEV II - Preventive Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Business: Associate in Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/business/business-associate-in-science-degree",
+      "total_credits": 84,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "125",
+              "title": "Starting a Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "150",
+              "title": "Basic Accounting and Finance for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 103 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLAW",
+              "number": "200",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "190",
+              "title": "Survey of International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "293",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business: Certificate of Achievement (Entrepreneurship)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/business/business-certificate-of-achievement-entrepreneurship",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "125",
+              "title": "Starting a Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "190",
+              "title": "Survey of International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "150",
+              "title": "Basic Accounting and Finance for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 103 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLAW",
+              "number": "200",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "293",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business: Certificate of Achievement (Management)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/business/business-certificate-of-achievement-management",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLAW",
+              "number": "200",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "293",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 103 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business: Certificate of Competence (Entrepreneurship)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/business/business-certificate-of-competence-entrepreneurship",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "125",
+              "title": "Starting a Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "150",
+              "title": "Basic Accounting and Finance for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Carpentry Technology: Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/carpentry-technology/carpentry-technology-associate-in-applied-science-degree",
+      "total_credits": 132,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120B",
+              "title": "Basic Carpentry Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120C",
+              "title": "Applied Carpentry Skills",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "117",
+              "title": "Introduction to Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "Shop Tools and Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "141B",
+              "title": "Rough Framing and Exterior Finish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "141C",
+              "title": "Rough Framing and Exterior Finish II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "122B",
+              "title": "Concrete Forms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122C",
+              "title": "Concrete Forms II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "142B",
+              "title": "Finishing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "142C",
+              "title": "Finishing II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122B",
+              "title": "Concrete Forms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122C",
+              "title": "Concrete Forms II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "117",
+              "title": "Introduction to Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "Shop Tools and Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "142B",
+              "title": "Finishing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "142C",
+              "title": "Finishing II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "120B",
+              "title": "Basic Carpentry Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120C",
+              "title": "Applied Carpentry Skills",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "141B",
+              "title": "Rough Framing and Exterior Finish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "141C",
+              "title": "Rough Framing and Exterior Finish II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business: Certificate of Competence (Management Essentials)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/business/business-certificate-of-competence-management-essentials",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Principles of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 103 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business: Certificate of Competence (Retail Essentials)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/business/business-certificate-of-competence-retail-essentials",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "120",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "130",
+              "title": "Marketing for the Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "130",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 103 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Carpentry Technology: Certificate of Competence (Facilities Maintenance Technology)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/carpentry-technology/carpentry-technology-certificate-of-competence-facilities-maintenance",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120B",
+              "title": "Basic Carpentry Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "117",
+              "title": "Introduction to Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "Shop Tools and Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "141B",
+              "title": "Rough Framing and Exterior Finish I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "122B",
+              "title": "Concrete Forms I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "142B",
+              "title": "Finishing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122B",
+              "title": "Concrete Forms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "117",
+              "title": "Introduction to Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "Shop Tools and Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "142B",
+              "title": "Finishing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "120B",
+              "title": "Basic Carpentry Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "141B",
+              "title": "Rough Framing and Exterior Finish I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Carpentry Technology: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/carpentry-technology/carpentry-technology-certificate-of-achievement",
+      "total_credits": 102,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120B",
+              "title": "Basic Carpentry Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120C",
+              "title": "Applied Carpentry Skills",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "141B",
+              "title": "Rough Framing and Exterior Finish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "141C",
+              "title": "Rough Framing and Exterior Finish II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "122B",
+              "title": "Concrete Forms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122C",
+              "title": "Concrete Forms II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "142B",
+              "title": "Finishing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "142C",
+              "title": "Finishing II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122B",
+              "title": "Concrete Forms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "122C",
+              "title": "Concrete Forms II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "142B",
+              "title": "Finishing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "142C",
+              "title": "Finishing II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "120B",
+              "title": "Basic Carpentry Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "120C",
+              "title": "Applied Carpentry Skills",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "141B",
+              "title": "Rough Framing and Exterior Finish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "141C",
+              "title": "Rough Framing and Exterior Finish II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Creative Media: Associate in Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/creative-media/creative-media-associate-in-science-degree",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Introduction to the Visual Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107D",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Introduction to Digital Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Introduction to Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Digital Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "207D",
+              "title": "Intermediate Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "120",
+              "title": "Introduction to Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "180",
+              "title": "Introduction to Website Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CM",
+              "number": "156",
+              "title": "Writing for Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "178",
+              "title": "Introduction to 3D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "220",
+              "title": "Intermediate Digital Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "280",
+              "title": "Intermediate Website Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "293",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "125",
+              "title": "Starting a Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 100 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/culinary-arts/culinary-arts-certificate-of-achievement",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "111",
+              "title": "Introduction to the Culinary Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "112",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "116",
+              "title": "Introduction to Culinary Sustainability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "121",
+              "title": "Culinary Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "130",
+              "title": "Intermediate Cookery",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "150",
+              "title": "Fundamentals of Baking",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "160",
+              "title": "Dining Room Operations",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts: Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/culinary-arts/culinary-arts-associate-in-applied-science-degree",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "111",
+              "title": "Introduction to the Culinary Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "112",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "116",
+              "title": "Introduction to Culinary Sustainability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "121",
+              "title": "Culinary Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "130",
+              "title": "Intermediate Cookery",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "106",
+              "title": "Technical Communication",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "106",
+              "title": "Technical Communication",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "100",
+              "title": "Math for the Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "150",
+              "title": "Fundamentals of Baking",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "160",
+              "title": "Dining Room Operations",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "185",
+              "title": "Culinary Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "221",
+              "title": "Continental Cuisine",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "222",
+              "title": "Asian Pacific Cuisine",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "271",
+              "title": "Purchasing and Cost Control",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "115",
+              "title": "Menu Merchandising",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "242",
+              "title": "Applied Garde Manger",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "275",
+              "title": "Human Resource Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "294",
+              "title": "Culinary Arts Practicum",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts: Certificate of Achievement (Advanced Culinary Arts)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/culinary-arts/culinary-arts-certificate-of-achievement-advanced-culinary-arts",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "185",
+              "title": "Culinary Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "221",
+              "title": "Continental Cuisine",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "222",
+              "title": "Asian Pacific Cuisine",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "271",
+              "title": "Purchasing and Cost Control",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "115",
+              "title": "Menu Merchandising",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "242",
+              "title": "Applied Garde Manger",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "275",
+              "title": "Human Resource Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "294",
+              "title": "Culinary Arts Practicum",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/culinary-arts/culinary-arts-certificate-of-competence",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "111",
+              "title": "Introduction to the Culinary Industry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "112",
+              "title": "Sanitation and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "116",
+              "title": "Introduction to Culinary Sustainability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "121",
+              "title": "Culinary Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "130",
+              "title": "Intermediate Cookery",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts: Certificate of Competence (Culinary Arts - Food Prep)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/culinary-arts/culinary-arts-certificate-of-competence-culinary-arts-food-prep",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "101B",
+              "title": "Introduction to Food Service, Basic Skills, and Sanitation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "101C",
+              "title": "Introduction to Food Service, Short Order, and Quantity Food Cookery",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "102B",
+              "title": "Introduction to Food Service, Breakfast Cookery, and Cafeteria Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "102C",
+              "title": "Introduction to Food Service, Pantry Development, and Basic Baking",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/early-childhood-education/early-childhood-education-certificate-of-achievement",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Developmentally Appropriate Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "115",
+              "title": "Health, Safety, and Nutrition for the Young Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "131",
+              "title": "Early Childhood Development: Theory Into Practice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "140",
+              "title": "Guiding Young Children in Group Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "191",
+              "title": "Early Childhood Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "245",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "264",
+              "title": "Inquiry and Physical Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education: Certificate of Competence (Initial Early Childhood Education)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/early-childhood-education/early-childhood-education-certificate-of-competence-initial-early",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Developmentally Appropriate Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "131",
+              "title": "Early Childhood Development: Theory Into Practice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education: Associate in Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/early-childhood-education/early-childhood-education-associate-in-science-degree",
+      "total_credits": 47,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Developmentally Appropriate Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "131",
+              "title": "Early Childhood Development: Theory Into Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "140",
+              "title": "Guiding Young Children in Group Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "191",
+              "title": "Early Childhood Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "245",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 100 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "115",
+              "title": "Health, Safety, and Nutrition for the Young Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "263",
+              "title": "Language and Creative Expression Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "170",
+              "title": "Introduction to Working with Infants and Toddlers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "264",
+              "title": "Inquiry and Physical Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "291",
+              "title": "Early Childhood Practicum II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical Installation and Maintenance Technology: Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electrical-installation-and-maintenance-technology/electrical-installation-and-maintenance-0",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "121",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "123",
+              "title": "Wiring Materials, Methods, and NEC Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "131",
+              "title": "Residential Installation Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "135",
+              "title": "Residential Installation Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "151",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "145",
+              "title": "Commercial Installation Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "147",
+              "title": "Commercial Installation Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "153",
+              "title": "AC/DC Systems and Equipment",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "123",
+              "title": "Plumbing Basics and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "175",
+              "title": "Advanced Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "140",
+              "title": "Commercial Refrigeration and Air Conditioning Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "175",
+              "title": "Advanced Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "140",
+              "title": "Commercial Refrigeration and Air Conditioning Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Installation and Maintenance Technology: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electrical-installation-and-maintenance-technology/electrical-installation-and-maintenance",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "121",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "123",
+              "title": "Wiring Materials, Methods, and NEC Codes",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "131",
+              "title": "Residential Installation Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "135",
+              "title": "Residential Installation Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "151",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "145",
+              "title": "Commercial Installation Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "147",
+              "title": "Commercial Installation Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "153",
+              "title": "AC/DC Systems and Equipment",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "175",
+              "title": "Advanced Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "140",
+              "title": "Commercial Refrigeration and Air Conditioning Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "175",
+              "title": "Advanced Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "140",
+              "title": "Commercial Refrigeration and Air Conditioning Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education: Certificate of Competence (Practitioner I)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/early-childhood-education/early-childhood-education-certificate-of-competence-practitioner-i",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Developmentally Appropriate Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "131",
+              "title": "Early Childhood Development: Theory Into Practice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "140",
+              "title": "Guiding Young Children in Group Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "191",
+              "title": "Early Childhood Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical Installation and Maintenance Technology: Certificate of Competence (Solar Energy Technology/Technician)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electrical-installation-and-maintenance-technology/electrical-installation-and-maintenance-2",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "123",
+              "title": "Wiring Materials, Methods, and NEC Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "121",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "175",
+              "title": "Advanced Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "123",
+              "title": "Plumbing Basics and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-achievement",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "101",
+              "title": "Introduction to Electronics Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "105",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "106",
+              "title": "Circuit Analysis II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "143",
+              "title": "Digital Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "143L",
+              "title": "Digital Electronics Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "257",
+              "title": "RF Communications",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Associate in Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-associate-in-science-degree",
+      "total_credits": 111,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "101",
+              "title": "Introduction to Electronics Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "105",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "140B",
+              "title": "Cisco Networking 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "106",
+              "title": "Circuit Analysis II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "140C",
+              "title": "Cisco Networking 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "287",
+              "title": "Computer Systems and Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "143",
+              "title": "Digital Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "143L",
+              "title": "Digital Electronics Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "210",
+              "title": "Electronic Technology 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "257",
+              "title": "RF Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "161",
+              "title": "Introduction to Optics and Photonics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "280",
+              "title": "Microprocessor Architecture, Programming, and Interfacing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "118",
+              "title": "General Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "240B",
+              "title": "Cisco Networking 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "240C",
+              "title": "Cisco Networking 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "275",
+              "title": "Fundamentals of Linux",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electronics Track:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "118",
+              "title": "General Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Network Track:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "240B",
+              "title": "Cisco Networking 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "240C",
+              "title": "Cisco Networking 4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Programming Track:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "275",
+              "title": "Fundamentals of Linux",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Installation and Maintenance Technology: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electrical-installation-and-maintenance-technology/electrical-installation-and-maintenance-1",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "123",
+              "title": "Wiring Materials, Methods, and NEC Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "170",
+              "title": "Renewable Energy PV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "121",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "151",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "123",
+              "title": "Plumbing Basics and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Installation and Maintenance Technology: Certificate of Competence (Mechanical, Electrical, and Plumbing)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electrical-installation-and-maintenance-technology/electrical-installation-and-maintenance-3",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLPR",
+              "number": "122",
+              "title": "Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "123",
+              "title": "Wiring Materials, Methods, and NEC Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "120",
+              "title": "Facility Safety and Accident Prevention",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "130",
+              "title": "Basic Fundamentals of Air Conditioning and Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EIMT",
+              "number": "121",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIMT",
+              "number": "151",
+              "title": "Industrial Motor Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "123",
+              "title": "Plumbing Basics and Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FENG",
+              "number": "140",
+              "title": "Commercial Refrigeration and Air Conditioning Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-competence",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "101",
+              "title": "Introduction to Electronics Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "118",
+              "title": "General Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Achievement (Network Administrator and Security)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-achievement-network-administrator-and",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "101",
+              "title": "Introduction to Electronics Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "118",
+              "title": "General Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "140B",
+              "title": "Cisco Networking 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "140C",
+              "title": "Cisco Networking 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "287",
+              "title": "Computer Systems and Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "240B",
+              "title": "Cisco Networking 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "275",
+              "title": "Fundamentals of Linux",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "240C",
+              "title": "Cisco Networking 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "244",
+              "title": "Cisco CCNA Security",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Competence (Network Security)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-competence-network-security",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "140B",
+              "title": "Cisco Networking 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "275",
+              "title": "Fundamentals of Linux",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "140C",
+              "title": "Cisco Networking 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "244",
+              "title": "Cisco CCNA Security",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "287",
+              "title": "Computer Systems and Networking",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Competence (Cisco II)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-competence-cisco-ii",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "240B",
+              "title": "Cisco Networking 3",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "240C",
+              "title": "Cisco Networking 4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Competence (Computer Support)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-competence-computer-support",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "118",
+              "title": "General Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETRO",
+              "number": "140B",
+              "title": "Cisco Networking 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "287",
+              "title": "Computer Systems and Networking",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Competence (Cisco I)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-competence-cisco-i",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "140B",
+              "title": "Cisco Networking 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "140C",
+              "title": "Cisco Networking 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology: Certificate of Competence (Programming)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/electronics-technology/electronics-technology-certificate-of-competence-programming",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETRO",
+              "number": "275",
+              "title": "Fundamentals of Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hawaiian Studies: Associate in Arts Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hawaiian-studies/hawaiian-studies-associate-in-arts-degree",
+      "total_credits": 907,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "211",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "211",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "288",
+              "title": "Survey of Pacific Islands History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "200",
+              "title": "Principles of Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "101",
+              "title": "General Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "200L",
+              "title": "Principles of Horticulture Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "185",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "231",
+              "title": "Performance of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversification: Arts (DA)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversification: Humanities (DH)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "288",
+              "title": "Survey of Pacific Islands History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversification: Literatures (DL)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biological Sciences (DB):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "200",
+              "title": "Principles of Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "101",
+              "title": "General Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physical Sciences (DP):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "200L",
+              "title": "Principles of Horticulture Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Culture, History and Arts:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Environment:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "'Ōlelo:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "185",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "231",
+              "title": "Performance of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "288",
+              "title": "Survey of Pacific Islands History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversification: Arts (DA)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversification: Humanities (DH)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "288",
+              "title": "Survey of Pacific Islands History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diversification: Literatures (DL)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Culture, History and Arts:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Environment:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "'Ōlelo:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "200",
+              "title": "Principles of Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "101",
+              "title": "General Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "211",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biological Sciences (DB):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "200",
+              "title": "Principles of Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "101",
+              "title": "General Botany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physical Sciences (DP):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "211",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Culture, History and Arts:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "229",
+              "title": "Hula ʻAuana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Environment:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "'Ōlelo:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hawaiian Studies: Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hawaiian-studies/hawaiian-studies-academic-subject-certificate",
+      "total_credits": 257,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of the Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284K",
+              "title": "History of Kaua‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "111",
+              "title": "The Hawaiian ‘Ohana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "128",
+              "title": "Introduction to Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "129",
+              "title": "Introduction to Hula ‘Auana",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "177",
+              "title": "Hawaiian Music in Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "228",
+              "title": "Hula Kahiko",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "290",
+              "title": "Rediscovering Polynesian Connections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "299V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "221",
+              "title": "Introduction to Hawaiian Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "222",
+              "title": "Introduction to Hawaiian Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "262",
+              "title": "Hawaiian Literature in Translation: 1800 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ho‘okele (Polynesian Voyaging): Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hawaiian-studies/hookele-polynesian-voyaging-academic-subject-certificate",
+      "total_credits": 90,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151L",
+              "title": "College Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151L",
+              "title": "College Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151L",
+              "title": "College Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151L",
+              "title": "College Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality and Tourism: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hospitality-and-tourism/hospitality-and-tourism-certificate-of-achievement",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "100",
+              "title": "Career and Customer Service Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality and Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "150",
+              "title": "Housekeeping Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "154",
+              "title": "Food and Beverage Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "152",
+              "title": "Front Office Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "280",
+              "title": "Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "293",
+              "title": "Hospitality and Tourism Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality and Tourism: Certificate of Achievement (Hospitality Management)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hospitality-and-tourism/hospitality-and-tourism-certificate-of-achievement-hospitality-management",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "100",
+              "title": "Career and Customer Service Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality and Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "150",
+              "title": "Housekeeping Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "152",
+              "title": "Front Office Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "280",
+              "title": "Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mālama ‘Āina: Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hawaiian-studies/malama-aina-academic-subject-certificate",
+      "total_credits": 427,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "207",
+              "title": "Hawaiian Perspectives in Ahupua‘a Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "Interdisciplinary Studies: Ahupuaʻa Field Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171L",
+              "title": "Introduction to Marine Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "207",
+              "title": "Hawaiian Perspectives in Ahupua‘a Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "Interdisciplinary Studies: Ahupuaʻa Field Study",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171L",
+              "title": "Introduction to Marine Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171L",
+              "title": "Introduction to Marine Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171L",
+              "title": "Introduction to Marine Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171L",
+              "title": "Introduction to Marine Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I - Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "141",
+              "title": "Mahi‘ai II: Hawaiian Cultivation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "213",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295",
+              "title": "Ahupuaʻa Research Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171L",
+              "title": "Introduction to Marine Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality and Tourism: Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hospitality-and-tourism/hospitality-and-tourism-associate-in-applied-science-degree",
+      "total_credits": 123,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "100",
+              "title": "Career and Customer Service Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality and Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "150",
+              "title": "Housekeeping Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "154",
+              "title": "Food and Beverage Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Survey of General Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Survey of General Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any MATH course higher than MATH 115 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "152",
+              "title": "Front Office Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "280",
+              "title": "Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLAW",
+              "number": "200",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "293",
+              "title": "Hospitality and Tourism Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Survey of General Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Any ENG course higher than ENG 200 will also fulfill this category.",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "110",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Survey of General Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality and Tourism: Certificate of Competence (Hospitality Essentials)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hospitality-and-tourism/hospitality-and-tourism-certificate-of-competence-hospitality-essentials",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "100",
+              "title": "Career and Customer Service Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality and Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English: Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/liberal-arts/english-academic-subject-certificate",
+      "total_credits": 96,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "270",
+              "title": "Introduction to Literature: Literary History",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Introduction to Literature: Literature and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277B",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Multiethnic Literatures of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "104",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Introduction to Literature: Genre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian/Pacific Literature:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277B",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Multiethnic Literatures of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literary Genre and Creative Writing:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "104",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Introduction to Literature: Genre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277B",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Multiethnic Literatures of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "104",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Introduction to Literature: Genre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian/Pacific Literature:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "272P",
+              "title": "Landscapes in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277B",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Multiethnic Literatures of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277E",
+              "title": "Introduction to Literature: Pacific Cultures and Literature: Literature of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "261",
+              "title": "Hawaiian Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literary Genre and Creative Writing:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "104",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Introduction to Literature: Genre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Hospitality and Tourism: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/hospitality-and-tourism/hospitality-and-tourism-certificate-of-competence",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "100",
+              "title": "Career and Customer Service Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality and Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hawaiian Botany: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/liberal-arts/hawaiian-botany-certificate-of-competence",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts: Associate in Arts Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/liberal-arts/liberal-arts-associate-in-arts-degree",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "181",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "231",
+              "title": "Performance of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "151",
+              "title": "Personal and Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "181",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "231",
+              "title": "Performance of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "251",
+              "title": "Principles of Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Marine Option Program: Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/liberal-arts/marine-option-program-academic-subject-certificate",
+      "total_credits": 169,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCN",
+              "number": "101",
+              "title": "Introduction to Marine Option Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171L",
+              "title": "Introduction to Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172L",
+              "title": "Introduction to Biology Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "162L",
+              "title": "General Chemistry II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "101L",
+              "title": "Introduction to Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "214",
+              "title": "Kaua‘i and Ni‘ihau Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172",
+              "title": "Introduction to Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "162",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "101",
+              "title": "Introduction to Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "130",
+              "title": "Geological Hazards",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "214",
+              "title": "Kaua‘i and Ni‘ihau Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Philosophy: Environmental Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSM",
+              "number": "101",
+              "title": "Introduction to the Science of Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSM",
+              "number": "110",
+              "title": "Sustainable Water and Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172",
+              "title": "Introduction to Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "172",
+              "title": "Introduction to Marine Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCN",
+              "number": "101",
+              "title": "Introduction to Marine Option Program",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "199V",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "171L",
+              "title": "Introduction to Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172L",
+              "title": "Introduction to Biology Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151L",
+              "title": "Elementary Survey of Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "162L",
+              "title": "General Chemistry II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "101L",
+              "title": "Introduction to Geology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "214",
+              "title": "Kaua‘i and Ni‘ihau Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121L",
+              "title": "Introduction to Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122L",
+              "title": "Introduction to Physical Science Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172",
+              "title": "Introduction to Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "Elementary Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "162",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "101",
+              "title": "Introduction to Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "130",
+              "title": "Geological Hazards",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "214",
+              "title": "Kaua‘i and Ni‘ihau Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "281",
+              "title": "Hoʻokele I : Hawaiian Astronomy and Weather",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "282",
+              "title": "Hoʻokele II: Hawaiian Navigation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Philosophy: Environmental Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Introduction to Science (Biological Science)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Introduction to Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSCI",
+              "number": "250",
+              "title": "Environmental Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSM",
+              "number": "101",
+              "title": "Introduction to the Science of Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSM",
+              "number": "110",
+              "title": "Sustainable Water and Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Ethnozoology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172",
+              "title": "Introduction to Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "171",
+              "title": "Introduction to Marine Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARE",
+              "number": "172",
+              "title": "Introduction to Marine Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCN",
+              "number": "199V",
+              "title": "Directed Study",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Arts: Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/liberal-arts/visual-arts-academic-subject-certificate",
+      "total_credits": 93,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Introduction to the Visual Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Introduction to Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "213",
+              "title": "Intermediate Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Introduction to Watercolor Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "123",
+              "title": "Introduction to Painting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Introduction to Watercolor Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "123",
+              "title": "Introduction to Painting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "211",
+              "title": "Intermediate Watercolor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Intermediate Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Introduction to Ceramics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Intermediate Ceramics: Handbuilding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Intermediate Ceramics: Wheel Throwing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "211",
+              "title": "Intermediate Watercolor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Intermediate Painting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Introduction to Ceramics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Intermediate Ceramics: Handbuilding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Intermediate Ceramics: Wheel Throwing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Introduction to Ceramics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107D",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Introduction to Digital Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "207D",
+              "title": "Intermediate Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Intermediate Ceramics: Handbuilding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Intermediate Ceramics: Wheel Throwing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Introduction to Ceramics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107D",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Introduction to Digital Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "207D",
+              "title": "Intermediate Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Intermediate Ceramics: Handbuilding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Intermediate Ceramics: Wheel Throwing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Medical Assisting: Certificate of Achievement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/medical-assisting/medical-assisting-certificate-of-achievement",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Spring (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "140",
+              "title": "Introduction to Human Body Systems and Related Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "140",
+              "title": "Introduction to Human Body Systems and Related Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Prehistory of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 2)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEDA",
+              "number": "105",
+              "title": "Introduction to Medical Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "120",
+              "title": "Clinical Medical Assisting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "120L",
+              "title": "Clinical Medical Assisting I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "143",
+              "title": "Administrative Medical Assisting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "143L",
+              "title": "Administrative Medical Assisting I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "150",
+              "title": "Medical Assisting Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "176",
+              "title": "Administration of Medications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "176L",
+              "title": "Administration of Medications Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 3)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEDA",
+              "number": "123",
+              "title": "Clinical Medical Assisting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "123L",
+              "title": "Clinical Medical Assisting II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "165",
+              "title": "Administrative Medical Assisting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "201",
+              "title": "Medical Law and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "205",
+              "title": "Medical Assisting Certification Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "220",
+              "title": "Medical Assisting Preceptorship",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics: Academic Subject Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/liberal-arts/mathematics-academic-subject-certificate",
+      "total_credits": 149,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "STEM COLLEGE-READY SEQUENCE",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140X",
+              "title": "PreCalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CALCULUS-READY SEQUENCE (OPTION 1)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "243",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "244",
+              "title": "Calculus IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CALCULUS-READY SEQUENCE (OPTION 2)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "245",
+              "title": "Multivariable Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "111",
+              "title": "Math for Elementary Teachers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Math for Elementary Teachers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140X",
+              "title": "PreCalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "243",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "244",
+              "title": "Calculus IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "245",
+              "title": "Multivariable Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "111",
+              "title": "Math for Elementary Teachers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Math for Elementary Teachers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140X",
+              "title": "PreCalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "243",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "244",
+              "title": "Calculus IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "245",
+              "title": "Multivariable Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "NON-STEM EXPLORATION SEQUENCE",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140X",
+              "title": "PreCalculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ELEMENTARY EDUCATOR SPECIALIZATION SEQUENCE",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "111",
+              "title": "Math for Elementary Teachers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Math for Elementary Teachers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Introduction to Statistics and Probability",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Natural Science: Associate in Science Degree (Biological Sciences)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/natural-science/natural-science-associate-in-science-degree-biological-sciences",
+      "total_credits": 59,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "170",
+              "title": "STEMinar: Science, Technology, Engineering, and Mathematics Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "162",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "162L",
+              "title": "General Chemistry II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "171",
+              "title": "Introduction to Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "171L",
+              "title": "Introduction to Biology Laboratory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "170",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "151L",
+              "title": "College Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "170L",
+              "title": "General Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "170",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "151L",
+              "title": "College Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "170L",
+              "title": "General Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "172",
+              "title": "Introduction to Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172L",
+              "title": "Introduction to Biology Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "272",
+              "title": "General Physics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "152L",
+              "title": "College Physics II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "272L",
+              "title": "General Physics II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "272",
+              "title": "General Physics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "152L",
+              "title": "College Physics II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "272L",
+              "title": "General Physics II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing: Associate in Science Degree (Registered Nursing)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/nursing/nursing-associate-in-science-degree-registered-nursing",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1): Pre-admission",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "130",
+              "title": "General Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "141L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2): Pre-admission",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HDFS",
+              "number": "230",
+              "title": "Human Devlopment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "142L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "210",
+              "title": "Health Promotion Across the Lifespan",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "211",
+              "title": "Professionalism in Nursing I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "203",
+              "title": "General Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Health and Illness I",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Session (Semester 5)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "230",
+              "title": "Clinical Immersion I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 6)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "320",
+              "title": "Health and Illness II",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 7)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "360",
+              "title": "Health and Illness III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "362",
+              "title": "Professionalism in Nursing II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Natural Science: Associate in Science Degree (Engineering)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/natural-science/natural-science-associate-in-science-degree-engineering",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "170",
+              "title": "STEMinar: Science, Technology, Engineering, and Mathematics Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "162",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "170",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "170L",
+              "title": "General Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "245",
+              "title": "Multivariable Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "243",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "244",
+              "title": "Calculus IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Option 1 (4 credits)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "245",
+              "title": "Multivariable Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Option 2 (6 credits)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "243",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "244",
+              "title": "Calculus IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "272",
+              "title": "General Physics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "272L",
+              "title": "General Physics II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Nurse Aide: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/nurse-aide/nurse-aide-certificate-of-competence",
+      "total_credits": 5,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FALL (Semester 1)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "100",
+              "title": "Certified Nurse Aide",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "100L",
+              "title": "Certified Nurse Aide Clinical Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Natural Science: Associate in Science Degree (Physical Sciences)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/natural-science/natural-science-associate-in-science-degree-physical-sciences",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "241",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "170",
+              "title": "STEMinar: Science, Technology, Engineering, and Mathematics Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "162",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "242",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "162L",
+              "title": "General Chemistry II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "162L",
+              "title": "General Chemistry II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "111",
+              "title": "Introduction to Computer Science I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "170",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "170L",
+              "title": "General Physics I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "272",
+              "title": "General Physics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "272L",
+              "title": "General Physics II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing: Certificate of Achievement (Practical Nursing)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/nursing/nursing-certificate-of-achievement-practical-nursing",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1): Pre-admission",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "130",
+              "title": "General Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "141L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2): Pre-admission",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HDFS",
+              "number": "230",
+              "title": "Human Devlopment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "142L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall (Semester 3)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "210",
+              "title": "Health Promotion Across the Lifespan",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "211",
+              "title": "Professionalism in Nursing I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 4)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "203",
+              "title": "General Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Health and Illness I",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Session (Semester 5)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "230",
+              "title": "Clinical Immersion I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Plant Biology and Tropical Agriculture: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/plant-biology-and-tropical-agriculture/plant-biology-and-tropical-agriculture-certificate-of",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "122",
+              "title": "Soil Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "200",
+              "title": "Principles of Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "200L",
+              "title": "Principles of Horticulture Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "141",
+              "title": "Integrated Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Public Health: Certificate of Competence",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.kauai.hawaii.edu/public-health/public-health-certificate-of-competence",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall (Semester 1)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PH",
+              "number": "201",
+              "title": "Introduction to Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring (Semester 2)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PH",
+              "number": "202",
+              "title": "Public Health Issues in Hawaiʻi",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "203",
+              "title": "Introduction to Global Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/hi/programs/windward-community-college.json
+++ b/data/hi/programs/windward-community-college.json
@@ -1,0 +1,3282 @@
+{
+  "college_slug": "windward-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.windward.hawaii.edu/degrees",
+  "scraped_at": "2026-06-06T17:55:34.354Z",
+  "programs": [
+    {
+      "title": "Agripharmatech",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/agriculture/agripharmatech",
+      "total_credits": 77,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (11 credits)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "100",
+              "title": "Survey of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "130",
+              "title": "General Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "140L",
+              "title": "General Microbiology Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ethnopharmacognosy and Plant Biotechnology Required Courses (6–7 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "152",
+              "title": "Orchid Culture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Limu Culture Track: Required Courses (7 credits)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "111",
+              "title": "Introduction to Algae",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110",
+              "title": "Introduction to Algae Cultivation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110L",
+              "title": "Introduction to Algae Cultivation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ethnopharmacognosy Track: Electives (8-9 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "149",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110",
+              "title": "Introduction to Algae Cultivation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110L",
+              "title": "Introduction to Algae Cultivation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "111",
+              "title": "Introduction to Algae",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "192V",
+              "title": "Special Topics in Plant Science",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "122",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSHN",
+              "number": "185",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Plant Biotechnology Track: Electives (8-9 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AQUA",
+              "number": "110",
+              "title": "Introduction to Algae Cultivation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110L",
+              "title": "Introduction to Algae Cultivation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "111",
+              "title": "Introduction to Algae",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "192V",
+              "title": "Special Topics in Plant Science",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "122",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Limu Culture Track: Electives (8-9 Credits)",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AQUA",
+              "number": "106",
+              "title": "Small Scale Aquaculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "106L",
+              "title": "Small Scale Aquaculture Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "The Hawai‘i Fishpond",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201L",
+              "title": "The Hawai‘i Fishpond Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "171",
+              "title": "Farm Renewable Energy Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "120",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "170",
+              "title": "Introduction to Aquaponics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "192V",
+              "title": "Special Topics in Agriculture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "202",
+              "title": "Agriculture, Environment, and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "202L",
+              "title": "Agriculture, Environment, and Society Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "The Ahupua‘a",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "122B",
+              "title": "Introduction to Entrepreneurship: Sustainable Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "161L",
+              "title": "General Chemistry I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Assisting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/animal-sciences/veterinary-assisting",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (31 credits)",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANSC",
+              "number": "140",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "142",
+              "title": "Anatomy and Physiology of Domestic Animals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "142L",
+              "title": "Anatomy of Domestic Animals Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "151",
+              "title": "Clinical Laboratory Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "151L",
+              "title": "Clinical Laboratory Techniques Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "153",
+              "title": "Companion Animal Nursing and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "153L",
+              "title": "Companion Animal Nursing Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "191",
+              "title": "Veterinary Office and Computer Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "125",
+              "title": "Survey of Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sustainable Agriculture",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/agriculture/sustainable-agriculture",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "120",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "170",
+              "title": "Introduction to Aquaponics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "192V",
+              "title": "Special Topics in Agriculture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "202",
+              "title": "Agriculture, Environment, and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "122B",
+              "title": "Introduction to Entrepreneurship: Sustainable Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "The Ahupua‘a",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Science in Veterinary Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/animal-sciences/associate-in-science-in-veterinary-technology",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Year One: General Education and Preparatory Classes (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Veterinary Assisting Core Classes (22 credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANSC",
+              "number": "140",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "142",
+              "title": "Anatomy and Physiology of Domestic Animals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "142L",
+              "title": "Anatomy of Domestic Animals Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "151",
+              "title": "Clinical Laboratory Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "151L",
+              "title": "Clinical Laboratory Techniques Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "153",
+              "title": "Companion Animal Nursing and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "153L",
+              "title": "Companion Animal Nursing Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "191",
+              "title": "Veterinary Office and Computer Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "125",
+              "title": "Survey of Medical Terminology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Year Two: Veterinary Technology Core Classes (39 credits)",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANSC",
+              "number": "152",
+              "title": "Companion Animal Diseases and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "190",
+              "title": "Veterinary Clinical Practices and Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "252",
+              "title": "Diagnostic Imaging for Veterinary Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "252L",
+              "title": "Diagnostic Imaging for Veterinary Technicians Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "253",
+              "title": "Applied Pharmacology for Veterinary Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "258",
+              "title": "Clinical Laboratory Techniques II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "258L",
+              "title": "Clinical Laboratory Techniques II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "261",
+              "title": "Anesthesiology and Dentistry for Veterinary Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "261L",
+              "title": "Anesthesiology and Veterinary Dentistry for Veterinary Technicians Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "262",
+              "title": "Clinical Procedures for Large Animals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "262L",
+              "title": "Clinical Procedures for Large Animals Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "263",
+              "title": "Exotic and Laboratory Animal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "263L",
+              "title": "Exotic and Laboratory Animal Procedures Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "266",
+              "title": "Veterinary Clinical Practices & Internship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "271",
+              "title": "Anesthesiology and Surgical Nursing for Veterinary Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "271L",
+              "title": "Anesthesiology and Surgical Nursing for Veterinary Technicians Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANSC",
+              "number": "290",
+              "title": "Veterinary Technician Exam Review",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Limu Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/agriculture/limu-studies",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "111",
+              "title": "Introduction to Algae",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110",
+              "title": "Introduction to Algae Cultivation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plant Food Production and Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/agriculture/plant-food-production-and-technology",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses: Minimum 9 credits",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "120",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "149",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "152",
+              "title": "Orchid Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOC",
+              "number": "106",
+              "title": "Ono Cooking and Food Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "111",
+              "title": "Introduction to Algae",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "160",
+              "title": "Identification of Tropical Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "192V",
+              "title": "Special Topics in Plant Science",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "199",
+              "title": "Independent Study",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSHN",
+              "number": "185",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/business/business",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "130",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "131",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "209",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "101",
+              "title": "Digital Tools for the Information World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hawaiian Knowledge Innovation",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/hawaiian-studies/hawaiian-knowledge-innovation",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "107",
+              "title": "Web Site Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "295A",
+              "title": "Hawaiian Knowledge Innovation Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area A: Hawaiian Studies Elective Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "110",
+              "title": "Huakaʻi Waʻa: Introduction to Hawaiian Voyaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "135",
+              "title": "Kālai Lā‘au: Hawaiian Woodwork and Wood Carving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I: Hawaiian Taro Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "222",
+              "title": "Ma‘awe No‘eau: Hawaiian Fiber Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "285",
+              "title": "Lā‘au Lapa‘au I: Hawaiian Medicinal Herbs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "The Ahupua‘a",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area B: Information and Computer Science Elective Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "122",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "209",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "119",
+              "title": "Introduction to Social Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "123",
+              "title": "Introduction to Digital Audio and Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "203",
+              "title": "Digital Image Editing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts in Hawaiian Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/hawaiian-studies/associate-in-arts-in-hawaiian-studies",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Graduation Requirements: Hawaiian Studies Requirements",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Foundation Requirements: Written Communication (FW)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art: Drawing and Painting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/art/art-drawing-and-painting",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Introduction to Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Introduction to Color",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Introduction to 2D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "123",
+              "title": "Introduction to Oil Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "213",
+              "title": "Intermediate Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Introduction to Life Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Hawaiian Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/hawaiian-studies/hawaiian-studies",
+      "total_credits": 59,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Ke Kahua - Core Courses (11 credits)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "‘Ōlelo Hawai‘i (Hawaiian Language) Concentration (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mo‘olelo Hawai‘i (Hawaiian History and Traditions) (Any 9 credits from list below)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "110",
+              "title": "Huakaʻi Waʻa: Introduction to Hawaiian Voyaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "115",
+              "title": "Mo‘okūauhau: Hawaiian Genealogies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "215",
+              "title": "Oli Hōlona: Beginning Hawaiian Protocol and Chant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "217",
+              "title": "Understanding Polynesian Religions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "253",
+              "title": "Kamehameha I and the Hawaiian Kingdom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "255",
+              "title": "Introduction to the Hawaiian Kingdom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "263",
+              "title": "Hawaiian and Indigenous Film & Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "180",
+              "title": "Introduction to Hawaiian Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "217",
+              "title": "Understanding Polynesian Religions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Performing Arts (Any 9 credits from list below)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HWST",
+              "number": "130",
+              "title": "Hula ‘Ōlapa: Traditional Hawaiian Dance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "131",
+              "title": "Hula Ōlapa ‘elua: Traditional Hawaiian Dance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "215",
+              "title": "Oli Hōlona: Beginning Hawaiian Protocol and Chant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121F",
+              "title": "Slack Key Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121H",
+              "title": "Hawaiian Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121Z",
+              "title": "‘Ukulele 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122F",
+              "title": "Slack Key Guitar 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122H",
+              "title": "Hawaiian Singing 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122Z",
+              "title": "‘Ukulele 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "130F",
+              "title": "Slack Key Guitar Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "177",
+              "title": "Intro to Hawaiian Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Intro to Hawaiian Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Visual Art and Design (Any 9 credits from list below)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Introduction to Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "135",
+              "title": "Kālai Lā‘au: Hawaiian Woodwork and Wood Carving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "136",
+              "title": "Kālai Lā‘au II: Advanced Techniques in Hawaiian Carving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "222",
+              "title": "Ma‘awe No‘eau: Hawaiian Fiber Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "263",
+              "title": "Hawaiian and Indigenous Film & Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "273",
+              "title": "Tattoo Traditions of Polynesia",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ahupua‘a (Hawaiian Land and Ocean Systems) (Any 9 credits from list below)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "175",
+              "title": "Polynesian Surf Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "The Hawai‘i Fishpond",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "200",
+              "title": "Coral Reefs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "205",
+              "title": "Ethnobotanical Pharmacognosy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "103",
+              "title": "Geology of Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "110",
+              "title": "Huakaʻi Waʻa: Introduction to Hawaiian Voyaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I: Hawaiian Taro Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "142",
+              "title": "Mahi‘ai Kalo II - Traditional and Modern Techniques of Lo‘i Kalo Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "275",
+              "title": "Wahi Pana: Mythology of the Hawaiian Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "285",
+              "title": "Lā‘au Lapa‘au I: Hawaiian Medicinal Herbs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "The Ahupua‘a",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "210",
+              "title": "Polynesian Voyaging: Seamanship and Stewardship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Use of Fish and Aquatic Invertebrates",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives (5–6 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "175",
+              "title": "Polynesian Surf Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "175L",
+              "title": "Surf Culture Field Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110",
+              "title": "Introduction to Algae Cultivation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "110L",
+              "title": "Introduction to Algae Cultivation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "The Hawai‘i Fishpond",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201L",
+              "title": "The Hawai‘i Fishpond Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Introduction to Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "110",
+              "title": "Survey of Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "200",
+              "title": "Coral Reefs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130L",
+              "title": "Plants in the Hawaiian Environment Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "103",
+              "title": "Geology of Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "210",
+              "title": "O‘ahu Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "211",
+              "title": "Big Island Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "212",
+              "title": "Maui Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "213",
+              "title": "Moloka‘i, Lana‘i, and Kaho‘olawe Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "214",
+              "title": "Kaua‘i and Ni‘ihau Field Geology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "110",
+              "title": "Huakaʻi Waʻa: Introduction to Hawaiian Voyaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "115",
+              "title": "Mo‘okūauhau: Hawaiian Genealogies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "130",
+              "title": "Hula ‘Ōlapa: Traditional Hawaiian Dance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "131",
+              "title": "Hula Ōlapa ‘elua: Traditional Hawaiian Dance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "135",
+              "title": "Kālai Lā‘au: Hawaiian Woodwork and Wood Carving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "136",
+              "title": "Kālai Lā‘au II: Advanced Techniques in Hawaiian Carving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I: Hawaiian Taro Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "142",
+              "title": "Mahi‘ai Kalo II - Traditional and Modern Techniques of Lo‘i Kalo Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "215",
+              "title": "Oli Hōlona: Beginning Hawaiian Protocol and Chant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "217",
+              "title": "Understanding Polynesian Religions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "222",
+              "title": "Ma‘awe No‘eau: Hawaiian Fiber Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "253",
+              "title": "Kamehameha I and the Hawaiian Kingdom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "255",
+              "title": "Introduction to the Hawaiian Kingdom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "263",
+              "title": "Hawaiian and Indigenous Film & Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "270",
+              "title": "Hawaiian Mythology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "273",
+              "title": "Tattoo Traditions of Polynesia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "275",
+              "title": "Wahi Pana: Mythology of the Hawaiian Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "285",
+              "title": "Lā‘au Lapa‘au I: Hawaiian Medicinal Herbs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "296",
+              "title": "Special Topics in Hawaiian Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "284",
+              "title": "History of Hawai‘i",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "The Ahupua‘a",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121F",
+              "title": "Slack Key Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121H",
+              "title": "Hawaiian Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121Z",
+              "title": "‘Ukulele 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122F",
+              "title": "Slack Key Guitar 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122H",
+              "title": "Hawaiian Singing 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122Z",
+              "title": "‘Ukulele 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "130F",
+              "title": "Slack Key Guitar Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "177",
+              "title": "Intro to Hawaiian Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Intro to Hawaiian Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "201",
+              "title": "Science of the Sea",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "260",
+              "title": "Pacific Surf Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "260L",
+              "title": "O‘ahu Surf Science and Technology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PACS",
+              "number": "108",
+              "title": "Pacific Worlds: an Introduction to Pacific Islands Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "180",
+              "title": "Introduction to Hawaiian Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "205",
+              "title": "Understanding Hawaiian Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "217",
+              "title": "Understanding Polynesian Religions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "210",
+              "title": "Polynesian Voyaging: Seamanship and Stewardship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "210L",
+              "title": "Polynesian Voyaging: Seamanship and Stewardship Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Use of Fish and Aquatic Invertebrates",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Security Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/information-and-computer-sciences/information-security-specialist",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "171",
+              "title": "Introduction to Computer Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "184",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "281",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "282",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Support",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/information-and-computer-sciences/web-support",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Course",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "107",
+              "title": "Web Site Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives (6 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICS",
+              "number": "119",
+              "title": "Introduction to Social Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "123",
+              "title": "Introduction to Digital Audio and Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "203",
+              "title": "Digital Image Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICS",
+              "number": "207",
+              "title": "Building Web Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Creative Writing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/english/creative-writing",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "204A",
+              "title": "Introduction to Creative Writing (Fiction)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204B",
+              "title": "Introduction to Creative Writing (Poetry)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204C",
+              "title": "Introduction to Creative Writing (Screenwriting)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "204C",
+              "title": "Introduction to Creative Writing (Screenwriting)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204D",
+              "title": "Introduction to Creative Writing: Creative Nonfiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Introduction to Literature: Genre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Introduction to Literature: Culture and Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "280",
+              "title": "Book Production: Pueo Literary and Art Journal",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CM",
+              "number": "280",
+              "title": "Book Production: Pueo Literary and Art Journal",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ahupuaʻa Systems: Indigenous Resource Management & Food Production",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/natural-sciences/ahupuaa-systems-indigenous-resource-management-food-production",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6-7 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IS",
+              "number": "201",
+              "title": "The Ahupua‘a",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses for Area of Emphasis: Natural Resources",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AG",
+              "number": "120",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AG",
+              "number": "202",
+              "title": "Agriculture, Environment, and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "210",
+              "title": "Archaeology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "The Hawai‘i Fishpond",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201L",
+              "title": "The Hawai‘i Fishpond Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "200",
+              "title": "Coral Reefs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "105",
+              "title": "Ethnobotany",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "130",
+              "title": "Plants in the Hawaiian Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ERTH",
+              "number": "103",
+              "title": "Geology of Hawaiian Islands",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "The Natural Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "107",
+              "title": "Hawai‘i: Center of the Pacific",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "140",
+              "title": "Mahi‘ai I: Hawaiian Taro Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "155L",
+              "title": "Nā Limu Hawaiʻi: Hawaiian Seaweeds and their Uses Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "275",
+              "title": "Wahi Pana: Mythology of the Hawaiian Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "102",
+              "title": "Introduction to the Environment and Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCN",
+              "number": "120",
+              "title": "Global Environmental Challenges",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses for Area of Emphasis: Cultural Practice",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "201",
+              "title": "Intermediate Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAW",
+              "number": "202",
+              "title": "Intermediate Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "110",
+              "title": "Huakaʻi Waʻa: Introduction to Hawaiian Voyaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "135",
+              "title": "Kālai Lā‘au: Hawaiian Woodwork and Wood Carving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "222",
+              "title": "Ma‘awe No‘eau: Hawaiian Fiber Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "285",
+              "title": "Lā‘au Lapa‘au I: Hawaiian Medicinal Herbs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "105",
+              "title": "Hawaiian Use of Fish and Aquatic Invertebrates",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hawaiian Music",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/music/hawaiian-music",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "101",
+              "title": "Elementary Hawaiian I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "108",
+              "title": "Music Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "177",
+              "title": "Intro to Hawaiian Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Intro to Hawaiian Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Intro to Hawaiian Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAW",
+              "number": "102",
+              "title": "Elementary Hawaiian II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "130",
+              "title": "Hula ‘Ōlapa: Traditional Hawaiian Dance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HWST",
+              "number": "131",
+              "title": "Hula Ōlapa ‘elua: Traditional Hawaiian Dance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "College Chorus",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121B",
+              "title": "Voice 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121C",
+              "title": "Piano 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121D",
+              "title": "Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121F",
+              "title": "Slack Key Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121G",
+              "title": "Hawaiian Steel Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121Z",
+              "title": "‘Ukulele 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122B",
+              "title": "Voice 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122C",
+              "title": "Piano 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122F",
+              "title": "Slack Key Guitar 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122Z",
+              "title": "‘Ukulele 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "140",
+              "title": "Introduction to Audio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "166",
+              "title": "Popular Music in America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "212",
+              "title": "Polynesian Music",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221C",
+              "title": "Piano 3",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222C",
+              "title": "Piano 4",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231B",
+              "title": "Applied Music, Western (Voice)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231C",
+              "title": "Applied Music, Western (Piano)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Introduction to Digital Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "241",
+              "title": "Digital Music Production II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "253",
+              "title": "Elementary Music in Action",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "277",
+              "title": "Mele, Mo‘olelo, and Motion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "296",
+              "title": "Special Topics in Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music: General",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/music/music-general",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "108",
+              "title": "Music Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (2 credits)",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "106",
+              "title": "Intro to Music Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "College Chorus",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121B",
+              "title": "Voice 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121D",
+              "title": "Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121F",
+              "title": "Slack Key Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121G",
+              "title": "Hawaiian Steel Guitar 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121H",
+              "title": "Hawaiian Singing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121Z",
+              "title": "‘Ukulele 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122B",
+              "title": "Voice 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122C",
+              "title": "Piano 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122F",
+              "title": "Slack Key Guitar 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122H",
+              "title": "Hawaiian Singing 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122Z",
+              "title": "‘Ukulele 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "140",
+              "title": "Introduction to Audio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "166",
+              "title": "Popular Music in America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "177",
+              "title": "Intro to Hawaiian Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Intro to Hawaiian Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "212",
+              "title": "Polynesian Music",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221C",
+              "title": "Piano 3",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222C",
+              "title": "Piano 4",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231B",
+              "title": "Applied Music, Western (Voice)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231C",
+              "title": "Applied Music, Western (Piano)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231F",
+              "title": "Applied Music, Western (Slack Key Guitar)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231Z",
+              "title": "Applied Music, Western (‘Ukulele)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Introduction to Digital Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "241",
+              "title": "Digital Music Production II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "253",
+              "title": "Elementary Music in Action",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "277",
+              "title": "Mele, Mo‘olelo, and Motion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "296",
+              "title": "Special Topics in Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mental Health Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/psychology/mental-health-technician",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "253",
+              "title": "Conflict Resolution & Mediation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "170",
+              "title": "Psychology of Adjustment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "224",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Introduction to Clinical Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Foundation in Acting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/theatre/foundation-in-acting",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (Total Credits: 29)",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Introduction to Drama and Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "133",
+              "title": "Stage Combat Workshop Level I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "220",
+              "title": "Beginning Voice and Movement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "221",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "222",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "225",
+              "title": "Shakespeare Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "251",
+              "title": "Applied Theatre",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "251",
+              "title": "Applied Theatre",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "252",
+              "title": "Professional Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "260",
+              "title": "Dramatic Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Development & Family Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/social-sciences/human-development-family-studies",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (Total Credits: 6)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HDFS",
+              "number": "230",
+              "title": "Human Development and Family Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "251",
+              "title": "Introduction to Sociology of the Family",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (6 credits from the following elective courses)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HDFS",
+              "number": "231",
+              "title": "Infancy and Early Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HDFS",
+              "number": "232",
+              "title": "Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HDFS",
+              "number": "241",
+              "title": "Parenting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mental Health Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/psychology/mental-health-technician-0",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (30 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "123",
+              "title": "Introduction to Clinical Skills and Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYL",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HDFS",
+              "number": "230",
+              "title": "Human Development and Family Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "224",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "253",
+              "title": "Conflict Resolution & Mediation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Introduction to Clinical Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psycho-Social Developmental Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.windward.hawaii.edu/psychology/psychosocial-developmental-studies",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Survey of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "224",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Survey of General Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "251",
+              "title": "Introduction to Sociology of the Family",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/hi/config.ts
+++ b/lib/states/hi/config.ts
@@ -80,7 +80,20 @@ const hiConfig: StateConfig = {
     // Prereqs aggregated from course-search prerequisite_text (data/hi/prereqs.json,
     // 418 parsed chains). No dedicated catalog scraper; refreshed from committed courses.
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: programs — Phase 5+.
+    // Programs: Kauai + Windward CC publish Clean Catalog (catalog.<campus>.hawaii.edu).
+    // The other 4 UH CCs are platform ceilings — see documentedCeilings.programs.
+    programs: [{ scripts: ["scripts/hi/scrape-programs.ts"], runner: "http" }],
+  },
+
+  documentedCeilings: {
+    // Programs reach 2 of 6 colleges: only Kauai CC and Windward CC publish a
+    // scrapeable online catalog (Clean Catalog, 98 programs — shipped). The other
+    // four have no public program source (verified 2026-06): Hawaii CC and Leeward
+    // CC run Kuali whose program/group API is auth-gated (401; only the catalog
+    // list is public); Honolulu CC is a bespoke WordPress catalog; Kapiolani CC
+    // publishes degree requirements as PDFs only.
+    programs:
+      "Only Kauai CC and Windward CC publish a scrapeable online catalog (Clean Catalog, 98 programs — shipped). Hawaii CC + Leeward CC run Kuali with an auth-gated program API (public catalog list only); Honolulu CC is bespoke WordPress; Kapiolani CC is PDF-only. No public program source for those four. Verified 2026-06.",
   },
 };
 

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -64,7 +64,19 @@ const meConfig: StateConfig = {
     courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
     transfers: [{ scripts: ["scripts/me/scrape-transfer-mainestreet.ts"], runner: "playwright" }],
     prereqs: [{ scripts: ["scripts/me/scrape-catalog-prereqs.ts"], runner: "http" }],
-    // manual-only: programs — Acalog program scraper not yet wired up for this state.
+    // manual-only: programs — all 7 MCCS colleges publish catalogs as PDF/DOCX
+    // only (no Acalog/Coursedog/CourseLeaf/etc.); see documentedCeilings.programs.
+  },
+
+  documentedCeilings: {
+    // No programs: all 7 Maine CC System colleges (cmcc/emcc/kvcc/nmcc/smcc/wccc/
+    // yccc) publish their catalog as PDF or DOCX behind WordPress (verified
+    // 2026-06). The programs-of-study web pages are marketing prose with no course
+    // codes; requirements live only inside the PDF/DOCX. No supported catalog
+    // platform is present, so the degree-path planner is data-limited here pending
+    // a PDF-extraction approach.
+    programs:
+      "All 7 Maine CC System colleges publish catalogs as PDF/DOCX behind WordPress (no Acalog/Coursedog/CourseLeaf/SmartCatalogIQ/CleanCatalog). Program requirements exist only inside the PDFs/DOCX; the web program pages carry no course codes. Planner is data-limited pending PDF extraction. Verified 2026-06.",
   },
 };
 

--- a/scripts/hi/scrape-programs.ts
+++ b/scripts/hi/scrape-programs.ts
@@ -1,0 +1,73 @@
+/**
+ * scrape-programs.ts — degree/program requirements for Hawaii community colleges.
+ *
+ * Of UH's 6 community colleges, only two publish a scrapeable online catalog:
+ * Kauai CC and Windward CC both run Clean Catalog (catalog.<campus>.hawaii.edu).
+ * The other four are platform ceilings (see lib/states/hi/config.ts
+ * documentedCeilings.programs): Hawaii CC and Leeward CC use Kuali whose
+ * program/group API is auth-gated (only the catalog list is public), Honolulu CC
+ * is a bespoke WordPress catalog, and Kapiolani CC publishes PDFs only.
+ *
+ * Usage:
+ *   npx tsx scripts/hi/scrape-programs.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { scrapeCleanCatalogPrograms } from "../lib/scrape-cleancatalog-programs.js";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { CleanCatalogProgramConfig } from "../lib/scrape-cleancatalog-programs.js";
+
+const COLLEGES: CleanCatalogProgramConfig[] = [
+  {
+    collegeSlug: "kauai-community-college",
+    baseUrl: "https://catalog.kauai.hawaii.edu",
+    indexPaths: ["/degrees-and-certificates"],
+    catalogYear: "2026-2027",
+  },
+  {
+    collegeSlug: "windward-community-college",
+    baseUrl: "https://catalog.windward.hawaii.edu",
+    indexPaths: ["/degrees"],
+    catalogYear: "2025-2026",
+  },
+];
+
+async function main() {
+  const outDir = path.join(process.cwd(), "data", "hi", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`HI program scraper — ${COLLEGES.length} college(s)\n`);
+  let totalPrograms = 0;
+
+  for (const config of COLLEGES) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Scraping ${config.collegeSlug} (${config.baseUrl})`);
+    console.log("=".repeat(60));
+
+    try {
+      const data = await scrapeCleanCatalogPrograms(config);
+      if (data.programs.length === 0) {
+        console.log(`  No programs found for ${config.collegeSlug}, skipping.`);
+        continue;
+      }
+      const { matched, unmatched } = applyProgramMatching(data.programs);
+      console.log(`  Matcher: ${matched} matched, ${unmatched} unmatched`);
+
+      const outPath = path.join(outDir, `${config.collegeSlug}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+      console.log(`  ✓ Wrote ${data.programs.length} programs to ${outPath}`);
+      totalPrograms += data.programs.length;
+    } catch (e) {
+      console.error(`  ERROR scraping ${config.collegeSlug}: ${e}`);
+    }
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`Done. Total: ${totalPrograms} programs.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Students at **Kauai Community College** and **Windward Community College** (Hawaii) now have a working **degree-path planner** — pick a major, get a term-by-term course plan. Before this, Hawaii had *zero* program data, so the planner was blank for every UH community college even though Hawaii already had full course and transfer data. Example: Kauai's **Accounting (AAS)** now renders all four semesters (ACC 124, ACC 255, ENG 100 … 127 total credits). This adds **98 programs** (Kauai 76, Windward 22), each with course-level requirements.

Stated plainly: this covers **2 of Hawaii's 6** community colleges and **0 of Maine's 7**. The rest don't publish a machine-readable catalog, so there's nothing to scrape without a new platform scraper or PDF parsing. Each one — and why — is recorded as a documented ceiling, so it's clear this is a platform limit, not an oversight.

## What landed
- **`scripts/hi/scrape-programs.ts`** — programs scraper reusing the existing CleanCatalog engine for Kauai (`catalog.kauai.hawaii.edu`) + Windward (`catalog.windward.hawaii.edu`). Wired into `StateConfig.scrapers.programs` for cron.
- **`data/hi/programs/{kauai,windward}-community-college.json`** — 98 programs with `requirement_groups` (term-by-term course lists), matched to registry program slugs. Filenames match `institutions.json` slugs (the planner join key — the bug that hid MS #964 / TN #966 programs).

## Documented ceilings — no public program source (verified 2026-06)
| College(s) | State | Catalog reality |
|---|---|---|
| Hawaii CC, Leeward CC | HI | **Kuali** — program/group API auth-gated (401); only the catalog list is public |
| Honolulu CC | HI | bespoke WordPress catalog (`/post/program/{code}/`) |
| Kapiolani CC | HI | PDF-only catalog |
| cmcc, emcc, kvcc, nmcc, smcc, wccc, yccc | ME | **PDF/DOCX behind WordPress** — web pages have no course codes; requirements live only in the PDFs |

Recorded in `lib/states/{hi,me}/config.ts` `documentedCeilings.programs`. Reaching these needs a Kuali scraper (public API doesn't expose programs) or a PDF-extraction pipeline — separate efforts (PDF catalog parsing has been unreliable in past attempts).

## Test plan
- `npx tsx scripts/hi/scrape-programs.ts` → Kauai 76 + Windward 22 = 98 programs, all with ≥1 course requirement; filenames == institutions slugs.
- `npm run dev` → `/hi/college/kauai-community-college/programs` lists 76; Accounting AAS detail renders the 4-semester plan; `/hi/programs` + Windward list render. (Planner reads file via Supabase→file fallback, so it works pre-import.)
- `tsc --noEmit` clean · `eslint` clean · `check:scrapers` passes (HI programs wired; ME `// manual-only` marker) · `check:config-data` OK · `npm run build` ✓ Compiled successfully.

**Post-merge:** the planner works immediately from the committed JSON (Supabase has no HI programs → file fallback). Cron also imports to Supabase on the next programs scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
