### PR TITLE
id: add programs for 3 of 4 Idaho colleges — unlock the Degree-Path Planner

### DIFF
--- a/data/id/programs/college-of-eastern-idaho.json
+++ b/data/id/programs/college-of-eastern-idaho.json
@@ -1,0 +1,7512 @@
+{
+  "college_slug": "college-of-eastern-idaho",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.cei.edu",
+  "scraped_at": "2026-06-07T00:48:38.795Z",
+  "programs": [
+    {
+      "title": "Automotive Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=486",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Manual Drive-Train",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "164",
+              "title": "&nbsp;-&nbsp;Introduction to Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "173",
+              "title": "&nbsp;-&nbsp;Automotive/Diesel Basic HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Auto/Diesel Technology Fundamentals &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Mechanical Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Workplace Technical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Automotive Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "103L",
+              "title": "&nbsp;-&nbsp;Automotive Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "203",
+              "title": "&nbsp;-&nbsp;Automotive II Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "203L",
+              "title": "&nbsp;-&nbsp;Automotive II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "204",
+              "title": "&nbsp;-&nbsp;Automotive III Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "204L",
+              "title": "&nbsp;-&nbsp;Automotive III Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM Any GEM elective course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Math in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology, ATC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=487",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Manual Drive-Train",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "164",
+              "title": "&nbsp;-&nbsp;Introduction to Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "173",
+              "title": "&nbsp;-&nbsp;Automotive/Diesel Basic HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Auto/Diesel Technology Fundamentals &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Mechanical Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Workplace Technical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Automotive Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "103L",
+              "title": "&nbsp;-&nbsp;Automotive Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "203",
+              "title": "&nbsp;-&nbsp;Automotive II Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "203L",
+              "title": "&nbsp;-&nbsp;Automotive II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "204",
+              "title": "&nbsp;-&nbsp;Automotive III Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "204L",
+              "title": "&nbsp;-&nbsp;Automotive III Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=488",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Manual Drive-Train",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "164",
+              "title": "&nbsp;-&nbsp;Introduction to Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "173",
+              "title": "&nbsp;-&nbsp;Automotive/Diesel Basic HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Auto/Diesel Technology Fundamentals &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Mechanical Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Workplace Technical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Automotive Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "103L",
+              "title": "&nbsp;-&nbsp;Automotive Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Bookkeeping, BTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=503",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "126",
+              "title": "&nbsp;-&nbsp;QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Accounting Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "&nbsp;-&nbsp;Business Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Business Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "&nbsp;-&nbsp;Current Topics in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=464",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "&nbsp;-&nbsp;Business Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Sales &amp; Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "255",
+              "title": "&nbsp;-&nbsp;Leadership Development Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Business Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 3 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "&nbsp;-&nbsp;Current Topics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Accounting Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "126",
+              "title": "&nbsp;-&nbsp;QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "216",
+              "title": "&nbsp;-&nbsp;Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "261",
+              "title": "&nbsp;-&nbsp;Legal Environments of Organizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "206",
+              "title": "&nbsp;-&nbsp;Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Entrepreneurship &amp; Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=465",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "122",
+              "title": "&nbsp;-&nbsp;Business Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Business Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose 6 Courses Below:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "255",
+              "title": "&nbsp;-&nbsp;Leadership Development Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "261",
+              "title": "&nbsp;-&nbsp;Legal Environments of Organizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any GEM 3 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 Any GEM 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "124",
+              "title": "&nbsp;-&nbsp;Current Topics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Accounting Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "126",
+              "title": "&nbsp;-&nbsp;QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "216",
+              "title": "&nbsp;-&nbsp;Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Sales &amp; Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=505",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 4 class and/or lab 3-4 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "216",
+              "title": "&nbsp;-&nbsp;Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Please check with the transfer advisor from the university for which you are transferring to choose the right course(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "261",
+              "title": "&nbsp;-&nbsp;Legal Environments of Organizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Business Elective Please check with the transfer advisor from the university to which yo are transferring to choose the right course(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Different GEM 4 Class and/or lab 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Business Elective Please check with the transfer advisor from the university to which yo are transferring to choose the right course(s).",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any non-ECON GEM 6 class 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Dental Assisting, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=468",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "121",
+              "title": "&nbsp;-&nbsp;Orientation to Dental Assisting and Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "124",
+              "title": "&nbsp;-&nbsp;Basic Dental Science &amp; Medical Situations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Dental Operatory Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "126",
+              "title": "&nbsp;-&nbsp;Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose from the following:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DTL",
+              "number": "129",
+              "title": "&nbsp;-&nbsp;Dental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DTL",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Dental Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "128",
+              "title": "&nbsp;-&nbsp;Dental Specialties",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "131",
+              "title": "&nbsp;-&nbsp;Dental Lab Materials &amp; Expanded Functions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTL",
+              "number": "132",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=504",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "&nbsp;-&nbsp;Introduction to Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "239",
+              "title": "&nbsp;-&nbsp;Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GEM 3: Choose One of the Following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GEM 6: Choose One of the Following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DH",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Intro to Dental Hygiene Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "101C",
+              "title": "&nbsp;-&nbsp;Dental Hygiene Clinic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "115L",
+              "title": "&nbsp;-&nbsp;Dental Radiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "122",
+              "title": "&nbsp;-&nbsp;Head and Neck Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "132",
+              "title": "&nbsp;-&nbsp;Dental Anatomy, Embryology and Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "145",
+              "title": "&nbsp;-&nbsp;Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "145L",
+              "title": "&nbsp;-&nbsp;Dental Materials Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DH",
+              "number": "151",
+              "title": "&nbsp;-&nbsp;Dental Hygiene theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "151C",
+              "title": "&nbsp;-&nbsp;Dental Hygiene Clinic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "175",
+              "title": "&nbsp;-&nbsp;Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "185",
+              "title": "&nbsp;-&nbsp;Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "190",
+              "title": "&nbsp;-&nbsp;Periodontology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DH",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Dental Hygiene Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "201C",
+              "title": "&nbsp;-&nbsp;Dental Hygiene Clinic III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "215",
+              "title": "&nbsp;-&nbsp;Local Anesthesia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "215L",
+              "title": "&nbsp;-&nbsp;Local Anesthesia Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "245",
+              "title": "&nbsp;-&nbsp;Periodontology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DH",
+              "number": "251",
+              "title": "&nbsp;-&nbsp;Dental Hygiene Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "251C",
+              "title": "&nbsp;-&nbsp;Dental Hygiene Clinic IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "270",
+              "title": "&nbsp;-&nbsp;Community Dental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "280",
+              "title": "&nbsp;-&nbsp;Practice Management and Board Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Forensics, BAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=528",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Junior Year Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "300",
+              "title": "&nbsp;-&nbsp;Intro to Digital Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "315",
+              "title": "&nbsp;-&nbsp;Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 4 with a lab 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Junior Year Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "305",
+              "title": "&nbsp;-&nbsp;Database Administration and Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "310",
+              "title": "&nbsp;-&nbsp;Data Analytics Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "320",
+              "title": "&nbsp;-&nbsp;Incident Planning and Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 4 (New prefix required) 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Senior Year Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "255",
+              "title": "&nbsp;-&nbsp;Leadership Development Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "400",
+              "title": "&nbsp;-&nbsp;Intro to Cyber Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "405",
+              "title": "&nbsp;-&nbsp;Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "415",
+              "title": "&nbsp;-&nbsp;Device Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "123",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Senior Year Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFA",
+              "number": "410",
+              "title": "&nbsp;-&nbsp;Forensics Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFA",
+              "number": "490",
+              "title": "&nbsp;-&nbsp;Forensics Analytics Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 5 (New prefix required) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Students who have already completed courses will not be required to retake them, but will be expected to complete an alternative course with approval. Students must complete the minimum 120 credit hours.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media Specialist, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=480",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "151",
+              "title": "&nbsp;-&nbsp;Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "151L",
+              "title": "&nbsp;-&nbsp;DMS Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "152",
+              "title": "&nbsp;-&nbsp;Web Authoring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "152L",
+              "title": "&nbsp;-&nbsp;DMS Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Digital Media Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153L",
+              "title": "&nbsp;-&nbsp;DMS Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "154",
+              "title": "&nbsp;-&nbsp;Web Authoring II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "154L",
+              "title": "&nbsp;-&nbsp;DMS Lab IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose 1 of the following 2 courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "180",
+              "title": "&nbsp;-&nbsp;Financial Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any Mathematical WOK 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=526",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 1-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "&nbsp;-&nbsp;Families, Communities, and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 4 with a lab 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "&nbsp;-&nbsp;Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "157",
+              "title": "&nbsp;-&nbsp;Math Pedagogy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "&nbsp;-&nbsp;Education Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 5 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "257",
+              "title": "&nbsp;-&nbsp;Math Pedagogy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "225",
+              "title": "&nbsp;-&nbsp;Literacy, Language, &amp; Texts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 4 with a lab in a different discipline from previous 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 5 in a different discipline from previous 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 1-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "&nbsp;-&nbsp;Families, Communities, and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 4 with a lab 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "&nbsp;-&nbsp;Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "&nbsp;-&nbsp;Education Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 5 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Systems Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=509",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ESE",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Engineering Technology Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Engineering Technology Orientation Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "140",
+              "title": "&nbsp;-&nbsp;Applied Technical Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "145",
+              "title": "&nbsp;-&nbsp;Electronic Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ESE",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Introduction to Process Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "110L",
+              "title": "&nbsp;-&nbsp;Introduction to Process Control Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "154",
+              "title": "&nbsp;-&nbsp;Electronic Control Devices Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "156",
+              "title": "&nbsp;-&nbsp;Electronic Control Devices Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "150",
+              "title": "&nbsp;-&nbsp;Employment Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101L",
+              "title": "&nbsp;-&nbsp;Introduction to Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "230",
+              "title": "&nbsp;-&nbsp;PLC and VFD Fundamental System Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "&nbsp;-&nbsp;Human Machine Interface",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Computer Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Instrumentation and Process Control Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Electrical Motor Control Wiring Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "225",
+              "title": "&nbsp;-&nbsp;Level/Flow/Pressure Process Measurement and Control Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "245",
+              "title": "&nbsp;-&nbsp;Building Automation Controls Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "255",
+              "title": "&nbsp;-&nbsp;Radiation Protection Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "215",
+              "title": "&nbsp;-&nbsp;Level/Flow/Pressure Process Measurement and Control Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 5 or GEM 6 Course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Systems Technology, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=489",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Engineering Technology Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Engineering Technology Orientation Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "140",
+              "title": "&nbsp;-&nbsp;Applied Technical Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "145",
+              "title": "&nbsp;-&nbsp;Electronic Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "150",
+              "title": "&nbsp;-&nbsp;Employment Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "154",
+              "title": "&nbsp;-&nbsp;Electronic Control Devices Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "156",
+              "title": "&nbsp;-&nbsp;Electronic Control Devices Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101L",
+              "title": "&nbsp;-&nbsp;Introduction to Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose 1 of the following courses or combination of courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Introduction to Process Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "110L",
+              "title": "&nbsp;-&nbsp;Introduction to Process Control Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=502",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Accounting Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "126",
+              "title": "&nbsp;-&nbsp;QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "216",
+              "title": "&nbsp;-&nbsp;Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "255",
+              "title": "&nbsp;-&nbsp;Leadership Development Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "261",
+              "title": "&nbsp;-&nbsp;Legal Environments of Organizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Entrepreneurship &amp; Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies, AA (Transfer Degree)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=463",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General AA Electives: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies, AS (Transfer Degree)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=466",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General AS Electives: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Health Physics Technologies, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=479",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPT",
+              "number": "121",
+              "title": "&nbsp;-&nbsp;Radiation Protection Principles I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "121L",
+              "title": "&nbsp;-&nbsp;Radiation Safety Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "122",
+              "title": "&nbsp;-&nbsp;Radiation Protection Principles II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "122L",
+              "title": "&nbsp;-&nbsp;Radiation Safety Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPT",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;40-Hr OSHA Hazwoper Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Radiation Protection Principles III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "123L",
+              "title": "&nbsp;-&nbsp;Radiation Safety Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "124",
+              "title": "&nbsp;-&nbsp;Radiation Protection Principles IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPT",
+              "number": "124L",
+              "title": "&nbsp;-&nbsp;Radiation Safety Lab IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Duty Diesel Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=490",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Manual Drive-Train",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "164",
+              "title": "&nbsp;-&nbsp;Introduction to Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "173",
+              "title": "&nbsp;-&nbsp;Automotive/Diesel Basic HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Auto/Diesel Technology Fundamentals &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Mechanical Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Workplace Technical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Diesel Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "105L",
+              "title": "&nbsp;-&nbsp;Diesel Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "205",
+              "title": "&nbsp;-&nbsp;Diesel Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "205L",
+              "title": "&nbsp;-&nbsp;Diesel II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "206",
+              "title": "&nbsp;-&nbsp;Diesel Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "206L",
+              "title": "&nbsp;-&nbsp;Diesel Lab III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM Any GEM elective course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Math in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Duty Diesel Technology, ATC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=491",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Manual Drive-Train",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "164",
+              "title": "&nbsp;-&nbsp;Introduction to Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "173",
+              "title": "&nbsp;-&nbsp;Automotive/Diesel Basic HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Auto/Diesel Technology Fundamentals &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Mechanical Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Workplace Technical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Diesel Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "105L",
+              "title": "&nbsp;-&nbsp;Diesel Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "205",
+              "title": "&nbsp;-&nbsp;Diesel Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "205L",
+              "title": "&nbsp;-&nbsp;Diesel II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "206",
+              "title": "&nbsp;-&nbsp;Diesel Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "206L",
+              "title": "&nbsp;-&nbsp;Diesel Lab III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Duty Diesel Technology, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=492",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Manual Drive-Train",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "164",
+              "title": "&nbsp;-&nbsp;Introduction to Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "173",
+              "title": "&nbsp;-&nbsp;Automotive/Diesel Basic HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Auto/Diesel Technology Fundamentals &amp; Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTD",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Mechanical Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Workplace Technical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Diesel Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "105L",
+              "title": "&nbsp;-&nbsp;Diesel Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Assurance and Cybersecurity, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=481",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Computer Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Operating System Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "129",
+              "title": "&nbsp;-&nbsp;Leadership 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any GEM 3 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Fundamentals in Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "&nbsp;-&nbsp;Linux 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "141",
+              "title": "&nbsp;-&nbsp;Linux 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "170",
+              "title": "&nbsp;-&nbsp;Networking 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "171",
+              "title": "&nbsp;-&nbsp;Networking 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "224",
+              "title": "&nbsp;-&nbsp;Server I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "229",
+              "title": "&nbsp;-&nbsp;Leadership 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "290",
+              "title": "&nbsp;-&nbsp;Practical Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "291",
+              "title": "&nbsp;-&nbsp;Digital Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "292",
+              "title": "&nbsp;-&nbsp;Intrusion Detection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "293",
+              "title": "&nbsp;-&nbsp;Emerging Trends in Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 Any GEM 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Law &amp; Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Assurance and Cybersecurity, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=482",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "224",
+              "title": "&nbsp;-&nbsp;Server I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "229",
+              "title": "&nbsp;-&nbsp;Leadership 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "290",
+              "title": "&nbsp;-&nbsp;Practical Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "291",
+              "title": "&nbsp;-&nbsp;Digital Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any GEM 3 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "292",
+              "title": "&nbsp;-&nbsp;Intrusion Detection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "293",
+              "title": "&nbsp;-&nbsp;Emerging Trends in Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 any GEM 6 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Law &amp; Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Assurance and Cybersecurity, SC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=483",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "224",
+              "title": "&nbsp;-&nbsp;Server I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "229",
+              "title": "&nbsp;-&nbsp;Leadership 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "290",
+              "title": "&nbsp;-&nbsp;Practical Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "291",
+              "title": "&nbsp;-&nbsp;Digital Forensics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "292",
+              "title": "&nbsp;-&nbsp;Intrusion Detection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "293",
+              "title": "&nbsp;-&nbsp;Emerging Trends in Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Law &amp; Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology Services, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=484",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Computer Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Operating System Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "129",
+              "title": "&nbsp;-&nbsp;Leadership 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any GEM 3 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Fundamentals in Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "&nbsp;-&nbsp;Linux 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "141",
+              "title": "&nbsp;-&nbsp;Linux 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "170",
+              "title": "&nbsp;-&nbsp;Networking 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "171",
+              "title": "&nbsp;-&nbsp;Networking 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "224",
+              "title": "&nbsp;-&nbsp;Server I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "225",
+              "title": "&nbsp;-&nbsp;Server II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "229",
+              "title": "&nbsp;-&nbsp;Leadership 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "271",
+              "title": "&nbsp;-&nbsp;Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Supervised Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "226",
+              "title": "&nbsp;-&nbsp;Server III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "270",
+              "title": "&nbsp;-&nbsp;Emerging Trends in Computer Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 Any GEM 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology Services, BTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=527",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Computer Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Operating System Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "129",
+              "title": "&nbsp;-&nbsp;Leadership 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Fundamentals in Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND take one group from below:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CEI",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;College, Experience, and Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CEI",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Career Exploration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "102L",
+              "title": "&nbsp;-&nbsp;Business Computer Applications Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology Services, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=485",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Computer Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Operating System Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "129",
+              "title": "&nbsp;-&nbsp;Leadership 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any GEM 3 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Fundamentals in Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "&nbsp;-&nbsp;Linux 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "141",
+              "title": "&nbsp;-&nbsp;Linux 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "170",
+              "title": "&nbsp;-&nbsp;Networking 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "171",
+              "title": "&nbsp;-&nbsp;Networking 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Legal Studies and Paralegal Training, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=476",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LSPT",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Introduction to Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Introduction to Law Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "104",
+              "title": "&nbsp;-&nbsp;Constitutional Law, Rights, and Responsibilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Introduction to Political Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LSPT",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Contract Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Tort Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 3 Any GEM 3 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM 6 Any GEM 6 course, preferably Criminal Justice, U.S. History, Economics 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "200",
+              "title": "&nbsp;-&nbsp;Civil Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Wills, Trusts, and Estates",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LSPT",
+              "number": "203",
+              "title": "&nbsp;-&nbsp;Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "204",
+              "title": "&nbsp;-&nbsp;Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "205",
+              "title": "&nbsp;-&nbsp;Debtor/Creditor Law and BKRPT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Legal Practices and Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "208",
+              "title": "&nbsp;-&nbsp;Family Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Studies and Paralegal Training, BTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=478",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Introduction to Political Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Introduction to Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Introduction to Law Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "104",
+              "title": "&nbsp;-&nbsp;Constitutional Law, Rights, and Responsibilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Studies and Paralegal Training, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=477",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "115",
+              "title": "&nbsp;-&nbsp;Computer Productivity Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Introduction to Law Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "104",
+              "title": "&nbsp;-&nbsp;Constitutional Law, Rights, and Responsibilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Introduction to Political Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gem 3 Course Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 6 Course Preferably Criminal Justice, U.S. History, Economics 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "103",
+              "title": "&nbsp;-&nbsp;Tort Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LSPT",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Contract Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=508",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ESE",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Engineering Technology Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Engineering Technology Orientation Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "140",
+              "title": "&nbsp;-&nbsp;Applied Technical Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "145",
+              "title": "&nbsp;-&nbsp;Electronic Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ESE",
+              "number": "110",
+              "title": "&nbsp;-&nbsp;Introduction to Process Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "110L",
+              "title": "&nbsp;-&nbsp;Introduction to Process Control Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "154",
+              "title": "&nbsp;-&nbsp;Electronic Control Devices Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "156",
+              "title": "&nbsp;-&nbsp;Electronic Control Devices Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101L",
+              "title": "&nbsp;-&nbsp;Introduction to Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "150",
+              "title": "&nbsp;-&nbsp;Employment Strategies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "290",
+              "title": "&nbsp;-&nbsp;Practical Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Robotics 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "211",
+              "title": "&nbsp;-&nbsp;Mechanical Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "212",
+              "title": "&nbsp;-&nbsp;Fluid and Pneumatic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "230",
+              "title": "&nbsp;-&nbsp;PLC and VFD Fundamental System Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "230",
+              "title": "&nbsp;-&nbsp;PLC and VFD Fundamental System Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "240",
+              "title": "&nbsp;-&nbsp;Human Machine Interface",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "&nbsp;-&nbsp;Human Machine Interface",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "&nbsp;-&nbsp;Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "251",
+              "title": "&nbsp;-&nbsp;Robotics 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "251L",
+              "title": "&nbsp;-&nbsp;Robotics 2 Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "252",
+              "title": "&nbsp;-&nbsp;Emerging Trends in Mechatronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "291",
+              "title": "&nbsp;-&nbsp;Mechatronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "291L",
+              "title": "&nbsp;-&nbsp;Mechatronics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 5 or GEM 6 Course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=469",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "109",
+              "title": "&nbsp;-&nbsp;Medical - Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Beginning Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "121",
+              "title": "&nbsp;-&nbsp;Beginning Medical Assisting Administrative Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "122",
+              "title": "&nbsp;-&nbsp;Beginning Medical Assisting Clinical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127L",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Intern/Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Pharmacology and Medication Administration Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "221",
+              "title": "&nbsp;-&nbsp;Advanced Medical Assisting Administration Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "222",
+              "title": "&nbsp;-&nbsp;Advanced Medical Assisting Clinical Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "210",
+              "title": "&nbsp;-&nbsp;Intern/Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(If not taken during Spring semester.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology (MLT), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=510",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR Higher GEM 1 course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Precalculus I: Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR Higher GEM 3 course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "&nbsp;-&nbsp;Introduction to Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose One of the Following Pair of Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ZOOL",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127L",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201L",
+              "title": "&nbsp;-&nbsp;Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR Any GEM 2 course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR Any GEM 6 course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose One of the Following Pair of Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;General Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "250L",
+              "title": "&nbsp;-&nbsp;General Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose One of the Following Pair of Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Essentials of Organic &amp; Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102L",
+              "title": "&nbsp;-&nbsp;Essentials of Organic &amp; Biochemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "&nbsp;-&nbsp;General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "&nbsp;-&nbsp;General Chemistry II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "124",
+              "title": "&nbsp;-&nbsp;Medical Lab Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "214",
+              "title": "&nbsp;-&nbsp;Hematology and Hemostasis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "222",
+              "title": "&nbsp;-&nbsp;Basic Concepts in Transfusion Medicine",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "218",
+              "title": "&nbsp;-&nbsp;Medical Lab Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "&nbsp;-&nbsp;Parasitology, Mycology and Virology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "&nbsp;-&nbsp;Urinalysis and Other Body Fluids",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "221",
+              "title": "&nbsp;-&nbsp;Medical Laboratory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "224",
+              "title": "&nbsp;-&nbsp;Advanced Medical Laboratory Technology Student Lab Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "226",
+              "title": "&nbsp;-&nbsp;Immunology and Laboratory Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Capstone Seminar and Exam Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "291",
+              "title": "&nbsp;-&nbsp;Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "292",
+              "title": "&nbsp;-&nbsp;Internship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Specialist, BTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=506",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "102L",
+              "title": "&nbsp;-&nbsp;Business Computer Applications Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "109",
+              "title": "&nbsp;-&nbsp;Medical - Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "121",
+              "title": "&nbsp;-&nbsp;Beginning Medical Assisting Administrative Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127L",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Operations Management, BAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=530",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Junior Year Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "&nbsp;-&nbsp;Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "216",
+              "title": "&nbsp;-&nbsp;Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "320",
+              "title": "&nbsp;-&nbsp;Operations Project Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Junior Year Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "370",
+              "title": "&nbsp;-&nbsp;Operational Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "385",
+              "title": "&nbsp;-&nbsp;Industry Internship Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 5 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Senior Year Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "400",
+              "title": "&nbsp;-&nbsp;Ethical Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "410",
+              "title": "&nbsp;-&nbsp;Cost Analysis and Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "420",
+              "title": "&nbsp;-&nbsp;Production and Supply Chain Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 4 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Senior Year Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSN",
+              "number": "430",
+              "title": "&nbsp;-&nbsp;Business Law and Human Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "440",
+              "title": "&nbsp;-&nbsp;Human Performance Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "450",
+              "title": "&nbsp;-&nbsp;Quality Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSN",
+              "number": "480",
+              "title": "&nbsp;-&nbsp;Operational Management Projects",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any additional GEM 4 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Phlebotomy, BTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=507",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "102L",
+              "title": "&nbsp;-&nbsp;Business Computer Applications Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "109",
+              "title": "&nbsp;-&nbsp;Medical - Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Beginning Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "105C",
+              "title": "&nbsp;-&nbsp;Phlebotomy Clinical Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ZOOL",
+              "number": "127L",
+              "title": "&nbsp;-&nbsp;Introduction to Human Biology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=470",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "LPN Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*Waived if has active CNA license",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "120",
+              "title": "&nbsp;-&nbsp;Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "LPN Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "117",
+              "title": "&nbsp;-&nbsp;Essential Fundamentals of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "117L",
+              "title": "&nbsp;-&nbsp;Essential Fundamentals of Nursing Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Foundations of Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "LPN Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NRS",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Introduction to Maternal/Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "243",
+              "title": "&nbsp;-&nbsp;Foundations of Medical-Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "285",
+              "title": "&nbsp;-&nbsp;Transition to LPN Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Principles of Nursing Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Mental Health Nursing Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Nutrition for Healthcare Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Registered Nursing (ADN), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=471",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "175",
+              "title": "&nbsp;-&nbsp;Literature &amp; Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Optional for FT option (otherwise will take in-program). Required for AS and Bridge options prior to program admission.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Registered Nursing (ADN), AAS ( Full-time)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=472",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisite Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Optional but highly recommended for FT option (otherwise will take in-program). Required for AS and Bridge options prior to program admission.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENGL",
+                  "number": "175",
+                  "title": "&nbsp;-&nbsp;Literature &amp; Ideas"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Optional for FT option (otherwise will take in-program). Required for AS and Bridge options prior to program admission.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Foundations of Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Foundations of Nursing Practice Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "120",
+              "title": "&nbsp;-&nbsp;Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Principles of Nursing Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "130",
+              "title": "&nbsp;-&nbsp;Advanced Foundations of Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "130L",
+              "title": "&nbsp;-&nbsp;Advanced Foundations of Nursing Practice Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "155",
+              "title": "&nbsp;-&nbsp;Concepts of Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Mental Health Nursing Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Nutrition for Healthcare Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "215",
+              "title": "&nbsp;-&nbsp;Concepts of Medical-Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "240",
+              "title": "&nbsp;-&nbsp;Maternal &amp; Pediatric Nursing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Maternal &amp; Pediatric Nursing Essentials Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "280",
+              "title": "&nbsp;-&nbsp;Clinical Preceptorship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "285",
+              "title": "&nbsp;-&nbsp;Transition to RN Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "175",
+              "title": "&nbsp;-&nbsp;Literature &amp; Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR Equivalent GEM 5 Course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Registered Nursing (ADN), AAS (Alternative Schedule)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=473",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisite Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENGL",
+                  "number": "175",
+                  "title": "&nbsp;-&nbsp;Literature &amp; Ideas"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Optional for FT option (otherwise will take in-program). Required for AS and Bridge options prior to program admission.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Foundations of Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Foundations of Nursing Practice Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "120",
+              "title": "&nbsp;-&nbsp;Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Summer)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Mental Health Nursing Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "125",
+              "title": "&nbsp;-&nbsp;Nutrition for Healthcare Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "155",
+              "title": "&nbsp;-&nbsp;Concepts of Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "130",
+              "title": "&nbsp;-&nbsp;Advanced Foundations of Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "130L",
+              "title": "&nbsp;-&nbsp;Advanced Foundations of Nursing Practice Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "215",
+              "title": "&nbsp;-&nbsp;Concepts of Medical-Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "240",
+              "title": "&nbsp;-&nbsp;Maternal &amp; Pediatric Nursing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5 (Summer)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Principles of Nursing Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "250",
+              "title": "&nbsp;-&nbsp;Maternal &amp; Pediatric Nursing Essentials Clinical",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "280",
+              "title": "&nbsp;-&nbsp;Clinical Preceptorship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "285",
+              "title": "&nbsp;-&nbsp;Transition to RN Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Registered Nursing (ADN), AAS (LPN-to-RN Bridge)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=474",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "&nbsp;-&nbsp;Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "175",
+              "title": "&nbsp;-&nbsp;Literature &amp; Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Equivalent GEM 5 Course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1 (Summer)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "120",
+              "title": "&nbsp;-&nbsp;Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Mental Health Nursing Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "205",
+              "title": "&nbsp;-&nbsp;Medical-Surgical Nursing Bridge Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "245",
+              "title": "&nbsp;-&nbsp;Advanced Fundamentals Course &amp; Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "165",
+              "title": "&nbsp;-&nbsp;Principles of Nursing Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "207",
+              "title": "&nbsp;-&nbsp;Introduction to Maternal/Child",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARN",
+              "number": "230",
+              "title": "&nbsp;-&nbsp;Bridge Maternal &amp; Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "235",
+              "title": "&nbsp;-&nbsp;Bridge Maternal &amp; Pediatric Nursing Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "275",
+              "title": "&nbsp;-&nbsp;Nursing Preceptorship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "276",
+              "title": "&nbsp;-&nbsp;Work Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "285",
+              "title": "&nbsp;-&nbsp;Transition to RN Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Transfer for LPN to RN Bridge:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NRS",
+              "number": "117",
+              "title": "&nbsp;-&nbsp;Essential Fundamentals of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "117L",
+              "title": "&nbsp;-&nbsp;Essential Fundamentals of Nursing Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "100",
+              "title": "&nbsp;-&nbsp;Foundations of Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "100L",
+              "title": "&nbsp;-&nbsp;Foundations of Nursing Practice Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "107",
+              "title": "&nbsp;-&nbsp;Introduction to Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "120",
+              "title": "&nbsp;-&nbsp;Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "144",
+              "title": "&nbsp;-&nbsp;Foundations of Mental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "220",
+              "title": "&nbsp;-&nbsp;Mental Health Nursing Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRS",
+              "number": "143",
+              "title": "&nbsp;-&nbsp;Foundations of Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARN",
+              "number": "155",
+              "title": "&nbsp;-&nbsp;Concepts of Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Surgical Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=475",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 and Semester 2: Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "&nbsp;-&nbsp;Human Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MICR",
+              "number": "111L",
+              "title": "&nbsp;-&nbsp;Introduction to Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Math in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SRT",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Pharmacology for Surgical Technologist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRT",
+              "number": "102",
+              "title": "&nbsp;-&nbsp;Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRT",
+              "number": "111",
+              "title": "&nbsp;-&nbsp;Surgical Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRT",
+              "number": "114",
+              "title": "&nbsp;-&nbsp;Surgical Clinic I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SRT",
+              "number": "202",
+              "title": "&nbsp;-&nbsp;Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRT",
+              "number": "211",
+              "title": "&nbsp;-&nbsp;Surgical Techniques II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRT",
+              "number": "214",
+              "title": "&nbsp;-&nbsp;Surgical Clinic II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=529",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101P",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I Plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 3 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM 6 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GEM course of choice 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=497",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCR",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Occupational Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "&nbsp;-&nbsp;Safety &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "132",
+              "title": "&nbsp;-&nbsp;Blueprint Reading for Welders I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Welding Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "134",
+              "title": "&nbsp;-&nbsp;SMAW Practical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "135",
+              "title": "&nbsp;-&nbsp;Cutting Operations Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "104",
+              "title": "&nbsp;-&nbsp;Welding Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "&nbsp;-&nbsp;Blueprint Reading for Welders II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "142",
+              "title": "&nbsp;-&nbsp;Welding Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "231",
+              "title": "&nbsp;-&nbsp;Welding Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "232",
+              "title": "&nbsp;-&nbsp;Welding Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "233",
+              "title": "&nbsp;-&nbsp;Welding Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "234",
+              "title": "&nbsp;-&nbsp;Welding Fabrication Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Fundamentals of Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Writing &amp; Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEM Any GEM elective course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "&nbsp;-&nbsp;Math in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following two courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "&nbsp;-&nbsp;Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology, ATC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=498",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCR",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Occupational Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "&nbsp;-&nbsp;Safety &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "132",
+              "title": "&nbsp;-&nbsp;Blueprint Reading for Welders I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Welding Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "134",
+              "title": "&nbsp;-&nbsp;SMAW Practical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "135",
+              "title": "&nbsp;-&nbsp;Cutting Operations Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "104",
+              "title": "&nbsp;-&nbsp;Welding Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "&nbsp;-&nbsp;Blueprint Reading for Welders II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "142",
+              "title": "&nbsp;-&nbsp;Welding Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "231",
+              "title": "&nbsp;-&nbsp;Welding Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "232",
+              "title": "&nbsp;-&nbsp;Welding Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "233",
+              "title": "&nbsp;-&nbsp;Welding Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "234",
+              "title": "&nbsp;-&nbsp;Welding Fabrication Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology, ITC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.cei.edu/preview_program.php?catoid=9&poid=499",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCR",
+              "number": "105",
+              "title": "&nbsp;-&nbsp;Occupational Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "&nbsp;-&nbsp;Safety &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "132",
+              "title": "&nbsp;-&nbsp;Blueprint Reading for Welders I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "&nbsp;-&nbsp;Welding Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "134",
+              "title": "&nbsp;-&nbsp;SMAW Practical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "135",
+              "title": "&nbsp;-&nbsp;Cutting Operations Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "104",
+              "title": "&nbsp;-&nbsp;Welding Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "&nbsp;-&nbsp;Blueprint Reading for Welders II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "142",
+              "title": "&nbsp;-&nbsp;Welding Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/id/programs/college-of-southern-idaho.json
+++ b/data/id/programs/college-of-southern-idaho.json
@@ -1,0 +1,22615 @@
+{
+  "college_slug": "college-of-southern-idaho",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/programs-of-study/",
+  "scraped_at": "2026-06-07T00:56:04.861Z",
+  "programs": [
+    {
+      "title": "Agribusiness, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/agribusiness/agribusiness-associate-of-arts",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Concepts of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "255",
+              "title": "Entrepreneurship in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Agriculture Program Electives (6 hours minimum)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "111",
+              "title": "Artificial Insemination of Cattle",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "121",
+              "title": "Pest Management*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "212",
+              "title": "Plant Nutrition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "240",
+              "title": "Forage Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "254",
+              "title": "Principles of Animal Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "101",
+              "title": "Introduction to Horses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126L",
+              "title": "Fundamentals of GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "106",
+              "title": "Equine Tack and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "230",
+              "title": "Introduction to Horseshoeing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "234",
+              "title": "Equine Health and Care",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business, Economics, and Accounting Electives (6 hrs. minimum)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Legal Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture Education AAS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/agriculture-education/agriculture-education-aas",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "181",
+              "title": "Intro to Ag Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "201",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "205",
+              "title": "Development/Individual Differences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "204",
+              "title": "Families Communities & Culture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Beginning Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "234",
+              "title": "Greenhouse Management*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "121",
+              "title": "Pest Management*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "212",
+              "title": "Plant Nutrition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/agriculture/agriculture-basic-technical-certificate",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester, Year 1",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester, Year 1",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agribusiness, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/agribusiness/agribusiness-intermediate-technical-certificate",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "255",
+              "title": "Entrepreneurship in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "111",
+              "title": "Artificial Insemination of Cattle",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "121",
+              "title": "Pest Management*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "121L",
+              "title": "Pest Management Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "126",
+              "title": "Fundamentals of Geographical Information Systems*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "126L",
+              "title": "Fundamentals of GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158L",
+              "title": "Applied Animal Nutrition Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "180",
+              "title": "Food System Science*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "180L",
+              "title": "Food System Science*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "212",
+              "title": "Plant Nutrition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "226",
+              "title": "Spatial Analysis with GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "227",
+              "title": "Agriculture Internship*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "240",
+              "title": "Forage Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271L",
+              "title": "Applied Animal Anatomy and Physiology Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130L",
+              "title": "Water Measurement Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/agriculture/agriculture-associate-of-arts",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (5 credits minimum)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "121",
+              "title": "Pest Management*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "212",
+              "title": "Plant Nutrition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "240",
+              "title": "Forage Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "254",
+              "title": "Principles of Animal Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "201",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "202",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "205",
+              "title": "Development/Individual Differences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126L",
+              "title": "Fundamentals of GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Beginning Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/agriculture/agriculture-associate-of-applied-science",
+      "total_credits": 123,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Session Freshman Year",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "227",
+              "title": "Agriculture Internship*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "286",
+              "title": "Agricultural Portfolio and Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Animal Science Pathway (minimum 21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "111",
+              "title": "Artificial Insemination of Cattle",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "240",
+              "title": "Forage Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "101",
+              "title": "Introduction to Horses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "106",
+              "title": "Equine Tack and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "230",
+              "title": "Introduction to Horseshoeing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "234",
+              "title": "Equine Health and Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Precision Ag & Agronomy Pathway (minimum 21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "121",
+              "title": "Pest Management*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "206",
+              "title": "UAS/Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "212",
+              "title": "Plant Nutrition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126L",
+              "title": "Fundamentals of GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "234",
+              "title": "Greenhouse Management*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ag. Management Pathway (minimum of 21 Credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Bookkeeping*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Bookkeeping Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "255",
+              "title": "Entrepreneurship in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "287",
+              "title": "Collegiate Judging Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animal Science, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/animal-science/animal-science-associate-of-science",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (7 Credits Minimum)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "111",
+              "title": "Artificial Insemination of Cattle",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "240",
+              "title": "Forage Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "254",
+              "title": "Principles of Animal Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "255",
+              "title": "Entrepreneurship in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "101",
+              "title": "Introduction to Horses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "106",
+              "title": "Equine Tack and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "230",
+              "title": "Introduction to Horseshoeing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "234",
+              "title": "Equine Health and Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus 1*",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aquaculture, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/aquaculture/aquaculture-intermediate-technical-certificate",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Aquaculture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "102",
+              "title": "Fish Health I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "104",
+              "title": "Fisheries I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "113",
+              "title": "Ichthyology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "Aquaculture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "202",
+              "title": "Fish Health II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "204",
+              "title": "Fisheries II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "235",
+              "title": "Society and Natural Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "213",
+              "title": "Ichthyology II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animal Science-Livestock Technician, Intermediate Technical Certificate",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/animal-science/animal-sciencelivestock-technician-intermediate-technical-certificate",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Elective Group 1 (minimum of 10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "101",
+              "title": "Introduction to Vet Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "102",
+              "title": "Animal Nursing and Restraint*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "103",
+              "title": "Animal Health Records Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "105",
+              "title": "Comparative Veterinary Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "110",
+              "title": "Specimen Collection Lab*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "120",
+              "title": "Clinical Laboratory Procedures 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "205",
+              "title": "Veterinary Pharmacology*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "210",
+              "title": "Animal Diseases*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective Group 2 (minimum of 10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "111",
+              "title": "Artificial Insemination of Cattle",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "227",
+              "title": "Agriculture Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "240",
+              "title": "Forage Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "255",
+              "title": "Entrepreneurship in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Aquaculture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "101",
+              "title": "Introduction to Horses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "230",
+              "title": "Introduction to Horseshoeing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "234",
+              "title": "Equine Health and Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EQUS",
+              "number": "106",
+              "title": "Equine Tack and Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aquaculture, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/aquaculture/aquaculture-associate-of-applied-science",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Aquaculture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "102",
+              "title": "Fish Health I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "104",
+              "title": "Agriculture Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "Aquaculture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "202",
+              "title": "Fish Health II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "104",
+              "title": "Fisheries I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "285",
+              "title": "Aquaculture Cooperative Education/Internships",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "113",
+              "title": "Ichthyology I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "235",
+              "title": "Society and Natural Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "204",
+              "title": "Fisheries II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "213",
+              "title": "Ichthyology II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Aquaculture Program Elective Courses",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "222",
+              "title": "Animal Reproduction and Breeding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "267",
+              "title": "Fire Ecology and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102L",
+              "title": "Environmental Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "242",
+              "title": "Wilderness Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISMT",
+              "number": "110",
+              "title": "Industrial Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "250",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Beginning Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Processing Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/food-processing-technology/food-processing-technology-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "130",
+              "title": "Sanitation in Food Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "170",
+              "title": "Equipment in Food Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "140",
+              "title": "HACCP / Food Safety Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "160",
+              "title": "General Industry Safety - OSHA 30",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "274",
+              "title": "Auditing of Food Plants",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "240",
+              "title": "Quality and Process Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "280",
+              "title": "Food Processing Projects",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective Coursework (A minimum of 19 credits required from the list below)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "142",
+              "title": "PLC Systems 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "150",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "165",
+              "title": "Lean Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "158",
+              "title": "Applied Animal Nutrition*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "180",
+              "title": "Food System Science*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "250",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "253",
+              "title": "Live Animal and Carcass Evaluation*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "259",
+              "title": "Meat Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic & Biochemistry*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "255",
+              "title": "Quality Control and Prerequisite Programs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "270",
+              "title": "Advanced Food Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Processing Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/food-processing-technology/food-processing-technology-basic-technical-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "130",
+              "title": "Sanitation in Food Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "160",
+              "title": "General Industry Safety - OSHA 30",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "140",
+              "title": "HACCP / Food Safety Management",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Processing Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/food-processing-technology/food-processing-technology-intermediate-technical-certificate",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "130",
+              "title": "Sanitation in Food Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "160",
+              "title": "General Industry Safety - OSHA 30",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FPTC",
+              "number": "140",
+              "title": "HACCP / Food Safety Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FPTC",
+              "number": "170",
+              "title": "Equipment in Food Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "165",
+              "title": "Lean Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geospatial Technology AAS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/geospatial-technology/geospatial-technology-aas",
+      "total_credits": 110,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "100",
+              "title": "Physical Geography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155L",
+              "title": "Introduction to Surveying Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "206",
+              "title": "UAS/Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "227",
+              "title": "Agriculture Internship*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "102",
+              "title": "Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Data Management and Analysis Pathway (minimum 25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "190",
+              "title": "Intro to Precision Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Business Statistics for Decision Making I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "208",
+              "title": "Business Statistics for Decision Making II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "111",
+              "title": "HTML and CSS Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "125",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "126",
+              "title": "Intermediate Programming*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "128",
+              "title": "Web App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "217",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRAT",
+              "number": "133",
+              "title": "Orthographic Projection",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field Spatial Data Acquisition Pathway (minimum 25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "108",
+              "title": "Crop Production",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201L",
+              "title": "Wildland Plant Identification Field Studies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "255",
+              "title": "Entrepreneurship in Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Fisheries Management 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101L",
+              "title": "Physical Geology Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "102",
+              "title": "Historical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "102L",
+              "title": "Historical Geology Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "104",
+              "title": "Natural Disasters and Env Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "104L",
+              "title": "Natural Disasters and Env Geo Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "275",
+              "title": "Field Geology*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130L",
+              "title": "Water Measurement Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geospatial Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/geospatial-technology/geospatial-technology-basic-technical-certificate",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126L",
+              "title": "Fundamentals of GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Natural Resources Management, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/natural-resources-management/natural-resources-management-associate-of-science",
+      "total_credits": 109,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "285",
+              "title": "Aquaculture Cooperative Education/Internships",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "235",
+              "title": "Society and Natural Resources",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: Rangeland Resources Pathway (15 Credits Min.)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Science of Animal Husbandry*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120L",
+              "title": "The Science of Animal Husbandry Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201L",
+              "title": "Wildland Plant Identification Field Studies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Business Statistics for Decision Making I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "208",
+              "title": "Business Statistics for Decision Making II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: General Pathway (15 Credits Min.)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "102",
+              "title": "Plant Science in Agriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "102L",
+              "title": "Plant Science in Agriculture Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201L",
+              "title": "Wildland Plant Identification Field Studies",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Aquaculture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "102",
+              "title": "Fish Health I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "104",
+              "title": "Fisheries I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "113",
+              "title": "Ichthyology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "213",
+              "title": "Ichthyology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130L",
+              "title": "Water Measurement Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "210",
+              "title": "Introduction to Hydrology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: Fisheries Pathway (15 Credits Min.)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Aquaculture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "102",
+              "title": "Fish Health I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "Aquaculture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "202",
+              "title": "Fish Health II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "113",
+              "title": "Ichthyology I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Natural Resources Management AAS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/natural-resources-management/natural-resources-management-aas",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "101",
+              "title": "Aquaculture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AQUA",
+              "number": "201",
+              "title": "Aquaculture II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "267",
+              "title": "Fire Ecology and Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "201",
+              "title": "Wildland Plant Identification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226L",
+              "title": "Spatial Analysis with GIS Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130L",
+              "title": "Water Measurement Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "235",
+              "title": "Society and Natural Resources",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "206",
+              "title": "UAS/Drone Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "227",
+              "title": "Agriculture Internship*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "134",
+              "title": "Backcountry Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "210",
+              "title": "Introduction to Hydrology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Outdoor Recreation Leadership, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/outdoor-recreation-leadership/outdoor-recreation-leadership-basic-technical-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "134",
+              "title": "Backcountry Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "138",
+              "title": "Outdoor Leadership and Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "139",
+              "title": "Wilderness First Responder",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "250",
+              "title": "Capstone/Risk Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives 3 hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "120",
+              "title": "Experiential Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "135",
+              "title": "Climbing Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "136",
+              "title": "Winter Mountain Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "137",
+              "title": "Whitewater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "140",
+              "title": "Beginning Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "141",
+              "title": "Intermediate Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "142",
+              "title": "Beginning Snowboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "143",
+              "title": "Intermediate/Advanced Snowboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "144",
+              "title": "Beginning Cross-country Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "145",
+              "title": "Introduction to Climbing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "146",
+              "title": "Intermediate Climbing*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "147",
+              "title": "Beginning Kayaking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "148",
+              "title": "Intermediate Kayaking*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "149",
+              "title": "Dutch Oven Cooking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "150",
+              "title": "Introduction to Whitewater Rafting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "151",
+              "title": "Intermediate White Water Rafting*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "152",
+              "title": "Stand-Up Paddleboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "153",
+              "title": "Introduction to Outdoor Cooking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "241",
+              "title": "Winter Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "242",
+              "title": "Wilderness Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "244",
+              "title": "Introduction to Mountain Biking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "247",
+              "title": "Swift Water Rescue",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "248",
+              "title": "Avalanche Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Outdoor Recreation Leadership, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/outdoor-recreation-leadership/outdoor-recreation-leadership-associate-of-arts",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "134",
+              "title": "Backcountry Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "138",
+              "title": "Outdoor Leadership and Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "139",
+              "title": "Wilderness First Responder",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "250",
+              "title": "Capstone/Risk Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: 12 hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "120",
+              "title": "Experiential Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "144",
+              "title": "Beginning Cross-country Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "145",
+              "title": "Introduction to Climbing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "146",
+              "title": "Intermediate Climbing*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "147",
+              "title": "Beginning Kayaking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "148",
+              "title": "Intermediate Kayaking*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "150",
+              "title": "Introduction to Whitewater Rafting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "151",
+              "title": "Intermediate White Water Rafting*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "152",
+              "title": "Stand-Up Paddleboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "153",
+              "title": "Introduction to Outdoor Cooking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "241",
+              "title": "Winter Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "242",
+              "title": "Wilderness Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "244",
+              "title": "Introduction to Mountain Biking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "247",
+              "title": "Swift Water Rescue",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "248",
+              "title": "Avalanche Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "140",
+              "title": "Beginning Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "141",
+              "title": "Intermediate Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "142",
+              "title": "Beginning Snowboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "143",
+              "title": "Intermediate/Advanced Snowboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "135",
+              "title": "Climbing Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "136",
+              "title": "Winter Mountain Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "137",
+              "title": "Whitewater",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Outdoor Recreation Leadership, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/outdoor-recreation-leadership/outdoor-recreation-leadership-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "134",
+              "title": "Backcountry Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "135",
+              "title": "Climbing Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "138",
+              "title": "Outdoor Leadership and Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "136",
+              "title": "Winter Mountain Travel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "137",
+              "title": "Whitewater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "139",
+              "title": "Wilderness First Responder",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "250",
+              "title": "Capstone/Risk Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses 0-5 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HREC",
+              "number": "148",
+              "title": "Intermediate Kayaking*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "244",
+              "title": "Introduction to Mountain Biking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "241",
+              "title": "Winter Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "152",
+              "title": "Stand-Up Paddleboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "242",
+              "title": "Wilderness Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "140",
+              "title": "Beginning Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "141",
+              "title": "Intermediate Skiing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "142",
+              "title": "Beginning Snowboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "143",
+              "title": "Intermediate/Advanced Snowboarding",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "153",
+              "title": "Introduction to Outdoor Cooking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "151",
+              "title": "Intermediate White Water Rafting*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "120",
+              "title": "Experiential Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "147",
+              "title": "Beginning Kayaking",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "145",
+              "title": "Introduction to Climbing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HREC",
+              "number": "199",
+              "title": "Special Topics",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/veterinary-technology/veterinary-technology-associate-of-applied-science",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "101",
+              "title": "Introduction to Vet Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "102",
+              "title": "Animal Nursing and Restraint*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "105",
+              "title": "Comparative Veterinary Anatomy and Physiology*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "110",
+              "title": "Specimen Collection Lab*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "120",
+              "title": "Clinical Laboratory Procedures 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "205",
+              "title": "Veterinary Pharmacology*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "103",
+              "title": "Animal Health Records Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "121",
+              "title": "Clinical Laboratory Procedures 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "201",
+              "title": "Anesthesiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "202",
+              "title": "Veterinary Surgical Assisting*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "203",
+              "title": "Veterinary Procedures Seminar*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "204",
+              "title": "Applied Radiology*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "210",
+              "title": "Animal Diseases*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Sophomore Year",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "286",
+              "title": "Clinic Experience*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Resource Management, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/agriculture-department/water-resource-management/water-resource-management-basic-technical-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WATR",
+              "number": "120",
+              "title": "Water Quality",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "120L",
+              "title": "Water Quality Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "130",
+              "title": "Water Measurement*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140",
+              "title": "Irrigation*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "140L",
+              "title": "Irrigation Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "100",
+              "title": "Agriculture and Natural Resources Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WATR",
+              "number": "210",
+              "title": "Introduction to Hydrology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Administrative Assistant, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/administrative-assistant/administrative-assistant-basic-technical-certificate",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Financial Bookkeeping Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "100",
+              "title": "Mechanics of Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "110",
+              "title": "Business Financial Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "130",
+              "title": "Principles of Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "116",
+              "title": "Spreadsheet Applications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "142",
+              "title": "Business Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/biology-department/biology/biology-associate-of-science",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "204",
+              "title": "Introduction to Cell Biology*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives 5 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "100",
+              "title": "Introduction to Allied Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "230",
+              "title": "Healthy Aspects of Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "203",
+              "title": "Principles of Range Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "172",
+              "title": "Workplace Ethics in Science",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "204",
+              "title": "Introduction to Cell Biology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "Science Literature & Environment*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "275",
+              "title": "Field Biology*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "253",
+              "title": "Quantitative Analysis*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "100",
+              "title": "Physical Geography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "104",
+              "title": "Natural Disasters and Env Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "144",
+              "title": "Precalculus II: Trigonometry*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "100",
+              "title": "Survey of Physics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Child and Adolescent Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "211",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Administrative Assistant, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/administrative-assistant/administrative-assistant-intermediate-technical-certificate",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Bookkeeping*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Bookkeeping Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "100",
+              "title": "Mechanics of Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "110",
+              "title": "Business Financial Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADMN",
+              "number": "116",
+              "title": "Spreadsheet Applications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "142",
+              "title": "Business Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Bookkeeping, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/applied-bookkeeping-accounting/applied-bookkeeping-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Financial Bookkeeping Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "100",
+              "title": "Mechanics of Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "110",
+              "title": "Business Financial Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "130",
+              "title": "Principles of Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "229",
+              "title": "QuickBooks Accounting*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "116",
+              "title": "Spreadsheet Applications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMN",
+              "number": "142",
+              "title": "Business Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "224",
+              "title": "Payroll Accounting*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "231",
+              "title": "Principles of Cost and Managerial Bookkeeping*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "232",
+              "title": "Data Analytics for Bookkeeping*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "102",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "260",
+              "title": "Professional and Ethical Behavior",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "290",
+              "title": "Program Capstone*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "261",
+              "title": "Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baking and Pastry Arts, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/baking-and-pastry-arts/baking-and-pastry-arts-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "110",
+              "title": "Professional Baking and Pastry 1*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Food Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266",
+              "title": "Food and Beverage Service*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266L",
+              "title": "Desert Cafe Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "120",
+              "title": "Professional Baking and Pastry 2*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Menu Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "230",
+              "title": "Professional Baking and Pastry 3*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "170",
+              "title": "Food Service Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "240",
+              "title": "Professional Baking and Pastry 4*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "180",
+              "title": "Food Service Purchasing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: 6 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Design 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "285",
+              "title": "Cooperative Education in Baking*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "261",
+              "title": "Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "173",
+              "title": "Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "174",
+              "title": "Customer Service and Conflict Resolution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "267",
+              "title": "Food and Beverage Controls*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "267L",
+              "title": "Desert Cafe Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "277",
+              "title": "Hospitality Management Association",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baking and Pastry Arts, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/baking-and-pastry-arts/baking-and-pastry-arts-basic-technical-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "110",
+              "title": "Professional Baking and Pastry 1*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Food Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "120",
+              "title": "Professional Baking and Pastry 2*",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baking and Pastry Arts, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/baking-and-pastry-arts/baking-and-pastry-arts-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "110",
+              "title": "Professional Baking and Pastry 1*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Food Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266",
+              "title": "Food and Beverage Service*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266L",
+              "title": "Desert Cafe Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "120",
+              "title": "Professional Baking and Pastry 2*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Menu Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/business-administration/business-administration-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Business Statistics for Decision Making I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "208",
+              "title": "Business Statistics for Decision Making II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Legal Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Support Technician, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/computer-support-technician/computer-support-technician-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "107",
+              "title": "Computer Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "213",
+              "title": "CISCO Networking I*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "213L",
+              "title": "Cisco Networking I Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "110",
+              "title": "Troubleshooting the PC*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "110L",
+              "title": "Troubleshooting Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "131",
+              "title": "Server Technologies I*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "216",
+              "title": "CISCO Networking II*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "216L",
+              "title": "Cisco Networking II Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "125",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/culinary-arts/culinary-arts-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "The Professional Kitchen I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Food Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266",
+              "title": "Food and Beverage Service*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266L",
+              "title": "Desert Cafe Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Introduction to Food Preparation*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Menu Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "170",
+              "title": "Food Service Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "230",
+              "title": "Adv Entrees & Plate Presentation*",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "180",
+              "title": "Food Service Purchasing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "240",
+              "title": "Advanced Entrees/Intro to Bakeshop*",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: 6 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSM",
+              "number": "261",
+              "title": "Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "173",
+              "title": "Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "174",
+              "title": "Customer Service and Conflict Resolution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "267",
+              "title": "Food and Beverage Controls*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "267L",
+              "title": "Desert Cafe Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "277",
+              "title": "Hospitality Management Association",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "285",
+              "title": "Cooperative Education*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/culinary-arts/culinary-arts-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "The Professional Kitchen I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Food Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266",
+              "title": "Food and Beverage Service*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "266L",
+              "title": "Desert Cafe Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Introduction to Food Preparation*",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Menu Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity and Programming, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/cybersecurity-and-programming/cybersecurity-and-programming-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "125",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "107",
+              "title": "Computer Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "213",
+              "title": "CISCO Networking I*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "213L",
+              "title": "Cisco Networking I Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "110",
+              "title": "Troubleshooting the PC*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "110L",
+              "title": "Troubleshooting Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "131",
+              "title": "Server Technologies I*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "216",
+              "title": "CISCO Networking II*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "216L",
+              "title": "Cisco Networking II Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "126",
+              "title": "Intermediate Programming*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "236",
+              "title": "Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "128",
+              "title": "Web App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "217",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "240",
+              "title": "IT Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISW",
+              "number": "245",
+              "title": "Digital Forensics & Incident Response*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "250",
+              "title": "Ethical Hacking and Countermeasures*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "298",
+              "title": "Comprehensive IT Project*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "223",
+              "title": "Advanced Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Introduction to Cybersecurity, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/cybersecurity-and-programming/introduction-to-cybersecurity-basic-technical-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "104",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "125",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISW",
+              "number": "286",
+              "title": "Intro to Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Culinary Arts, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/culinary-arts/culinary-arts-basic-technical-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "The Professional Kitchen I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Food Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Introduction to Food Preparation*",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/digital-media/digital-media-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISG",
+              "number": "101",
+              "title": "Photoshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "105",
+              "title": "Survey of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "109",
+              "title": "Video Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "116",
+              "title": "Introduction to Vector Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISG",
+              "number": "106",
+              "title": "Typography and Letterforms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "110",
+              "title": "Video Production II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "111",
+              "title": "HTML and CSS Coding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISG",
+              "number": "102",
+              "title": "Photoshop II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "113",
+              "title": "Client Web Design*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "207",
+              "title": "Page Layout and Design*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "210",
+              "title": "2D Animation*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISG",
+              "number": "204",
+              "title": "Copy Editing*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "208",
+              "title": "Advanced Electronic Publishing*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "213",
+              "title": "Client Branding*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "280",
+              "title": "Digital Media Portfolio*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/digital-media/digital-media-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISG",
+              "number": "101",
+              "title": "Photoshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "105",
+              "title": "Survey of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "109",
+              "title": "Video Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "116",
+              "title": "Introduction to Vector Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISG",
+              "number": "110",
+              "title": "Video Production II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISG",
+              "number": "106",
+              "title": "Typography and Letterforms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "111",
+              "title": "HTML and CSS Coding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship and Business Operations, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/entrepreneurship-and-business-operations/entrepreneurship-and-business-operations-intermediate-technical-certificate",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "145",
+              "title": "Marketing Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "261",
+              "title": "Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Financial Bookkeeping Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "181",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "265",
+              "title": "Principles of Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Network Systems Technician, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/network-systems-technician/network-systems-technician-associate-of-applied-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "107",
+              "title": "Computer Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "213",
+              "title": "CISCO Networking I*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "213L",
+              "title": "Cisco Networking I Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "110",
+              "title": "Troubleshooting the PC*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "110L",
+              "title": "Troubleshooting Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "131",
+              "title": "Server Technologies I*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "216",
+              "title": "CISCO Networking II*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "216L",
+              "title": "Cisco Networking II Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "125",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISA",
+              "number": "103",
+              "title": "Workforce Skills Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "218",
+              "title": "CISCO Networking III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "236",
+              "title": "Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "128",
+              "title": "Web App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "240",
+              "title": "IT Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CISS",
+              "number": "233",
+              "title": "Server Technologies II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "242",
+              "title": "Systems Integration*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISS",
+              "number": "223",
+              "title": "Advanced Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "217",
+              "title": "Database Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship and Business Operations, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/entrepreneurship-and-business-operations/entrepreneurship-and-business-operations-associate-of-applied-science",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "145",
+              "title": "Marketing Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "261",
+              "title": "Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Financial Bookkeeping Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "181",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "265",
+              "title": "Principles of Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "231",
+              "title": "Principles of Cost and Managerial Bookkeeping*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Legal Environment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "245",
+              "title": "Digital Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "262",
+              "title": "Entrepreneurship Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "290",
+              "title": "Program Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "102",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: 3 hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCB",
+              "number": "229",
+              "title": "QuickBooks Accounting*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Business Statistics for Decision Making I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "166",
+              "title": "Retail Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Operations Management, Bachelor of Applied Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/business-and-information-systems-department/operations-management/operations-management-bachelor-of-applied-science",
+      "total_credits": 242,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Requirements (AAS Concentration)",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Junior Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "300",
+              "title": "Principles of Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "320",
+              "title": "Operations Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Junior Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "310",
+              "title": "Business Law & Human Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "370",
+              "title": "Operational Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "385",
+              "title": "Industry Internship Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Senior Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "400",
+              "title": "Ethical Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "410",
+              "title": "Cost Analysis & Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "420",
+              "title": "Production & Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Senior Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "440",
+              "title": "Human Performance Improvement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "450",
+              "title": "Total Quality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "480",
+              "title": "Operations Management Projects",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Pre-Admission Requirements (AA/AS Concentration)",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fall Semester Junior Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "300",
+              "title": "Principles of Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "320",
+              "title": "Operations Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "181",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Junior Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "310",
+              "title": "Business Law & Human Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "370",
+              "title": "Operational Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "385",
+              "title": "Industry Internship Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129",
+              "title": "Introduction to Financial Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCB",
+              "number": "129L",
+              "title": "Introduction to Financial Bookkeeping Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Senior Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "400",
+              "title": "Ethical Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "410",
+              "title": "Cost Analysis & Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "420",
+              "title": "Production & Supply Chain Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "145",
+              "title": "Marketing Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "262",
+              "title": "Entrepreneurship Essentials*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Senior Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASOM",
+              "number": "440",
+              "title": "Human Performance Improvement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "450",
+              "title": "Total Quality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASOM",
+              "number": "480",
+              "title": "Operations Management Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSM",
+              "number": "245",
+              "title": "Digital Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "102",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Early Childhood Education, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/education-department/early-childhood-education/early-childhood-education-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "109",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "111",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "154",
+              "title": "Early Childhood Practicum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "164",
+              "title": "Early Childhood Curriculum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "105",
+              "title": "Early Childhood Environments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "174",
+              "title": "Early Childhood Practicum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "184",
+              "title": "Early Childhood Curriculum II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "203",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "204",
+              "title": "Families Communities & Culture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "207",
+              "title": "Infant & Toddler Care & Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "254",
+              "title": "Early Childhood Practicum III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "264",
+              "title": "Early Childhood Curriculum III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "196",
+              "title": "Trauma Informed Classroom Practices",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "209",
+              "title": "Inclusive Practices for Infants & Toddlers*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "222",
+              "title": "Introduction to Teaching Children’s Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "274",
+              "title": "Early Childhood Practicum IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "284",
+              "title": "Early Childhood Curriculum IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUA",
+              "number": "231",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/education-department/early-childhood-education/early-childhood-education-basic-technical-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall or Spring Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "109",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "111",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "203",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/education-department/early-childhood-education/early-childhood-education-intermediate-technical-certificate",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "109",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "111",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "154",
+              "title": "Early Childhood Practicum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "164",
+              "title": "Early Childhood Curriculum I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "105",
+              "title": "Early Childhood Environments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "203",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "204",
+              "title": "Families, Communities, & Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "174",
+              "title": "Early Childhood Practicum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "184",
+              "title": "Early Childhood Curriculum II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Teacher Apprenticeship Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/education-department/teacher-apprenticeship/teacher-apprenticeship-program",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "282",
+              "title": "Teacher Education Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/education-department/education/education-associate-of-arts",
+      "total_credits": 89,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "201",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "202",
+              "title": "Field Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "204",
+              "title": "Families, Communities, & Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "205",
+              "title": "Development/Individual Differences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "215",
+              "title": "Educational Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "290",
+              "title": "Education Exit Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: Secondary Education",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "101",
+              "title": "Art History 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "102",
+              "title": "Art History 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "150",
+              "title": "Beginning Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201L",
+              "title": "Biology 1 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202L",
+              "title": "Biology 2 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209L",
+              "title": "General Ecology Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy & Physiology 1 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy & Physiology 2 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "General Chemistry II Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "105",
+              "title": "Early Childhood Environments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Intro to Literary Analysis*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "257",
+              "title": "Survey of World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "258",
+              "title": "Survey of World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "267",
+              "title": "Survey of British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "268",
+              "title": "Survey of British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "277",
+              "title": "Survey of American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "278",
+              "title": "Survey of American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "102",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "104",
+              "title": "Natural Disasters and Env Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "104L",
+              "title": "Natural Disasters and Env Geo Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIIS",
+              "number": "270",
+              "title": "Information Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "310",
+              "title": "Ordinary Differential Equations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Survey of Astronomy*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101L",
+              "title": "Survey of Astronomy Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111L",
+              "title": "General Physics I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112L",
+              "title": "General Physics II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211L",
+              "title": "Physics Scientists & Engineers I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212L",
+              "title": "Physics Scientists & Engineers II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "221",
+              "title": "Intro to International Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "201",
+              "title": "Intermediate Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "202",
+              "title": "Intermediate Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: Elementary and/or Special Education",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EARC",
+              "number": "222",
+              "title": "Introduction to Teaching Children’s Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUA",
+              "number": "231",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUA",
+              "number": "245",
+              "title": "Special Education Policies & Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUA",
+              "number": "248",
+              "title": "Behavior Intervention & the Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUA",
+              "number": "276",
+              "title": "Assistive Tech and Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "211",
+              "title": "Physical Education for Elementary Teachers*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "157",
+              "title": "Math for Elementary Teachers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "257",
+              "title": "Math for Elementary Teachers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "233",
+              "title": "Music Methods for Elementary Tchrs",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemistry, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/chemistry/chemistry-associate-of-science",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "253",
+              "title": "Quantitative Analysis*",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "253",
+              "title": "Quantitative Analysis*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/computer-science/computer-science-associate-of-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229L",
+              "title": "Computer Science & Programming I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250",
+              "title": "Computer Science and Programming II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250L",
+              "title": "Computer Science & Programming II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "176",
+              "title": "Discrete Mathematics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "260",
+              "title": "Comp. Organization & Architecture*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "PROGRAM ELECTIVES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "230",
+              "title": "Introduction to Linear Algebra*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "253",
+              "title": "Intro to Systems Programming*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Construction Management, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/construction-management/construction-management-associate-of-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "144",
+              "title": "Precalculus II: Trigonometry*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111L",
+              "title": "General Physics I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101L",
+              "title": "Physical Geology Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112L",
+              "title": "General Physics II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Business Statistics for Decision Making I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Legal Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "295",
+              "title": "Strengths of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155L",
+              "title": "Introduction to Surveying Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate of Engineering",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/engineering/associate-of-engineering",
+      "total_credits": 116,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "General Chemistry I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "120",
+              "title": "Introduction to Engineering*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211L",
+              "title": "Physics Scientists & Engineers I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "187",
+              "title": "Computer Aided Design",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "212",
+              "title": "Applied Coding for Engineers and Scientists",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240L",
+              "title": "Electrical Circuits Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "295",
+              "title": "Strengths of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "176",
+              "title": "Discrete Mathematics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "230",
+              "title": "Introduction to Linear Algebra*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "310",
+              "title": "Ordinary Differential Equations*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201L",
+              "title": "Biology 1 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "General Chemistry II Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298L",
+              "title": "Organic Chemistry I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299L",
+              "title": "Organic Chemistry II Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229L",
+              "title": "Computer Science & Programming I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250",
+              "title": "Computer Science and Programming II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250L",
+              "title": "Computer Science & Programming II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "260",
+              "title": "Comp. Organization & Architecture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101L",
+              "title": "Physical Geology Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155L",
+              "title": "Introduction to Surveying Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212L",
+              "title": "Physics Scientists & Engineers II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Engineering Technician, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/engineering/electronics-engineering-technician",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "110",
+              "title": "DC Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "144",
+              "title": "Precalculus II: Trigonometry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "120",
+              "title": "AC Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "142",
+              "title": "PLC Systems 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISW",
+              "number": "125",
+              "title": "Introduction to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "130",
+              "title": "Digital Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "172",
+              "title": "Industrial Electronics & Motor Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "210",
+              "title": "Semiconductor Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "100",
+              "title": "Survey of Physics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "100L",
+              "title": "Survey of Physics Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "236",
+              "title": "Industrial Communications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "278",
+              "title": "Diagnostics and Troubleshooting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "230",
+              "title": "Electronic Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "250",
+              "title": "Electronic Circuitry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Geology, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/geology/geology-associate-of-science",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "102",
+              "title": "Historical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective Courses (choose 6 hours):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOL",
+              "number": "275",
+              "title": "Field Geology*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/engineering/engineering-associate-of-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGI",
+              "number": "120",
+              "title": "Introduction to Engineering*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "General Chemistry I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211L",
+              "title": "Physics Scientists & Engineers I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "310",
+              "title": "Ordinary Differential Equations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "230",
+              "title": "Introduction to Linear Algebra*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Agricultural Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "295",
+              "title": "Strengths of Materials*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "205L",
+              "title": "General Soils Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biological Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "295",
+              "title": "Strengths of Materials*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Chemical Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Civil Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "295",
+              "title": "Strengths of Materials*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250",
+              "title": "Computer Science and Programming II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250L",
+              "title": "Computer Science & Programming II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "260",
+              "title": "Comp. Organization & Architecture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "176",
+              "title": "Discrete Mathematics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electrical Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250",
+              "title": "Computer Science and Programming II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mechanical Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "295",
+              "title": "Strengths of Materials*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Pharmacy (PRE), Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/pharmacy-pre/pharmacy-pre-associate-of-science",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/physics/physics-associate-of-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229L",
+              "title": "Computer Science & Programming I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "230",
+              "title": "Introduction to Linear Algebra*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "310",
+              "title": "Ordinary Differential Equations*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/english-language-and-philosophy-department/spanish/spanish-associate-of-arts",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "201",
+              "title": "Intermediate Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "202",
+              "title": "Intermediate Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ANY THREE OF THE SURVEY COURSES: 9 HOURS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "257",
+              "title": "Survey of World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "258",
+              "title": "Survey of World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "267",
+              "title": "Survey of British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "268",
+              "title": "Survey of British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "277",
+              "title": "Survey of American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "278",
+              "title": "Survey of American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second language sequence (8 credits):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FREN",
+              "number": "101",
+              "title": "Elementary French 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "102",
+              "title": "Elementary French 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PORT",
+              "number": "101",
+              "title": "Elementary Portuguese 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PORT",
+              "number": "102",
+              "title": "Elementary Portuguese 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "101",
+              "title": "American Sign Language 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "102",
+              "title": "American Sign Language 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "201",
+              "title": "American Sign Language 3*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "202",
+              "title": "American Sign Language 4*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science, Technology, Engineering, and Math (STEM), Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/engineering-physical-and-computer-sciences-department/science-technology-engineering-and-math-stem/science-technology-engineering-and-math-stem-associate-of-science",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Life Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "205",
+              "title": "General Soils*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "204",
+              "title": "Introduction to Cell Biology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "209",
+              "title": "General Ecology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "Science Literature & Environment*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "230L",
+              "title": "Donor Body Prosection*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "275",
+              "title": "Field Biology*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physical Science/Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic & Biochemistry*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "253",
+              "title": "Quantitative Analysis*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "299",
+              "title": "Organic Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "120",
+              "title": "Introduction to Engineering*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "210",
+              "title": "Mechanics Statics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "220",
+              "title": "Mechanics Dynamics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "240",
+              "title": "Electrical Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "102",
+              "title": "Historical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "275",
+              "title": "Field Geology*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics Scientists & Engineers II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math/Technology",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "250",
+              "title": "Computer Science and Programming II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "260",
+              "title": "Comp. Organization & Architecture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGI",
+              "number": "105",
+              "title": "Engineering Graphical Communication",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "226",
+              "title": "Spatial Analysis With GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "144",
+              "title": "Precalculus II: Trigonometry*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "176",
+              "title": "Discrete Mathematics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "230",
+              "title": "Introduction to Linear Algebra*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus 3*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "310",
+              "title": "Ordinary Differential Equations*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Spanish for Health Professions AA",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/english-language-and-philosophy-department/spanish/spanish-for-health-professions-aa",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "201",
+              "title": "Intermediate Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "203",
+              "title": "Spanish for Heritage Speakers I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "211",
+              "title": "Spanish for Health Professions I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "202",
+              "title": "Intermediate Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "204",
+              "title": "Spanish for Heritage Speakers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "212",
+              "title": "Spanish for Health Professions II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish for Heritage Speakers, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/english-language-and-philosophy-department/spanish/spanish-for-heritage-speakers-associate-of-arts",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "203",
+              "title": "Spanish for Heritage Speakers I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "204",
+              "title": "Spanish for Heritage Speakers II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "210",
+              "title": "The Spanish Language in the World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPAN",
+              "number": "200I",
+              "title": "Spanish Independent Study*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ANY THREE OF THE SURVEY COURSES: 9 HOURS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "257",
+              "title": "Survey of World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "258",
+              "title": "Survey of World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "267",
+              "title": "Survey of British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "268",
+              "title": "Survey of British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "277",
+              "title": "Survey of American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "278",
+              "title": "Survey of American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/general-and-liberal-studies-department/liberal-arts/liberal-arts-concentration-general-studies-associate-of-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Education Competency Areas",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/general-education-core-courses/general-education-competency-areas",
+      "total_credits": 372,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AA & AS (2 different disciplines) (6 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "101",
+              "title": "Art History 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "102",
+              "title": "Art History 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "103",
+              "title": "Appreciation and History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Design 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "101",
+              "title": "Dance Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "126",
+              "title": "Film & Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "175",
+              "title": "Literature and Ideas*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "215",
+              "title": "Survey of World Mythology*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "257",
+              "title": "Survey of World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "258",
+              "title": "Survey of World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "267",
+              "title": "Survey of British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "268",
+              "title": "Survey of British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "277",
+              "title": "Survey of American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "278",
+              "title": "Survey of American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "101",
+              "title": "Introduction to Humanities 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "106",
+              "title": "Introduction to Modern Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "107",
+              "title": "Music Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PORT",
+              "number": "101",
+              "title": "Elementary Portuguese 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PORT",
+              "number": "102",
+              "title": "Elementary Portuguese 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "101",
+              "title": "American Sign Language 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "102",
+              "title": "American Sign Language 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "201",
+              "title": "American Sign Language 3*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "202",
+              "title": "American Sign Language 4*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "201",
+              "title": "Intermediate Spanish 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "202",
+              "title": "Intermediate Spanish 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "203",
+              "title": "Spanish for Heritage Speakers I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "201",
+              "title": "History of World Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "202",
+              "title": "Modern Theatre and Musicals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AAS (3 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus 1*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AA, AS, AAS (3 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Critical Thinking and Argumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AA & AS (2 different disciplines/1 lab) (7-8 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "180",
+              "title": "Food System Science*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "104",
+              "title": "Introduction to Biological Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "104L",
+              "title": "Biological Anthropology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Concepts of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102L",
+              "title": "Environmental Science Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic & Biochemistry*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "100",
+              "title": "Physical Geography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "102",
+              "title": "Historical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "104",
+              "title": "Natural Disasters and Env Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "105",
+              "title": "Geology of National Parks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "100",
+              "title": "Survey of Physics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Survey of Astronomy*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics Scientists & Engineers I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AA & AS (2 DIFFERENT DISCIPLINES) (6 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "235",
+              "title": "Society and Natural Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Physical Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "103",
+              "title": "Introduction to Law and Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "204",
+              "title": "Families, Communities, & Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "102",
+              "title": "Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "202",
+              "title": "World Regional Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "221",
+              "title": "Intro to International Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "102",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AAS (3 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Physical Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Critical Thinking and Argumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "103",
+              "title": "Introduction to Law and Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "204",
+              "title": "Families, Communities, & Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "102",
+              "title": "Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "202",
+              "title": "World Regional Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "221",
+              "title": "Intro to International Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "102",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "105",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AAS (3 hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assistant, Intermediate Technical Certificate",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/dental-assistant/dental-assistant-intermediate-technical-certificate",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "105",
+              "title": "Human Structure & Function*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENA",
+              "number": "101",
+              "title": "Dental Assisting Theory 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "101L",
+              "title": "Dental Assisting Theory 1 Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "103",
+              "title": "Dental Anatomy & Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "105",
+              "title": "Infection Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "115",
+              "title": "Dental Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "115L",
+              "title": "Dental Radiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "135",
+              "title": "Dental Preventative Materials and Procedures*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "135C",
+              "title": "Dental Preventative Materials and Procedures Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "142",
+              "title": "Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENA",
+              "number": "151",
+              "title": "Dental Assisting Theory 2*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "151C",
+              "title": "Dental Assisting Theory 2 Clinical*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "151L",
+              "title": "Dental Assisting Theory 2 Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "165",
+              "title": "Dental Materials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "165L",
+              "title": "Dental Materials Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "175",
+              "title": "Dental Practice Management*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENA",
+              "number": "185",
+              "title": "Expanded Functions*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "185C",
+              "title": "Expanded Functions Practicum*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENA",
+              "number": "185L",
+              "title": "Expanded Functions Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/emergency-medical-services/emergency-medical-services-basic-technical-certificate",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "100",
+              "title": "Introduction to Allied Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "102",
+              "title": "Emergency Medical Technician",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "102L",
+              "title": "Emergency Medical Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/emergency-medical-services/emergency-medical-services-associate-of-applied-science",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements Term 1",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "110",
+              "title": "Introduction to Emergency Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "120",
+              "title": "Introduction to Emergency Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "130",
+              "title": "Introduction Emergency Radio Communications",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Pre-Admission Program Requirements Term 2",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "102",
+              "title": "Emergency Medical Technician",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "102L",
+              "title": "Emergency Medical Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 3",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMSE",
+              "number": "201",
+              "title": "EMS Operations*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "202",
+              "title": "Pharmacology and Pathophysiology in Paramedicine*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "203",
+              "title": "Patient Assessment*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "204",
+              "title": "Airway Management*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "205",
+              "title": "Trauma Emergencies*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "251L",
+              "title": "Paramedic Lab 1*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "271C",
+              "title": "Paramedic Clinical 1",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 4",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMSE",
+              "number": "206",
+              "title": "Medical Emergencies*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "207",
+              "title": "Cardiovascular Emergencies*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "208",
+              "title": "Respiratory Emergencies*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "209",
+              "title": "Special Populations*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "210",
+              "title": "Pediatric Emergencies*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "252L",
+              "title": "Paramedic Lab 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "272C",
+              "title": "Paramedic Clinical 2*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 5",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMSE",
+              "number": "273C",
+              "title": "Paramedic Clinical 3*",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/dental-hygiene/dental-hygiene-associate-of-applied-science",
+      "total_credits": 90,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements Term 1",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Pre-Admission Program Requirements Term 2",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 3",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENH",
+              "number": "101",
+              "title": "Introduction to Dental Hygiene",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "101C",
+              "title": "Dental Hygiene Clinic 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "115",
+              "title": "Dental Radiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "115L",
+              "title": "Dental Radiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "122",
+              "title": "Dental Head And Neck Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "132",
+              "title": "Dental Anatomy Embryology & Histology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "142",
+              "title": "Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 4",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENH",
+              "number": "151",
+              "title": "Dental Hygiene Theory 2*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "151C",
+              "title": "Dental Hygiene Clinic 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "165",
+              "title": "Dental Materials*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "165L",
+              "title": "Dental Materials Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "175",
+              "title": "Dental Pharmacology*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "185",
+              "title": "Oral Pathology*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "190",
+              "title": "Periodontics 1*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 5",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENH",
+              "number": "201",
+              "title": "Dental Hygiene Theory 3*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "201C",
+              "title": "Dental Hygiene Clinic 3*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "215",
+              "title": "Pain Control and Methodology*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "215L",
+              "title": "Pain Control and Methodology Lab*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "235",
+              "title": "Community Dental Health*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "245",
+              "title": "Periodontics 2*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 6",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENH",
+              "number": "251",
+              "title": "Dental Hygiene Theory 4*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "251C",
+              "title": "Dental Hygiene Theory Clinic 4*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "265",
+              "title": "Special Needs Patients",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "270",
+              "title": "Community Dental Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "280",
+              "title": "Legal and Ethical Issues",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENH",
+              "number": "295",
+              "title": "Testing and Board Reviews",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/emergency-medical-services/emergency-medical-services-intermediate-technical-certificate",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements Term 1",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements Term 2",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "151",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "151C",
+              "title": "Advanced Emergency Medical Technician Clinic*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "151L",
+              "title": "Advanced Emergency Medical Technician Lab*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "110",
+              "title": "Introduction to Emergency Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "120",
+              "title": "Introduction to Emergency Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "130",
+              "title": "Introduction Emergency Radio Communications",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/fire-science/fire-science-associate-of-applied-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAFE",
+              "number": "110",
+              "title": "Introduction to Emergency Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "120",
+              "title": "Introduction to Emergency Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "130",
+              "title": "Introduction Emergency Radio Communications",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "110",
+              "title": "Fire Fighter I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "110L",
+              "title": "Fire Fighter I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "120",
+              "title": "Fire Fighter 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "120L",
+              "title": "Fire Fighter 2 Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "130",
+              "title": "Hazardous Materials Awareness and Operations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "201",
+              "title": "Building Construction for Fire Protection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "202",
+              "title": "Fire Behavior and Combustion",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "203",
+              "title": "Fire Prevention",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "204",
+              "title": "Fire Protection Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "205",
+              "title": "Fire Fighter Safety and Survival",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "206",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "207",
+              "title": "Fire and Emergency Service Administration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "208",
+              "title": "Fire Prevention Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Third Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "140",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "160",
+              "title": "Extrication Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "250",
+              "title": "Fire Science Externship",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/fire-science/fire-science-intermediate-technical-certificate",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAFE",
+              "number": "110",
+              "title": "Introduction to Emergency Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "120",
+              "title": "Introduction to Emergency Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "130",
+              "title": "Introduction Emergency Radio Communications",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "110",
+              "title": "Fire Fighter I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "110L",
+              "title": "Fire Fighter I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "120",
+              "title": "Fire Fighter 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "120L",
+              "title": "Fire Fighter 2 Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "130",
+              "title": "Hazardous Materials Awareness and Operations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/law-enforcement/law-enforcement-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "102",
+              "title": "Introduction to Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "103",
+              "title": "Introduction to Law and Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "276",
+              "title": "Law of Arrest, Search and Seizure",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIJ",
+              "number": "104",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Critical Thinking and Argumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "275",
+              "title": "Criminal Evidence Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAWE",
+              "number": "205",
+              "title": "Detention Academy",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAWE",
+              "number": "201",
+              "title": "Enforcement Skills 1",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAWE",
+              "number": "202",
+              "title": "Law Enforcement Skills 2",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAWE",
+              "number": "203",
+              "title": "Law Enforcement Skills 3",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Health Science, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/health-science/health-science-associate-of-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "100",
+              "title": "Introduction to Allied Health",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives 16 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "102",
+              "title": "Certified Nursing Assistant",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "103",
+              "title": "Pharmacy Technician",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "104",
+              "title": "Central Sterile Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "230",
+              "title": "Healthy Aspects of Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "105",
+              "title": "Human Structure & Function*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Biology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "204",
+              "title": "Introduction to Cell Biology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "215",
+              "title": "Information Science and Data Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "250",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic & Biochemistry*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EARC",
+              "number": "203",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "102",
+              "title": "Emergency Medical Technician",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "102L",
+              "title": "Emergency Medical Technician Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "144",
+              "title": "Precalculus II: Trigonometry*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "100",
+              "title": "Survey of Physics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Child and Adolescent Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "211",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "238",
+              "title": "Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "110",
+              "title": "Introduction to Emergency Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "120",
+              "title": "Introduction to Emergency Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAFE",
+              "number": "130",
+              "title": "Introduction Emergency Radio Communications",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/medical-assistant/medical-assistant-intermediate-technical-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Post-Admission Program Requirements",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "105",
+              "title": "Human Structure & Function*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "105L",
+              "title": "Human Structure and Function Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy & Physiology 1 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy & Physiology 2 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Critical Thinking and Argumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "131",
+              "title": "Medical Office Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "220",
+              "title": "Human Diseases*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "233",
+              "title": "Clinical Procedures 1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "233L",
+              "title": "Clinical Procedures 1 Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "109",
+              "title": "Pharmacology*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "201",
+              "title": "Integrated Medical Procedures*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "234",
+              "title": "Clinical Procedures 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "234L",
+              "title": "Clinical Procedures 2 Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "235",
+              "title": "Medical Assisting Practicum*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELL",
+              "number": "255",
+              "title": "Wellness Through Healthy Living",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/medical-laboratory-technology/medical-laboratory-technology-associate-of-applied-science",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "105",
+              "title": "Human Structure & Function*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "Introductory Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "250",
+              "title": "General Microbiology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic & Biochemistry*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Requirements Spring Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTE",
+              "number": "100",
+              "title": "Phlebotomy*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "124",
+              "title": "Medical Lab Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "214",
+              "title": "Hematology and Hemostasis*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "222",
+              "title": "Basic Concepts in Transfusion Medicine",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Requirements Summer Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTE",
+              "number": "218",
+              "title": "Medical Lab Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "225",
+              "title": "Parasitology, Mycology and Virology",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post Admission Requirements Fall Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTE",
+              "number": "112",
+              "title": "Urinalysis and Other Body Fluids",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "221",
+              "title": "Medical Laboratory Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "224",
+              "title": "Adv Medical Laboratory Tech Student Practice",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "226",
+              "title": "Immunology and Laboratory Operations",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Requirements Spring Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTE",
+              "number": "250",
+              "title": "Capstone Seminar and Exam Review",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "291",
+              "title": "Internship I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTE",
+              "number": "292",
+              "title": "Internship II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/physical-therapist-assistant/physical-therapist-assistant-associate-of-applied-science",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAE",
+              "number": "101",
+              "title": "Physical Therapy In Health Care*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "107",
+              "title": "Kinesiology*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "107L",
+              "title": "Kinesiology Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "110",
+              "title": "Principles & Procedures of PT*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "110L",
+              "title": "Principles and Procedures of PT Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "211",
+              "title": "Data Collection*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAE",
+              "number": "207",
+              "title": "Therapeutic Exercise*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "208",
+              "title": "Orthopedic Rehabilitation*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "217",
+              "title": "Neurological Rehabilitation*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "113",
+              "title": "Clinical Pathology *",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "204",
+              "title": "Therapeutic Modalities*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "240",
+              "title": "Clinical Experience 1*",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "215",
+              "title": "Special Populations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "221",
+              "title": "Seminar*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "241",
+              "title": "Clinical Experience 2*",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/radiologic-technology/radiologic-technology-associate-of-applied-science",
+      "total_credits": 79,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements Semester 1",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy & Physiology 1 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Pre-Admission Program Requirements Semester 2",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Critical Thinking and Argumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy & Physiology 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy & Physiology 2 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Semester 1",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "101",
+              "title": "Radiologic Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "102",
+              "title": "Orientation to Radiologic Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "151",
+              "title": "Radiographic Procedures 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Semester 2",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "162",
+              "title": "Radiographic Procedures II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "164",
+              "title": "Imaging & Processing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "152",
+              "title": "Radiation Protection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "181C",
+              "title": "Clinical Radiography I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Semester 3",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "182C",
+              "title": "Clinical Radiography II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Semester 4",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "154",
+              "title": "Radiographic Procedures III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "163",
+              "title": "Imaging Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "183C",
+              "title": "Clinical Radiography III",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Semester 5",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "156",
+              "title": "Radiographic Pathology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "185",
+              "title": "Radiologic Technology Review",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "184C",
+              "title": "Clinical Radiography IV",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical/Central Sterile Processing Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/surgical-central-sterile-processing-technology/surgicalcentral-sterile-processing-technology-basic-technical-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Post-Admission Program Requirements",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "100",
+              "title": "Introduction to Allied Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "104",
+              "title": "Central Sterile Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/health-professions-department/surgical-technology/surgical-technology-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements Term 1",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "100",
+              "title": "Introduction to Allied Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "104",
+              "title": "Central Sterile Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "105",
+              "title": "Human Structure & Function*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 2",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURT",
+              "number": "102",
+              "title": "Surgical concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "104",
+              "title": "Surgical Practice and Procedures",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "109",
+              "title": "Clinical Readiness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "111",
+              "title": "Human Anatomy and Disease",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 3",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURT",
+              "number": "110",
+              "title": "Leadership Skills for Surgical Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "116",
+              "title": "Surgical Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "140",
+              "title": "Beginning Surgical Procedures*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "162",
+              "title": "Wound Closure Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "286C",
+              "title": "Clinicals",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Post-Admission Program Requirements Term 4",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURT",
+              "number": "285C",
+              "title": "Clinicals*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "161",
+              "title": "Advanced Surgical Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/math-department/mathematics/mathematics-associate-of-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "275",
+              "title": "Calculus III*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "176",
+              "title": "Discrete Mathematics*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229",
+              "title": "Computer Science and Programming I*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "229L",
+              "title": "Computer Science & Programming I Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "310",
+              "title": "Ordinary Differential Equations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "230",
+              "title": "Introduction to Linear Algebra*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Certified Nursing Assistant, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/nursing-department/certified-nursing-assistant/certified-nursing-assistant-basic-technical-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "100",
+              "title": "Introduction to Allied Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALLH",
+              "number": "102",
+              "title": "Certified Nursing Assistant",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing – Registered, Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/nursing-department/nursing-registered/nursing-registered-associate-of-science",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission Program Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALLH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy & Physiology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy & Physiology 1 Lab*",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Criminal Justice, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/social-science-and-communication-department/criminal-justice/criminal-justice-associate-of-arts",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "103",
+              "title": "Introduction to Law and Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIJ",
+              "number": "102",
+              "title": "Introduction to Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "275",
+              "title": "Criminal Evidence Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIJ",
+              "number": "104",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "276",
+              "title": "Law of Arrest, Search and Seizure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "History, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/social-science-and-communication-department/history/history-associate-of-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "history"
+    },
+    {
+      "title": "Political Science, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/social-science-and-communication-department/political-science/political-science-associate-of-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLS",
+              "number": "221",
+              "title": "Intro to International Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLS",
+              "number": "202",
+              "title": "American State & Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/social-science-and-communication-department/psychology/psychology-associate-of-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "120",
+              "title": "Careers in Psychology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Child and Adolescent Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Concepts of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Biology 1*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "217",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "207",
+              "title": "Introduction to Psychological Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Social Work, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/social-science-and-communication-department/social-work/social-work-associate-of-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Concepts of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "201",
+              "title": "Introduction to Social Work/Social Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "272",
+              "title": "Human Behavior & Social Environment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Child and Adolescent Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "202",
+              "title": "Foundations of Social Work*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "238",
+              "title": "Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/social-science-and-communication-department/sociology/sociology-associate-of-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELL",
+              "number": "102",
+              "title": "Lifelong Wellness 2",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "102",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCY",
+              "number": "238",
+              "title": "Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Cond - Refrig and Heat, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/air-cond-refrig-and-heat/air-cond-refrig-and-heat-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIRC",
+              "number": "137",
+              "title": "Fossil Fuel Furnaces",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "139",
+              "title": "Heat Pumps",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIRC",
+              "number": "134",
+              "title": "HVAC/R State and Industry Codes",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "135",
+              "title": "Air Conditioning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "136",
+              "title": "EPA",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "140",
+              "title": "Commercial Refrigeration",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIRC",
+              "number": "138",
+              "title": "Ammonia Refrigeration",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Recommended Elective Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIRC",
+              "number": "285",
+              "title": "Cooperative Education*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Concepts of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Cond - Refrig and Heat, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/air-cond-refrig-and-heat/air-cond-refrig-and-heat-basic-technical-certificate",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Electives: 8 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIRC",
+              "number": "134",
+              "title": "HVAC/R State and Industry Codes",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "135",
+              "title": "Air Conditioning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "136",
+              "title": "EPA",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "137",
+              "title": "Fossil Fuel Furnaces",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "138",
+              "title": "Ammonia Refrigeration",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "139",
+              "title": "Heat Pumps",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "140",
+              "title": "Commercial Refrigeration",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Technology and Apprenticeship, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/applied-technology-and-apprenticeship/applied-technology-and-apprenticeship-associate-of-applied-science",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives 45 Hours",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "280",
+              "title": "Communications Technician Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELCL",
+              "number": "280",
+              "title": "Electrical Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GSPC",
+              "number": "280",
+              "title": "Generation Specialist Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTEC",
+              "number": "280",
+              "title": "Generation Technician Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LINE",
+              "number": "280",
+              "title": "Lineworker Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOTC",
+              "number": "280",
+              "title": "Line Operation Technician Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAIN",
+              "number": "280",
+              "title": "Industrial Maintenance Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "METR",
+              "number": "280",
+              "title": "Meter Technician Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLUM",
+              "number": "280",
+              "title": "Plumbing Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTEC",
+              "number": "280",
+              "title": "Relay Technician Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "280",
+              "title": "Station Technician Apprenticeship",
+              "credits": 45,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation Engineering Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/automation-engineering-technology/automation-engineering-technology-associate-of-applied-science",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "110",
+              "title": "DC Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "150",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "120",
+              "title": "AC Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "142",
+              "title": "PLC Systems 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "165",
+              "title": "Lean Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "172",
+              "title": "Industrial Electronics & Motor Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "242",
+              "title": "PLC Systems 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "243",
+              "title": "Collaborative Robotic Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "244",
+              "title": "Industrial Robotic Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "236",
+              "title": "Industrial Communications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "237",
+              "title": "Integrated Process Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "247",
+              "title": "Applied Automation*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "280",
+              "title": "Automation Engineering Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "278",
+              "title": "Diagnostics and Troubleshooting",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "285",
+              "title": "Cooperative Education / Internships",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Automation Engineering Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/automation-engineering-technology/automation-engineering-technology-basic-technical-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "110",
+              "title": "DC Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "150",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Air Cond - Refrig and Heat, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/air-cond-refrig-and-heat/air-cond-refrig-and-heat-intermediate-technical-certificate",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives: 23.5 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIRC",
+              "number": "134",
+              "title": "HVAC/R State and Industry Codes",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "135",
+              "title": "Air Conditioning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "136",
+              "title": "EPA",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "137",
+              "title": "Fossil Fuel Furnaces",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "138",
+              "title": "Ammonia Refrigeration",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "139",
+              "title": "Heat Pumps",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIRC",
+              "number": "140",
+              "title": "Commercial Refrigeration",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation Engineering Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/automation-engineering-technology/automation-engineering-technology-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "110",
+              "title": "DC Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "150",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "120",
+              "title": "AC Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "142",
+              "title": "PLC Systems 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "165",
+              "title": "Lean Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Automotive Service Educational Program (ASEP), Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/automotive-service-educational-program-asep-astp/automotive-service-educational-program-asep-associate-of-applied-science",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASEP",
+              "number": "100",
+              "title": "Automotive Technology Fund & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "101",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "105",
+              "title": "Automotive Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "106",
+              "title": "Electrical/Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASEP",
+              "number": "104",
+              "title": "Automotive Steering and Suspension*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "107",
+              "title": "Heating & Air Conditioning*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "121",
+              "title": "Work Experience 1",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASEP",
+              "number": "222",
+              "title": "Work Experience 2",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASEP",
+              "number": "206",
+              "title": "Electrical/Electronic Systems 2*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "208",
+              "title": "Engine Performance*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "223",
+              "title": "Work Experience",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASEP",
+              "number": "202",
+              "title": "Automatic Transmission & Transaxle*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "203",
+              "title": "Manual Drivetrain and Axles*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASEP",
+              "number": "268",
+              "title": "Engine Performance2/Adv Diagnosis*",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Service Technology Program (ASTP), Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/automotive-service-technology-program/automotive-service-technology-program-astp-associates-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTP",
+              "number": "100",
+              "title": "General Automotive Fundamentals",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTP",
+              "number": "145",
+              "title": "Automotive Chassis Systems",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTP",
+              "number": "121",
+              "title": "Work Experience I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTP",
+              "number": "167",
+              "title": "Electrical and HVAC",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTP",
+              "number": "122",
+              "title": "Work Experience II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTP",
+              "number": "218",
+              "title": "Engine Repair and Performance",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTP",
+              "number": "223",
+              "title": "Work Experience III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASTP",
+              "number": "224",
+              "title": "Work Experience IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTP",
+              "number": "286",
+              "title": "Advanced Vehicle Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Collision Repair Technology - Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/collision-repair-technology/collision-repair-technology-basic-technical-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "103",
+              "title": "Detailing and Polishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "130",
+              "title": "Introduction to Welding for Collision Repair*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "130L",
+              "title": "Intro. to Welding for Collision Repair Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "150",
+              "title": "Introduction to Collision Repair Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "152",
+              "title": "Minor Collision Repair*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "152L",
+              "title": "Minor Collision Repair Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "155",
+              "title": "Plastic & Adhesives",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/collision-repair-technology/collision-repair-technology-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FALL SEMESTER FRESHMAN YEAR",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "103",
+              "title": "Detailing and Polishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "130",
+              "title": "Introduction to Welding for Collision Repair*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "130L",
+              "title": "Intro. to Welding for Collision Repair Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "150",
+              "title": "Introduction to Collision Repair Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "152",
+              "title": "Minor Collision Repair*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "152L",
+              "title": "Minor Collision Repair Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "155",
+              "title": "Plastic & Adhesives",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING SEMESTER FRESHMAN YEAR",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "136",
+              "title": "Electrical & Components",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "151",
+              "title": "Panel Repair Replacement & Adjustment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "163",
+              "title": "Painting & Refinishing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SUMMER SEMESTER FRESHMAN YEAR",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "165",
+              "title": "Mechanical and Electrical Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "166",
+              "title": "Structural Repairs",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FALL SEMESTER SOPHOMORE YEAR",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "286",
+              "title": "Management and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair Technology - Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/collision-repair-technology/collision-repair-technology-intermediate-technical-certificate",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "103",
+              "title": "Detailing and Polishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "130",
+              "title": "Introduction to Welding for Collision Repair*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "130L",
+              "title": "Intro. to Welding for Collision Repair Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "150",
+              "title": "Introduction to Collision Repair Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "152",
+              "title": "Minor Collision Repair*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "152L",
+              "title": "Minor Collision Repair Lab*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "155",
+              "title": "Plastic & Adhesives",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "136",
+              "title": "Electrical & Components",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "151",
+              "title": "Panel Repair Replacement & Adjustment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTB",
+              "number": "163",
+              "title": "Painting & Refinishing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTB",
+              "number": "166",
+              "title": "Structural Repairs",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/diesel-technology/diesel-technology-associate-of-applied-science",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "101",
+              "title": "Safety and Intro to Shop Practices",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "103",
+              "title": "Introduction to Electrical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "105",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "107",
+              "title": "Applied Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "108",
+              "title": "Heating, Ventilation & AC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "109",
+              "title": "Analysis of Hydraulics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "111",
+              "title": "Hydraulic & Air Brake Systems*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "113",
+              "title": "Diesel Fuel Injection",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "115",
+              "title": "Basic Diesel Engines*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "117",
+              "title": "Advanced Diesel Engines*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "119",
+              "title": "Drive Train Fundamentals*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "123",
+              "title": "Suspensions & Steering Systems*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "125",
+              "title": "Preventative Maintenance*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "201",
+              "title": "Advance Diesel Technology*",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "158",
+              "title": "Advanced Occupational Communication",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/diesel-technology/diesel-technology-basic-technical-certificate",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Fall Semester",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "101",
+              "title": "Safety and Intro to Shop Practices",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "103",
+              "title": "Introduction to Electrical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "105",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "107",
+              "title": "Applied Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Spring Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "108",
+              "title": "Heating, Ventilation & AC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "109",
+              "title": "Analysis of Hydraulics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "111",
+              "title": "Hydraulic & Air Brake Systems*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Fall Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "113",
+              "title": "Diesel Fuel Injection",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "115",
+              "title": "Basic Diesel Engines*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "117",
+              "title": "Advanced Diesel Engines*",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Spring Semester",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "119",
+              "title": "Drive Train Fundamentals*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "123",
+              "title": "Suspensions & Steering Systems*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "125",
+              "title": "Preventative Maintenance*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/diesel-technology/diesel-technology-intermediate-technical-certificate",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIET",
+              "number": "101",
+              "title": "Safety and Intro to Shop Practices",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "103",
+              "title": "Introduction to Electrical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "105",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "107",
+              "title": "Applied Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "108",
+              "title": "Heating, Ventilation & AC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "109",
+              "title": "Analysis of Hydraulics*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "111",
+              "title": "Hydraulic & Air Brake Systems*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "113",
+              "title": "Diesel Fuel Injection",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "115",
+              "title": "Basic Diesel Engines*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "117",
+              "title": "Advanced Diesel Engines*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "119",
+              "title": "Drive Train Fundamentals*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "123",
+              "title": "Suspensions & Steering Systems*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "125",
+              "title": "Preventative Maintenance*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/drafting-technology/drafting-technology-associate-of-applied-science",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Electives 3 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRAT",
+              "number": "285",
+              "title": "Cooperative Education*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "126",
+              "title": "Fundamentals of GIS*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELL",
+              "number": "255",
+              "title": "Wellness Through Healthy Living",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "106",
+              "title": "SolidWorks CSWA Cert. Prep.*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/drafting-technology/drafting-technology-intermediate-technical-certificate",
+      "total_credits": 1,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Elective Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRAT",
+              "number": "285",
+              "title": "Cooperative Education*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment/Ag Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/heavy-equipment-ag-technology/heavy-equipmentag-technology-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEAT",
+              "number": "101",
+              "title": "Safety & Intro to Shop Practices and Ldrshp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "103",
+              "title": "Intro to Heavy Equipment Basic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "105",
+              "title": "Fundamentals of Hydraulic Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "110",
+              "title": "Basic Powertrain",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "120",
+              "title": "Advanced Engines and Engine Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "125",
+              "title": "Heavy Equipment Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "130",
+              "title": "Advanced Powertrain",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEAT",
+              "number": "201",
+              "title": "Applied Heavy Equipment Technology",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEAT",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIET",
+              "number": "158",
+              "title": "Advanced Occupational Communication",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment/Ag Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/heavy-equipment-ag-technology/heavy-equipmentag-technology-intermediate-technical-certificate",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEAT",
+              "number": "101",
+              "title": "Safety & Intro to Shop Practices and Ldrshp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "103",
+              "title": "Intro to Heavy Equipment Basic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "105",
+              "title": "Fundamentals of Hydraulic Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "110",
+              "title": "Basic Powertrain",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "120",
+              "title": "Advanced Engines and Engine Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "125",
+              "title": "Heavy Equipment Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAT",
+              "number": "130",
+              "title": "Advanced Powertrain",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Maintenance Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/industrial-systems-maintenance-technology/industrial-systems-maintenance-technology-intermediate-technical-certificate",
+      "total_credits": 44,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "110",
+              "title": "DC Circuits",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "135",
+              "title": "Controls and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "150",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AETC",
+              "number": "120",
+              "title": "AC Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "142",
+              "title": "PLC Systems 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives ISMT Track",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISMT",
+              "number": "130",
+              "title": "Mechanical Drive Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISMT",
+              "number": "140",
+              "title": "Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "111",
+              "title": "Introduction to MIG Welding",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives AETC Track",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "165",
+              "title": "Lean Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "111",
+              "title": "Introduction to MIG Welding",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machining and Manufacturing Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/machining-and-manufacturing-technology/machining-and-manufacturing-technology-associate-of-applied-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "120",
+              "title": "Blueprint Reading",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "133",
+              "title": "Manual Machine Tool Theory*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "133L",
+              "title": "Manual Machine Tool Lab*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "140",
+              "title": "CNC Set Up & Operation",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Beginning Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "106",
+              "title": "SolidWorks CSWA Cert. Prep.*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "145",
+              "title": "CNC Programming I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "156",
+              "title": "CAD/CAM Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "146",
+              "title": "CNC Programming II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "205",
+              "title": "Advanced CAD Engineering Design*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "157",
+              "title": "CAD/CAM Applications II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "150",
+              "title": "Machine Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "243",
+              "title": "Collaborative Robotic Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "280",
+              "title": "Manufacturing Projects",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "147",
+              "title": "CNC Programming III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "165",
+              "title": "Lean Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "256",
+              "title": "CAD/CAM Applications III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "290",
+              "title": "Comprehensive Manufacturing Project",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machining and Manufacturing Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/machining-and-manufacturing-technology/machining-and-manufacturing-technology-basic-technical-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "120",
+              "title": "Blueprint Reading",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "133",
+              "title": "Manual Machine Tool Theory*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "133L",
+              "title": "Manual Machine Tool Lab*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "140",
+              "title": "CNC Set Up & Operation",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machining and Manufacturing Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/machining-and-manufacturing-technology/machining-and-manufacturing-technology-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANT",
+              "number": "105",
+              "title": "CAD Engineering Graphics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "120",
+              "title": "Blueprint Reading",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "133",
+              "title": "Manual Machine Tool Theory*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "133L",
+              "title": "Manual Machine Tool Lab*",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "140",
+              "title": "CNC Set Up & Operation",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Beginning Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "106",
+              "title": "SolidWorks CSWA Cert. Prep.*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "145",
+              "title": "CNC Programming I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANT",
+              "number": "156",
+              "title": "CAD/CAM Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Residential Construction, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/residential-construction/residential-construction-basic-technical-certificate",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "102",
+              "title": "Residential Construction Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "103",
+              "title": "Residential Construction Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "200I",
+              "title": "Cabinetmaking Independent Study*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/welding-technology/welding-technology-basic-technical-certificate",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "107",
+              "title": "Safety and Leadership*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "132",
+              "title": "Thermal Cutting Process",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "149",
+              "title": "Blueprint Reading for Welders",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "154",
+              "title": "SMAW Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "151",
+              "title": "Welding Theory",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "150",
+              "title": "Intermediate Blueprint Reading*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "156",
+              "title": "GMAW & FCAW",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "158",
+              "title": "GTAW",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/welding-technology/welding-technology-associate-of-applied-science",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "107",
+              "title": "Safety and Leadership*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "132",
+              "title": "Thermal Cutting Process",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "149",
+              "title": "Blueprint Reading for Welders",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "151",
+              "title": "Welding Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "154",
+              "title": "SMAW Practical",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "150",
+              "title": "Intermediate Blueprint Reading*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "156",
+              "title": "GMAW & FCAW",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "158",
+              "title": "GTAW",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "235",
+              "title": "GMAW/FCAW*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "237",
+              "title": "GTAW Project Application*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRAT",
+              "number": "103",
+              "title": "Intro to Construction Drawings in AutoCAD*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "238",
+              "title": "Pipe Welding*",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "240",
+              "title": "Sanitary Welding",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "239",
+              "title": "Structural Steel Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "280",
+              "title": "Project Capstone",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/welding-technology/welding-technology-intermediate-technical-certificate",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "107",
+              "title": "Safety and Leadership*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "132",
+              "title": "Thermal Cutting Process",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "149",
+              "title": "Blueprint Reading for Welders",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "151",
+              "title": "Welding Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "154",
+              "title": "SMAW Practical",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "150",
+              "title": "Intermediate Blueprint Reading*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "156",
+              "title": "GMAW & FCAW",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "158",
+              "title": "GTAW",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "285",
+              "title": "Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "235",
+              "title": "GMAW/FCAW*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "237",
+              "title": "GTAW Project Application*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Woodworking Technology, Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/woodworking/woodworking-technology-associate-of-applied-science",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "104",
+              "title": "Woodshop Foundations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "105",
+              "title": "Technical Woodworking Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "106",
+              "title": "Applied Joinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "112",
+              "title": "Introduction to Cabinetmaking*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "113",
+              "title": "Intermediate Cabinetmaking*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "114",
+              "title": "Advanced Cabinetmaking*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "115",
+              "title": "Cabinetmaking Concepts*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "201",
+              "title": "Finishing Techniques*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "202",
+              "title": "Furniture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "220",
+              "title": "CNC Projects*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "221",
+              "title": "CNC Applications*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "212",
+              "title": "Project Management*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "213",
+              "title": "Advanced Furniture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "203",
+              "title": "Advanced Woodworking Applications*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective Courses: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "101",
+              "title": "Intro to Woodworking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "102",
+              "title": "Residential Construction Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "103",
+              "title": "Residential Construction Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "200I",
+              "title": "Cabinetmaking Independent Study*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "225",
+              "title": "Advanced CNC Applications*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "285",
+              "title": "Cooperative Education*",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Woodworking Technology, Basic Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/woodworking/woodworking-technology-basic-technical-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "104",
+              "title": "Woodshop Foundations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "105",
+              "title": "Technical Woodworking Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "106",
+              "title": "Applied Joinery",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Woodworking Technology, Intermediate Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/trade-and-industry-department/woodworking/woodworking-technology-intermediate-technical-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "104",
+              "title": "Woodshop Foundations*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "105",
+              "title": "Technical Woodworking Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "106",
+              "title": "Applied Joinery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CABW",
+              "number": "112",
+              "title": "Introduction to Cabinetmaking*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "113",
+              "title": "Intermediate Cabinetmaking*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "114",
+              "title": "Advanced Cabinetmaking*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CABW",
+              "number": "115",
+              "title": "Cabinetmaking Concepts*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art – Visual, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/art-visual/art-visual-associate-of-arts",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Design 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "251",
+              "title": "Photography Darkroom",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "101",
+              "title": "Art History 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "106",
+              "title": "Design 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "215",
+              "title": "Painting 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "102",
+              "title": "Art History 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "280",
+              "title": "Art Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective 2D:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "209",
+              "title": "Introduction to Printmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "212",
+              "title": "Drawing 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "252",
+              "title": "Photography Darkroom 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "253",
+              "title": "Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "260",
+              "title": "Figure Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "275",
+              "title": "Painting 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective 3D:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "225",
+              "title": "Ceramics 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "226",
+              "title": "Ceramics 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "231",
+              "title": "Sculpture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "110",
+              "title": "Book Arts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Music, Concentration: Brass, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-brass-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "142",
+              "title": "Brass Lesson 1 for Brass Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "142",
+              "title": "Brass Lesson 1 for Brass Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "242",
+              "title": "Brass Lesson 2 for Brass Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, Concentration: Classical Guitar, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-classical-guitar-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "122",
+              "title": "Guitar Lesson 1 for Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "122",
+              "title": "Guitar Lesson 1 for Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "222",
+              "title": "Guitar Lesson 2 for Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, Concentration: Keyboard, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-keyboard-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "112",
+              "title": "Piano Lesson 1 for Piano Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "112",
+              "title": "Piano Lesson 1 for Piano Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "212",
+              "title": "Piano Lesson 2 for Piano Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, Concentration: Percussion, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-percussion-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "162",
+              "title": "Percussion Lesson l/Percussion Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "162",
+              "title": "Percussion Lesson l/Percussion Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "262",
+              "title": "Percussion Lesson 1/Percussion Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, Concentration: String, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-string-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "132",
+              "title": "String Lesson 1 for String Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "132",
+              "title": "String Lesson 1 for String Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "232",
+              "title": "String Lesson 2 for String Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, Concentration: Vocal, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-vocal-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "102",
+              "title": "Voice Lesson 1 Voice Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "102",
+              "title": "Voice Lesson 1 Voice Majors",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "202",
+              "title": "Voice Lesson 2 for Voice Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, Concentration: Woodwind, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/music/music-concentration-woodwind-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "152",
+              "title": "Woodwind Lesson 1 for Wind Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "152",
+              "title": "Woodwind Lesson 1 for Wind Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSA",
+              "number": "252",
+              "title": "Woodwind Lesson 2 for Wind Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Ensemble Electives (2 hours required)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "122",
+              "title": "Wind Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/theatre/theatre-associate-of-arts",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "111",
+              "title": "Fundamentals of Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "130",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "151",
+              "title": "Play Production",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "112",
+              "title": "Intermediate Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "151",
+              "title": "Play Production",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSA",
+              "number": "100",
+              "title": "Voice Lesson 1 for Non-Majors",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THEA",
+              "number": "151",
+              "title": "Play Production*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "201",
+              "title": "History of World Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "113",
+              "title": "Script Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "280",
+              "title": "Theatre Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THEA",
+              "number": "202",
+              "title": "Modern Theatre and Musicals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "240",
+              "title": "Stage Makeup",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual and Performing Arts, Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://csi.smartcatalogiq.com/en/2026-2027/2026-2027-catalog/visual-performing-and-liberal-arts-department/visual-and-performing-arts/visual-and-performing-arts-associate-of-arts",
+      "total_credits": 82,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GNED",
+              "number": "101",
+              "title": "Introduction to General Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Freshman Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Sophomore Year",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUMA",
+              "number": "280",
+              "title": "VPA Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Sophomore Year",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Electives List - 9 credits total",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Elective - EXPLORE Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "101",
+              "title": "Art History 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "102",
+              "title": "Art History 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "103",
+              "title": "Appreciation and History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Design 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "106",
+              "title": "Design 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "110",
+              "title": "Book Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "117",
+              "title": "Visual Art 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "101",
+              "title": "Dance Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "110",
+              "title": "Ballet 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "117",
+              "title": "Dance 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "120",
+              "title": "Jazz 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "130",
+              "title": "Modern I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "103",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "117",
+              "title": "Music 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "130",
+              "title": "Chamber Choir",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "131",
+              "title": "College MV Chorale",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "144",
+              "title": "Class Guitar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "145",
+              "title": "Class Voice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "150",
+              "title": "Beginning Class Piano 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "117",
+              "title": "Theatre 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "130",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives - USE Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "127",
+              "title": "Visual Art 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "150",
+              "title": "Beginning Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "209",
+              "title": "Introduction to Printmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "215",
+              "title": "Painting 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "225",
+              "title": "Ceramics 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "226",
+              "title": "Ceramics 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "127",
+              "title": "Dance 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "210",
+              "title": "Ballet II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "220",
+              "title": "Dance Team Technique",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "230",
+              "title": "Modern II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "251",
+              "title": "Composition 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "100",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "104",
+              "title": "Music Theory 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "111",
+              "title": "Aural Skills 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "108",
+              "title": "Survey of Jazz & Pop Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "120",
+              "title": "Symphonic Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "121",
+              "title": "Symphony Orchestra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "127",
+              "title": "Music 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "140",
+              "title": "Jazz Improvisation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "151",
+              "title": "Beginning Class Piano 2*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "202",
+              "title": "Modern Theatre and Musicals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "111",
+              "title": "Fundamentals of Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "127",
+              "title": "Theatre 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "201",
+              "title": "History of World Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "240",
+              "title": "Stage Makeup",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective - BUILD Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "212",
+              "title": "Drawing 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "217",
+              "title": "Visual Art 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "251",
+              "title": "Photography Darkroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "253",
+              "title": "Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "260",
+              "title": "Figure Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "275",
+              "title": "Painting 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "170",
+              "title": "Dance Repertory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "217",
+              "title": "Dance 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "252",
+              "title": "Dance Composition 2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "105",
+              "title": "Music Theory 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "112",
+              "title": "Aural Skills 2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "125",
+              "title": "Jazz Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "133",
+              "title": "Percussion Ensemble",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "135",
+              "title": "Madrigal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "155",
+              "title": "Intermediate Class Piano 1*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "156",
+              "title": "Intermediate Class Piano 2*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "201",
+              "title": "Music Theory 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "211",
+              "title": "Aural Skills 3",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "217",
+              "title": "Music 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "255",
+              "title": "Piano Literature 1*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "233",
+              "title": "Music Methods for Elementary Tchrs",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "256",
+              "title": "Piano Pedagogy 1*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "270",
+              "title": "introduction to Conducting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "112",
+              "title": "Intermediate Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "113",
+              "title": "Script Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "217",
+              "title": "Theatre 3",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Elective - CREATE Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "201",
+              "title": "Studio Drawing*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "202",
+              "title": "Studio Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "203",
+              "title": "Studio Ceramics*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "204",
+              "title": "Studio Photography*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "205",
+              "title": "Studio Sculpture*",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "207",
+              "title": "Studio Printmaking",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "210",
+              "title": "Studio Book Arts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "227",
+              "title": "Visual Art 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "280",
+              "title": "Art Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "227",
+              "title": "Dance 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "253",
+              "title": "Dance Composition 3",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "280",
+              "title": "DANC Portfolio*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "123",
+              "title": "Pep Band",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "202",
+              "title": "Music Theory 4*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "212",
+              "title": "Aural Skills 4*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "227",
+              "title": "Music 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "243",
+              "title": "Music Portfolio and Final Recital",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSI",
+              "number": "257",
+              "title": "Piano Pedagogy 2*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "151",
+              "title": "Play Production",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "227",
+              "title": "Theatre 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "280",
+              "title": "Theatre Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/id/programs/college-of-western-idaho.json
+++ b/data/id/programs/college-of-western-idaho.json
@@ -1,0 +1,14045 @@
+{
+  "college_slug": "college-of-western-idaho",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.cwi.edu/programs-study/",
+  "scraped_at": "2026-06-07T00:50:25.496Z",
+  "programs": [
+    {
+      "title": "Accounting and Tax - Academic Certificate (AC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/accounting/accounting-and-tax-ac/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "250",
+              "title": "Income Tax Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "251",
+              "title": "Volunteer Income Tax Assistance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "293",
+              "title": "Accounting Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "290",
+              "title": "Foundations of the Accounting Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Writing - Basic Technical Certificate (BTC)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/administrative-specialist/business-writing-btc/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "230",
+              "title": "Business Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "231",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Technology - Basic Technical Certificate (BTC)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/administrative-specialist/business-technology-btc/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADMS",
+              "number": "145",
+              "title": "Advanced Office Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "245",
+              "title": "The Virtual Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Administrative Specialist - Associate of Applied Science Degree (AAS)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/administrative-specialist/administrative-specialist-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "112",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "145",
+              "title": "Advanced Office Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "230",
+              "title": "Business Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "231",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "245",
+              "title": "The Virtual Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "290",
+              "title": "Administrative Specialist Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "293",
+              "title": "Administrative Specialist Internship",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "151",
+              "title": "Fundamental Accounting Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "255",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Mechatronics Engineering Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/advanced-mechatronics-engineering-technology/advanced-mechatronics-engineering-technology-aas/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMET",
+              "number": "121",
+              "title": "DC Circuits and Application",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "131",
+              "title": "AC Circuits and Application",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "136",
+              "title": "Industrial Tools and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "141",
+              "title": "Analog Circuits and Application",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "151",
+              "title": "Digital Circuits and Application",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "196",
+              "title": "Fundamentals of Microcontrollers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "201",
+              "title": "Programmable Logic Controllers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "221",
+              "title": "Industrial Automated Controls and Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "231",
+              "title": "Industrial Robotics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "236",
+              "title": "Fluid Power Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "241",
+              "title": "Industrial Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "251",
+              "title": "Industry Certifications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "290",
+              "title": "Applied Mechatronics",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Mechatronics Engineering Technology - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/advanced-mechatronics-engineering-technology/advanced-mechatronics-engineering-technology-btc/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMET",
+              "number": "121",
+              "title": "DC Circuits and Application",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "131",
+              "title": "AC Circuits and Application",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "136",
+              "title": "Industrial Tools and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "141",
+              "title": "Analog Circuits and Application",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMET",
+              "number": "151",
+              "title": "Digital Circuits and Application",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Agricultural Business, Leadership, and Education - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/agricultural-business-leadership-education/agricultural-business-leadership-education-aa/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Global Food Perspectives - Farm to Plate (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology I (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111L",
+              "title": "Biology I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Introduction to Chemistry Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "278",
+              "title": "Farm and Agribusiness Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "289",
+              "title": "Agricultural Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "290",
+              "title": "Agricultural Science Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "140",
+              "title": "Soils and Plant Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Scienceand Principles of Animal Science Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FERM",
+              "number": "110",
+              "title": "Grapes and Hops: Specialty Crops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FERM",
+              "number": "120",
+              "title": "Introduction to Fermented Foods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "126",
+              "title": "Fundamentals of GIS",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "110",
+              "title": "Plant Science",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Office Management - Basic Technical Certificate (BTC)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/administrative-specialist/office-management-btc/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADMS",
+              "number": "112",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "151",
+              "title": "Fundamental Accounting Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "255",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Animal Veterinary Sciences - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/animal-veterinary-sciences/animal-veterinary-sciences-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "120",
+              "title": "Global Food Perspectives - Farm to Plate (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109",
+              "title": "Principles of Animal Science (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "109L",
+              "title": "Principles of Animal Science Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology I (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111L",
+              "title": "Biology I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271",
+              "title": "Animal Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "271L",
+              "title": "Animal Anatomy and Physiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "290",
+              "title": "Agricultural Science Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Technology and Apprenticeship - Associate of Applied Science (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/apprenticeship/apprenticeship-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "APPR",
+              "number": "230",
+              "title": "Electrical Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "235",
+              "title": "HVAC Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "240",
+              "title": "Plumbing Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "245",
+              "title": "Communications Technician Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "250",
+              "title": "Generation Specialist Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "255",
+              "title": "Generation Technician Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "260",
+              "title": "Line Operation Technician Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "265",
+              "title": "Lineworker Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "270",
+              "title": "Meter Technician Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "275",
+              "title": "Relay Technician Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APPR",
+              "number": "280",
+              "title": "Station Technician Apprenticeship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Anthropology - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/anthropology/anthropology-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "102",
+              "title": "Cultural Anthropology (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math in Modern Society (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "100",
+              "title": "Physical Geography (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "100L",
+              "title": "Physical Geography Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "104",
+              "title": "Biological Anthropology (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "250",
+              "title": "Fundamentals of Social Science Research (GEM 6)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "103",
+              "title": "Introduction to Archaeology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "220",
+              "title": "Indigenous Peoples of North America",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "240",
+              "title": "Basque Heritage and Contemporary People",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "250",
+              "title": "Indigenous Mythology and Rituals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "260",
+              "title": "Mexican Heritage and Contemporary Peoples",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "126",
+              "title": "Fundamentals of GIS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Artificial Intelligence and Cloud Computing - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/artificial-intelligence/aicc-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning (GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "110",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "120",
+              "title": "Introduction to Python Programming and the Cloud",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "130",
+              "title": "Linux for Artificial Intelligence and Cloud Computing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "150",
+              "title": "Python for Artificial Intelligence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "160",
+              "title": "Math for Artificial Intelligence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "170",
+              "title": "Database, Data Mining, and Big Data",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "210",
+              "title": "Machine Learning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "230",
+              "title": "Artificial Intelligence and Cloud Computing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "250",
+              "title": "Computer Vision",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "260",
+              "title": "Natural Language Processing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "270",
+              "title": "Artificial Intelligence for Cybersecurity and the SOC",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AICC",
+              "number": "290",
+              "title": "Artificial Intelligence and Cloud Computing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/automotive-technology/automotive-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "112",
+              "title": "Automotive Foundations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "115",
+              "title": "Automotive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "121",
+              "title": "Automotive Electrical Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "125",
+              "title": "Automotive Electrical Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "131",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "135",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "141",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "145",
+              "title": "Manual Drivetrain and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "250",
+              "title": "Engine Management Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "255",
+              "title": "Engine Management Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "260",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "265",
+              "title": "Heating and Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "270",
+              "title": "Light-Duty Diesel Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "275",
+              "title": "Electric Vehicle and Hybrid Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "280",
+              "title": "Automotive Shop Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "290",
+              "title": "Automotive Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/automotive-technology/automotive-technology-atc/",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "112",
+              "title": "Automotive Foundations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "115",
+              "title": "Automotive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "121",
+              "title": "Automotive Electrical Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "125",
+              "title": "Automotive Electrical Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "131",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "135",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "141",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "145",
+              "title": "Manual Drivetrain and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "250",
+              "title": "Engine Management Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "255",
+              "title": "Engine Management Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "260",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "265",
+              "title": "Heating and Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "270",
+              "title": "Light-Duty Diesel Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "275",
+              "title": "Electric Vehicle and Hybrid Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "280",
+              "title": "Automotive Shop Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "290",
+              "title": "Automotive Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Maintenance and Light Repair - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/automotive-technology/maintenance-light-repair-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "112",
+              "title": "Automotive Foundations and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "115",
+              "title": "Automotive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "121",
+              "title": "Automotive Electrical Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "125",
+              "title": "Automotive Electrical Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "131",
+              "title": "Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "135",
+              "title": "Suspension and Steering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "141",
+              "title": "Engine Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "145",
+              "title": "Manual Drivetrain and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Laboratory Assistant - Academic Certificate (AC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/biotechnology/biotechnology-lab-assistant-ac/",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111L",
+              "title": "Biology I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112",
+              "title": "Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112L",
+              "title": "Biology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Introduction to Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "General Chemistry I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "General Chemistry II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298L",
+              "title": "Organic Chemistry I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "260",
+              "title": "Introduction to Cell Biologyand Introduction to Cell Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "280",
+              "title": "Geneticsand Genetics Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "293",
+              "title": "Biology Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "293",
+              "title": "Biotechnology Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "293",
+              "title": "Chemistry Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "200",
+              "title": "Vertically Integrated Projects (VIP)",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Biology - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/biology/biol-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology I (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111L",
+              "title": "Biology I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "General Chemistry I Plusand General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112",
+              "title": "Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112L",
+              "title": "Biology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "General Chemistry II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "113",
+              "title": "Biology III: Principles of Structure and Functionand Biology III: Principles of Structure and Function Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "280",
+              "title": "Geneticsand Genetics Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Bookkeeping and Accounting - Associate of Applied Science Degree (AAS)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/bookkeeping-and-accounting/bookkeeping-and-accounting-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "250",
+              "title": "Income Tax Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "251",
+              "title": "Volunteer Income Tax Assistance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "293",
+              "title": "Accounting Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "293",
+              "title": "Bookkeeping and Accounting Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "145",
+              "title": "Advanced Office Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "231",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "245",
+              "title": "The Virtual Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "151",
+              "title": "Fundamental Accounting Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "252",
+              "title": "Applied Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "255",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "258",
+              "title": "Payroll and Human Resource Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "260",
+              "title": "Professional Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "290",
+              "title": "Bookkeeping and Accounting Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "290",
+              "title": "Foundations of the Accounting Profession",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "257",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Bookkeeping and Accounting - Advanced Technical Certificate (ATC)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/bookkeeping-and-accounting/bookkeeping-and-accounting-atc/",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "250",
+              "title": "Income Tax Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "251",
+              "title": "Volunteer Income Tax Assistance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "293",
+              "title": "Accounting Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "293",
+              "title": "Bookkeeping and Accounting Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "145",
+              "title": "Advanced Office Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "231",
+              "title": "Business Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "245",
+              "title": "The Virtual Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "151",
+              "title": "Fundamental Accounting Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "252",
+              "title": "Applied Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "255",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "258",
+              "title": "Payroll and Human Resource Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "260",
+              "title": "Professional Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "290",
+              "title": "Bookkeeping and Accounting Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "290",
+              "title": "Foundations of the Accounting Profession",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Professional Bookkeeping - Basic Technical Certificate (BTC)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/bookkeeping-and-accounting/bookkeeping-btc/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOOK",
+              "number": "151",
+              "title": "Fundamental Accounting Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "252",
+              "title": "Applied Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "255",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "258",
+              "title": "Payroll and Human Resource Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "260",
+              "title": "Professional Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - Bachelor of Applied Science Degree (BAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/business-administration/business-admin-bas/",
+      "total_credits": 120,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 120,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (or any general education elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Communication and Culture (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "350",
+              "title": "Accounting for Managers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "301",
+              "title": "Organizational Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "308",
+              "title": "Analytics for Managers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "325",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "335",
+              "title": "Organizational Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "438",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "452",
+              "title": "Small Business Management and Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "465",
+              "title": "Applied Business and Employment Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "490",
+              "title": "Business Policy and Practice Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "340",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Analytics - Academic Certificate (AC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/business-analytics/bus-analytics-ac/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Introduction to Business Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "208",
+              "title": "Business Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "270",
+              "title": "Big Data and Business Analytics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/business/business-aa/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Introduction to Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Introduction to Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "207",
+              "title": "Introduction to Business Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "208",
+              "title": "Business Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "265",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "290",
+              "title": "Business Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemistry - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/chemistry/chemistry-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I (GEM 3)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "General Chemistry I Plusand General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Scientists and Engineers Iand Physics for Scientists and Engineers I Lab (GEM 4)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "General Chemistry II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "298L",
+              "title": "Organic Chemistry I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cisco Networking and Security Technologies - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cisco-networking-security-technologies/cisco-networking-security-technologies-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "124",
+              "title": "IT Essentials",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "127",
+              "title": "Introduction to Networks",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "129",
+              "title": "Switching, Routing, and Wireless Essentials",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "135",
+              "title": "Enterprise Networking, Security, and Automation",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "230",
+              "title": "Linux Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "238",
+              "title": "Cisco Certified Network Associate (CCNA) Cyber Ops",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "240",
+              "title": "Virtualization Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "242",
+              "title": "Cisco DevNet Associate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "244",
+              "title": "Linux Advanced",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "249",
+              "title": "Command Line and Scripting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cisco Networking and Security Technologies - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cisco-networking-security-technologies/cisco-networking-security-technologies-atc/",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "124",
+              "title": "IT Essentials",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "127",
+              "title": "Introduction to Networks",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "129",
+              "title": "Switching, Routing, and Wireless Essentials",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "135",
+              "title": "Enterprise Networking, Security, and Automation",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "230",
+              "title": "Linux Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "238",
+              "title": "Cisco Certified Network Associate (CCNA) Cyber Ops",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "240",
+              "title": "Virtualization Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "242",
+              "title": "Cisco DevNet Associate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "244",
+              "title": "Linux Advanced",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "249",
+              "title": "Command Line and Scripting Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cisco Networking and Security Technologies - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cisco-networking-security-technologies/cisco-networking-security-technologies-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "124",
+              "title": "IT Essentials",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "127",
+              "title": "Introduction to Networks",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "129",
+              "title": "Switching, Routing, and Wireless Essentials",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "135",
+              "title": "Enterprise Networking, Security, and Automation",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud, Security, and System Administration - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cloud-security-system-admin/cssa-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSSA",
+              "number": "141",
+              "title": "Fundamentals of Windows Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "143",
+              "title": "Network Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "145",
+              "title": "Network Design and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "147",
+              "title": "Network Fundamentals and Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "150",
+              "title": "Server Administration",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "160",
+              "title": "Security",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "260",
+              "title": "Server Hybrid Infrastructure",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "262",
+              "title": "Email Systems and Failover Clustering",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "266",
+              "title": "Database Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "268",
+              "title": "PowerShell and Certification",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "271",
+              "title": "Virtualization Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud, Security, and System Administration - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cloud-security-system-admin/cssa-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSSA",
+              "number": "141",
+              "title": "Fundamentals of Windows Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "143",
+              "title": "Network Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "145",
+              "title": "Network Design and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "147",
+              "title": "Network Fundamentals and Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "150",
+              "title": "Server Administration",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "160",
+              "title": "Security",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud, Security, and System Administration - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cloud-security-system-admin/cssa-itc/",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSSA",
+              "number": "141",
+              "title": "Fundamentals of Windows Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "143",
+              "title": "Network Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "145",
+              "title": "Network Design and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "147",
+              "title": "Network Fundamentals and Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "150",
+              "title": "Server Administration",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "160",
+              "title": "Security",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "260",
+              "title": "Server Hybrid Infrastructure",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "262",
+              "title": "Email Systems and Failover Clustering",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "266",
+              "title": "Database Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "268",
+              "title": "PowerShell and Certification",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSA",
+              "number": "271",
+              "title": "Virtualization Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/collision-repair-technology/crt-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Safety and Welding for Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "125",
+              "title": "Basic Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "135",
+              "title": "Estimating, Damage Analysis, and Structural Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "145",
+              "title": "Intermediate Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "215",
+              "title": "Refinishing for Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "235",
+              "title": "Advanced Collision Repair and Refinishing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "260",
+              "title": "Collision Repair Cooperative",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair Technology - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/collision-repair-technology/crt-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Safety and Welding for Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "125",
+              "title": "Basic Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "135",
+              "title": "Estimating, Damage Analysis, and Structural Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "145",
+              "title": "Intermediate Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair Technology - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/collision-repair-technology/crt-itc/",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "115",
+              "title": "Safety and Welding for Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "125",
+              "title": "Basic Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "135",
+              "title": "Estimating, Damage Analysis, and Structural Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "145",
+              "title": "Intermediate Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "215",
+              "title": "Refinishing for Collision Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "235",
+              "title": "Advanced Collision Repair and Refinishing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "260",
+              "title": "Collision Repair Cooperative",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/communication/communication-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "112",
+              "title": "Argumentation and Debate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "221",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "290",
+              "title": "Communication Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "114",
+              "title": "Intercollegiate Speech and Debate",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Communication and Culture",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "268",
+              "title": "Introduction to Video Production",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "269",
+              "title": "Introduction to Audio Production",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "271",
+              "title": "Introduction to Mass Media",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "293",
+              "title": "Communication Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Support Specialist - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/computer-support-specialist/computer-support-specialist-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSSP",
+              "number": "104",
+              "title": "Fundamentals of Computing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "106",
+              "title": "Survey of Peripheral Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "107",
+              "title": "Information Technology and Cloud Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "109",
+              "title": "Computer Essentials I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "111",
+              "title": "Computer Essentials II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "114",
+              "title": "PC Security and Troubleshooting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "200",
+              "title": "Principles of Networking",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "202",
+              "title": "Advanced Networking and Troubleshooting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "216",
+              "title": "Principles of Network Security",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "218",
+              "title": "Advanced Network Security and Auditing",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Support Specialist - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/computer-support-specialist/computer-support-specialist-itc/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSSP",
+              "number": "104",
+              "title": "Fundamentals of Computing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "106",
+              "title": "Survey of Peripheral Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "107",
+              "title": "Information Technology and Cloud Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "109",
+              "title": "Computer Essentials I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "111",
+              "title": "Computer Essentials II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "114",
+              "title": "PC Security and Troubleshooting",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/computer-science/computer-science-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "112",
+              "title": "Argumentation and Debate",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus (GEM 3)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Scientists and Engineers I (GEM 4)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211L",
+              "title": "Physics for Scientists and Engineers I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "121",
+              "title": "Computer Science I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "153",
+              "title": "Navigating Computer Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "155",
+              "title": "Introduction to Version Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "208",
+              "title": "Introduction to Full Stack Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "221",
+              "title": "Computer Science II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/criminal-justice/criminal-justice-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "280",
+              "title": "Victimology (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "102",
+              "title": "Social Problems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "102",
+              "title": "Introduction to Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "103",
+              "title": "Introduction to Law and Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "104",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "190",
+              "title": "Writing for Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "190",
+              "title": "Writing for the Social Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "270",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "290",
+              "title": "Criminal Justice Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "293",
+              "title": "Criminal Justice Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Support Specialist - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/computer-support-specialist/computer-support-specialist-atc/",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSSP",
+              "number": "104",
+              "title": "Fundamentals of Computing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "106",
+              "title": "Survey of Peripheral Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "107",
+              "title": "Information Technology and Cloud Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "109",
+              "title": "Computer Essentials I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "111",
+              "title": "Computer Essentials II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "114",
+              "title": "PC Security and Troubleshooting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "200",
+              "title": "Principles of Networking",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "202",
+              "title": "Advanced Networking and Troubleshooting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "216",
+              "title": "Principles of Network Security",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSSP",
+              "number": "218",
+              "title": "Advanced Network Security and Auditing",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cybersecurity/cybersecurity-atc/",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSEC",
+              "number": "111",
+              "title": "Cybersecurity Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "115",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "119",
+              "title": "Introduction to Internetworking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "127",
+              "title": "Server Operating Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "129",
+              "title": "Fundamentals of Linux",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "131",
+              "title": "Introduction to Information Security",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "246",
+              "title": "Securing a Directory Services Infrastructure",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "248",
+              "title": "Advanced Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "252",
+              "title": "Introduction to Programming for Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "255",
+              "title": "Ethical Hacking and Countermeasures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "257",
+              "title": "Introduction to Digital Forensics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "290",
+              "title": "Cybersecurity Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Assisting - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/dental-assisting/dental-assisting-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistryand Introduction to Chemistry Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "100",
+              "title": "Dental Materials and Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "102",
+              "title": "Dental Clinical Skills I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "103",
+              "title": "Dental Prosthodontic Materials and Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "105",
+              "title": "Dental Clinical Skills II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "106",
+              "title": "Dental Assisting Clinical Experience",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "107",
+              "title": "Dental Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "107L",
+              "title": "Dental Radiography Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "108",
+              "title": "Dental Office Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "115L",
+              "title": "Dental Assisting Pre-Clinical Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "120L",
+              "title": "Dental Assisting Pre-Clinical Lab II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "151",
+              "title": "Dental Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "152",
+              "title": "Dental Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "153",
+              "title": "Dental Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "154",
+              "title": "Dental Theory IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "225",
+              "title": "Advanced Dental Assisting Practicum",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/cybersecurity/cybersecurity-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSEC",
+              "number": "111",
+              "title": "Cybersecurity Essentials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "115",
+              "title": "Introduction to Networks",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "119",
+              "title": "Introduction to Internetworking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "127",
+              "title": "Server Operating Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "129",
+              "title": "Fundamentals of Linux",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "131",
+              "title": "Introduction to Information Security",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "246",
+              "title": "Securing a Directory Services Infrastructure",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "248",
+              "title": "Advanced Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "252",
+              "title": "Introduction to Programming for Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "255",
+              "title": "Ethical Hacking and Countermeasures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "257",
+              "title": "Introduction to Digital Forensics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSEC",
+              "number": "290",
+              "title": "Cybersecurity Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Assisting - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/dental-assisting/dental-assisting-itc/",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENT",
+              "number": "100",
+              "title": "Dental Materials and Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "102",
+              "title": "Dental Clinical Skills I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "103",
+              "title": "Dental Prosthodontic Materials and Procedures",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "105",
+              "title": "Dental Clinical Skills II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "107",
+              "title": "Dental Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "107L",
+              "title": "Dental Radiography Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "106",
+              "title": "Dental Assisting Clinical Experience",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "108",
+              "title": "Dental Office Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "115L",
+              "title": "Dental Assisting Pre-Clinical Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "120L",
+              "title": "Dental Assisting Pre-Clinical Lab II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "151",
+              "title": "Dental Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "152",
+              "title": "Dental Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "153",
+              "title": "Dental Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "154",
+              "title": "Dental Theory IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Photography - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/digital-photography/phot-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Introduction to 2-D Art Foundations (GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "220",
+              "title": "Entrepreneurial Strategy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "255",
+              "title": "Leadership Development Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "268",
+              "title": "Introduction to Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "269",
+              "title": "Introduction to Audio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "110",
+              "title": "Introduction to Film Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "150",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "250",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "251",
+              "title": "Studio Lighting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "252",
+              "title": "Location Lighting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "260",
+              "title": "Portrait Photography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "261",
+              "title": "Landscape and Architectural Photography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "262",
+              "title": "Event Photography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "263",
+              "title": "Still Life Photography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "270",
+              "title": "Documentary Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "290",
+              "title": "Digital Photography Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Photography - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/digital-photography/phot-btc/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Introduction to 2-D Art Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "268",
+              "title": "Introduction to Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "150",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "250",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "251",
+              "title": "Studio Lighting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "252",
+              "title": "Location Lighting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/drafting-technology/drafting-technology-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math in Modern Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143P",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "100",
+              "title": "Construction Materials and Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "114",
+              "title": "Drafting Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "118",
+              "title": "Introduction to Revit",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "119",
+              "title": "Introduction to AutoCAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "120",
+              "title": "Residential Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "123",
+              "title": "Introduction to Solidworks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "139",
+              "title": "Applied Problem Solving for Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "190",
+              "title": "Job Skills for Drafting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "211",
+              "title": "Civil Drafting and Math",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "212",
+              "title": "Structural and HVAC System Drafting",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "213",
+              "title": "Machine Drafting and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "217",
+              "title": "Commercial Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "218",
+              "title": "Electrical and Plumbing Systems Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "239",
+              "title": "Advanced Revit Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "290",
+              "title": "Drafting Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting Technology - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/drafting-technology/drafting-technology-itc/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math in Modern Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143P",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "100",
+              "title": "Construction Materials and Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "114",
+              "title": "Drafting Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "118",
+              "title": "Introduction to Revit",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "119",
+              "title": "Introduction to AutoCAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "120",
+              "title": "Residential Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "123",
+              "title": "Introduction to Solidworks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "139",
+              "title": "Applied Problem Solving for Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "190",
+              "title": "Job Skills for Drafting",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting Technology - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/drafting-technology/drafting-technology-atc/",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 55,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math in Modern Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143P",
+              "title": "Precalculus I: Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "160",
+              "title": "Survey of Calculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "100",
+              "title": "Construction Materials and Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "114",
+              "title": "Drafting Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "118",
+              "title": "Introduction to Revit",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "119",
+              "title": "Introduction to AutoCAD",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "120",
+              "title": "Residential Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "123",
+              "title": "Introduction to Solidworks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "139",
+              "title": "Applied Problem Solving for Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "190",
+              "title": "Job Skills for Drafting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "211",
+              "title": "Civil Drafting and Math",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "212",
+              "title": "Structural and HVAC System Drafting",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "213",
+              "title": "Machine Drafting and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "217",
+              "title": "Commercial Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "218",
+              "title": "Electrical and Plumbing Systems Drafting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "239",
+              "title": "Advanced Revit Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "290",
+              "title": "Drafting Technology Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/early-childhood-education/early-childhood-education-btc/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "101",
+              "title": "Child Development and Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Teaching Young Children I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105L",
+              "title": "Teaching Young Children I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "141",
+              "title": "Health, Safety, and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "171",
+              "title": "Early Childhood Curriculum I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Engineering - Associate of Engineering Degree (AE) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/engineering/engineering-ae/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I (GEM 3)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry I (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111P",
+              "title": "General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "General Chemistry I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Scientists and Engineers I (GEM 4)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211L",
+              "title": "Physics for Scientists and Engineers I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "120",
+              "title": "Introduction to Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "290",
+              "title": "Engineering Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Early Childhood Education - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/early-childhood-education/early-childhood-education-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "101",
+              "title": "Child Development and Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Teaching Young Children I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105L",
+              "title": "Teaching Young Children I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "106",
+              "title": "Teaching Young Children II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "106L",
+              "title": "Teaching Young Children II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "141",
+              "title": "Health, Safety, and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "171",
+              "title": "Early Childhood Curriculum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "173",
+              "title": "Early Childhood Curriculum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "184",
+              "title": "Family and Community Partnerships",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "202",
+              "title": "Child Growth and Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "203L",
+              "title": "Early Childhood Education Practicum Lab",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "220",
+              "title": "Inclusion in Early Childhood Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "232",
+              "title": "Early Childhood Program Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "220",
+              "title": "Diversity in the Schools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "257",
+              "title": "Infant and Toddler Care and Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "290",
+              "title": "Early Childhood Education Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Elementary Education - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/education-elementary/education-elementary-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "200",
+              "title": "Education Around the World (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "257",
+              "title": "Math for Elementary Teachers II (GEM 3)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "120",
+              "title": "Foundations of Education (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "United States History I (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "United States History II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "150",
+              "title": "Educational Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "250",
+              "title": "Education Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "220",
+              "title": "Diversity in the Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "230",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "280",
+              "title": "Integrated Teaching and Field Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "290",
+              "title": "Education Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "157",
+              "title": "Math for Elementary Teachers I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English - Creative Writing Emphasis - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/english/english-aa-creative-writing-emphasis/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "185",
+              "title": "Introduction to English Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literary Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "241",
+              "title": "Creative Writing Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "242",
+              "title": "Creative Writing Fiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "243",
+              "title": "Creative Writing Nonfiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "267",
+              "title": "Survey of British Literature Iand Survey of British Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "277",
+              "title": "Survey of American Literature Iand Survey of American Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "285",
+              "title": "Craft Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "286",
+              "title": "Literary Magazine",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "293",
+              "title": "English Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "290",
+              "title": "English Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "English - Literature Emphasis - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/english/english-aa-literature-emphasis/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "230",
+              "title": "Multicultural American Literature (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "185",
+              "title": "Introduction to English Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literary Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "267",
+              "title": "Survey of British Literature Iand Survey of British Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "277",
+              "title": "Survey of American Literature Iand Survey of American Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "290",
+              "title": "English Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "English - Professional Writing Emphasis - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/english/english-aa-professional-writing/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Communication and Culture (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "185",
+              "title": "Introduction to English Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Technical Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "229",
+              "title": "Workplace Writing with Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "290",
+              "title": "English Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "293",
+              "title": "English Internship",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Exercise Science - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/exercise-science/exercise-science-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "280",
+              "title": "Global Health (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus (GEM 3)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227P",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "155",
+              "title": "Health and Wellness (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "200",
+              "title": "Introduction to Kinesiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "201",
+              "title": "Cultural, Historical, and Philosophical Foundations of Physical Activity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "243",
+              "title": "Applied Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "270",
+              "title": "Motor Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "270L",
+              "title": "Motor Learning Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "280",
+              "title": "Exercise Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "280L",
+              "title": "Exercise Physiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHA",
+              "number": "102",
+              "title": "Couch to 10K",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHA",
+              "number": "103",
+              "title": "Stress Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHA",
+              "number": "104",
+              "title": "Stay Active, Live Well!",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHA",
+              "number": "105",
+              "title": "Walking for Health and Fitness",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fermentation Science - Academic Certificate (AC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/fermentation-science/fermentation-science-ac/",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGRI",
+              "number": "290",
+              "title": "Agricultural Science Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Introduction to Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic and Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102L",
+              "title": "Essentials of Organic and Biochemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FERM",
+              "number": "110",
+              "title": "Grapes and Hops: Specialty Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FERM",
+              "number": "120",
+              "title": "Introduction to Fermented Foods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111",
+              "title": "Introductory Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111L",
+              "title": "Introductory Microbiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship and Small Business Management - Academic Certificate (AC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/entrepreneurship/entrepreneurship-and-small-business-management-ac/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSA",
+              "number": "220",
+              "title": "Entrepreneurial Strategy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "255",
+              "title": "Leadership Development Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Fire Service Technology - Associate of Arts (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/fire-service-technology/fire-service-technology-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "100",
+              "title": "Concepts of Chemistryand Concepts of Chemistry Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistryand Introduction to Chemistry Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "110",
+              "title": "Physical Fitness for Firefighters",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "101",
+              "title": "Fire Fighter",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "120",
+              "title": "Principles of Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "200",
+              "title": "Building Construction for Fire Protection",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "210",
+              "title": "Fire Behavior and Combustion",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "220",
+              "title": "Principles of Safety and Survival for Fire and Emergency Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "230",
+              "title": "Fire Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "240",
+              "title": "Fire Protection Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "160",
+              "title": "Work Experience Iand Work Experience IIand Work Experience III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "290",
+              "title": "Fire Service Capstone",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Service Technology - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/fire-service-technology/fst-btc/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "101",
+              "title": "Fire Fighter",
+              "credits": 12,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "110",
+              "title": "Physical Fitness for Firefighters",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "255",
+              "title": "Leadership Development Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Development and Esports Management - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/game-dev-and-esports-mgmt/gdem-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "111",
+              "title": "Introduction to Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "153",
+              "title": "Navigating Computer Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "155",
+              "title": "Introduction to Version Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "101",
+              "title": "Game Design Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "190",
+              "title": "Esports Ecosystems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "202",
+              "title": "Visual Storytelling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "210",
+              "title": "Game Asset Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "225",
+              "title": "2D Game Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "235",
+              "title": "Esports Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "250",
+              "title": "3D Game Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "290",
+              "title": "Game Development and Esports Management Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GDEM",
+              "number": "295",
+              "title": "Game Development and Esports Management Internship",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "General Studies - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/general-studies/gen-studies-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "290",
+              "title": "General Studies Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Geographic Information Systems - Academic Certificate (AC)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/geographic-information-systems/geographic-information-systems-ac/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "120",
+              "title": "Web GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "126",
+              "title": "Fundamentals of GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "225",
+              "title": "Cartography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "226",
+              "title": "Spatial Analysis With GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "230",
+              "title": "Remote Sensing/GIS Integration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "240",
+              "title": "Python Scripting for GIS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geography - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/geography/geography-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "200",
+              "title": "World Regional Geography (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "153",
+              "title": "Statistical Reasoning (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "100",
+              "title": "Physical Geography (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "100L",
+              "title": "Physical Geography Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVI",
+              "number": "100",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVI",
+              "number": "100L",
+              "title": "Environmental Science Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101L",
+              "title": "Physical Geology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "102",
+              "title": "Cultural Geography (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "270",
+              "title": "Global Climate Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "126",
+              "title": "Fundamentals of GIS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geosciences - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/geosciences/geosciences-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "105",
+              "title": "Earth's Natural Resources (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus (GEM 3)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101L",
+              "title": "Physical Geology Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "General Chemistry I Plusand General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "275",
+              "title": "Field Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "126",
+              "title": "Fundamentals of GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics Iand General Physics I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Scientists and Engineers Iand Physics for Scientists and Engineers I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science and Public Health - Associate of Science Degree (AS)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/health-science/health-science-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "115",
+              "title": "Lifestyle Diseases and Their Global Burden",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "280",
+              "title": "Global Health",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebraand Precalculus II: Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Statistical Methods",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "220",
+              "title": "Fundamentals of Nutrition (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology Iand Biology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "155",
+              "title": "Health and Wellness (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112",
+              "title": "Biology IIand Biology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology IIand Human Anatomy and Physiology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "202",
+              "title": "Introduction to Health Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "120",
+              "title": "Introduction to Public Health and Health Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "212",
+              "title": "Introduction to Health Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "295",
+              "title": "Determinants of Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy-Duty Truck Technician - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/heavy-duty-truck-technician/heavy-duty-truck-technician-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "111",
+              "title": "Introduction to Heavy-Duty Truck Technologies",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "121",
+              "title": "Basic Electrical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "131",
+              "title": "Fundamentals of Heavy-Duty Diesel Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "141",
+              "title": "Heavy-Duty Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "151",
+              "title": "Drivetrains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "161",
+              "title": "Suspension and Steering Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "171",
+              "title": "Preventive Maintenance and CDL Prep",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "181",
+              "title": "Truck Driving Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "211",
+              "title": "Fuel, Air, and Emissions",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "221",
+              "title": "Electrical/Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "231",
+              "title": "HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "241",
+              "title": "Truck Dealership Practices",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy-Duty Truck Technician - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/heavy-duty-truck-technician/heavy-duty-truck-technician-atc/",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "111",
+              "title": "Introduction to Heavy-Duty Truck Technologies",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "121",
+              "title": "Basic Electrical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "131",
+              "title": "Fundamentals of Heavy-Duty Diesel Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "141",
+              "title": "Heavy-Duty Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "151",
+              "title": "Drivetrains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "161",
+              "title": "Suspension and Steering Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "171",
+              "title": "Preventive Maintenance and CDL Prep",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "211",
+              "title": "Fuel, Air, and Emissions",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "221",
+              "title": "Electrical/Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "231",
+              "title": "HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TTEC",
+              "number": "241",
+              "title": "Truck Dealership Practices",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment Technician - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/heavy-equipment-technician/heavy-equipment-technician-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "111",
+              "title": "Introduction to Heavy Equipment Service Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "121",
+              "title": "DC Circuits & Basic Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "131",
+              "title": "Track Systems and Mechanical Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "141",
+              "title": "Diesel Engine Theory of Operation and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "151",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "161",
+              "title": "HVAC System Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "171",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "181",
+              "title": "Principles of Electronically Managed Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "211",
+              "title": "Gearing and Driveline Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "221",
+              "title": "Mobile Equipment Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "231",
+              "title": "Transmissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "241",
+              "title": "On-Board Vehicle Networks and Electronic Systems Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "251",
+              "title": "Engine Emissions and Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "261",
+              "title": "Hydraulic System Service and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "271",
+              "title": "Industry Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment Technician - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/heavy-equipment-technician/heavy-equipment-technician-atc/",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "111",
+              "title": "Introduction to Heavy Equipment Service Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "121",
+              "title": "DC Circuits & Basic Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "131",
+              "title": "Track Systems and Mechanical Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "141",
+              "title": "Diesel Engine Theory of Operation and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "151",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "161",
+              "title": "HVAC System Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "171",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "181",
+              "title": "Principles of Electronically Managed Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "211",
+              "title": "Gearing and Driveline Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "221",
+              "title": "Mobile Equipment Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "231",
+              "title": "Transmissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "241",
+              "title": "On-Board Vehicle Networks and Electronic Systems Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "251",
+              "title": "Engine Emissions and Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "261",
+              "title": "Hydraulic System Service and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "271",
+              "title": "Industry Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment Technician - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/heavy-equipment-technician/heavy-equipment-technician-itc/",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas (Recommended GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "111",
+              "title": "Introduction to Heavy Equipment Service Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "121",
+              "title": "DC Circuits & Basic Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "131",
+              "title": "Track Systems and Mechanical Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "141",
+              "title": "Diesel Engine Theory of Operation and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "151",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "161",
+              "title": "HVAC System Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "171",
+              "title": "Fundamentals of Fluid Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "181",
+              "title": "Principles of Electronically Managed Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "211",
+              "title": "Gearing and Driveline Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "221",
+              "title": "Mobile Equipment Hydraulic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "231",
+              "title": "Transmissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "241",
+              "title": "On-Board Vehicle Networks and Electronic Systems Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "251",
+              "title": "Engine Emissions and Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTEC",
+              "number": "261",
+              "title": "Hydraulic System Service and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/horticulture-technology/hrtc-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "106",
+              "title": "Annuals and Perennials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "107",
+              "title": "Landscape Management: Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "108",
+              "title": "Plant Propagation and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "110",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "140",
+              "title": "Soils and Plant Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "144",
+              "title": "Horticulture Internship and Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "152",
+              "title": "Landscape Management: Irrigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "155",
+              "title": "Urban Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "203",
+              "title": "Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "204",
+              "title": "Landscape Management: Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "208",
+              "title": "Greenhouse and Nursery Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "220",
+              "title": "Interior and Floral Plant Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "257",
+              "title": "Landscape Design II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "252",
+              "title": "Landscape Management: QWEL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "255",
+              "title": "Integrated Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "256",
+              "title": "Landscape Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "295",
+              "title": "Horticulture Business Management Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/history/history-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "103",
+              "title": "Western Civilization I (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "104",
+              "title": "Western Civilization II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "World History I (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "World History II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "United States History I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "United States History II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "190",
+              "title": "Introduction to the Study of History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "210",
+              "title": "History Through Biography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "220",
+              "title": "Great Ideas in History",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "230",
+              "title": "Themes in U.S. History",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "239",
+              "title": "United States Military History",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "240",
+              "title": "Themes in Western History",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "history"
+    },
+    {
+      "title": "Horticulture Technology - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/horticulture-technology/hrtc-itc/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "106",
+              "title": "Annuals and Perennials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "107",
+              "title": "Landscape Management: Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "108",
+              "title": "Plant Propagation and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "110",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "140",
+              "title": "Soils and Plant Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "144",
+              "title": "Horticulture Internship and Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "155",
+              "title": "Urban Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "208",
+              "title": "Greenhouse and Nursery Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture Technology - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/horticulture-technology/hrtc-atc/",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "106",
+              "title": "Annuals and Perennials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "107",
+              "title": "Landscape Management: Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "108",
+              "title": "Plant Propagation and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "110",
+              "title": "Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "140",
+              "title": "Soils and Plant Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "144",
+              "title": "Horticulture Internship and Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "152",
+              "title": "Landscape Management: Irrigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "155",
+              "title": "Urban Agriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "203",
+              "title": "Landscape Plants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "204",
+              "title": "Landscape Management: Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "208",
+              "title": "Greenhouse and Nursery Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "220",
+              "title": "Interior and Floral Plant Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "257",
+              "title": "Landscape Design II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "252",
+              "title": "Landscape Management: QWEL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "255",
+              "title": "Integrated Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "256",
+              "title": "Landscape Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRTC",
+              "number": "295",
+              "title": "Horticulture Business Management Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/law-enforcement/law-enforcement-itc/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAWE",
+              "number": "100",
+              "title": "Law Enforcement I",
+              "credits": 18,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAWE",
+              "number": "200",
+              "title": "Law Enforcement II",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Law Enforcement - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/law-enforcement/law-enforcement-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "103",
+              "title": "Introduction to Law and Justice (GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "102",
+              "title": "Introduction to Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "104",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "270",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "280",
+              "title": "Victimology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAWE",
+              "number": "100",
+              "title": "Law Enforcement I",
+              "credits": 18,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAWE",
+              "number": "200",
+              "title": "Law Enforcement II",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Machine Tool Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/machine-tool-technology/machine-tool-technology-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MACH",
+              "number": "103",
+              "title": "Machine Shop Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "104",
+              "title": "Machine Shop Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "105",
+              "title": "Machine Shop Laboratory III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "126",
+              "title": "Related Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "127",
+              "title": "Related Blueprint Reading II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "153",
+              "title": "Machine Shop Theory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "154",
+              "title": "Machine Shop Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "155",
+              "title": "Machine Shop Theory III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "203",
+              "title": "CNC Machining Center Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "204",
+              "title": "CNC Turning Center Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "210",
+              "title": "Fundamentals of Computer-Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "212",
+              "title": "Computer-Aided Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "224",
+              "title": "Tool Design for Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "253",
+              "title": "CNC Machining Center Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "254",
+              "title": "CNC Turning Center Theory",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/machine-tool-technology/machine-tool-technology-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MACH",
+              "number": "103",
+              "title": "Machine Shop Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "104",
+              "title": "Machine Shop Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "105",
+              "title": "Machine Shop Laboratory III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "126",
+              "title": "Related Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "127",
+              "title": "Related Blueprint Reading II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "153",
+              "title": "Machine Shop Theory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "154",
+              "title": "Machine Shop Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "155",
+              "title": "Machine Shop Theory III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "224",
+              "title": "Tool Design for Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/machine-tool-technology/machine-tool-technology-itc/",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MACH",
+              "number": "103",
+              "title": "Machine Shop Laboratory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "104",
+              "title": "Machine Shop Laboratory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "105",
+              "title": "Machine Shop Laboratory III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "126",
+              "title": "Related Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "127",
+              "title": "Related Blueprint Reading II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "153",
+              "title": "Machine Shop Theory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "154",
+              "title": "Machine Shop Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "155",
+              "title": "Machine Shop Theory III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "203",
+              "title": "CNC Machining Center Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "204",
+              "title": "CNC Turning Center Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "210",
+              "title": "Fundamentals of Computer-Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "212",
+              "title": "Computer-Aided Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "224",
+              "title": "Tool Design for Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "253",
+              "title": "CNC Machining Center Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MACH",
+              "number": "254",
+              "title": "CNC Turning Center Theory",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/management/mgmt-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXHS",
+              "number": "155",
+              "title": "Health and Wellness (Recommended GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "112",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "145",
+              "title": "Advanced Office Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOOK",
+              "number": "151",
+              "title": "Fundamental Accounting Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "201",
+              "title": "Business Communication and Professionalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "255",
+              "title": "Leadership Development Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "221",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "293",
+              "title": "Management Internship",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Digital Marketing - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/marketing-communications/digital-marketing-btc/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "125",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing Communications - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/marketing-communications/marketing-communications-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "278",
+              "title": "Principles of Public Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "125",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "203",
+              "title": "Principles of Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "240",
+              "title": "Social Media Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "246",
+              "title": "Advanced Digital Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "290",
+              "title": "Marketing Communications Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing Communications - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/marketing-communications/marketing-communications-atc/",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "278",
+              "title": "Principles of Public Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "125",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "203",
+              "title": "Principles of Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "240",
+              "title": "Social Media Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "246",
+              "title": "Advanced Digital Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "290",
+              "title": "Marketing Communications Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Assistant - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/medical-assistant/medical-assistant-aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127",
+              "title": "Human Structure and Functionand Human Structure and Function Lab (GE Elective)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "109",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "115",
+              "title": "Human Relations in Healthcare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "223",
+              "title": "Integrated Medical Office Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "132",
+              "title": "Medical Office Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "180",
+              "title": "Medical Assisting Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "201",
+              "title": "Medical Assisting Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "237",
+              "title": "Ethics for Medical Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "242",
+              "title": "Clinical Procedures I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "243",
+              "title": "Clinical Procedures II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "245",
+              "title": "Medical Assistant Practicum",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/medical-assistant/medical-assistant-itc/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEDA",
+              "number": "109",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "132",
+              "title": "Medical Office Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "180",
+              "title": "Medical Assisting Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "201",
+              "title": "Medical Assisting Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "242",
+              "title": "Clinical Procedures I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "243",
+              "title": "Clinical Procedures II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "245",
+              "title": "Medical Assistant Practicum",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mining Technician - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/mining-technician/mine-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "105",
+              "title": "Earth's Natural Resources (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebraand Precalculus II: Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geologyand Physical Geology Lab (GEM 4)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVI",
+              "number": "100",
+              "title": "Environmental Scienceand Environmental Science Lab (GEM 4)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "175",
+              "title": "Geomatics and Geospatial Data",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "208",
+              "title": "Hydrology and Water Resources",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "275",
+              "title": "Field Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "290",
+              "title": "Mining Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "126",
+              "title": "Fundamentals of GIS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Arts - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/media-arts/media-arts-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "112",
+              "title": "Argumentation and Debate",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "261",
+              "title": "Multimedia Storytelling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "268",
+              "title": "Introduction to Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "269",
+              "title": "Introduction to Audio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "271",
+              "title": "Introduction to Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "273",
+              "title": "Media News Writing and Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "278",
+              "title": "Principles of Public Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "290",
+              "title": "Communication Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "150",
+              "title": "Digital Photography I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "293",
+              "title": "Communication Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/occupational-therapy-assistant/ota-aas/",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology IIand Human Anatomy and Physiology II Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "100",
+              "title": "Introduction to Occupational Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "130",
+              "title": "Professional Issues I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "155",
+              "title": "Movement in Human Occupation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "170",
+              "title": "Fieldwork Level I: Placement I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "175",
+              "title": "Fieldwork Level I: Placement II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "180",
+              "title": "Fieldwork Level I: Placement III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "206",
+              "title": "Pediatric Occupational Therapy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "210",
+              "title": "Psychosocial Interventions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "210L",
+              "title": "Therapeutic Activity Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "215",
+              "title": "Adult Physical Dysfunction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "215L",
+              "title": "Adult Rehabilitation Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "231",
+              "title": "Professional Issues II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "240",
+              "title": "Geriatric Occupational Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "270",
+              "title": "Fieldwork Level II: Placement I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "275",
+              "title": "Fieldwork Level II: Placement II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/physical-therapist-assistant/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Philosophy - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/philosophy/philosophy-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "209",
+              "title": "Logic and Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "211",
+              "title": "Philosophical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/occupational-therapy-assistant/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/political-science/political-science-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "101",
+              "title": "American National Government (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "102",
+              "title": "Introduction to Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "210",
+              "title": "Introduction to Comparative Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "221",
+              "title": "Introduction to International Relations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "230",
+              "title": "Political Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "240",
+              "title": "American Constitutional Foundations",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing Communications - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/marketing-communications/marketing-communications-itc/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADMS",
+              "number": "133",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "120",
+              "title": "Business Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "278",
+              "title": "Principles of Public Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "125",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "203",
+              "title": "Principles of Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "240",
+              "title": "Social Media Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRKT",
+              "number": "257",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Physical Therapist Assistant - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/physical-therapist-assistant/physical-therapist-assistant-aas/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "101",
+              "title": "Physical Therapy in Healthcare",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "107",
+              "title": "Kinesiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "107L",
+              "title": "Kinesiology Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "110",
+              "title": "Principles and Procedures of Physical Therapy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "110L",
+              "title": "Principles and Procedures of Physical Therapy Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "113",
+              "title": "Clinical Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "204",
+              "title": "Therapeutic Modalities",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "204L",
+              "title": "Therapeutic Modalities Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "207",
+              "title": "Therapeutic Exercise",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "207L",
+              "title": "Therapeutic Exercise Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "208",
+              "title": "Orthopedic Rehabilitation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "208L",
+              "title": "Orthopedic Rehabilitation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "211",
+              "title": "Data Collection",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "211L",
+              "title": "Data Collection Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "215",
+              "title": "Special Populations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "215L",
+              "title": "Special Populations Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "217",
+              "title": "Neurological Rehabilitation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "217L",
+              "title": "Neurological Rehabilitation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "221",
+              "title": "Seminar Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "240",
+              "title": "Clinical Affiliation I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAE",
+              "number": "241",
+              "title": "Clinical Affiliation II",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Powersports and Small Engine Repair Technology - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/powersports-small-engine-repair-technology/powersports-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSER",
+              "number": "100",
+              "title": "Foundations of Safety and Dealership Operations",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "111",
+              "title": "Basic Fuel Systems and Outdoor Power Equipment Maintenance",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "112",
+              "title": "Outdoor Power Equipment Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "125",
+              "title": "Basic Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "130",
+              "title": "Drivetrain and Chassis Components",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Powersports and Small Engine Repair Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/powersports-small-engine-repair-technology/powersports-small-engine-repair-technology-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (Recommended GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (Recommended GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Technical Mathand Technical Math Lab (Recommended GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Macroeconomics (Recommended GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics (Recommended GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "100",
+              "title": "Foundations of Safety and Dealership Operations",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "111",
+              "title": "Basic Fuel Systems and Outdoor Power Equipment Maintenance",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "112",
+              "title": "Outdoor Power Equipment Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "125",
+              "title": "Basic Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "130",
+              "title": "Drivetrain and Chassis Components",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "200",
+              "title": "Powersports Maintenance and Light Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "240",
+              "title": "Engine Management and Advanced Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "245",
+              "title": "Advanced Electrical Systems and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "255",
+              "title": "Suspension Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "265",
+              "title": "Powersports Engines and Performance Technology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "295",
+              "title": "Powersports Industry Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/practical-nursing/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127",
+              "title": "Human Structure and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127L",
+              "title": "Human Structure and Function Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227P",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111",
+              "title": "Introductory Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111L",
+              "title": "Introductory Microbiology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Powersports and Small Engine Repair Technology - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/powersports-small-engine-repair-technology/powersports-small-engine-repair-technology-itc/",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSER",
+              "number": "100",
+              "title": "Foundations of Safety and Dealership Operations",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "111",
+              "title": "Basic Fuel Systems and Outdoor Power Equipment Maintenance",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "112",
+              "title": "Outdoor Power Equipment Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "125",
+              "title": "Basic Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "130",
+              "title": "Drivetrain and Chassis Components",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "200",
+              "title": "Powersports Maintenance and Light Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "240",
+              "title": "Engine Management and Advanced Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "245",
+              "title": "Advanced Electrical Systems and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "255",
+              "title": "Suspension Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "265",
+              "title": "Powersports Engines and Performance Technology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSER",
+              "number": "295",
+              "title": "Powersports Industry Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/practical-nursing/practical-nursing-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127",
+              "title": "Human Structure and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127L",
+              "title": "Human Structure and Function Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227P",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111",
+              "title": "Introductory Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111L",
+              "title": "Introductory Microbiology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics (GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "280",
+              "title": "Global Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "110",
+              "title": "Fundamentals of Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "110L",
+              "title": "Fundamentals of Nursing Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "115",
+              "title": "Mental Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "121",
+              "title": "Nursing Care of the Elderly",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "121L",
+              "title": "Nursing Care of the Elderly Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "125",
+              "title": "Pharmacology for Practical Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "130",
+              "title": "Comprehensive Care of Adults",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "130L",
+              "title": "Comprehensive Care of Adults Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "140",
+              "title": "Nursing Care of the Developing Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "151",
+              "title": "Transition to Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "151L",
+              "title": "Transition to Practice Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/practical-nursing/practical-nursing-itc/",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127",
+              "title": "Human Structure and Function",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127L",
+              "title": "Human Structure and Function Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227P",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111",
+              "title": "Introductory Microbiology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111L",
+              "title": "Introductory Microbiology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "110",
+              "title": "Fundamentals of Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "110L",
+              "title": "Fundamentals of Nursing Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "115",
+              "title": "Mental Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "121",
+              "title": "Nursing Care of the Elderly",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "121L",
+              "title": "Nursing Care of the Elderly Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "125",
+              "title": "Pharmacology for Practical Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "130",
+              "title": "Comprehensive Care of Adults",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "130L",
+              "title": "Comprehensive Care of Adults Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "140",
+              "title": "Nursing Care of the Developing Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "151",
+              "title": "Transition to Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "151L",
+              "title": "Transition to Practice Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Psychology - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/psychology/psychology-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIJ",
+              "number": "280",
+              "title": "Victimology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "110",
+              "title": "Drug Use and Misuse",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "211",
+              "title": "Psychosocial Aspects of Dying and Death",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "221",
+              "title": "Gender",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "231",
+              "title": "Human Sexuality",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Global Issues",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "120",
+              "title": "Career Exploration",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "190",
+              "title": "Writing for the Social Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Child and Adolescent Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "250",
+              "title": "Fundamentals of Social Science Research",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "251",
+              "title": "Statistical Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "290",
+              "title": "Professional Development",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Registered Nursing - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/registered-nursing/nurs-as/",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "115",
+              "title": "Lifestyle Diseases and Their Global Burden",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "280",
+              "title": "Global Health",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "106",
+              "title": "Making Sense of Microbiotic Me",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111",
+              "title": "Introductory Microbiology (GEM 4)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMBS",
+              "number": "111L",
+              "title": "Introductory Microbiology Lab (GEM 4)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "100",
+              "title": "Fundamentals of Nursing and Health Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "103",
+              "title": "Nursing and Health Assessment Skills Lab/Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "104",
+              "title": "Basic Medical Surgical Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "105",
+              "title": "Basic Medical Surgical Nursing Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "106",
+              "title": "Basic Pharmacology for Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "200",
+              "title": "Nursing Specialties",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "201",
+              "title": "Nursing Specialties Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "202",
+              "title": "Advanced Medical Surgical Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "203",
+              "title": "Advanced Medical Surgical Nursing Lab/Clinical",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Secondary Education - Social Science - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/secondary-education/secondary-education-social-science-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "200",
+              "title": "Education Around the World (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "120",
+              "title": "Foundations of Education (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "150",
+              "title": "Educational Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "250",
+              "title": "Education Technology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "220",
+              "title": "Diversity in the Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "230",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "280",
+              "title": "Integrated Teaching and Field Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "290",
+              "title": "Education Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Secondary Education - STEM - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/secondary-education/secondary-education-stem-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "200",
+              "title": "Education Around the World (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "123",
+              "title": "Artificial Intelligence and Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "120",
+              "title": "Foundations of Education (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "220",
+              "title": "Diversity in the Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "230",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "280",
+              "title": "Integrated Teaching and Field Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "290",
+              "title": "Education Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Semiconductor Manufacturing Technology - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/semiconductor-manufacturing-technology/smt-btc/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Introduction to Chemistry Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "143",
+              "title": "Precalculus I: Algebra (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "200",
+              "title": "Programming for Semiconductor Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "210",
+              "title": "Nanofabrication I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "220",
+              "title": "Quality Control and Statistical Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SMT",
+              "number": "260",
+              "title": "Nanofabrication II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sign Language Studies - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/sign-language-studies/sign-language-studies-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "102",
+              "title": "American Sign Language II (Global Perspectives)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "101",
+              "title": "American Sign Language I (GEM 5)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "203",
+              "title": "Fingerspelling and Numbers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "204",
+              "title": "Introduction to Interpreting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "220",
+              "title": "Deaf Culture and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SIGL",
+              "number": "290",
+              "title": "American Sign Language Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/social-work/social-work-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "100",
+              "title": "Concepts of Biologyand Concepts of Biology Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology Iand Biology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "127",
+              "title": "Human Structure and Functionand Human Structure and Function Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plusand Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology Iand Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "190",
+              "title": "Writing for the Social Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "101",
+              "title": "Introduction to Social Work and Social Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "202",
+              "title": "Foundations of Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "290",
+              "title": "Social Work Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/sociology/sociology-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Global Issues (Global Perspectives)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Fundamentals of Oral Communication (GEM 2)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Sociology of Deviance (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Introduction to Ethnic Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "270",
+              "title": "Social Movements",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "280",
+              "title": "Sociological Research",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/software-development/software-development-aas/",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "259",
+              "title": "Communicating Through Web Design (GE Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "153",
+              "title": "Navigating Computer Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "155",
+              "title": "Introduction to Version Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "110",
+              "title": "Intermediate Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "116",
+              "title": "Introduction to Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "141",
+              "title": "Intermediate Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "152",
+              "title": "Systems Analysis and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "210",
+              "title": "Introduction to Server-Side Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "220",
+              "title": "Fundamentals of Database Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "235",
+              "title": "Advanced Web Application Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "265",
+              "title": "Mobile Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "275",
+              "title": "Software Development Tools and Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "278",
+              "title": "Cloud Platforms and Services",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "280",
+              "title": "Collaborative Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "290",
+              "title": "Software Development Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development - Advanced Technical Certificate (ATC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/software-development/software-development-atc/",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "153",
+              "title": "Navigating Computer Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "155",
+              "title": "Introduction to Version Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "110",
+              "title": "Intermediate Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "116",
+              "title": "Introduction to Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "141",
+              "title": "Intermediate Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "152",
+              "title": "Systems Analysis and Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "210",
+              "title": "Introduction to Server-Side Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "220",
+              "title": "Fundamentals of Database Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "235",
+              "title": "Advanced Web Application Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "265",
+              "title": "Mobile Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "275",
+              "title": "Software Development Tools and Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "278",
+              "title": "Cloud Platforms and Services",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "280",
+              "title": "Collaborative Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "290",
+              "title": "Software Development Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/software-development/software-development-btc/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPSC",
+              "number": "153",
+              "title": "Navigating Computer Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "155",
+              "title": "Introduction to Version Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "110",
+              "title": "Intermediate Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "116",
+              "title": "Introduction to Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "141",
+              "title": "Intermediate Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "210",
+              "title": "Introduction to Server-Side Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "265",
+              "title": "Mobile Development",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/software-development/software-development-itc/",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "140",
+              "title": "Human Relations for Career and Personal Success (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "153",
+              "title": "Navigating Computer Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSC",
+              "number": "155",
+              "title": "Introduction to Version Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "110",
+              "title": "Intermediate Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "116",
+              "title": "Introduction to Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "141",
+              "title": "Intermediate Web Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "210",
+              "title": "Introduction to Server-Side Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWDV",
+              "number": "265",
+              "title": "Mobile Development",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish - Associate of Arts Degree (AA)* — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/spanish/spanish-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish II (Global Perspectives)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish I (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "111",
+              "title": "Spanish for Healthcare",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "110",
+              "title": "Spanish Conversations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "201",
+              "title": "Intermediate Spanish I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "202",
+              "title": "Intermediate Spanish II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "227",
+              "title": "Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "290",
+              "title": "Spanish Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science, Technology, Engineering, and Math (STEM) - Associate of Science Degree (AS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/stem/stem-as/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "147",
+              "title": "Precalculus (GEM 3)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Biology Iand Biology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Introduction to Chemistryand Introduction to Chemistry Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "111",
+              "title": "General Physics Iand General Physics I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Scientists and Engineers Iand Physics for Scientists and Engineers I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Ethics in Science (GEM 6)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112",
+              "title": "Biology IIand Biology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Essentials of Organic and Biochemistryand Essentials of Organic and Biochemistry Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "General Chemistry IIand General Chemistry II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "112",
+              "title": "General Physics IIand General Physics II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics for Scientists and Engineers IIand Physics for Scientists and Engineers II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "175",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "290",
+              "title": "STEM Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Studio Art - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/studio-art/studio-art-aa/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Writing and Rhetoric I (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Writing and Rhetoric II (GEM 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "105",
+              "title": "Introduction to 2-D Art Foundations (GEM 5)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "101",
+              "title": "Prehistoric to Medieval Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "102",
+              "title": "Renaissance to Modern Art in the West",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "106",
+              "title": "Introduction to 3-D Art Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "109",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "215",
+              "title": "Painting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "231",
+              "title": "Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "290",
+              "title": "Studio Art Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "212",
+              "title": "Drawing II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "275",
+              "title": "Painting II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "293",
+              "title": "Studio Art Internship",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Surgical First Assistant - Specialized Certificate (SC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/surgical-first-assistant/sfa-sc/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SFA",
+              "number": "210",
+              "title": "Principles of Surgical Assistingand Principles of Surgical Assisting Lab",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "215",
+              "title": "Surgical Bioscience",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "225",
+              "title": "Advanced Surgical Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "235",
+              "title": "Advanced Surgical Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "240",
+              "title": "Clinical Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "241",
+              "title": "Clinical Practicum II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical First Assistant - Associate of Arts Degree (AA) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/surgical-first-assistant/sfa-aa/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CWI",
+              "number": "101",
+              "title": "Connecting With Ideas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "210",
+              "title": "Principles of Surgical Assisting",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "210L",
+              "title": "Principles of Surgical Assisting Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "215",
+              "title": "Surgical Bioscience",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "225",
+              "title": "Advanced Surgical Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "235",
+              "title": "Advanced Surgical Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "240",
+              "title": "Clinical Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SFA",
+              "number": "241",
+              "title": "Clinical Practicum II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/surgical-technology/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227P",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/surgical-technology/surgical-technology-aas/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "226",
+              "title": "Human Anatomy and Physiology I Plus",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227P",
+              "title": "Human Anatomy and Physiology I (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227L",
+              "title": "Human Anatomy and Physiology I Lab (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "228L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "227",
+              "title": "Human Anatomy and Physiology I (GE Elective)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "100",
+              "title": "Introduction and Basic Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "101",
+              "title": "Operating Room Techniques",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "102",
+              "title": "Sterilization and Disinfection",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "103",
+              "title": "Surgical Technological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "110",
+              "title": "Preparation of the Surgical Patient",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "111",
+              "title": "Surgical Procedures I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "116",
+              "title": "Perioperative Care of Surgical Patients",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "132",
+              "title": "Surgery Clinical Practice",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "150",
+              "title": "Professionalism and Leadership for Surgical Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "290",
+              "title": "Surgical Procedures II",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Aerial Systems - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/unmanned-aerial-systems/uas-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FINA",
+              "number": "109",
+              "title": "Personal Finance and Business Math (GEM 3)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "220",
+              "title": "Entrepreneurial Strategy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSA",
+              "number": "255",
+              "title": "Leadership Development Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "272",
+              "title": "Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOS",
+              "number": "170",
+              "title": "Introduction to Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "110",
+              "title": "Digital Imagery Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "115",
+              "title": "Privacy and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "125",
+              "title": "Flight Theory - Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "130",
+              "title": "Flight Lab I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "136",
+              "title": "Flight Lab II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "140",
+              "title": "Mission Planning and Implementation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "150",
+              "title": "GIS Integrations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Aerial Systems - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/unmanned-aerial-systems/uas-btc/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "UAS",
+              "number": "110",
+              "title": "Digital Imagery Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "115",
+              "title": "Privacy and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "125",
+              "title": "Flight Theory - Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "130",
+              "title": "Flight Lab I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "136",
+              "title": "Flight Lab II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "140",
+              "title": "Mission Planning and Implementation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "150",
+              "title": "GIS Integrations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "155",
+              "title": "Introduction to GPS",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding and Metals Fabrication - Associate of Applied Science Degree (AAS) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/welding-metals-fabrication/welding-metals-fabrication-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEMF",
+              "number": "111",
+              "title": "Safety and Leadership I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "112",
+              "title": "Safety and Leadership II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "125",
+              "title": "Blueprint Reading for Welders I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "126",
+              "title": "Blueprint Reading for Welders II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "127",
+              "title": "Blueprint Reading for Welders III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "128",
+              "title": "Blueprint Reading for Welders IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "135",
+              "title": "Gas Metal Arc Welding (GMAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "155",
+              "title": "Welding Theory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "156",
+              "title": "Welding Theory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "157",
+              "title": "Welding Theory III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "158",
+              "title": "Welding Theory IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "175",
+              "title": "Shielded Metal Arc Welding (SMAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "180",
+              "title": "Production Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "185",
+              "title": "Gas Tungsten Arc Welding (GTAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "225",
+              "title": "Blueprint Reading and Layout V",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "226",
+              "title": "Blueprint Reading and Layout VI",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "227",
+              "title": "Blueprint Reading and Layout VII",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "228",
+              "title": "Blueprint Reading and Layout VIII",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "255",
+              "title": "Welding and Fabrication Workshop I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "256",
+              "title": "Welding and Fabrication Workshop II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "257",
+              "title": "Welding and Fabrication Workshop III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "258",
+              "title": "Welding and Fabrication Workshop IV",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding and Metals Fabrication - Intermediate Technical Certificate (ITC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/welding-metals-fabrication/wemf-itc/",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEMF",
+              "number": "111",
+              "title": "Safety and Leadership I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "112",
+              "title": "Safety and Leadership II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "125",
+              "title": "Blueprint Reading for Welders I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "126",
+              "title": "Blueprint Reading for Welders II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "127",
+              "title": "Blueprint Reading for Welders III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "128",
+              "title": "Blueprint Reading for Welders IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "135",
+              "title": "Gas Metal Arc Welding (GMAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "155",
+              "title": "Welding Theory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "156",
+              "title": "Welding Theory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "157",
+              "title": "Welding Theory III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "158",
+              "title": "Welding Theory IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "175",
+              "title": "Shielded Metal Arc Welding (SMAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "180",
+              "title": "Production Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "185",
+              "title": "Gas Tungsten Arc Welding (GTAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "225",
+              "title": "Blueprint Reading and Layout V",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "226",
+              "title": "Blueprint Reading and Layout VI",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "227",
+              "title": "Blueprint Reading and Layout VII",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "228",
+              "title": "Blueprint Reading and Layout VIII",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "255",
+              "title": "Welding and Fabrication Workshop I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "256",
+              "title": "Welding and Fabrication Workshop II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "257",
+              "title": "Welding and Fabrication Workshop III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "258",
+              "title": "Welding and Fabrication Workshop IV",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding and Metals Fabrication - Basic Technical Certificate (BTC) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.cwi.edu/programs-study/welding-metals-fabrication/wemf-btc/",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEMF",
+              "number": "111",
+              "title": "Safety and Leadership I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "112",
+              "title": "Safety and Leadership II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "125",
+              "title": "Blueprint Reading for Welders I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "126",
+              "title": "Blueprint Reading for Welders II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "127",
+              "title": "Blueprint Reading for Welders III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "128",
+              "title": "Blueprint Reading for Welders IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "135",
+              "title": "Gas Metal Arc Welding (GMAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "155",
+              "title": "Welding Theory I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "156",
+              "title": "Welding Theory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "157",
+              "title": "Welding Theory III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "158",
+              "title": "Welding Theory IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "175",
+              "title": "Shielded Metal Arc Welding (SMAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "180",
+              "title": "Production Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEMF",
+              "number": "185",
+              "title": "Gas Tungsten Arc Welding (GTAW) Practical",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/lib/states/id/config.ts
+++ b/lib/states/id/config.ts
@@ -72,8 +72,11 @@ const idConfig: StateConfig = {
     // and parses the per-receiver equivalency results pages.
     transfers: [{ scripts: ["scripts/id/scrape-transfer.ts"], runner: "http" }],
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: programs — no college's catalog matched a templated
-    // platform (acalog/courseleaf/smartcatalogiq/coursedog/cleancatalog).
+    // Per-college program catalogs across 3 platforms: CEI (Acalog, via
+    // Playwright for its TLS chain), CWI (CourseLeaf @ catalog.cwi.edu), CSI
+    // (SmartCatalogIQ). North Idaho College (Coursedog) is deferred — see the
+    // DEFERRED-scrapers note in scripts/id/scrape-programs.ts.
+    programs: [{ scripts: ["scripts/id/scrape-programs.ts"], runner: "playwright" }],
   },
 };
 

--- a/scripts/id/scrape-programs.ts
+++ b/scripts/id/scrape-programs.ts
@@ -1,0 +1,110 @@
+/**
+ * scrape-programs.ts — degree/program requirements for Idaho.
+ *
+ * ID has 4 community colleges, each on a different catalog platform — all with
+ * shared lib scrapers:
+ *   - college-of-eastern-idaho  → Acalog        (catalog.cei.edu)
+ *   - college-of-western-idaho  → CourseLeaf     (cwi.edu/catalog)
+ *   - north-idaho-college       → Coursedog      (catalog.nic.edu)
+ *   - college-of-southern-idaho → SmartCatalogIQ (csi.smartcatalogiq.com)
+ *
+ * Output filename MUST equal the institution college_slug (slug-align gotcha).
+ *
+ * Usage:
+ *   npx tsx scripts/id/scrape-programs.ts                 # all colleges
+ *   npx tsx scripts/id/scrape-programs.ts --college north-idaho-college
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import { scrapeAcalogPrograms } from "../lib/scrape-acalog-programs.js";
+import { scrapeCourseleafPrograms } from "../lib/scrape-courseleaf-programs.js";
+import { scrapeSmartCatalogIqPrograms } from "../lib/scrape-smartcatalogiq-programs.js";
+
+type Result = { programs: unknown[] };
+
+async function writeOut(slug: string, data: Result): Promise<number> {
+  if (!data.programs || data.programs.length === 0) {
+    console.log(`  ${slug}: 0 programs — not writing (left untouched)`);
+    return 0;
+  }
+  const { matched, unmatched } = applyProgramMatching(data.programs as never);
+  console.log(`  ${slug}: matcher ${matched} matched / ${unmatched} unmatched`);
+  const outDir = path.join(process.cwd(), "data", "id", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outDir, `${slug}.json`),
+    JSON.stringify(data, null, 2),
+  );
+  console.log(`  ✓ ${slug}: ${data.programs.length} programs`);
+  return data.programs.length;
+}
+
+const RUNNERS: Record<string, () => Promise<Result>> = {
+  // catalog.cei.edu has an incomplete TLS chain (UNABLE_TO_VERIFY_LEAF_SIGNATURE
+  // on Node fetch); Chromium tolerates it, so route through Playwright. Programs
+  // aren't on a nav page — discovered via search_advanced.php. catoid=9 current.
+  "college-of-eastern-idaho": () =>
+    scrapeAcalogPrograms({
+      collegeSlug: "college-of-eastern-idaho",
+      baseUrl: "https://catalog.cei.edu",
+      catoidFallback: 9,
+      autoDiscoverCatoid: false,
+      programNavoids: [],
+      useSearchDiscovery: true,
+      usePlaywright: true,
+    }),
+  // CourseLeaf lives on catalog.cwi.edu (cwi.edu/catalog is a front door).
+  "college-of-western-idaho": () =>
+    scrapeCourseleafPrograms({
+      collegeSlug: "college-of-western-idaho",
+      baseUrl: "https://catalog.cwi.edu",
+    }),
+  // DEFERRED-scrapers: north-idaho-college — Coursedog (catalog.nic.edu,
+  // tenant nic_colleague_ethos) lists 165 programs but the shared Coursedog
+  // parser extracts 0 requirement groups from them (known Coursedog ceiling —
+  // see memory reference_programs_scraping_playbook). Fixing the shared
+  // scrape-coursedog-programs.ts parser is out of scope for this PR. Re-enable
+  // here once that parser handles NIC's requirement format.
+  // "north-idaho-college": () =>
+  //   scrapeCoursedogPrograms({
+  //     collegeSlug: "north-idaho-college",
+  //     catalogDomain: "catalog.nic.edu",
+  //     catalogYear: "2026-2027",
+  //   }),
+  // CSI's catalog path is "2026-2027-catalog"; programs-of-study holds the
+  // ~155 program pages (default programsPath, but the non-default catalogPath
+  // is what the default config got wrong).
+  "college-of-southern-idaho": () =>
+    scrapeSmartCatalogIqPrograms({
+      collegeSlug: "college-of-southern-idaho",
+      baseUrl: "https://csi.smartcatalogiq.com",
+      catalogYear: "2026-2027",
+      catalogPath: "2026-2027-catalog",
+      programsPath: "programs-of-study",
+      followSiblingPaths: true,
+    }),
+};
+
+async function main() {
+  const i = process.argv.indexOf("--college");
+  const only = i >= 0 ? process.argv[i + 1] : null;
+  console.log("ID program scraper");
+  let total = 0;
+  for (const [slug, run] of Object.entries(RUNNERS)) {
+    if (only && slug !== only) continue;
+    console.log(`\n=== ${slug} ===`);
+    try {
+      total += await writeOut(slug, await run());
+    } catch (e) {
+      console.error(`  ✗ ${slug} failed: ${e}`);
+    }
+  }
+  console.log(`\nTotal: ${total} programs across ID`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

**Idaho students can now use the Degree-Path Planner** at 3 of Idaho's 4 community colleges. The planner was dead for the state (courses, transfers, and prereqs existed but no program data to plan toward). This adds **297 programs** across:
- **College of Western Idaho** — 125 programs (AAS, AS, AA, certificates)
- **College of Southern Idaho** — 126 programs  
- **College of Eastern Idaho** — 46 programs

Students can pick a program and see its required courses mapped to live sections and prerequisites.

## How it works (technical)

ID's 4 colleges each run a different catalog platform. New `scripts/id/scrape-programs.ts` orchestrates all three working platforms:
- **CWI** → CourseLeaf (`catalog.cwi.edu`, not `cwi.edu/catalog` — the real hostname)  
- **CSI** → SmartCatalogIQ (`csi.smartcatalogiq.com`, `catalogPath=2026-2027-catalog`)  
- **CEI** → Acalog (`catalog.cei.edu`, `usePlaywright:true` because CEI's TLS chain is incomplete for Node's built-in fetch)

The planner reads programs from Supabase with a flat-file fallback, so it works locally on the committed JSON. Prod needs an import dispatch (below).

## Known gaps (named, not hidden)

**NIC (North Idaho College, Coursedog)** — `DEFERRED-scrapers`: the shared Coursedog parser finds 165 programs but extracts 0 requirement groups. This is a known Coursedog ceiling. Noted in the scraper with a DEFERRED-scrapers comment for future fix.

**CSI course sections** — CSI's SIS is a Campus Management WebForms portal (manual-only in courses scrapers). CSI programs display requirements but link to 0 live sections. This is accurate (per-college join, no cross-college confusion) — just partial until CSI courses are added.

## Test plan
- 297 programs, all with `requirement_groups`; course-ref resolution: CWI 71%, CEI 60% (CSI courses not in flat files yet)
- `/id/plan`, `/id/college/college-of-western-idaho/programs`, `/id/college/college-of-eastern-idaho/programs`, `/id/college/college-of-southern-idaho/programs` all render 200 with requirements
- `check:scrapers` OK, `tsc` clean, lint 0 errors, `next build` clean
- Staged only the 5 intended files (3 data + scraper + config)

## Post-merge (required manual step)
Dispatch `scripts/import-programs.ts --state id` so the planner reads from Supabase.

## Files
- `scripts/id/scrape-programs.ts` (new) — multi-platform orchestrator
- `data/id/programs/college-of-{eastern,western,southern}-idaho.json` (new) — 46/125/126 programs
- `lib/states/id/config.ts` — programs scraper declared; NIC deferred with DEFERRED-scrapers marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)
