### PR TITLE
mi: document 14 course-coverage ceilings — courses C→B (uncovered colleges have no public section source)

### DIFF
--- a/lib/states/mi/config.ts
+++ b/lib/states/mi/config.ts
@@ -103,6 +103,31 @@ const miConfig: StateConfig = {
       },
     ],
   },
+
+  documentedCeilings: {
+    // Course-coverage ceilings — every uncovered MI college was fingerprinted +
+    // probed (2026-06-06); none of these 14 expose public live class-schedule
+    // (section) data to scrape, so they're excluded from the coverage denominator.
+    // alpena is deliberately NOT here: its Colleague host (acc-ss.colleague.
+    // elluciancloud.com) responds 200 but the scraper finds 0 sections — a
+    // term-selector bug to debug (a deferred buildable), not a ceiling.
+    courses: [
+      { collegeSlug: "bay-de-noc-community-college", reason: "Jenzabar JICS — guest course-search disabled (verified 2026-05-28)" },
+      { collegeSlug: "gogebic-community-college", reason: "Jenzabar JICS — SAML auto-redirect, no guest access (verified 2026-05-28)" },
+      { collegeSlug: "kirtland-community-college", reason: "Jenzabar JICS — SAML auto-redirect, no guest access (verified 2026-05-28)" },
+      { collegeSlug: "keweenaw-bay-ojibwa-community-college", reason: "Jenzabar JICS — guest course-search disabled (tribal college, verified 2026-05-28)" },
+      { collegeSlug: "grand-rapids-community-college", reason: "Banner SSB 9 — section API redirects to login (0 sections, verified 2026-06)" },
+      { collegeSlug: "west-shore-community-college", reason: "Banner SSB 9 — section API behind CAPTCHA (0 sections, verified 2026-06)" },
+      { collegeSlug: "northwestern-michigan-college", reason: "Course search auth-gated; no public section endpoint (verified 2026-06)" },
+      { collegeSlug: "wayne-county-community-college-district", reason: "Acalog catalog only — no public live class schedule (verified 2026-06)" },
+      { collegeSlug: "monroe-county-community-college", reason: "Acalog catalog only — no public live class schedule (verified 2026-06)" },
+      { collegeSlug: "henry-ford-college", reason: "Coursedog catalog only (catalog.hfcc.edu) — no public live section data (verified 2026-06)" },
+      { collegeSlug: "lake-michigan-college", reason: "Coursedog catalog only — no public live section data (verified 2026-06)" },
+      { collegeSlug: "kalamazoo-valley-community-college", reason: "Custom site; no public Banner/Colleague section endpoint found (verified 2026-06)" },
+      { collegeSlug: "bay-mills-community-college", reason: "Tribal college — no public SIS / section search (verified 2026-06)" },
+      { collegeSlug: "saginaw-chippewa-tribal-college", reason: "Tribal college — no public SIS / section search (verified 2026-06)" },
+    ],
+  },
 };
 
 export default miConfig;


### PR DESCRIPTION
## What changes for someone using the site

**Nothing new renders** — this is a data-grade correction, not a feature, and it's important to be upfront about that. Michigan's course search already covers 16 of its 31 community colleges. This PR investigated the other 15 and found that **14 of them have no public class-schedule (section) data anyone can scrape** — they sit behind login walls, CAPTCHAs, or SAML, or publish only a static catalog with no live sections. Recording those 14 as documented ceilings makes the site's internal data-quality grade reflect Michigan's *reachable* coverage (16 of 17 reachable colleges = 94%) instead of penalizing it for colleges that physically can't be collected.

The honest headline: I could **not** add live sections for any uncovered Michigan college — every one is gated or catalog-only. So this lands the grade where it should be and records exactly why each college is unreachable, so no one re-investigates them from scratch.

## Grade impact
- MI **courses C → B** (52% raw → **94% effective** after excluding the 14 unreachable colleges from the denominator). Composite **C → B** (courses was MI's only sub-A dimension).
- B is MI's true ceiling for now: the 16 covered colleges' data also carries 14 collector-flagged "suspicious" term codes (a separate, pre-existing format issue) that independently caps courses at B — so even scraping more colleges wouldn't reach A without a separate term-cleanup.

## What landed
One file: `lib/states/mi/config.ts` — adds `documentedCeilings.courses` (14 entries, each with a verified reason). **MI is the first state to use the per-college course-ceiling field** (`registry.ts:122`); the `/state-audit` collector drops these from the coverage denominator.

## The investigation (verified 2026-06-06)
Fingerprinted all 15 uncovered colleges (`scripts/lib/fingerprint-college.ts`) and probed each platform:

| Bucket | Colleges | Evidence |
|---|---|---|
| Jenzabar guest-disabled / SAML | bay-de-noc, gogebic, kirtland, keweenaw-bay-ojibwa | already documented in `scrape-jenzabar-webforms.ts` (only NCMC renders without auth) |
| Banner SSB 9 gated | grand-rapids, west-shore | **ran the scraper → 0 sections** (login redirect / CAPTCHA) |
| Catalog-only (no live sections) | henry-ford + lake-michigan (Coursedog), wayne-county + monroe-county (Acalog) | platform serves course descriptions, not class schedules |
| Auth-gated | northwestern-michigan | fingerprint: auth-gated |
| Custom / tribal, no public SIS | kalamazoo-valley, bay-mills, saginaw-chippewa | no Banner/Colleague subdomain responds; tribal colleges have no public SIS |

## Deferred (intentionally NOT ceiling'd)
**alpena-community-college** — its Colleague host `acc-ss.colleague.elluciancloud.com` responds 200, but `scrape-colleague.ts` extracts 0 sections (term-selector drift, the same pattern as nj/camden). Left open as a focused-debug buildable; fixing it is +1 covered but won't change the B grade (suspicious-term cap holds).

## Test plan
- `collect-audit-data.ts mi` → courses **B** (94%, 14 colleges exempted), composite **B**; `ceilingsApplied` lists the 14.
- `tsc --noEmit` clean · `check:scrapers` OK · `check:config-data` OK · `npm run build` ✓ Compiled successfully.
- Config-only: no data files or scrapers changed. (No dev render check — nothing new renders.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
