### PR TITLE
PA programs: CCAC + Reading Area degree requirements

### DIFF
--- a/data/pa/programs/ccac.json
+++ b/data/pa/programs/ccac.json
@@ -1,0 +1,26374 @@
+{
+  "college_slug": "ccac",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.ccac.edu",
+  "scraped_at": "2026-06-07T02:59:21.234Z",
+  "programs": [
+    {
+      "title": "Dual Enrollment University Academy",
+      "credential": "other",
+      "program_code": "015",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3664",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Year One Fall/Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Year Two Fall/Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and/or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and/or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Communications, A.S. (374.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3445",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "147",
+              "title": "History of Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Art History - Ancient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Art History - Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "248",
+              "title": "Graphic Communication 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "168",
+              "title": "Raster Graphics with Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "249",
+              "title": "Graphic Communication 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "144",
+              "title": "Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "170",
+              "title": "Interactive Design 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "250",
+              "title": "Graphic Communication 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE Discipline or Career Elective 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "266",
+              "title": "Portfolio Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE Discipline or Career Elective 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Discipline Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Art History - Ancient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Art History - Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "Painting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "129",
+              "title": "Printmaking 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "165",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design, Certificate (376.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3446",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "144",
+              "title": "Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "168",
+              "title": "Raster Graphics with Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "248",
+              "title": "Graphic Communication 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "165",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "170",
+              "title": "Interactive Design 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "249",
+              "title": "Graphic Communication 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "250",
+              "title": "Graphic Communication 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "265",
+              "title": "Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Art, A.S. (026) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3443",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Art History - Ancient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Art History - Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "207",
+              "title": "Drawing 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "265",
+              "title": "Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18-19 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Digital Design, Certificate",
+      "credential": "certificate",
+      "program_code": "176",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3444",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "144",
+              "title": "Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "168",
+              "title": "Raster Graphics with Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "248",
+              "title": "Graphic Communication 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "165",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "170",
+              "title": "Interactive Design 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "250",
+              "title": "Graphic Communication 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Theatre, Certificate (125.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3450",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "117",
+              "title": "Theatre Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "121",
+              "title": "Technical Theatre 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "118",
+              "title": "Theatre Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "122",
+              "title": "Technical Theatre 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "120",
+              "title": "Basics of Prop Making",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "150",
+              "title": "Scenic Paint for Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "119",
+              "title": "Introduction to Stage Direction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "221",
+              "title": "Introduction to Lighting Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "222",
+              "title": "Stage Make-Up",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "223",
+              "title": "Stage Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ethnic & Diversity Studies, Certificate (114.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3448",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETH",
+              "number": "101",
+              "title": "Ethnic and Diversity Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "113",
+              "title": "Introduction to Black Women and Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "114",
+              "title": "Achieving Cultural Competence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETH",
+              "number": "112",
+              "title": "Understanding Violence in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "118",
+              "title": "Women As Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "207",
+              "title": "African-American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "121",
+              "title": "Current Issues in Ethnic and Diversity Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "122",
+              "title": "Race and Ethnic Relations in the Global Economy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "205",
+              "title": "Latino/a Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "215",
+              "title": "African Art/Artifacts in the Cycle of Life",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "220",
+              "title": "History of the Pittsburgh Civil Rights Movement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "203",
+              "title": "African American History 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "205",
+              "title": "African American History 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "219",
+              "title": "History of Women",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "253",
+              "title": "History of Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "106",
+              "title": "Psychology of African Americans",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "109",
+              "title": "Psychology of Women",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "160",
+              "title": "Introduction to Women&#039;s Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "208",
+              "title": "Urban Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "211",
+              "title": "Sociology of Race and Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "150",
+              "title": "Cultural Competence and Diverse Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "A minimum of 12 credits should be selected from courses designated as ETH (Ethnic and Diversity Studies). Note: Electives other than those listed above may be substitutes upon program approval. When considering other course substitutions, the philosophy is that a student should take 18 credits in courses that expose them to a wide variety of subjects that enable them to understand that we live in a multi-cultural society.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film Technician, A.S. (128.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3630",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "105",
+              "title": "Film and Video Editing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "106",
+              "title": "Introduction to Filmmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "161",
+              "title": "Cinematography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective: 3-4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "108",
+              "title": "Film Theory and Criticism 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "202",
+              "title": "Production Design for Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective: 3-4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLM",
+              "number": "103",
+              "title": "Film Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "104",
+              "title": "Production Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "131",
+              "title": "Grip and Electric 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLM",
+              "number": "201",
+              "title": "Navigating the Film Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "203",
+              "title": "Film Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective: 3-6",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-17 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "Painting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "112",
+              "title": "Multimedia Broadcasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "271",
+              "title": "Music and Audio in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Psychology in the Movies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "117",
+              "title": "Theatre Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "118",
+              "title": "Theatre Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "121",
+              "title": "Technical Theatre 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "122",
+              "title": "Technical Theatre 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "154",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "210",
+              "title": "Acting for Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre, A.S. (025.3) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3643",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAN",
+              "number": "101",
+              "title": "Modern Dance 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "108",
+              "title": "Acting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "121",
+              "title": "Technical Theatre 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "104",
+              "title": "Modern Drama",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "109",
+              "title": "Acting 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "117",
+              "title": "Theatre Production 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "102",
+              "title": "Voice and Speech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "154",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "210",
+              "title": "Acting for Television",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "119",
+              "title": "Introduction to Stage Direction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "155",
+              "title": "Improvisation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "130P",
+              "title": "Acting Practicum 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film Technician, Certificate (126.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3619",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLM",
+              "number": "105",
+              "title": "Film and Video Editing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "106",
+              "title": "Introduction to Filmmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "161",
+              "title": "Cinematography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective: 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-16 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLM",
+              "number": "108",
+              "title": "Film Theory and Criticism 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "131",
+              "title": "Grip and Electric 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "202",
+              "title": "Production Design for Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective: 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLM",
+              "number": "103",
+              "title": "Film Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "104",
+              "title": "Production Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "201",
+              "title": "Navigating the Film Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective: 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-14 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "Painting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "112",
+              "title": "Multimedia Broadcasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "271",
+              "title": "Music and Audio in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Psychology in the Movies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "117",
+              "title": "Theatre Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "118",
+              "title": "Theatre Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "121",
+              "title": "Technical Theatre 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "122",
+              "title": "Technical Theatre 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "154",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "210",
+              "title": "Acting for Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Theatre, A.S. (027.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3644",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAN",
+              "number": "101",
+              "title": "Modern Dance 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "108",
+              "title": "Acting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "117",
+              "title": "Theatre Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "121",
+              "title": "Technical Theatre 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "104",
+              "title": "Modern Drama",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "118",
+              "title": "Theatre Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "122",
+              "title": "Technical Theatre 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "154",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "210",
+              "title": "Acting for Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "222",
+              "title": "Stage Make-Up",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18-19 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "221",
+              "title": "Introduction to Lighting Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "223",
+              "title": "Stage Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education, Certificate",
+      "credential": "certificate",
+      "program_code": "085",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3451",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Cultural Competency Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18-19 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Cultural Competency Electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "117",
+              "title": "Globalization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "118",
+              "title": "Women As Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "101",
+              "title": "Ethnic and Diversity Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "112",
+              "title": "Understanding Violence in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "113",
+              "title": "Introduction to Black Women and Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "114",
+              "title": "Achieving Cultural Competence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "121",
+              "title": "Current Issues in Ethnic and Diversity Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "122",
+              "title": "Race and Ethnic Relations in the Global Economy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "205",
+              "title": "Latino/a Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "215",
+              "title": "African Art/Artifacts in the Cycle of Life",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "220",
+              "title": "History of the Pittsburgh Civil Rights Movement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "203",
+              "title": "African American History 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "205",
+              "title": "African American History 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "219",
+              "title": "History of Women",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "111",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "106",
+              "title": "Psychology of African Americans",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "109",
+              "title": "Psychology of Women",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "114",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "160",
+              "title": "Introduction to Women&#039;s Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "202",
+              "title": "Human Aging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "208",
+              "title": "Urban Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Sociology of Sexualities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "211",
+              "title": "Sociology of Race and Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Technology, A.S.",
+      "credential": "AS",
+      "program_code": "140",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3453",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "119",
+              "title": "Introduction to Music Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "128",
+              "title": "Music Theory and Analysis 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "137",
+              "title": "Musicianship Skills 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "Class Piano 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music Ensemble Elective",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "129",
+              "title": "Music Theory and Analysis 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "138",
+              "title": "Musicianship Skills 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "170",
+              "title": "Audio Recording 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "270",
+              "title": "Electronic and Computer Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music Ensemble Elective",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Audio Recording 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "228",
+              "title": "Music Theory and Analysis 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "237",
+              "title": "Musicianship Skills 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "271",
+              "title": "Music and Audio in Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17-18 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "172",
+              "title": "The Business of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "272",
+              "title": "Live Sound Reinforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music History Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Music Ensemble Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "113",
+              "title": "Show Choir",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "College Choir",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Instrumental/Vocal Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music History Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "History of Western Art Music 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122",
+              "title": "History of Western Art Music 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "American Popular Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "253",
+              "title": "History of Jazz",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts and Sciences A.S. (006.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3623",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies, A.S. (089.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3622",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Music, A.S. (018.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3452",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "History of Western Art Music 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "128",
+              "title": "Music Theory and Analysis 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "137",
+              "title": "Musicianship Skills 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "Class Piano 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music Ensemble Elective",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122",
+              "title": "History of Western Art Music 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "129",
+              "title": "Music Theory and Analysis 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "138",
+              "title": "Musicianship Skills 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Class Piano 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music Ensemble Elective",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "149",
+              "title": "Applied Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "119",
+              "title": "Introduction to Music Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "228",
+              "title": "Music Theory and Analysis 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "237",
+              "title": "Musicianship Skills 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music Ensemble Elective",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "149",
+              "title": "Applied Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "229",
+              "title": "Music Theory and Analysis 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "238",
+              "title": "Musicianship Skills 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Music Ensemble Elective",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "149",
+              "title": "Applied Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14–15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Music Ensemble Electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "113",
+              "title": "Show Choir",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "College Choir",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Instrumental/Vocal Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Technology, Certificate",
+      "credential": "certificate",
+      "program_code": "141",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3454",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "119",
+              "title": "Introduction to Music Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "128",
+              "title": "Music Theory and Analysis 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "137",
+              "title": "Musicianship Skills 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "170",
+              "title": "Audio Recording 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "172",
+              "title": "The Business of Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Audio Recording 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "270",
+              "title": "Electronic and Computer Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "271",
+              "title": "Music and Audio in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "272",
+              "title": "Live Sound Reinforcement",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "PA TRAC Transfer Framework",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3624",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Framework Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "109",
+              "title": "Drawing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "152",
+              "title": "General Biology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Introductory Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "Introductory Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "103",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "General Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization From Ancient Times Through 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "United States History from Early Colonization thru 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "105",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "155",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "107",
+              "title": "Introductory Astronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "141",
+              "title": "Physics 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "142",
+              "title": "Physics 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "Introduction to Political Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "103",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "201",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "212",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "101",
+              "title": "Elementary French 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Elementary Spanish 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Specialist, A.S.",
+      "credential": "AS",
+      "program_code": "340",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3455",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Accounting Electives (2)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Accounting Electives (2)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Accounting Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Computer Applications in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Intermediate Accounting 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "204",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "210",
+              "title": "Payroll Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Tax 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Principles of Tax 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business, IUP: Bachelor of Science - Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3615",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, IUP: Bachelor of Science - Marketing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3616",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, IUP: Bachelor of Science - Accounting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3610",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, IUP: Bachelor of Science, Double Major - Management and Human Resource Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3617",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting, Certificate",
+      "credential": "certificate",
+      "program_code": "217",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3457",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10–11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Computer Applications in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Administrative Assistant, A.S. (785.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3461",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "102",
+              "title": "Computer Keyboarding for Professional Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "Word Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "142",
+              "title": "Desktop Publishing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "607",
+              "title": "Office Management:Outlook",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives (2)",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "206",
+              "title": "Administrative Technology and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives (3)",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management, Certificate (216.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3465",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective –4 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, IUP: Bachelor of Science, Double Major - Management and Marketing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3618",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, Non-TAOC Transfer, A.S.",
+      "credential": "AS",
+      "program_code": "004B",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3627",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Major Field Elective 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-18 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Major Field Elective 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "103",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Major Field Elective 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13-17 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Analytical Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Department-approved Mathematics Course Note: MAT-195, Business Mathematics will not satisfy the mathematics requirement in Business (004.2).",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Probability &amp; Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship, Certificate (219.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3620",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "140",
+              "title": "Introduction to E-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "143",
+              "title": "Internet Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "E-commerce, Certificate",
+      "credential": "certificate",
+      "program_code": "221",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3466",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "140",
+              "title": "Introduction to E-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "143",
+              "title": "Internet Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Web Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business, TAOC Transfer, A.S. (004A) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3462",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "103",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Probability &amp; Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12–14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, CCAC & Indiana University of PA, A.S/ B.S. (097.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3463",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "103",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "122",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Probability &amp; Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "111",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "155",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IUP Course: ACCT-304 Intermediate Accounting I (for Accounting majors) or MGMT-300 Human Resource Management (for Management or HRM majors) or MRKT Elective (for Marketing majors)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization From Ancient Times Through 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "United States History from Early Colonization thru 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "105",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "213",
+              "title": "Twentieth Century World History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IUP Course: ACCT-305 Intermediate Accounting II (for Accounting majors) or MGMT-311 Human Behavior in Organizations (for Management or HRM majors) or MKTG-321 Consumer Behavior (for Marketing majors)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IUP Courses (dependent on major)",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "World Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IUP Courses (dependent on major)",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Seventh Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IUP Courses (dependent on major)",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Eighth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "171",
+              "title": "Personal and Community Health and Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "General Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "209",
+              "title": "World Literature to 1650",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "World Literature From 1650 to the Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IUP Courses (dependent on major)",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting, A.S.",
+      "credential": "AS",
+      "program_code": "105",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3456",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "103",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting 1",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "120",
+                  "title": "Analytical Methods"
+                }
+              ]
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Intermediate Accounting 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Supervision and Leadership, Certificate (386.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3635",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9-10 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective:",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9-11 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management, A.S. (385.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3662",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Management Focus Elective 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective –4 3",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Management Focus Elective 2",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Marketing Focus Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Public Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "140",
+              "title": "Introduction to E-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "143",
+              "title": "Internet Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "212",
+              "title": "Principles of Selling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Small Business Focus Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Principles of Retailing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "212",
+              "title": "Principles of Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Human Resource Focus Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Labor Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "International Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Computer Applications in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Elective Recommendations",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Recommended for Marketing and Small Business:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "170",
+              "title": "Interactive Design 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "111",
+              "title": "Digital Design for Multimedia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "112",
+              "title": "Multimedia Broadcasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Recommended for Human Resources:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "114",
+              "title": "Achieving Cultural Competence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "History of American Labor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General focus may select any general elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, IUP: Bachelor of Science - Human Resource Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3642",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Court Reporter, A.S. (327.4)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3468",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "100",
+              "title": "Court Reporting Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "Court Reporting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "103",
+              "title": "Machine Shorthand Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "102",
+              "title": "Court Reporting 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "104",
+              "title": "Speedbuilding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "111",
+              "title": "Court Transcription 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "205",
+              "title": "Machine Shorthand Companion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "106",
+              "title": "Question and Answer 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "107",
+              "title": "Jury Charge 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "108",
+              "title": "Literary 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "206",
+              "title": "Question and Answer 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "207",
+              "title": "Jury Charge 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "208",
+              "title": "Literary 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "211",
+              "title": "Court Transcription 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "216",
+              "title": "Question and Answer 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "217",
+              "title": "Jury Charge 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "215",
+              "title": "Court Transcription 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "218",
+              "title": "Literary 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "226",
+              "title": "Question and Answer 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "227",
+              "title": "Jury Charge 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "228",
+              "title": "Literary 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "252P",
+              "title": "Court Reporting Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Court Reporting, Certificate (329.4)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3469",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "100",
+              "title": "Court Reporting Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "101",
+              "title": "Court Reporting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "103",
+              "title": "Machine Shorthand Theory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "102",
+              "title": "Court Reporting 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "104",
+              "title": "Speedbuilding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "111",
+              "title": "Court Transcription 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "205",
+              "title": "Machine Shorthand Companion",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "106",
+              "title": "Question and Answer 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "107",
+              "title": "Jury Charge 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "108",
+              "title": "Literary 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "206",
+              "title": "Question and Answer 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "207",
+              "title": "Jury Charge 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "208",
+              "title": "Literary 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "211",
+              "title": "Court Transcription 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "216",
+              "title": "Question and Answer 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "217",
+              "title": "Jury Charge 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "215",
+              "title": "Court Transcription 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "218",
+              "title": "Literary 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "226",
+              "title": "Question and Answer 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "227",
+              "title": "Jury Charge 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "228",
+              "title": "Literary 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "252P",
+              "title": "Court Reporting Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Basics, Certificate",
+      "credential": "certificate",
+      "program_code": "671",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3628",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "110",
+              "title": "Foodservice Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "117",
+              "title": "Fundamentals of Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "201",
+              "title": "Introduction to Baking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "118",
+              "title": "Meat and Seafood Fabrication and Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "202",
+              "title": "Basic Garde Manger Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "229",
+              "title": "Culinary Retail Kitchen",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, A.S. (670.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3470",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "100",
+              "title": "Introduction to Foodservice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "110",
+              "title": "Foodservice Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "117",
+              "title": "Fundamentals of Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "201",
+              "title": "Introduction to Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "102",
+              "title": "Food and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "118",
+              "title": "Meat and Seafood Fabrication and Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "202",
+              "title": "Basic Garde Manger Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "210",
+              "title": "Pastry Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "105",
+              "title": "Supervision and Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "203",
+              "title": "Advanced Garde Manger and Charcuterie Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "220",
+              "title": "American Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "119",
+              "title": "Elements of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "211",
+              "title": "Menu Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "205",
+              "title": "Purchasing Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "228",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "230",
+              "title": "Culinary Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality, Tourism and Event Management, A.S. (676.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3634",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "101",
+              "title": "Introduction to Hospitality, Tourism and Event Planning Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "106",
+              "title": "Club and Casino Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "108",
+              "title": "Lodging Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "203",
+              "title": "Hospitality Sales and Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Credits: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "109",
+              "title": "Food and Beverage Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "126",
+              "title": "Hospitality Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "130",
+              "title": "Hospitality Event Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "140",
+              "title": "Tourism Destinations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "125",
+              "title": "Professional Development in the Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "105",
+              "title": "Hospitality Human Resources and Public Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "240",
+              "title": "Commercial Recreation and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "241",
+              "title": "Contemporary Travel and Tourism Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "120",
+              "title": "Legal Issues in Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "212",
+              "title": "Sustainability in Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "256P",
+              "title": "Hospitality, Tourism and Event Planning Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality, Tourism and Event Management, Certificate (677.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3633",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "101",
+              "title": "Introduction to Hospitality, Tourism and Event Planning Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "105",
+              "title": "Hospitality Human Resources and Public Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "203",
+              "title": "Hospitality Sales and Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives (choose 2 courses)",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "109",
+              "title": "Food and Beverage Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "120",
+              "title": "Legal Issues in Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "126",
+              "title": "Hospitality Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "130",
+              "title": "Hospitality Event Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "140",
+              "title": "Tourism Destinations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "212",
+              "title": "Sustainability in Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "125",
+              "title": "Professional Development in the Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "256P",
+              "title": "Hospitality, Tourism and Event Planning Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTE",
+              "number": "106",
+              "title": "Club and Casino Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "108",
+              "title": "Lodging Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "240",
+              "title": "Commercial Recreation and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTE",
+              "number": "241",
+              "title": "Contemporary Travel and Tourism Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Foodservice Restaurant Management, A.S.",
+      "credential": "AS",
+      "program_code": "672",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3663",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "100",
+              "title": "Introduction to Foodservice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "110",
+              "title": "Foodservice Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "117",
+              "title": "Fundamentals of Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "201",
+              "title": "Introduction to Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "102",
+              "title": "Food and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "105",
+              "title": "Supervision and Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "118",
+              "title": "Meat and Seafood Fabrication and Cooking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "240",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "250",
+              "title": "Global Food Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "260",
+              "title": "Banquet Production Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "119",
+              "title": "Elements of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "205",
+              "title": "Purchasing Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "211",
+              "title": "Menu Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "230",
+              "title": "Culinary Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Baking and Pastry Arts, A.S.",
+      "credential": "AS",
+      "program_code": "673",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3667",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "100",
+              "title": "Introduction to Foodservice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "110",
+              "title": "Foodservice Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "117",
+              "title": "Fundamentals of Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "130",
+              "title": "Fundamental Baking Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "102",
+              "title": "Food and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "135",
+              "title": "Quick Breads and Cookies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "140",
+              "title": "Pies, Tarts and Pastries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "202",
+              "title": "Basic Garde Manger Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLR",
+              "number": "105",
+              "title": "Supervision and Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "119",
+              "title": "Elements of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "211",
+              "title": "Menu Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "235",
+              "title": "Chocolate, Confections and Plated Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "245",
+              "title": "Cakes and Tortes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "205",
+              "title": "Purchasing Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "225",
+              "title": "Pastry Café",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLR",
+              "number": "230",
+              "title": "Culinary Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal, Certificate (605.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3475",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "203",
+              "title": "Evidence and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "101",
+              "title": "Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "102",
+              "title": "Paralegal Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "115",
+              "title": "U.S. Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RLE",
+              "number": "101",
+              "title": "Real Estate Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLE",
+              "number": "102",
+              "title": "Real Estate Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives",
+              "credits": 12,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "124",
+              "title": "Juvenile Justice and Juvenile Delinquency",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "105",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "110",
+              "title": "Torts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "111",
+              "title": "Litigation 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "112",
+              "title": "Litigation 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "114",
+              "title": "Immigration Law and Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "121",
+              "title": "Estates and Trusts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "135",
+              "title": "Employee Benefits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "201",
+              "title": "Advanced Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal, A.S. (604.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3476",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "101",
+              "title": "Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "102",
+              "title": "Paralegal Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "111",
+              "title": "Litigation 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "112",
+              "title": "Litigation 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "135",
+              "title": "Employee Benefits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "103",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "203",
+              "title": "Evidence and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "121",
+              "title": "Estates and Trusts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLE",
+              "number": "101",
+              "title": "Real Estate Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLE",
+              "number": "102",
+              "title": "Real Estate Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAL",
+              "number": "110",
+              "title": "Torts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "201",
+              "title": "Advanced Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "115",
+              "title": "U.S. Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives (2)",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "124",
+              "title": "Juvenile Justice and Juvenile Delinquency",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "151",
+              "title": "Introduction to Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "105",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAL",
+              "number": "114",
+              "title": "Immigration Law and Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language – English Interpreting, A.S. (915.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3477",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester (Fall 1)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "209",
+              "title": "Advanced ASL &amp; Cognitive Processing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "103",
+              "title": "Discourse Analysis and Translation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "105",
+              "title": "Introduction to Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "210",
+              "title": "Advanced ASL &amp; Cognitive Processing 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "104",
+              "title": "Consecutive Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "200",
+              "title": "Linguistics of ASL and English",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "112",
+              "title": "Service Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "206",
+              "title": "Ethics and Business of Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "208",
+              "title": "Simultaneous Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "211",
+              "title": "NIC &amp; EIPA Test Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-14 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "212",
+              "title": "Educational Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "250P",
+              "title": "Practicum and Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "American Sign Language, Certificate (912.5)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3478",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "Elem American Sign Language 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "104",
+              "title": "Visual Gestural Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "Elementary American Sign Language 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "109",
+              "title": "Deaf Culture",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester - First Summer Session",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "Intermediate American Sign Language 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester - Second Summer Session",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "Intermediate American Sign Language 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice & Criminology, A.S. (600.7) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3598",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "102",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "124",
+              "title": "Juvenile Justice and Juvenile Delinquency",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "151",
+              "title": "Introduction to Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "152",
+              "title": "Ethics in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "General Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "201",
+              "title": "Fundamentals of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "203",
+              "title": "Evidence and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "206",
+              "title": "Police Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "204",
+              "title": "Criminal Justice System Organization and Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "205",
+              "title": "Introduction to Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "207",
+              "title": "Introduction to Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "214P",
+              "title": "First Responder Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Humanities Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "211",
+              "title": "Treatment Offenders: Issues and Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "112",
+              "title": "Understanding Violence in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "103",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Homeland Security, A.S.",
+      "credential": "AS",
+      "program_code": "615",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3660",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "101",
+              "title": "Orient Hmlnd Security/Emerg Prep, Plan, Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "102",
+              "title": "Perspectives on Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLS",
+              "number": "103",
+              "title": "Intro Phys Security/Deterrents to Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "203",
+              "title": "Emerg Medical Services/Health Services Orient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "214P",
+              "title": "First Responder Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "206",
+              "title": "Continuity of Operation Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "207",
+              "title": "Homeland Security and Emergency Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Homeland Security, Certificate",
+      "credential": "certificate",
+      "program_code": "616",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3661",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "101",
+              "title": "Orient Hmlnd Security/Emerg Prep, Plan, Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "102",
+              "title": "Perspectives on Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "103",
+              "title": "Intro Phys Security/Deterrents to Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "214P",
+              "title": "First Responder Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLS",
+              "number": "206",
+              "title": "Continuity of Operation Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Care, Diploma (655.4)",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3491",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "101",
+              "title": "Intro to Early Education and Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "103",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "104",
+              "title": "Preschool Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education Paraprofessional, A.S. (679.4)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3497",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "101",
+              "title": "Intro to Early Education and Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "113",
+              "title": "Middle Childhood and Adolescent Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "125",
+              "title": "Foundations of Middle Level and Secondary Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "135P",
+              "title": "Practicum: Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "201",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Educational and Assistive Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "English Language Learners in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 - 16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "Elem American Sign Language 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "104",
+              "title": "Preschool Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "107",
+              "title": "Health and Safety of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "115",
+              "title": "Introduction to School Age Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "210",
+              "title": "Interaction and Prevention Skills With Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "211",
+              "title": "Family Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "212",
+              "title": "Language, Literacy and Literature in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "214",
+              "title": "Curriculum for Early Childhood Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "Psychology of Intervention",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "School-Age Credential, Diploma",
+      "credential": "diploma",
+      "program_code": "687",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3698",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "115",
+              "title": "Introduction to School Age Programs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "113",
+              "title": "Middle Childhood and Adolescent Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "107",
+              "title": "Health and Safety of Children",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Director Core, Diploma (654.3)",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3494",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "214",
+              "title": "Curriculum for Early Childhood Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "218",
+              "title": "Child Care Management and Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Infant Mental Health Certificate",
+      "credential": "certificate",
+      "program_code": "657",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3640",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "101",
+              "title": "Intro to Early Education and Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "103",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "107",
+              "title": "Health and Safety of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "209",
+              "title": "Introduction to Infant/Early Childhood Mental Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "135P",
+              "title": "Practicum: Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "210",
+              "title": "Interaction and Prevention Skills With Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "211",
+              "title": "Family Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "130P",
+              "title": "Practicum: Infant/Toddler",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "131",
+              "title": "Reflective Supervision: Infant and Toddler",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Education & Child Development, Transfer, A.S. (621.7) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3700",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "101",
+              "title": "Intro to Early Education and Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "103",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "104",
+              "title": "Preschool Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "135P",
+              "title": "Practicum: Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "212",
+              "title": "Language, Literacy and Literature in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "United States History from Early Colonization thru 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Math for Elementary Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "211",
+              "title": "Family Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "World Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization From Ancient Times Through 1500",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "214",
+              "title": "Curriculum for Early Childhood Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "240P",
+              "title": "Practicum: Pre-K - 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "English Language Learners in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematics for Elementary Education 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development & Special Education, Certificate (623.7)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3699",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "101",
+              "title": "Intro to Early Education and Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "103",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "104",
+              "title": "Preschool Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "135P",
+              "title": "Practicum: Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "107",
+              "title": "Health and Safety of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "113",
+              "title": "Middle Childhood and Adolescent Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "115",
+              "title": "Introduction to School Age Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "210",
+              "title": "Interaction and Prevention Skills With Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "211",
+              "title": "Family Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "212",
+              "title": "Language, Literacy and Literature in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "214",
+              "title": "Curriculum for Early Childhood Classroom",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Teacher Education: Middle Level & Secondary, A.S. (099.5)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3702",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "125",
+              "title": "Foundations of Middle Level and Secondary Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Math for Elementary Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Humanities Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "113",
+              "title": "Middle Childhood and Adolescent Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Political Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Educational and Assistive Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "United States History from Early Colonization thru 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematics for Elementary Education 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "201",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "English Language Learners in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "World Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization From Ancient Times Through 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Concentration Elective –4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Recommended Courses for Middle Level Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "World Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Math for Elementary Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematics for Elementary Education 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Political Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Economics Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Courses for Secondary Level Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization From Ancient Times Through 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted Humanities Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Art History - Ancient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Art History - Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "103",
+              "title": "Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "111",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended English Literature Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "General Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "117",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "205",
+              "title": "American Literature to 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Education & Child Development, Career, A.S.",
+      "credential": "AS",
+      "program_code": "686",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3701",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "101",
+              "title": "Intro to Early Education and Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "103",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "104",
+              "title": "Preschool Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "135P",
+              "title": "Practicum: Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "211",
+              "title": "Family Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE SOSC - Social Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE MAT - Mathematics Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "202",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "212",
+              "title": "Language, Literacy and Literature in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE HUM - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "214",
+              "title": "Curriculum for Early Childhood Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "240P",
+              "title": "Practicum: Pre-K - 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE HUM - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CHOOSE MATSC - Mathematics or Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECD",
+              "number": "107",
+              "title": "Health and Safety of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "113",
+              "title": "Middle Childhood and Adolescent Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "115",
+              "title": "Introduction to School Age Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "210",
+              "title": "Interaction and Prevention Skills With Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECD",
+              "number": "218",
+              "title": "Child Care Management and Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "English Language Learners in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Psychology, A.A. (053.4) ♦",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3486",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "202",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Psychology Life Span/Developmental Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Human Biology in Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Statistics for Behavioral and Social Sciences",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13–14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Psychology Life Span/ Developmental Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "113",
+              "title": "Psychology of Death and Dying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "204",
+              "title": "Adolescent Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "214",
+              "title": "Psychology of Adulthood",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Social Work Foundation, A.S. (630.4) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3489",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "155",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "103",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "101",
+              "title": "Introduction to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "125",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "201",
+              "title": "Artificial Intelligence and Digital Literacy in Social Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16- 17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "United States History from Early Colonization thru 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "105",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "117",
+              "title": "Theories of Addiction and Recovery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "150",
+              "title": "Cultural Competence and Diverse Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "106",
+              "title": "Interviewing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "110P",
+              "title": "Social Work Service Learning Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "118P",
+              "title": "Substance Use and Public Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "210",
+              "title": "Human Behavior in the Social Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "230",
+              "title": "Trauma, Addiction and Mental Health in Social Work Practice: Theory and Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Work Elective (1)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Social Work Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "120",
+              "title": "Child Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "130",
+              "title": "Community Resources",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Global Studies, Certificate (103.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3484",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "117",
+              "title": "Globalization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "World Literature From 1650 to the Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "114",
+              "title": "Achieving Cultural Competence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "122",
+              "title": "Race and Ethnic Relations in the Global Economy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "World Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "213",
+              "title": "Twentieth Century World History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "111",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "204",
+              "title": "Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "206",
+              "title": "International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "228H",
+              "title": "Honors Comparative Cultures &amp; Politics of India and United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "229H",
+              "title": "Honors Women and Politics Around the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "211",
+              "title": "Sociology of Race and Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences, A.A. (059A, 059B, 059C, 059D)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3487",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization From Ancient Times Through 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "United States History from Early Colonization thru 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Intro to Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "Introduction to Political Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "103",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives in Concentration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives in Concentration",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work Drug & Alcohol, Certificate (414.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3706",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "117",
+              "title": "Theories of Addiction and Recovery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "150",
+              "title": "Cultural Competence and Diverse Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "201",
+              "title": "Artificial Intelligence and Digital Literacy in Social Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "106",
+              "title": "Interviewing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "118P",
+              "title": "Substance Use and Public Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "110P",
+              "title": "Social Work Service Learning Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "230",
+              "title": "Trauma, Addiction and Mental Health in Social Work Practice: Theory and Intervention",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Recommended Restricted Electives (Not Required for Graduation)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "103",
+              "title": "Introduction to Case Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "120",
+              "title": "Child Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "130",
+              "title": "Community Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "101",
+              "title": "Introduction to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Recommended electives support stackability with Social Work programs but are not required for completion of the Drug & Alcohol Certificate.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "210",
+              "title": "Human Behavior in the Social Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work: Fundamentals of Social Work Foundation, Certificate (658.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3490",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "101",
+              "title": "Introduction to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "125",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "150",
+              "title": "Cultural Competence and Diverse Populations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "110P",
+              "title": "Social Work Service Learning Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "118P",
+              "title": "Substance Use and Public Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "201",
+              "title": "Artificial Intelligence and Digital Literacy in Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "210",
+              "title": "Human Behavior in the Social Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Work Electives (1)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Social Work Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOW",
+              "number": "103",
+              "title": "Introduction to Case Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "106",
+              "title": "Interviewing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "120",
+              "title": "Child Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "130",
+              "title": "Community Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "117",
+              "title": "Theories of Addiction and Recovery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOW",
+              "number": "230",
+              "title": "Trauma, Addiction and Mental Health in Social Work Practice: Theory and Intervention",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Anesthesia Technologist, A.S. (462.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3503",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANE",
+              "number": "110",
+              "title": "Basic Prin of Anesthesia Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANE",
+              "number": "111",
+              "title": "Basic Prin of Anesthesia Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "106",
+              "title": "Mathematics for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANE",
+              "number": "114",
+              "title": "Advanced Prin of Anesthesia Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANE",
+              "number": "116",
+              "title": "Advanced Anesthesia Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANE",
+              "number": "203C",
+              "title": "Anesthesia Technology Clinical 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANE",
+              "number": "214",
+              "title": "Anesthesia Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Introductory Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "Introductory Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "221",
+              "title": "EKG Application and Advanced Cardiac Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANE",
+              "number": "221C",
+              "title": "Anesthesia Technology Clinical 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester (Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANE",
+              "number": "220",
+              "title": "Professional Issues for the Anesthesia Technologist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANE",
+              "number": "222C",
+              "title": "Anesthesia Technology Clinical 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, Certificate (419.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3505",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "104",
+              "title": "Administrative Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "105",
+              "title": "Clinical Medical Assisting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "208",
+              "title": "Medical Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "106",
+              "title": "Basic Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "103",
+              "title": "Medical Assisting Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "106",
+              "title": "Clinical Medical Assisting 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "107",
+              "title": "Laboratory Procedures for the Medical Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDA",
+              "number": "108C",
+              "title": "Medical Assisting Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, A.S. (535.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3504",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "104",
+              "title": "Administrative Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "105",
+              "title": "Clinical Medical Assisting 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "208",
+              "title": "Medical Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "106",
+              "title": "Basic Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "103",
+              "title": "Medical Assisting Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "106",
+              "title": "Clinical Medical Assisting 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "107",
+              "title": "Laboratory Procedures for the Medical Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDA",
+              "number": "108C",
+              "title": "Medical Assisting Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "125",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "107",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "117",
+              "title": "Introduction to Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Human Reproduction and Sexually Transmitted Diseases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "101",
+              "title": "Ethnic and Diversity Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "114",
+              "title": "Achieving Cultural Competence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "155",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "205",
+              "title": "Medical Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "117",
+              "title": "Understanding Chemical Dependency",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of Health and Illness",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy, A.S. (540.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3508",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "115",
+              "title": "Human Biology in Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Introductory Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "Introductory Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "123",
+              "title": "Physics for the Health Sciences/Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "111",
+              "title": "Respiratory Care Equipment 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "113",
+              "title": "Respiratory Therapy 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "209",
+              "title": "Cardiopulmonary Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "112",
+              "title": "Respiratory Equipment 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "114",
+              "title": "Respiratory Therapy 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RES",
+              "number": "115",
+              "title": "Fundamentals of Clinical Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "116",
+              "title": "Pulmonary Diagnostic Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "117",
+              "title": "Pulmonary and Related Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "118",
+              "title": "Respiratory Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "202",
+              "title": "Medical Aspects of Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "211C",
+              "title": "Respiratory Therapist Clinical 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RES",
+              "number": "212C",
+              "title": "Respiratory Therapist Clinical 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technologist, A.S. (530.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3509",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "123",
+              "title": "Medical Biology and Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical &amp; Central Service Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "175",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "106",
+              "title": "Mathematics for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "120",
+              "title": "Surgical Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "230",
+              "title": "Surgical Technology 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "231C",
+              "title": "Surgical Technology Clinical 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "240",
+              "title": "Surgical Technology 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "241C",
+              "title": "Surgical Technology Clinical 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Central Service Technician, Certificate (438.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3511",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "106",
+              "title": "Basic Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "615",
+              "title": "Computer Applications in Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "103",
+              "title": "Inventory Management for Central Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "112C",
+              "title": "Central Service Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "110",
+              "title": "Surgical &amp; Central Service Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dietetic Technician, A.S. (590.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3512",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "102",
+              "title": "Dietetic/Foodservice Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Nutrition Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "104",
+              "title": "Foods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105L",
+              "title": "Foods Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "106",
+              "title": "Fundamentals of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Foodservice Production and Purchasing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "114",
+              "title": "Medical Nutrition Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "125",
+              "title": "Food Protection Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Dietetic Practicum Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "201P",
+              "title": "Dietetic Supervised Practice 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "120",
+              "title": "Bio-Organic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "210",
+              "title": "Human Resource Management for Dietetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "208",
+              "title": "Community Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "209P",
+              "title": "Dietetic Supervised Practice 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "212",
+              "title": "Foodservice Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "214",
+              "title": "Dietetic Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Informatics, A.S. (550.6)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3514",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Healthcare Informatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "104",
+              "title": "Health Information Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Introduction to Human Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "107",
+              "title": "Healthcare Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Healthcare Information and Data Governance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Probability &amp; Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "107",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "103",
+              "title": "Healthcare Statistics &amp; Data Mining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "205",
+              "title": "Diagnostic Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "208",
+              "title": "Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "210",
+              "title": "Clinical Procedural Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "203C",
+              "title": "Professional Practice Experience and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "206",
+              "title": "Legal Aspects of Health Information",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "217",
+              "title": "Artificial Intelligence for Healthcare Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "Revenue Cycle Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "216",
+              "title": "Healthcare Data Analytics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Insurance Specialist, Certificate (595.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3515",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIS",
+              "number": "100",
+              "title": "Intro Medical Insurance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIS",
+              "number": "102",
+              "title": "Medical Coding for Insurance Billing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIS",
+              "number": "103",
+              "title": "Medical Insurance Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIS",
+              "number": "105",
+              "title": "Medical Insurance Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dietary Manager, Certificate (591.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3513",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "102",
+              "title": "Dietetic/Foodservice Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "103",
+              "title": "Nutrition Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "104",
+              "title": "Foods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "105L",
+              "title": "Foods Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "106",
+              "title": "Fundamentals of Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "210",
+              "title": "Human Resource Management for Dietetics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "110",
+              "title": "Foodservice Production and Purchasing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "114",
+              "title": "Medical Nutrition Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "125",
+              "title": "Food Protection Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIT",
+              "number": "113",
+              "title": "Dietetic Practicum Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "130P",
+              "title": "Dietary Manager Supervised Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomist, Diploma (513.3)",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3518",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "106",
+              "title": "Basic Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "101",
+              "title": "Clinical Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "201C",
+              "title": "Clinical Phlebotomy Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "211",
+              "title": "Clinical Phlebotomy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician, A.S. (525.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3528",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "111",
+              "title": "Clinical Laboratory Techniques 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "161",
+              "title": "Clinical Instrumentation and Clinical Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "112",
+              "title": "Clinical Laboratory Techniques 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "151",
+              "title": "Clinical Microbiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "162",
+              "title": "Clinical Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "152",
+              "title": "Clinical Microbiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "220",
+              "title": "Clinical Hematology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "225",
+              "title": "Clinical Immunohematology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "250",
+              "title": "Clinical Laboratory Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "251C",
+              "title": "Clinical Laboratory Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant, A.S. (628.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3520",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisite Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Introduction to Human Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "101",
+              "title": "Introduction to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "102",
+              "title": "Physical Therapy Principles and Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "103",
+              "title": "Physical Therapy Principles and Procedures 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "112C",
+              "title": "Introduction to Physical Therapy Clinical Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17-18 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3-4 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "201",
+              "title": "Physical Therapy Principles and Procedures 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "Physical Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "203",
+              "title": "Specialty Topics in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "211C",
+              "title": "Physical Therapy Clinical Education 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "212C",
+              "title": "Physical Therapy Clinical Education 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "213C",
+              "title": "Physical Therapy Clinical Education 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "215",
+              "title": "Physical Therapy Professional Exploration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiation Therapy, Certificate (566.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3531",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Radiobiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "241",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "125",
+              "title": "Applied Nuclear Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "203",
+              "title": "Radiation Therapy 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "204C",
+              "title": "Clinical Radiation Therapy 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "126",
+              "title": "Radiation Physics and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "213",
+              "title": "Radiation Therapy 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "214C",
+              "title": "Clinical Radiation Therapy 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "218",
+              "title": "Radiation Oncology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "221C",
+              "title": "Clinical Radiation Therapy 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "222",
+              "title": "Registry Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapist, A.S. (443.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3522",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "101",
+              "title": "Massage Therapy Principles/Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "110",
+              "title": "Musculoskeletal Palpation for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "102",
+              "title": "Massage Therapy Principles/Procedures 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "111",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "201",
+              "title": "Massage Therapy Principles/Procedures 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "208",
+              "title": "Adv Kinesiology &amp; Movement Dysfunction for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "220",
+              "title": "Massage Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "177",
+              "title": "First Aid and Athletic Injuries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "203",
+              "title": "Massage Therapy Modalities 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "204",
+              "title": "Massage Therapy Modalities 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "211L",
+              "title": "Massage Therapy Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester (Electives)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "143",
+              "title": "Internet Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Principles of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12-13 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant, A.S. (587.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3521",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "101",
+              "title": "Introduction to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "102",
+              "title": "Occupational Therapy in Pediatrics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "112C",
+              "title": "Occupational Therapy Level 1 Fieldwork in Pediatrics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "201",
+              "title": "Occupational Therapy in Physical Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "211C",
+              "title": "Occupational Therapy Level 1 Fieldwork in Physical Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "202",
+              "title": "Occupational Therapy in Behavioral and Community Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "203",
+              "title": "Occupational Therapy in Aging Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "204",
+              "title": "Professional Issues in Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "212C",
+              "title": "Occupational Therapy Level 1 Fieldwork in Behavioral and Community Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "213C",
+              "title": "Occupational Therapy Level 1 Fieldwork in Aging Populations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "221C",
+              "title": "Occupational Therapy Level 2 Fieldwork Session 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "222C",
+              "title": "Occupational Therapy Level 2 Fieldwork Session 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapist, Certificate (403.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3523",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Introduction to Human Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "101",
+              "title": "Massage Therapy Principles/Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "110",
+              "title": "Musculoskeletal Palpation for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "106",
+              "title": "Basic Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "102",
+              "title": "Massage Therapy Principles/Procedures 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "111",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "201",
+              "title": "Massage Therapy Principles/Procedures 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "208",
+              "title": "Adv Kinesiology &amp; Movement Dysfunction for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "220",
+              "title": "Massage Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technologist, A.S.",
+      "credential": "AS",
+      "program_code": "558",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3533",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "107",
+              "title": "Radiologic Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "108C",
+              "title": "Radiologic Technology Clinical 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "157",
+              "title": "Radiologic Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "158C",
+              "title": "Radiologic Technology Clinical 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "208C",
+              "title": "Radiologic Technology Clinical 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "128",
+              "title": "Physics for Health Science/Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "207",
+              "title": "Radiologic Technology 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "218C",
+              "title": "Radiologic Technology Clinical 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "217",
+              "title": "Radiologic Technology 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "258C",
+              "title": "Radiologic Technology Clinical 5",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonographer, General Ultrasound: Abdomen, Obstetrics & Gynecology",
+      "credential": "other",
+      "program_code": "554A",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3606",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "123",
+              "title": "Medical Biology and Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 22 credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "102",
+              "title": "Intro to Clinical Experience:Patient Care and Ethical/Legal Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "105",
+              "title": "Introduction to Cross-Sectional Anatomy for Ultrasonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "103",
+              "title": "Abdominal, Obstetrical and Gynecological Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "113C",
+              "title": "Ultrasound Clinical 1/Abdomen-OB/GYN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "127",
+              "title": "Physics for Health Science/Ultrasonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "115C",
+              "title": "Ultrasound Clinical 2/Abdomen-OB/GYN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "203",
+              "title": "Advanced Abdomen and Small Parts Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Ultrasound Instrumentation and Quality Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "223C",
+              "title": "Ultrasound Clinical 3/Abdomen-OB/GYN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "225C",
+              "title": "Ultrasound Clinical 4/Abdomen-OB/GYN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "227",
+              "title": "Advanced OB/GYN Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "228",
+              "title": "Doppler Vascular Sonography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonographer (Ultrasound), A.S. (554A, 554B, 554C)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3526",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Technology, A.S. (555.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3529",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "101",
+              "title": "Introduction to Nuclear Medicine Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "129",
+              "title": "Physics for Nuclear Medicine Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "102",
+              "title": "Clinical Nuclear Medicine Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "130",
+              "title": "Physics for Nuclear Medicine Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NMT",
+              "number": "201",
+              "title": "Clinical Nuclear Medicine Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "206",
+              "title": "Nuclear Medicine Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Radiobiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "241",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "202C",
+              "title": "Nuclear Medicine Clinical Practicum 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NMT",
+              "number": "203",
+              "title": "Nuclear Medicine Laboratory Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "204C",
+              "title": "Nuclear Medicine Clinical Practicum 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "207",
+              "title": "Nuclear Medicine Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NMT",
+              "number": "205C",
+              "title": "Nuclear Medicine Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "270",
+              "title": "Fundamentals of Molecular Imaging With PET",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Technology, Certificate (560.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3530",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Radiobiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "150",
+              "title": "Applied Nuclear Medicine Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "160C",
+              "title": "Introduction to Applied Nuclear Medicine Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "206",
+              "title": "Nuclear Medicine Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "129",
+              "title": "Physics for Nuclear Medicine Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NMT",
+              "number": "151",
+              "title": "Applied Nuclear Medicine Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "161C",
+              "title": "Applied Nuclear Medicine Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "203",
+              "title": "Nuclear Medicine Laboratory Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "207",
+              "title": "Nuclear Medicine Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "130",
+              "title": "Physics for Nuclear Medicine Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "241",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "205C",
+              "title": "Nuclear Medicine Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "270",
+              "title": "Fundamentals of Molecular Imaging With PET",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonographer, Vascular Ultrasound",
+      "credential": "other",
+      "program_code": "554C",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3609",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "123",
+              "title": "Medical Biology and Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 22 credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "102",
+              "title": "Intro to Clinical Experience:Patient Care and Ethical/Legal Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "105",
+              "title": "Introduction to Cross-Sectional Anatomy for Ultrasonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "125",
+              "title": "Vascular Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "135C",
+              "title": "Ultrasound Clinical 1/Vascular Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "127",
+              "title": "Physics for Health Science/Ultrasonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "137C",
+              "title": "Ultrasound Clinical 2/Vascular",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Advanced Vascular Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Ultrasound Instrumentation and Quality Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "235C",
+              "title": "Ultrasound Clinical 3/Vascular",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "237C",
+              "title": "Ultrasound Clinical 4/Vascular",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "239",
+              "title": "Abdominal OB-GYN/Cardiac Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonographer, Cardiac Ultrasound",
+      "credential": "other",
+      "program_code": "554B",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3608",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "123",
+              "title": "Medical Biology and Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 22 credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "102",
+              "title": "Intro to Clinical Experience:Patient Care and Ethical/Legal Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "105",
+              "title": "Introduction to Cross-Sectional Anatomy for Ultrasonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "104",
+              "title": "Cardiac Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "114C",
+              "title": "Ultrasound Clinical 1/Cardiac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "127",
+              "title": "Physics for Health Science/Ultrasonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "116C",
+              "title": "Ultrasound Clinical 2/Cardiac",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "204",
+              "title": "Advanced Cardiac Ultrasound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Ultrasound Instrumentation and Quality Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "224C",
+              "title": "Ultrasound Clinical 3/Cardiac",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "226C",
+              "title": "Ultrasound Clinical 4/Cardiac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "228",
+              "title": "Doppler Vascular Sonography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiation Therapy, A.S. (565.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3532",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALH",
+              "number": "140",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester - Spring 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "101",
+              "title": "Introduction to Radiation Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester - Summer 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "112C",
+              "title": "Radiation Therapy Clinical Practicum 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester - Fall 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "212",
+              "title": "Radiobiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "241",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "125",
+              "title": "Applied Nuclear Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "102",
+              "title": "Radiation Therapy Principles &amp; Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "120C",
+              "title": "Radiation Therapy Clinical Practicum 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester - Spring 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "126",
+              "title": "Radiation Physics and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "201",
+              "title": "Radiation Therapy Principles &amp; Procedures 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "202C",
+              "title": "Radiation Therapy Clinical Practicum 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "218",
+              "title": "Radiation Oncology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester - Summer 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "212C",
+              "title": "Radiation Therapy Clinical Practicum 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester - Fall 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "211",
+              "title": "Radiation Therapy Principles &amp; Procedures 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "215",
+              "title": "Simulation, Medical Imaging &amp; Cross-Sectional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "219",
+              "title": "Radiation Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "220C",
+              "title": "Radiation Therapy Clinical Practicum 5",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "222",
+              "title": "Registry Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technologist, Certificate",
+      "credential": "certificate",
+      "program_code": "582",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3707",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "107",
+              "title": "Radiologic Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "108C",
+              "title": "Radiologic Technology Clinical 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "207",
+              "title": "Radiologic Technology 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "157",
+              "title": "Radiologic Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "217",
+              "title": "Radiologic Technology 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, A.S. LPN to RN Option",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3626",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Pre-Requisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students must meet the eligibility requirements for college-level English or have completed college-level English courses.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Electives 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Prerequisite high school level chemistry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "LPN Advanced Standing",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "Foundation and Health Promotion Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "120",
+              "title": "Health Assessment Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "130",
+              "title": "Basic Health Concepts Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "140",
+              "title": "Evidence Based Nursing Drug Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "175",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "210",
+              "title": "Professional Nursing Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Adult Health Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "230",
+              "title": "Family Health Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "240",
+              "title": "Complex Health Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "250",
+              "title": "Leadership and Management Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Biology Pre-requisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Biology Waiver Exam",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "106",
+              "title": "Mathematics for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Analytical Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "135",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "147",
+              "title": "College Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Probability &amp; Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "251",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "253",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Health & Physical Education, A.S. (020.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3499",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "171",
+              "title": "Personal and Community Health and Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "172",
+              "title": "Foundations of Health and Physical Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "177",
+              "title": "First Aid and Athletic Injuries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "193P",
+              "title": "Practicum in Health and Physical Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPE",
+              "number": "201",
+              "title": "Applied Anatomy/Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "205",
+              "title": "Organization and Management of Adult Fitness Programs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPE",
+              "number": "207",
+              "title": "Fundamentals of Exercise Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "225",
+              "title": "Fundamentals of Fitness Theory, Programming and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, A.S (575.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3519",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "161",
+              "title": "Anatomy &amp; Physiology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "Foundation and Health Promotion Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "120",
+              "title": "Health Assessment Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematic Electives 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18-19 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "162",
+              "title": "Anatomy &amp; Physiology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "130",
+              "title": "Basic Health Concepts Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "140",
+              "title": "Evidence Based Nursing Drug Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "108",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "175",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "210",
+              "title": "Professional Nursing Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Adult Health Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "230",
+              "title": "Family Health Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "240",
+              "title": "Complex Health Concepts for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "250",
+              "title": "Leadership and Management Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematic Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "106",
+              "title": "Mathematics for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Analytical Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "135",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "147",
+              "title": "College Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "165",
+              "title": "Probability &amp; Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "251",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "253",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Biology, TAOC Transfer, A.S. (031A) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3537",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "152",
+              "title": "General Biology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective –4 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "202",
+              "title": "Organic Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective (2) –8 2",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Ecology and Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "207",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Research Methodology/Quality Assurance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Administrative Computer Specialist, Certificate",
+      "credential": "certificate",
+      "program_code": "234",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3541",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "141",
+              "title": "Word Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "600",
+              "title": "Windows Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "601",
+              "title": "Research using the Internet",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "142",
+              "title": "Desktop Publishing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "602",
+              "title": "Presentation Graphics: Powerpoint",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "140",
+              "title": "Introduction to E-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "206",
+              "title": "Administrative Technology and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "607",
+              "title": "Office Management:Outlook",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology, Non-TAOC Transfer, A.S.",
+      "credential": "AS",
+      "program_code": "031B",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3659",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17-19 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "152",
+              "title": "General Biology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "202",
+              "title": "Organic Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-18 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Chemistry, A.S. (035.1) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3540",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Physics for Science and Engineering 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "201",
+              "title": "Organic Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Physics for Science and Engineering 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "202",
+              "title": "Organic Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "223",
+              "title": "Physics for Science and Engineering 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems, A.S. (050.4) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3543",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Object-Oriented Programming Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "217",
+              "title": "Computer Organization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "244",
+              "title": "Object-Oriented Design, Data Structures and Algorithms Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "Data Structures and Algorithms Using C++",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14–15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "230",
+              "title": "Database Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14–15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development, A.S. (780.4)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3549",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Networking Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Object-Oriented Programming Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CIT Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Programming in Visual Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "244",
+              "title": "Object-Oriented Design, Data Structures and Algorithms Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CIT Restricted Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "215",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "230",
+              "title": "Database Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CIT Restricted Electives",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "CIT Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "119",
+              "title": "Programming in Python",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Web Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "145",
+              "title": "Programming in C",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "165",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "Data Structures and Algorithms Using C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "264",
+              "title": "Mobile Apps Programming Using Android",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "266",
+              "title": "Mobile Apps Programming using iOS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development, Certificate (243.5)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3550",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Object-Oriented Programming Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Programming in Visual Basic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "230",
+              "title": "Database Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7-8 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "215",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Restricted Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10–11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "CIT Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "119",
+              "title": "Programming in Python",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "125",
+              "title": "Web Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "145",
+              "title": "Programming in C",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "165",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "244",
+              "title": "Object-Oriented Design, Data Structures and Algorithms Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "Data Structures and Algorithms Using C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "264",
+              "title": "Mobile Apps Programming Using Android",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "266",
+              "title": "Mobile Apps Programming using iOS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity and IT Support Specialist, A.S.",
+      "credential": "AS",
+      "program_code": "790",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3647",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Networking Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "150",
+              "title": "Computer Configuration and Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "205",
+              "title": "Help Desk and User Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "182",
+              "title": "Principles of Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "220",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "250",
+              "title": "Network Routing and Switching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "251",
+              "title": "Windows Server Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "253",
+              "title": "Infrastructure Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "254",
+              "title": "Ethical Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "282",
+              "title": "Mobile Device and Cloud Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Network Support Specialist, Certificate",
+      "credential": "certificate",
+      "program_code": "792",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3648",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Networking Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "150",
+              "title": "Computer Configuration and Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "182",
+              "title": "Principles of Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "250",
+              "title": "Network Routing and Switching",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "205",
+              "title": "Help Desk and User Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "220",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "251",
+              "title": "Windows Server Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity Support Specialist, Certificate",
+      "credential": "certificate",
+      "program_code": "791",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3649",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Networking Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "150",
+              "title": "Computer Configuration and Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "182",
+              "title": "Principles of Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "250",
+              "title": "Network Routing and Switching",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "253",
+              "title": "Infrastructure Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "254",
+              "title": "Ethical Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "282",
+              "title": "Mobile Device and Cloud Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Nanofabrication Technology, Certificate",
+      "credential": "certificate",
+      "program_code": "709",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3562",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MFT",
+              "number": "211",
+              "title": "Material Safety and Equipment Overview",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFT",
+              "number": "212",
+              "title": "Basic Nanofabrication Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFT",
+              "number": "213",
+              "title": "Materials in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFT",
+              "number": "214",
+              "title": "Lithography for Nanofabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFT",
+              "number": "215",
+              "title": "Materials Modification for Nanofabrication Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFT",
+              "number": "216",
+              "title": "Characterization, Testing of Nanotechnology Structures &amp; Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Sales Engineer, Certificate",
+      "credential": "certificate",
+      "program_code": "725",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3654",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (2)",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "212",
+              "title": "Principles of Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (2)",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12-14 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Production Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Technical Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "133",
+              "title": "Environmental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "103",
+              "title": "Introduction to Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "104",
+              "title": "Introduction to Mechanical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "107",
+              "title": "Manufacturing Tech: Math, Technology &amp; Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "108",
+              "title": "Programmable Logic Controllers 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "109",
+              "title": "Manufacturing Tech: Processes, Controls &amp; Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Mechatronics &amp; Industry 4.0",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "115",
+              "title": "Introduction to Polymers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "116",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "117",
+              "title": "Applied Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "121",
+              "title": "Computer-Assisted Design (CAD) Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "125",
+              "title": "Advanced Materials and Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "132",
+              "title": "How to Make Almost Anything",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "134",
+              "title": "Soldering and Making with Machine Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "135",
+              "title": "Introduction to Computer Numerical Control Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "136",
+              "title": "Applied Computer Numerical Control Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "150",
+              "title": "Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "156",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Welding for Artists EXPERIMENTAL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics Technology, A.S. (722.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3564",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "103",
+              "title": "Introduction to Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "104",
+              "title": "Introduction to Mechanical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Mechatronics &amp; Industry 4.0",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "150",
+              "title": "Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "107",
+              "title": "Manufacturing Tech: Math, Technology &amp; Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "106",
+              "title": "Industrial Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "108",
+              "title": "Programmable Logic Controllers 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "110",
+              "title": "Digital Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "156",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "109",
+              "title": "Manufacturing Tech: Processes, Controls &amp; Quality",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or higher level",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "141",
+              "title": "Physics 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Transfer Students",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "141",
+              "title": "Physics 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "115",
+              "title": "Introduction to Polymers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "116",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "125",
+              "title": "Advanced Materials and Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "204",
+              "title": "AC/DC Electronic Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "208",
+              "title": "Programmable Logic Controllers 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "221",
+              "title": "Advanced Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "222",
+              "title": "Programming Industrial Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "225",
+              "title": "Automated Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "245",
+              "title": "Industrial Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Welding for Artists EXPERIMENTAL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Process Technology OptionStudents interested in a career in Process Technology may apply 10 credits from the Community College of Beaver County towards the Mechatronics degree without prior permission. These credits should be taken from the following courses:PTEC 100 or PTEC 150-152: Introduction to Process Technology - 3 CreditsPTEC 102 or PTEC 160-162: Safety Health & Environment - 3 CreditsPTEC 104 or PTEC 170-173: Process Technology Equipment - 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics Technology, Certificate (723.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3565",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "103",
+              "title": "Introduction to Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "104",
+              "title": "Introduction to Mechanical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Mechatronics &amp; Industry 4.0",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "150",
+              "title": "Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "107",
+              "title": "Manufacturing Tech: Math, Technology &amp; Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "106",
+              "title": "Industrial Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "108",
+              "title": "Programmable Logic Controllers 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "110",
+              "title": "Digital Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "156",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "109",
+              "title": "Manufacturing Tech: Processes, Controls &amp; Quality",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Polymer Technology, Certificate (724.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3632",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "107",
+              "title": "Manufacturing Tech: Math, Technology &amp; Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "109",
+              "title": "Manufacturing Tech: Processes, Controls &amp; Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "115",
+              "title": "Introduction to Polymers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "103",
+              "title": "Introduction to Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "116",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "125",
+              "title": "Advanced Materials and Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Robotics Technician, Certificate",
+      "credential": "certificate",
+      "program_code": "727",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3703",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "107",
+              "title": "Manufacturing Tech: Math, Technology &amp; Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "109",
+              "title": "Manufacturing Tech: Processes, Controls &amp; Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "103",
+              "title": "Introduction to Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Mechatronics &amp; Industry 4.0",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Automation Systems, Certificate",
+      "credential": "certificate",
+      "program_code": "726",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3668",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAS",
+              "number": "100",
+              "title": "Introduction to Building Automation Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "110",
+              "title": "Building Automation Systems for HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "101",
+              "title": "Basic Electrical Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "120",
+              "title": "HVAC Technical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Building Automation Systems Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "130",
+              "title": "Building Automation Systems Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "140",
+              "title": "Building Automation Systems Control Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "120",
+              "title": "Networking Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "221",
+              "title": "Circuits and Controls for HVAC 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAS",
+              "number": "170P",
+              "title": "Building Automation Systems Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics & Sciences, A.S. (003.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3563",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13–16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Multimedia Programming, Simulation & Gaming, A.S. (108.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3566",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "113",
+              "title": "Multimedia Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "160",
+              "title": "Game Design and Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "165",
+              "title": "2D Game Design and Creation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "130",
+              "title": "Object-Oriented Programming Using Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "165",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "170",
+              "title": "Virtual Design and Simulated Realities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Art Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "260",
+              "title": "3D Modeling Design and Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "250",
+              "title": "Game Environments and Interactivity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted English Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "Data Structures and Algorithms Using C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "270",
+              "title": "3D Animation and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "280",
+              "title": "Multimedia Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13-14 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Art Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "144",
+              "title": "Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted English Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "105",
+              "title": "Creative Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "117",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "120",
+              "title": "The Art of Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "223",
+              "title": "Science Fiction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted Science Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Introduction to Biological Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "109",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "141",
+              "title": "Physics 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurial Design & Manufacturing, A.S.",
+      "credential": "AS",
+      "program_code": "729",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3705",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "116",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "131",
+              "title": "Makerspace Safety and Access Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "132",
+              "title": "How to Make Almost Anything",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "134",
+              "title": "Soldering and Making with Machine Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "117",
+              "title": "Applied Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "121",
+              "title": "Computer-Assisted Design (CAD) Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "135",
+              "title": "Introduction to Computer Numerical Control Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "136",
+              "title": "Applied Computer Numerical Control Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "294",
+              "title": "Design for Manufacturing Capstone 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "141",
+              "title": "Physics 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "137",
+              "title": "AI-Assisted Design and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "295",
+              "title": "Design for Manufacturing Capstone 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurial Design & Manufacturing, Certificate",
+      "credential": "certificate",
+      "program_code": "728",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3704",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "116",
+              "title": "Introduction to Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "131",
+              "title": "Makerspace Safety and Access Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "132",
+              "title": "How to Make Almost Anything",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "134",
+              "title": "Soldering and Making with Machine Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEM",
+              "number": "105",
+              "title": "College Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "117",
+              "title": "Applied Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "121",
+              "title": "Computer-Assisted Design (CAD) Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "135",
+              "title": "Introduction to Computer Numerical Control Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multimedia Game Design, Certificate",
+      "credential": "certificate",
+      "program_code": "109",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3625",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMC",
+              "number": "113",
+              "title": "Multimedia Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "160",
+              "title": "Game Design and Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "165",
+              "title": "2D Game Design and Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "250",
+              "title": "Game Environments and Interactivity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "260",
+              "title": "3D Modeling Design and Layout",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "144",
+              "title": "Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "170",
+              "title": "Virtual Design and Simulated Realities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMC",
+              "number": "270",
+              "title": "3D Animation and Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Management, A.S.",
+      "credential": "AS",
+      "program_code": "378",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3458",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "104",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "101",
+              "title": "Flight Theory/Private Pilot",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "103",
+              "title": "Air Traffic Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "105",
+              "title": "Private Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "108",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "212",
+              "title": "Principles of Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "110",
+              "title": "Aviation Meteorology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "251",
+              "title": "Business Law 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Aviation Technology, A.S. (382.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3459",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "101",
+              "title": "Flight Theory/Private Pilot",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "103",
+              "title": "Air Traffic Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "105",
+              "title": "Private Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "110",
+              "title": "Aviation Meteorology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "116",
+              "title": "Navigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "111",
+              "title": "Flight Theory/Instrument",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "115",
+              "title": "Instrument Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "201",
+              "title": "Aircraft Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "217",
+              "title": "Legal Environment of Aviation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "205",
+              "title": "Commercial Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "211",
+              "title": "Flight Theory/Commercial",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "216",
+              "title": "Flight Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "220",
+              "title": "Flight Theory/Multi-Engine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "225",
+              "title": "Multi Engine Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ASEP/ASSET/CAP Manufacturer Automotive Technology Program, A.A.S. (507.4)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3665",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Automotive Systems/Minor Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "106",
+              "title": "Emission Inspector Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "108",
+              "title": "State Inspection Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "126",
+              "title": "Steering and Suspension",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "130",
+              "title": "Automotive Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "121",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "122",
+              "title": "Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "151",
+              "title": "Automotive Climate Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "160",
+              "title": "Advanced Auto Electricity/Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16–17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "131",
+              "title": "Major Engine Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Advanced Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "230",
+              "title": "Engine Performance 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "245",
+              "title": "Engine Performance 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "234",
+              "title": "Standard Transmission/Transaxle/Drivetrain",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "235",
+              "title": "Auto Transmissions and Transaxles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology Program, A.A.S. (349.4)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3666",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Automotive Systems/Minor Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "106",
+              "title": "Emission Inspector Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "108",
+              "title": "State Inspection Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "126",
+              "title": "Steering and Suspension",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "130",
+              "title": "Automotive Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "121",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "122",
+              "title": "Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "151",
+              "title": "Automotive Climate Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "160",
+              "title": "Advanced Auto Electricity/Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "131",
+              "title": "Major Engine Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Advanced Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "230",
+              "title": "Engine Performance 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "245",
+              "title": "Engine Performance 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "234",
+              "title": "Standard Transmission/Transaxle/Drivetrain",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "235",
+              "title": "Auto Transmissions and Transaxles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Building Construction Estimating, A.S. (515.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3572",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "100",
+              "title": "Construction Plans",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6-7 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "103",
+              "title": "Construction Planning and Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "121",
+              "title": "Construction Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "205",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "294",
+              "title": "Construction Estimating 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6-7 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "295",
+              "title": "Construction Estimating 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology Program, Certificate (350.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3571",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "103",
+              "title": "Automotive Systems/Minor Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "106",
+              "title": "Emission Inspector Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "108",
+              "title": "State Inspection Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "126",
+              "title": "Steering and Suspension",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "130",
+              "title": "Automotive Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "121",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "122",
+              "title": "Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "151",
+              "title": "Automotive Climate Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "160",
+              "title": "Advanced Auto Electricity/Electronics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "131",
+              "title": "Major Engine Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "207",
+              "title": "Advanced Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "230",
+              "title": "Engine Performance 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "245",
+              "title": "Engine Performance 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATE",
+              "number": "234",
+              "title": "Standard Transmission/Transaxle/Drivetrain",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATE",
+              "number": "235",
+              "title": "Auto Transmissions and Transaxles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety &amp; Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Building Construction Technology, A.S. (441.2)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3574",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "100",
+              "title": "Construction Plans",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "121",
+              "title": "Construction Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "103",
+              "title": "Construction Planning and Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "192",
+              "title": "Construction Contracting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "203",
+              "title": "Surveying",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "205",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "294",
+              "title": "Construction Estimating 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "191",
+              "title": "Construction Industry Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "295",
+              "title": "Construction Estimating 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Construction Supervision, A.S. (514.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3573",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "100",
+              "title": "Computer Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "140",
+              "title": "Spreadsheets for Business Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6-8 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "192",
+              "title": "Construction Contracting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "294",
+              "title": "Construction Estimating 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "103",
+              "title": "Construction Planning and Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "205",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6-7 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLC",
+              "number": "191",
+              "title": "Construction Industry Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLC",
+              "number": "203",
+              "title": "Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating & Air Conditioning, A.S. (313.4)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3575",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "101",
+              "title": "Basic Electrical Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "120",
+              "title": "HVAC Technical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "201",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "202",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "130",
+              "title": "Job Safety &amp; First Aid",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "131",
+              "title": "Intro to OSHA/Industrial Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "102",
+              "title": "Refrigeration Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "107",
+              "title": "EPA Refrigerant Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "224",
+              "title": "HVAC Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "225",
+              "title": "Planned Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "203",
+              "title": "Estimating Thermal Loads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "221",
+              "title": "Circuits and Controls for HVAC 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "108",
+              "title": "Industry Competency Exam Preparation (ICE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "204",
+              "title": "Duct and Hydronic System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "231",
+              "title": "Circuits and Controls for HVAC 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Facilities Maintenance Technology, Certificate (383.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3588",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "101",
+              "title": "Basic Electrical Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "120",
+              "title": "HVAC Technical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "201",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "202",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMT",
+              "number": "130",
+              "title": "Job Safety &amp; First Aid",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "131",
+              "title": "Intro to OSHA/Industrial Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "204",
+              "title": "Maintenance Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives: 6-8",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14–16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "107",
+              "title": "EPA Refrigerant Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "204",
+              "title": "Duct and Hydronic System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "221",
+              "title": "Circuits and Controls for HVAC 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "224",
+              "title": "HVAC Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "225",
+              "title": "Planned Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "106",
+              "title": "Industrial Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "108",
+              "title": "Programmable Logic Controllers 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "150",
+              "title": "Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "156",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "221",
+              "title": "Advanced Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating & Air Conditioning Technology, Certificate (312.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3576",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "101",
+              "title": "Basic Electrical Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "120",
+              "title": "HVAC Technical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "201",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "202",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "130",
+              "title": "Job Safety &amp; First Aid",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "131",
+              "title": "Intro to OSHA/Industrial Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "102",
+              "title": "Refrigeration Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "107",
+              "title": "EPA Refrigerant Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "224",
+              "title": "HVAC Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "225",
+              "title": "Planned Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Facilities Maintenance Technology, A.S. (384.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3587",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "101",
+              "title": "Basic Electrical Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "120",
+              "title": "HVAC Technical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "201",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "202",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMT",
+              "number": "130",
+              "title": "Job Safety &amp; First Aid",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "131",
+              "title": "Intro to OSHA/Industrial Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "204",
+              "title": "Maintenance Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives –9 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14–17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives:–8 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives: –8 1",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "107",
+              "title": "EPA Refrigerant Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "108",
+              "title": "Industry Competency Exam Preparation (ICE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "203",
+              "title": "Estimating Thermal Loads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "204",
+              "title": "Duct and Hydronic System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "221",
+              "title": "Circuits and Controls for HVAC 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "224",
+              "title": "HVAC Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "225",
+              "title": "Planned Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "100",
+              "title": "Mechatronics Safety and Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "102",
+              "title": "Mechatronics Industrial Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "103",
+              "title": "Introduction to Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "106",
+              "title": "Industrial Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "108",
+              "title": "Programmable Logic Controllers 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Introduction to Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "150",
+              "title": "Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "156",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "204",
+              "title": "AC/DC Electronic Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "208",
+              "title": "Programmable Logic Controllers 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "221",
+              "title": "Advanced Industrial Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "225",
+              "title": "Automated Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "245",
+              "title": "Industrial Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "101",
+              "title": "Plumbing Skills 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "201",
+              "title": "Plumbing Skills 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, A.S. (316.4)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3592",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Advanced Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "107",
+              "title": "Blueprint Reading for Welders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "201",
+              "title": "Prep for Welding Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "202",
+              "title": "MIG &amp; TIG Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "211",
+              "title": "Welding Inspection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "217",
+              "title": "MIG Flux Core Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "130",
+              "title": "Job Safety &amp; First Aid",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "131",
+              "title": "Intro to OSHA/Industrial Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "222",
+              "title": "Pipe Welding 1 Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14-17 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "223",
+              "title": "Pipe Welding 2 Advanced",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "History of American Labor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDS",
+              "number": "112",
+              "title": "The Job Search",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "105",
+              "title": "Technical Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "224",
+              "title": "Pipe Welding 3 - Downhill",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology, Certificate (317.3)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3591",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Advanced Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "107",
+              "title": "Blueprint Reading for Welders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "201",
+              "title": "Prep for Welding Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "202",
+              "title": "MIG &amp; TIG Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "217",
+              "title": "MIG Flux Core Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding, Gas & Oil, Certificate (319.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3593",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Advanced Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "201",
+              "title": "Prep for Welding Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "222",
+              "title": "Pipe Welding 1 Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "223",
+              "title": "Pipe Welding 2 Advanced",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "224",
+              "title": "Pipe Welding 3 - Downhill",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Plumbing and Heating, Certificate",
+      "credential": "certificate",
+      "program_code": "366",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3671",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "101",
+              "title": "Basic Electrical Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "120",
+              "title": "HVAC Technical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMT",
+              "number": "131",
+              "title": "Intro to OSHA/Industrial Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "101",
+              "title": "Plumbing Skills 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "221",
+              "title": "Brazing and Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "107",
+              "title": "EPA Refrigerant Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "201",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "202",
+              "title": "Air Conditioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "204",
+              "title": "Duct and Hydronic System Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAC",
+              "number": "224",
+              "title": "HVAC Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HAC",
+              "number": "225",
+              "title": "Planned Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "201",
+              "title": "Plumbing Skills 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLH",
+              "number": "204",
+              "title": "Maintenance Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment Operating Engineers Apprenticeship, Certificate",
+      "credential": "certificate",
+      "program_code": "740",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3580",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEO",
+              "number": "101",
+              "title": "Heavy Equipment Regulation and Safety 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEO",
+              "number": "102",
+              "title": "Equipment Operations 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEO",
+              "number": "105",
+              "title": "Heavy Equip Regulation &amp; Safety 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEO",
+              "number": "106",
+              "title": "Equipment Operations 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEO",
+              "number": "201",
+              "title": "Heavy Equip Regulation &amp; Safety 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEO",
+              "number": "202",
+              "title": "Equipment Operations 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEO",
+              "number": "205",
+              "title": "Equipment Operations 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEO",
+              "number": "206",
+              "title": "Industry Recertifications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Carpentry Apprenticeship, Certificate (339.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3578",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "101",
+              "title": "Carpentry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "105",
+              "title": "Carpentry Drafting and Blueprint Reading 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "115",
+              "title": "Mathematics for Carpenters 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "102",
+              "title": "Carpentry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "106",
+              "title": "Carpentry Drafting and Blueprint Reading 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "116",
+              "title": "Mathematics for Carpenters 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Carpentry 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "205",
+              "title": "Carpentry Drafting and Blueprint Reading 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "215",
+              "title": "Mathematics for Carpenters 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "202",
+              "title": "Carpentry 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "206",
+              "title": "Carpentry Drafting and Blueprint Reading 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "216",
+              "title": "Mathematics for Carpenters 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ironworker Apprenticeship, Certificate (289.2)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3581",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STI",
+              "number": "130",
+              "title": "Ornamental Ironworking 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "131",
+              "title": "Ironworker Reinforcing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "132",
+              "title": "Ironworker Safety 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "133",
+              "title": "Structural Ironworking 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "134",
+              "title": "Ironworker Welding 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STI",
+              "number": "195",
+              "title": "Ornamental Ironworking 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "196",
+              "title": "Ironworker Reinforcing 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "197",
+              "title": "Ironworker Safety 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "198",
+              "title": "Structural Ironworking 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "199",
+              "title": "Ironworker Welding 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STI",
+              "number": "210",
+              "title": "Ornamental Ironworking 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "211",
+              "title": "Ironworker Reinforcing 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "212",
+              "title": "Ironworker Safety 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "213",
+              "title": "Structural Ironworking 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STI",
+              "number": "214",
+              "title": "Ironworker Welding 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumber Apprenticeship, Certificate (389.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3582",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLT",
+              "number": "103",
+              "title": "Plumbing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "115",
+              "title": "Mathematics for Plumbing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "121",
+              "title": "Plumbing Drafting/Blueprint Reading 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "101",
+              "title": "Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLT",
+              "number": "105",
+              "title": "Introduction to Plumbing Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "221",
+              "title": "Plumbing Drafting/Blueprint Reading 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Advanced Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLT",
+              "number": "145",
+              "title": "Plumbing Code 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "222",
+              "title": "Mechanical CAD for Plumbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "196",
+              "title": "Welding for Plumbing 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLT",
+              "number": "205",
+              "title": "Plumbing 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "206",
+              "title": "Plumbing Code 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "296",
+              "title": "SMAW and Applied Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMT",
+              "number": "208",
+              "title": "Backflow Tester Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "224",
+              "title": "Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLT",
+              "number": "225",
+              "title": "Medical Gas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "202",
+              "title": "MIG &amp; TIG Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sheet Metal Worker Apprenticeship, A.S.",
+      "credential": "AS",
+      "program_code": "379",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3583",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "103",
+              "title": "Basic Sheet Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "104",
+              "title": "Basic Mechanical Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "295",
+              "title": "GMAW and Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "107",
+              "title": "Sheet Metal 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "108",
+              "title": "Advanced Mechanical Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "296",
+              "title": "SMAW and Applied Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18–19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "History of American Labor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "203",
+              "title": "Sheet Metal 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "204",
+              "title": "CAD and HVAC Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "207",
+              "title": "Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "297",
+              "title": "GTAW Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SHM",
+              "number": "208",
+              "title": "Industrial Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "209",
+              "title": "Advanced AutoCAD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "210",
+              "title": "Foreman Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "298",
+              "title": "Industrial Metal Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sheet Metal Worker Apprenticeship, Certificate (391.1)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3584",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SHM",
+              "number": "103",
+              "title": "Basic Sheet Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "104",
+              "title": "Basic Mechanical Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "295",
+              "title": "GMAW and Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "107",
+              "title": "Sheet Metal 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "108",
+              "title": "Advanced Mechanical Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "296",
+              "title": "SMAW and Applied Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SHM",
+              "number": "203",
+              "title": "Sheet Metal 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "204",
+              "title": "CAD and HVAC Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "207",
+              "title": "Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "297",
+              "title": "GTAW Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SHM",
+              "number": "208",
+              "title": "Industrial Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "209",
+              "title": "Advanced AutoCAD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "210",
+              "title": "Foreman Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SHM",
+              "number": "298",
+              "title": "Industrial Metal Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction Technology (IBEW), A.S. (608.3)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3650",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "101",
+              "title": "Electrical Construction Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "120",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "151",
+              "title": "Electrical Construction Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Technical English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "201",
+              "title": "Adv Electrical Construction Tech 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "History of American Labor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "251",
+              "title": "Adv Electrical Construction Tech 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or higher level 3-4 credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Interpersonal Comm Skills for Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Carpentry, A.S. (338.1)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3658",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "101",
+              "title": "Carpentry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "105",
+              "title": "Carpentry Drafting and Blueprint Reading 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "115",
+              "title": "Mathematics for Carpenters 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Technical English",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "102",
+              "title": "Carpentry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "106",
+              "title": "Carpentry Drafting and Blueprint Reading 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "116",
+              "title": "Mathematics for Carpenters 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "Technical Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "191",
+              "title": "Mathematics for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "201",
+              "title": "Carpentry 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "205",
+              "title": "Carpentry Drafting and Blueprint Reading 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "215",
+              "title": "Mathematics for Carpenters 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "101",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "161",
+              "title": "Physical Science for the Industries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Basic Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "202",
+              "title": "Carpentry 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "206",
+              "title": "Carpentry Drafting and Blueprint Reading 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "216",
+              "title": "Mathematics for Carpenters 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "151",
+              "title": "History of American Labor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "116",
+              "title": "Organizational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction Technology (IBEW), Certificate",
+      "credential": "certificate",
+      "program_code": "618",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3672",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "101",
+              "title": "Electrical Construction Technology 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "151",
+              "title": "Electrical Construction Technology 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "201",
+              "title": "Adv Electrical Construction Tech 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECT",
+              "number": "251",
+              "title": "Adv Electrical Construction Tech 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bricklayers & Allied Craftworkers Apprenticeship, Certificate",
+      "credential": "certificate",
+      "program_code": "732",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3708",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAC",
+              "number": "101",
+              "title": "Foundations of Masonry and Allied Crafts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAC",
+              "number": "151",
+              "title": "Layout Systems and Installation Practices",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAC",
+              "number": "201",
+              "title": "Structural Systems and Restoration Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAC",
+              "number": "251",
+              "title": "Advanced Systems Integration and Quality Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tile & Terrazzo Allied Craftworkers Apprenticeship, Certificate",
+      "credential": "certificate",
+      "program_code": "733",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3709",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TTF",
+              "number": "101",
+              "title": "Foundations of Tile and Terrazzo Finishing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TTF",
+              "number": "151",
+              "title": "Intermediate Surface Treatment and Equipment Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TTF",
+              "number": "201",
+              "title": "Advanced Finishing Techniques and Quality Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Barbering, Certificate",
+      "credential": "certificate",
+      "program_code": "751",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3639",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAR",
+              "number": "101",
+              "title": "Principles of Barbering 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "102",
+              "title": "Principles of Barbering 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "112C",
+              "title": "Barber Clinical 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAR",
+              "number": "103",
+              "title": "Principles of Barbering 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "104",
+              "title": "Principles of Barbering 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "113C",
+              "title": "Barber Clinical 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAR",
+              "number": "105",
+              "title": "Principles of Barbering 5",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "114C",
+              "title": "Barber Clinical 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics, A.S. (047.1) ♦",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3568",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "221",
+              "title": "Physics for Science and Engineering 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "222",
+              "title": "Physics for Science and Engineering 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted CIT Elective –4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14–15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "223",
+              "title": "Physics for Science and Engineering 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Elective –4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18–19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "251",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "224",
+              "title": "Modern Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted Electives (3 courses)",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15–18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted CIT Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "145",
+              "title": "Programming in C",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "161",
+              "title": "Programming in Visual Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "Data Structures and Algorithms Using C++",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restricted Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Introduction to Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "104",
+              "title": "Introduction to Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "203",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "253",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "101",
+              "title": "Earth Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "107",
+              "title": "Introductory Astronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "108",
+              "title": "Introduction to Weather",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "TESOL Certificate, Diploma",
+      "credential": "certificate",
+      "program_code": "659",
+      "catalog_url": "https://catalog.ccac.edu/preview_program.php?catoid=15&poid=3657",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "280",
+              "title": "ESL Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "281",
+              "title": "ESL Language Acquisition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "282",
+              "title": "ESL Teaching Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "283",
+              "title": "ESL Sociolinguistic Studies for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/pa/programs/racc.json
+++ b/data/pa/programs/racc.json
@@ -1,0 +1,1168 @@
+{
+  "college_slug": "racc",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.racc.edu",
+  "scraped_at": "2026-06-07T02:59:43.196Z",
+  "programs": [
+    {
+      "title": "Business Management, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3172",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3175",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Bookkeeping/Accounting, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3180",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3173",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Administration, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3181",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3182",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Technology, AAS ( Program may be completed online)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3185",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Site Development, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3222",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Proficiency, CC (Program may be completed online)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3235",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Administrative Office Specialist, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3237",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding and Billing Specialist, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3299",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3174",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Medical Laboratory Technician, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3205",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Defense, CC (Program may be completed online)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3302",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3184",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Site Development, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3223",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Support Specialist, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3298",
+      "total_credits": 21,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office/Health Records Specialist, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3300",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3217",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3316",
+      "total_credits": 51,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Office/Health Records Specialist, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3301",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Histotechnician Program, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3318",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing (EVENING), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3319",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Communications, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3183",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing (DAY), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3211",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Liberal Arts, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3202",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Art, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3234",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Administrative Office Specialist, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3304",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Creative Writing, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3238",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Arts, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3323",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nanoscience Technology: 2+2+2 Millerville University Transfer Option, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3168",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "2-High School/RACC Dual Enrollment (13 Credit Hours)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "130",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*Earned through your local high school or Head Start to College",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester I (13 Credit Hours)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSS",
+              "number": "103",
+              "title": "College Success Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFT",
+              "number": "110",
+              "title": "Microcomputer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "240",
+              "title": "Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "150",
+              "title": "Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester I (17 Credit Hours)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "141",
+              "title": "Technical Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "130",
+              "title": "The Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "155",
+              "title": "Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Fundamentals of Speech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "245",
+              "title": "Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester 2 (15 Credit Hours)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSC",
+              "number": "180",
+              "title": "Electronics for Nanoscience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "200",
+              "title": "Nanofabrication Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HUM ___ - Humanities Elective 3 Credit Hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "125",
+              "title": "The Individual &amp; Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester 2 at Penn State Main Campus (18 Credit Hours)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSC",
+              "number": "211",
+              "title": "Materials, Safety &amp; Equipment Overview for Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "212",
+              "title": "Basic Nanotechnology Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "213",
+              "title": "Materials in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "214",
+              "title": "Lithography for Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "215",
+              "title": "Materials Modification in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "216",
+              "title": "Characterization, Testing of Nanotechnology Structures and Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nanoscience Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3169",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (24 Credit Hours)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements (42 Credit Hours)",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Courses Taken at RACC",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "150",
+              "title": "Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "155",
+              "title": "Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "150",
+              "title": "Applied Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "180",
+              "title": "Electronics for Nanoscience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "200",
+              "title": "Nanofabrication Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Courses Taken at Penn State Main Campus",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSC",
+              "number": "211",
+              "title": "Materials, Safety &amp; Equipment Overview for Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "212",
+              "title": "Basic Nanotechnology Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "213",
+              "title": "Materials in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "214",
+              "title": "Lithography for Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "215",
+              "title": "Materials Modification in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "216",
+              "title": "Characterization, Testing of Nanotechnology Structures and Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3171",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Polysomnography Technician, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3423",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3203",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nanoscience Technology, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3210",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nanoscience Technology: 2+2+2 Penn State Berks College Transfer Option, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3209",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "2-High School/RACC Dual Enrollment (13 Credit Hours)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IFT",
+              "number": "110",
+              "title": "Microcomputer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester I (16 Credit Hours)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSS",
+              "number": "103",
+              "title": "College Success Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "General Physics Mechanics*** 4 Credit Hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "150",
+              "title": "Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "130",
+              "title": "The Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "125",
+              "title": "The Individual &amp; Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester I (15 Credit Hours)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "141",
+              "title": "Technical Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "245",
+              "title": "Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "155",
+              "title": "Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester 2 (16 Credit Hours)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "180",
+              "title": "Electronics for Nanoscience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "200",
+              "title": "Nanofabrication Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HUM ___ - Humanities Elective 3 Credit Hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "General Physics Electricity & Magnetism 4 Credit Hours ***",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester 2 at Penn State Main Campus (18 Credit Hours)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSC",
+              "number": "211",
+              "title": "Materials, Safety &amp; Equipment Overview for Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "212",
+              "title": "Basic Nanotechnology Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "213",
+              "title": "Materials in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "214",
+              "title": "Lithography for Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "215",
+              "title": "Materials Modification in Nanotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSC",
+              "number": "216",
+              "title": "Characterization, Testing of Nanotechnology Structures and Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technology Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3221",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics Engineering Technology, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3233",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Health Science AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3303",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Analytics, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3321",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Maintenance Technician I, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3322",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood CDA Prep, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3189",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Director, CC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3190",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Program Management, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3192",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Early Childhood Teaching (PreK-Grade 4), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3193",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Psychology, AA (May be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3216",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Mechatronics Engineering Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3204",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Social Work, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3219",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Addictions Studies/Human Services, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3287",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3242",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Data Science A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3320",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrative Studies, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3317",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Education College Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3324",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education: Middle/Secondary Grades (Program may be completed online)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3311",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3186",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Social Science, AA (Program may be completed online)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.racc.edu/preview_program.php?catoid=19&poid=3228",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/pa/config.ts
+++ b/lib/states/pa/config.ts
@@ -85,7 +85,10 @@ const paConfig: StateConfig = {
       { scripts: ["scripts/pa/scrape-pitt-tes.ts"], runner: "http" },
     ],
     prereqs: [{ scripts: ["scripts/pa/scrape-catalog-prereqs.ts"], runner: "http" }],
-    // manual-only: programs — Acalog program scraper not yet wired up for this state.
+    // Acalog (CCAC, Reading Area) via search_advanced discovery. Delaware County
+    // (CourseLeaf, 104 paths/0 parsed), Northampton (Coursedog 369/0 parsed) +
+    // CCP/HACC/Montgomery (catalogs unlocatable) are deferred.
+    programs: [{ scripts: ["scripts/pa/scrape-programs.ts"], runner: "http" }],
   },
 };
 

--- a/scripts/pa/scrape-programs.ts
+++ b/scripts/pa/scrape-programs.ts
@@ -1,0 +1,73 @@
+/**
+ * scrape-programs.ts — degree/program requirements for PA.
+ *
+ * Pennsylvania is the hardest state scouted: most colleges host catalogs at
+ * non-discoverable URLs, and the two templated catalogs that DO resolve well
+ * hit parser bugs. Currently scraped:
+ *   Acalog (search_advanced discovery): CCAC (Allegheny/Pittsburgh), Reading Area
+ *
+ * Deferred (catalog found, parser returns 0 — a shared-parser fix would unlock
+ * these, see [[reference_programs_scraping_playbook]]):
+ *   - dccc (Delaware County, CourseLeaf): discovery finds 104 program paths but
+ *     the detail parser extracts 0 (its requirement blocks differ).
+ *   - northampton (Coursedog): finds 369 programs, parses 0 (the documented
+ *     freeform / status-casing bug, same as SENMC).
+ * Deferred (catalog not locatable): CCP (Philadelphia), HACC, Montgomery (mc3),
+ * Bucks, and the rest.
+ *
+ * Usage:
+ *   npx tsx scripts/pa/scrape-programs.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import { scrapeAcalogPrograms } from "../lib/scrape-acalog-programs.js";
+
+async function run(
+  slug: string,
+  scrape: () => Promise<{ programs: unknown[]; catalog_year: string; catalog_url: string; college_slug: string; scraped_at: string }>,
+): Promise<void> {
+  console.log(`\n=== ${slug} ===`);
+  try {
+    const data = await scrape();
+    if (data.programs.length === 0) {
+      console.log(`  No programs found for ${slug}.`);
+      return;
+    }
+    const { matched, unmatched } = applyProgramMatching(data.programs as never);
+    console.log(`  Matcher: ${matched} matched / ${unmatched} unmatched`);
+    const outDir = path.join(process.cwd(), "data", "pa", "programs");
+    fs.mkdirSync(outDir, { recursive: true });
+    const outPath = path.join(outDir, `${slug}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+    console.log(`  ✓ Wrote ${data.programs.length} programs → ${outPath}`);
+  } catch (e) {
+    console.error(`  ✗ ${slug} failed: ${e}`);
+  }
+}
+
+async function main() {
+  console.log("PA program scraper");
+
+  for (const c of [
+    { collegeSlug: "ccac", baseUrl: "https://catalog.ccac.edu" },
+    { collegeSlug: "racc", baseUrl: "https://catalog.racc.edu" },
+  ]) {
+    await run(c.collegeSlug, () =>
+      scrapeAcalogPrograms({
+        collegeSlug: c.collegeSlug,
+        baseUrl: c.baseUrl,
+        catoidFallback: 0,
+        programNavoids: [],
+        autoDiscoverCatoid: true,
+        useSearchDiscovery: true,
+      }),
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Pennsylvania's degree planner was empty — pick any PA college and the "Plan my degree" path had nothing to plan against. This lands **204 degree/certificate programs** for the state's two biggest Acalog catalogs:

- **CCAC** (Community College of Allegheny County, Pittsburgh) — 147 programs, **127 fully plannable** (≥5 real course requirements)
- **Reading Area CC** — 57 programs, 3 fully plannable

A CCAC student can now open a program like "Accounting AAS", see its required courses, and have the planner lay them out by semester against live section data. PA had **zero** programs before this.

## What changes technically

New scraper `scripts/pa/scrape-programs.ts` pulls Acalog program requirements for `ccac` and `racc`. The gotcha: Acalog program lists are JS-rendered, so the usual navoid crawl returns 0 — this uses `search_advanced.php` discovery (`useSearchDiscovery:true`) to enumerate every program first. Wired to scheduled scraping via `StateConfig.scrapers` (replaces the old `manual-only: programs` marker), so it refreshes on cron going forward.

Validation: CCAC's top program prefix (ENG) maps to 193 ENG sections in PA's course data; sample codes (ACC 100/104/120/201) are real CCAC courses; program filenames match `institution.college_slug` so the planner won't hide them.

## Deferred (documented in the scraper docstring)

| College | Platform | Why deferred |
|---|---|---|
| Delaware County (dccc) | CourseLeaf | Discovery finds 104 program paths, detail parser extracts 0 (requirement blocks differ) |
| Northampton | Coursedog | Finds 369 programs, parses 0 — the known freeform/status-casing parser bug |
| CCP, HACC, Montgomery (mc3), Bucks, … | various | Catalog URLs don't resolve; need bespoke discovery |

The two parser-bug deferrals would be unlocked by a shared CourseLeaf/Coursedog parser fix, not a per-state template run. PA was the hardest state scouted — most colleges host catalogs at non-discoverable URLs.

## Test plan

- [x] `npm run check:scrapers` — 51 states × 4 datatypes accounted for
- [x] `npx tsc --noEmit` — clean (exit 0)
- [x] Slug-align: `ccac.json`/`racc.json` filenames == `institution.college_slug`
- [x] Code-align: program prefixes present in `data/pa/courses/`
- [ ] Plan page renders empty in local dev for all states (Supabase-dependent) — verify on prod after import-on-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)