### PR TITLE
cron: stop prereq aggregation wiping catalog-scraped entries

### DIFF
--- a/scripts/lib/__tests__/aggregate-prereqs.test.ts
+++ b/scripts/lib/__tests__/aggregate-prereqs.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  aggregateState,
+  preserveSourcedEntries,
+  hasScriptedPrereqs,
+  type PrereqEntry,
+} from "@/scripts/lib/aggregate-prereqs";
+
+/**
+ * Guards against the 2026-06 scheduled-scrape wipe: the prereqs cron tick
+ * ran `aggregate-prereqs.ts <state>` for EVERY state, and for states whose
+ * catalog scrapers merge `source`-tagged entries into prereqs.json the
+ * section-derived rebuild deleted them all (MA 1946→1020, every
+ * gcc/middlesex entry gone) while staying just above the 50% safety net.
+ */
+
+// ---------------------------------------------------------------------------
+// preserveSourcedEntries — pure merge semantics
+// ---------------------------------------------------------------------------
+
+describe("preserveSourcedEntries", () => {
+  const sourced = (text: string, source: string): PrereqEntry => ({
+    text,
+    courses: [],
+    source,
+  });
+
+  it("carries over sourced entries missing from the rebuild", () => {
+    const existing = {
+      "ENG 101": sourced("ENG 090", "gcc"),
+      "MAT 150": sourced("MAT 100", "middlesex"),
+    };
+    const { merged, preserved } = preserveSourcedEntries({}, existing);
+    expect(merged).toEqual(existing);
+    expect(preserved).toBe(2);
+  });
+
+  it("does NOT carry over untagged (aggregate-derived) entries", () => {
+    const existing: Record<string, PrereqEntry> = {
+      "BIO 101": { text: "CHM 101", courses: ["CHM 101"] },
+    };
+    const { merged, preserved } = preserveSourcedEntries({}, existing);
+    expect(merged).toEqual({});
+    expect(preserved).toBe(0);
+  });
+
+  it("stashes a sourced entry under source:key when the rebuild claims the plain key", () => {
+    const rebuilt: Record<string, PrereqEntry> = {
+      "ENG 101": { text: "ENG 100", courses: ["ENG 100"] },
+    };
+    const existing = { "ENG 101": sourced("ENG 090 or placement", "gcc") };
+    const { merged, preserved } = preserveSourcedEntries(rebuilt, existing);
+    expect(merged["ENG 101"]).toEqual(rebuilt["ENG 101"]);
+    expect(merged["gcc:ENG 101"]).toEqual(existing["ENG 101"]);
+    expect(preserved).toBe(1);
+  });
+
+  it("keeps already-namespaced collision keys as-is", () => {
+    const existing = { "gcc:ENG 101": sourced("ENG 090", "gcc") };
+    const { merged } = preserveSourcedEntries(
+      { "ENG 101": { text: "x", courses: [] } },
+      existing,
+    );
+    expect(merged["gcc:ENG 101"]).toEqual(existing["gcc:ENG 101"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasScriptedPrereqs — registry-driven skip predicate
+// ---------------------------------------------------------------------------
+
+describe("hasScriptedPrereqs", () => {
+  it("is true for a state declaring dedicated prereq scrape jobs (ma)", () => {
+    expect(hasScriptedPrereqs("ma")).toBe(true);
+  });
+
+  it("is false for an aggregate-from-courses state (va)", () => {
+    expect(hasScriptedPrereqs("va")).toBe(false);
+  });
+
+  it("is false for an unknown slug", () => {
+    expect(hasScriptedPrereqs("not-a-state")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateState — end-to-end against a temp data dir
+// ---------------------------------------------------------------------------
+
+describe("aggregateState", () => {
+  let root: string;
+
+  const writeJson = (rel: string, value: unknown) => {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, JSON.stringify(value, null, 2));
+  };
+  const readPrereqs = (state: string): Record<string, PrereqEntry> =>
+    JSON.parse(
+      fs.readFileSync(path.join(root, "data", state, "prereqs.json"), "utf-8"),
+    );
+
+  const section = (
+    prefix: string,
+    number: string,
+    text: string,
+    courses: string[] = [],
+  ) => ({
+    course_prefix: prefix,
+    course_number: number,
+    prerequisite_text: text,
+    prerequisite_courses: courses,
+  });
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "agg-prereqs-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("refuses to touch a scripted-prereqs state's file (the MA wipe)", () => {
+    // "ma" declares dedicated catalog scrapers in the real registry. Its
+    // committed prereqs.json mixes scraper output (source-tagged) with
+    // aggregate entries; course sections can only re-derive the latter.
+    const committed = {
+      "ACC 101": { text: "ACC 100", courses: ["ACC 100"] },
+      "ENG 101": { text: "ENG 090", courses: ["ENG 090"], source: "gcc" },
+      "MAT 150": { text: "MAT 100", courses: ["MAT 100"], source: "middlesex" },
+    };
+    writeJson("data/ma/prereqs.json", committed);
+    writeJson("data/ma/courses/some-college/2026FA.json", [
+      section("ACC", "101", "ACC 100", ["ACC 100"]),
+    ]);
+
+    const count = aggregateState("ma", { rootDir: root });
+
+    expect(count).toBe(3);
+    expect(readPrereqs("ma")).toEqual(committed);
+  });
+
+  it("rebuilds a scripted state under --force, still preserving sourced entries", () => {
+    writeJson("data/ma/prereqs.json", {
+      "STALE 999": { text: "gone", courses: [] },
+      "ENG 101": { text: "ENG 090", courses: ["ENG 090"], source: "gcc" },
+    });
+    writeJson("data/ma/courses/some-college/2026FA.json", [
+      section("ACC", "101", "ACC 100", ["ACC 100"]),
+    ]);
+
+    aggregateState("ma", { rootDir: root, force: true });
+
+    const out = readPrereqs("ma");
+    expect(out["STALE 999"]).toBeUndefined();
+    expect(out["ACC 101"]).toEqual({ text: "ACC 100", courses: ["ACC 100"] });
+    expect(out["ENG 101"]).toEqual({
+      text: "ENG 090",
+      courses: ["ENG 090"],
+      source: "gcc",
+    });
+  });
+
+  it("rebuilds an aggregate-from-courses state from sections", () => {
+    writeJson("data/va/courses/college-a/2026FA.json", [
+      section("BIO", "101", "CHM 101", ["CHM 101"]),
+      section("BIO", "102", ""),
+    ]);
+
+    const count = aggregateState("va", { rootDir: root });
+
+    expect(count).toBe(1);
+    expect(readPrereqs("va")).toEqual({
+      "BIO 101": { text: "CHM 101", courses: ["CHM 101"] },
+    });
+  });
+
+  it("preserves sourced entries an aggregate rebuild cannot re-derive", () => {
+    writeJson("data/va/prereqs.json", {
+      "BIO 101": { text: "old", courses: [] },
+      "NUR 200": { text: "BIO 101", courses: ["BIO 101"], source: "catalog" },
+    });
+    writeJson("data/va/courses/college-a/2026FA.json", [
+      section("BIO", "101", "CHM 101", ["CHM 101"]),
+    ]);
+
+    const count = aggregateState("va", { rootDir: root });
+
+    expect(count).toBe(2);
+    const out = readPrereqs("va");
+    expect(out["BIO 101"]).toEqual({ text: "CHM 101", courses: ["CHM 101"] });
+    expect(out["NUR 200"]).toEqual({
+      text: "BIO 101",
+      courses: ["BIO 101"],
+      source: "catalog",
+    });
+  });
+
+  it("refuses a rebuild below 50% of the existing entry count", () => {
+    const committed: Record<string, PrereqEntry> = {};
+    for (let i = 0; i < 10; i++) {
+      committed[`OLD ${100 + i}`] = { text: "x", courses: [] };
+    }
+    writeJson("data/va/prereqs.json", committed);
+    writeJson("data/va/courses/college-a/2026FA.json", [
+      section("BIO", "101", "CHM 101", ["CHM 101"]),
+    ]);
+
+    const count = aggregateState("va", { rootDir: root });
+
+    expect(count).toBe(10);
+    expect(readPrereqs("va")).toEqual(committed);
+  });
+});

--- a/scripts/lib/__tests__/scrape-diff.test.ts
+++ b/scripts/lib/__tests__/scrape-diff.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  countBySource,
+  sourceRegressions,
+  countRows,
+} from "@/scripts/lib/scrape-diff";
+
+/**
+ * Per-source regression detection for prereqs.json. The file-level 50%
+ * gate misses one input vanishing from a merged file: MA's 2026-06 cron
+ * run deleted all 926 gcc/middlesex catalog entries but kept 52.4% of
+ * total rows, so the workflow opened a routine-looking PR.
+ */
+
+const prereqs = (entries: Record<string, { source?: string }>) =>
+  JSON.stringify(
+    Object.fromEntries(
+      Object.entries(entries).map(([k, v]) => [
+        k,
+        { text: "x", courses: [], ...v },
+      ]),
+    ),
+  );
+
+const bulk = (prefix: string, n: number, source?: string) =>
+  Object.fromEntries(
+    Array.from({ length: n }, (_, i) => [
+      `${prefix} ${100 + i}`,
+      source ? { source } : {},
+    ]),
+  );
+
+describe("countBySource", () => {
+  it("groups tagged entries by source and untagged under 'aggregate'", () => {
+    const text = prereqs({
+      "ENG 101": { source: "gcc" },
+      "ENG 102": { source: "gcc" },
+      "MAT 150": { source: "middlesex" },
+      "BIO 101": {},
+    });
+    expect(countBySource(text)).toEqual({
+      gcc: 2,
+      middlesex: 1,
+      aggregate: 1,
+    });
+  });
+
+  it("returns no groups for arrays or unparseable text", () => {
+    expect(countBySource("[1,2,3]")).toEqual({});
+    expect(countBySource("not json")).toEqual({});
+  });
+});
+
+describe("sourceRegressions", () => {
+  it("flags a source that vanishes while the total stays above 50% (the MA wipe)", () => {
+    // 60 aggregate + 40 sourced → sourced deleted leaves 60% of rows:
+    // file-level gate passes, per-source gate must not.
+    const before = prereqs({ ...bulk("AGG", 60), ...bulk("GCC", 40, "gcc") });
+    const after = prereqs(bulk("AGG", 60));
+    expect(countRows(after) / countRows(before)).toBeGreaterThan(0.5);
+
+    const regressions = sourceRegressions("data/ma/prereqs.json", before, after);
+
+    expect(regressions).toHaveLength(1);
+    expect(regressions[0]).toMatchObject({
+      file: "data/ma/prereqs.json [source: gcc]",
+      before: 40,
+      after: 0,
+      ratio: "0.0%",
+    });
+  });
+
+  it("passes when every source retains at least half its entries", () => {
+    const before = prereqs({ ...bulk("AGG", 60), ...bulk("GCC", 40, "gcc") });
+    const after = prereqs({ ...bulk("AGG", 55), ...bulk("GCC", 22, "gcc") });
+    expect(sourceRegressions("f", before, after)).toEqual([]);
+  });
+
+  it("ignores groups smaller than minGroup — a 4→1 blip is not an abort", () => {
+    const before = prereqs(bulk("TINY", 4, "tiny"));
+    const after = prereqs(bulk("TINY", 1, "tiny"));
+    expect(sourceRegressions("f", before, after)).toEqual([]);
+  });
+
+  it("flags the aggregate group collapsing under sourced growth", () => {
+    // Sourced entries ballooning can mask aggregation dying entirely.
+    const before = prereqs({ ...bulk("AGG", 50), ...bulk("GCC", 50, "gcc") });
+    const after = prereqs({ ...bulk("AGG", 5), ...bulk("GCC", 90, "gcc") });
+
+    const regressions = sourceRegressions("f", before, after);
+
+    expect(regressions).toHaveLength(1);
+    expect(regressions[0]).toMatchObject({
+      file: "f [source: aggregate]",
+      before: 50,
+      after: 5,
+    });
+  });
+});

--- a/scripts/lib/aggregate-prereqs.ts
+++ b/scripts/lib/aggregate-prereqs.ts
@@ -10,8 +10,14 @@
  * Currently applicable to: VA, NC, SC, GA, DC (and any future state whose
  * scraper populates those fields).
  *
- * For states where the main scraper does NOT populate prerequisite data
- * (e.g., DE, TN), use the dedicated catalog fallback scrapers instead.
+ * States whose StateConfig declares dedicated prereq scrape jobs
+ * (`scrapers.prereqs` is an array — MA, TX, CT, …) are SKIPPED unless
+ * --force is passed: their catalog scrapers merge into prereqs.json
+ * themselves, and a section-derived rebuild would clobber that richer
+ * output. The 2026-06 scheduled-scrape runs did exactly that — MA dropped
+ * 1946→1020 keys (every gcc/middlesex catalog entry deleted) because this
+ * script ran unconditionally for every state on the prereqs cron tick and
+ * the result sat just above the 50% safety net below.
  *
  * Usage:
  *   npx tsx scripts/lib/aggregate-prereqs.ts va
@@ -21,7 +27,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { getAllStates } from "../../lib/states/registry";
+import { getAllStates, getStateConfig } from "../../lib/states/registry";
 
 interface CourseSection {
   course_prefix: string;
@@ -30,12 +36,14 @@ interface CourseSection {
   prerequisite_courses?: string[];
 }
 
-interface PrereqEntry {
+export interface PrereqEntry {
   text: string;
   courses: string[];
+  /** Set by dedicated catalog scrapers (e.g. "gcc", "middlesex") — never by aggregation. */
+  source?: string;
 }
 
-function mergePrereq(
+export function mergePrereq(
   prereqs: Record<string, PrereqEntry>,
   key: string,
   text: string,
@@ -54,8 +62,89 @@ function mergePrereq(
   }
 }
 
-function aggregateState(state: string): number {
-  const dataDir = path.join(process.cwd(), "data", state, "courses");
+/**
+ * Carry `source`-tagged entries from the committed prereqs.json into a
+ * fresh section-derived rebuild. Aggregation can only see what the course
+ * sections carry, so without this step a rebuild silently deletes
+ * everything a dedicated catalog scraper contributed.
+ *
+ * Collision convention mirrors the catalog scrapers themselves
+ * (scripts/ma/scrape-catalog-prereqs-gcc.ts): a sourced entry whose plain
+ * key is taken by an aggregate entry is stashed under "{source}:{key}".
+ */
+export function preserveSourcedEntries(
+  rebuilt: Record<string, PrereqEntry>,
+  existing: Record<string, PrereqEntry>,
+): { merged: Record<string, PrereqEntry>; preserved: number } {
+  const merged: Record<string, PrereqEntry> = { ...rebuilt };
+  let preserved = 0;
+  for (const [key, entry] of Object.entries(existing)) {
+    if (!entry || typeof entry !== "object" || !entry.source) continue;
+    if (!merged[key]) {
+      merged[key] = entry;
+      preserved++;
+    } else if (!merged[key].source) {
+      const slot = key.startsWith(`${entry.source}:`)
+        ? key
+        : `${entry.source}:${key}`;
+      if (!merged[slot]) {
+        merged[slot] = entry;
+        preserved++;
+      }
+    }
+  }
+  return { merged, preserved };
+}
+
+/** True when the state's registry config declares dedicated prereq scrape jobs. */
+export function hasScriptedPrereqs(state: string): boolean {
+  let cfg;
+  try {
+    cfg = getStateConfig(state);
+  } catch {
+    return false;
+  }
+  return Array.isArray(cfg?.scrapers?.prereqs);
+}
+
+function readJsonObject(
+  filePath: string,
+): Record<string, PrereqEntry> | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function aggregateState(
+  state: string,
+  opts: { force?: boolean; rootDir?: string } = {},
+): number {
+  const root = opts.rootDir ?? process.cwd();
+  const outPath = path.join(root, "data", state, "prereqs.json");
+  const existing = readJsonObject(outPath) ?? {};
+  const existingCount = Object.keys(existing).length;
+
+  // Dedicated catalog scrapers own this state's prereqs.json — they merge
+  // into it themselves. A section-derived rebuild would delete their
+  // entries (CLAUDE.md invariant #4: a failed/absent scrape must never
+  // replace good data). Cron calls this script for every state on the
+  // prereqs tick, so the guard lives here, not in workflow YAML.
+  if (hasScriptedPrereqs(state) && !opts.force) {
+    console.log(
+      `  ${state}: skipped — StateConfig declares dedicated prereq scrape ` +
+        `job(s) that merge into prereqs.json directly; a course-section ` +
+        `rebuild would clobber their output (kept ${existingCount} entries). ` +
+        `Pass --force to rebuild anyway.`,
+    );
+    return existingCount;
+  }
+
+  const dataDir = path.join(root, "data", state, "courses");
   if (!fs.existsSync(dataDir)) {
     console.error(`  No course data directory: ${dataDir}`);
     return 0;
@@ -109,7 +198,7 @@ function aggregateState(state: string): number {
   // alongside that exposes course-level prereqs. FL/FSCJ and FL/FSW are the
   // first such cases. The catalog scrapers write CoursedogCourse objects
   // (prefix / number / prerequisite_text / prerequisite_courses).
-  const catalogDir = path.join(process.cwd(), "data", state, "coursedog-catalog");
+  const catalogDir = path.join(root, "data", state, "coursedog-catalog");
   let catalogCourses = 0;
   let catalogWithPrereqs = 0;
   let catalogColleges = 0;
@@ -148,15 +237,17 @@ function aggregateState(state: string): number {
     }
   }
 
+  // Backstop for hybrid states: keep entries a dedicated catalog scraper
+  // tagged with `source` — aggregation cannot re-derive them from sections.
+  const { merged, preserved } = preserveSourcedEntries(prereqs, existing);
+
   // Write output
-  const outDir = path.join(process.cwd(), "data", state);
-  fs.mkdirSync(outDir, { recursive: true });
-  const outPath = path.join(outDir, "prereqs.json");
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
 
   // Sort keys for stable output
   const sorted: Record<string, PrereqEntry> = {};
-  for (const key of Object.keys(prereqs).sort()) {
-    sorted[key] = prereqs[key];
+  for (const key of Object.keys(merged).sort()) {
+    sorted[key] = merged[key];
   }
 
   // Safety net: refuse to overwrite a healthy prereqs.json with a rebuild
@@ -173,23 +264,16 @@ function aggregateState(state: string): number {
   // 50% mirrors scrape-diff.ts's ABORT_RATIO so the aggregator and the diff
   // agree on what "looks broken" means. Pass --force for genuine resets.
   const newCount = Object.keys(sorted).length;
-  if (fs.existsSync(outPath) && !process.argv.includes("--force")) {
-    let existingCount = 0;
-    try {
-      const existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
-      existingCount = existing && typeof existing === "object" ? Object.keys(existing).length : 0;
-    } catch { /* unreadable — treat as empty */ }
-    if (existingCount > 0 && newCount < existingCount * 0.5) {
-      console.error(
-        `  REFUSED to overwrite ${outPath}: aggregation produced ${newCount} ` +
-          `entries but the existing file has ${existingCount} (< 50%). The ` +
-          `dedicated catalog scraper's output or a WAF-degraded catalog likely ` +
-          `differs from section-derived aggregation — check ` +
-          `StateConfig.scrapers.prereqs and scraper health. ` +
-          `Re-run with --force to overwrite anyway.`,
-      );
-      return existingCount;
-    }
+  if (!opts.force && existingCount > 0 && newCount < existingCount * 0.5) {
+    console.error(
+      `  REFUSED to overwrite ${outPath}: aggregation produced ${newCount} ` +
+        `entries but the existing file has ${existingCount} (< 50%). The ` +
+        `dedicated catalog scraper's output or a WAF-degraded catalog likely ` +
+        `differs from section-derived aggregation — check ` +
+        `StateConfig.scrapers.prereqs and scraper health. ` +
+        `Re-run with --force to overwrite anyway.`,
+    );
+    return existingCount;
   }
 
   fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
@@ -198,53 +282,62 @@ function aggregateState(state: string): number {
     catalogColleges > 0
       ? ` + ${catalogWithPrereqs}/${catalogCourses} catalog courses across ${catalogColleges} Coursedog/Acalog colleges`
       : "";
+  const preservedNote =
+    preserved > 0 ? `; preserved ${preserved} source-tagged catalog entries` : "";
   console.log(
-    `  ${state}: ${Object.keys(sorted).length} unique courses with prereqs ` +
-      `(from ${withPrereqs}/${totalSections} sections across ${colleges.length} colleges${catalogNote})`,
+    `  ${state}: ${newCount} unique courses with prereqs ` +
+      `(from ${withPrereqs}/${totalSections} sections across ${colleges.length} colleges${catalogNote}${preservedNote})`,
   );
   console.log(`  → ${outPath}`);
 
-  return Object.keys(sorted).length;
+  return newCount;
 }
 
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
-const args = process.argv.slice(2);
+function main(): void {
+  const args = process.argv.slice(2);
+  const force = args.includes("--force");
 
-// Derived from the registry: any state whose StateConfig declares
-// `prereqs: { source: "aggregate-from-courses" }`. CLAUDE.md invariant #1
-// — no hardcoded state lists.
-const AGGREGATABLE_STATES = getAllStates()
-  .filter((c) => {
-    const p = c.scrapers?.prereqs;
-    return p && !Array.isArray(p) && p.source === "aggregate-from-courses";
-  })
-  .map((c) => c.slug);
+  // Derived from the registry: any state whose StateConfig declares
+  // `prereqs: { source: "aggregate-from-courses" }`. CLAUDE.md invariant #1
+  // — no hardcoded state lists.
+  const AGGREGATABLE_STATES = getAllStates()
+    .filter((c) => {
+      const p = c.scrapers?.prereqs;
+      return p && !Array.isArray(p) && p.source === "aggregate-from-courses";
+    })
+    .map((c) => c.slug);
 
-let states: string[];
+  let states: string[];
 
-if (args.includes("--all")) {
-  states = AGGREGATABLE_STATES;
-} else if (args.length > 0) {
-  states = args.filter((a) => !a.startsWith("-"));
-} else {
-  console.log("Usage: npx tsx scripts/lib/aggregate-prereqs.ts <state...> | --all");
-  console.log(`Available states: ${AGGREGATABLE_STATES.join(", ")}`);
-  process.exit(1);
+  if (args.includes("--all")) {
+    states = AGGREGATABLE_STATES;
+  } else if (args.length > 0) {
+    states = args.filter((a) => !a.startsWith("-"));
+  } else {
+    console.log("Usage: npx tsx scripts/lib/aggregate-prereqs.ts <state...> | --all [--force]");
+    console.log(`Available states: ${AGGREGATABLE_STATES.join(", ")}`);
+    process.exit(1);
+  }
+
+  if (states.length === 0) {
+    console.log("No states declare `aggregate-from-courses` in their config — nothing to do.");
+    process.exit(0);
+  }
+
+  console.log(`Aggregating prereqs for: ${states.join(", ")}\n`);
+
+  let totalEntries = 0;
+  for (const state of states) {
+    totalEntries += aggregateState(state, { force });
+  }
+
+  console.log(`\n✓ Done — ${totalEntries} total prereq entries across ${states.length} states`);
 }
 
-if (states.length === 0) {
-  console.log("No states declare `aggregate-from-courses` in their config — nothing to do.");
-  process.exit(0);
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
 }
-
-console.log(`Aggregating prereqs for: ${states.join(", ")}\n`);
-
-let totalEntries = 0;
-for (const state of states) {
-  totalEntries += aggregateState(state);
-}
-
-console.log(`\n✓ Done — ${totalEntries} total prereq entries across ${states.length} states`);

--- a/scripts/lib/scrape-diff.ts
+++ b/scripts/lib/scrape-diff.ts
@@ -9,6 +9,14 @@
  * change-detection preflight — the workflow and the import agree on what
  * "scraper looks broken" means.
  *
+ * For prereqs.json files the check additionally groups entries by their
+ * `source` tag and applies the 50% threshold per group. A prereqs.json is
+ * a merge of independent inputs (section-derived aggregation + one entry
+ * set per catalog scraper); one input vanishing entirely can leave the
+ * total just above 50% — MA's 2026-06 cron run deleted all 926
+ * gcc/middlesex entries yet kept 52.4% of rows, sailing through the
+ * file-level gate.
+ *
  * Usage:
  *   npx tsx scripts/lib/scrape-diff.ts --path data/ --format json
  *   npx tsx scripts/lib/scrape-diff.ts --path data/va/courses --format markdown
@@ -22,14 +30,11 @@ import { execSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-const ABORT_RATIO = 0.5;
-const ROOT = resolve(__dirname, "..", "..");
-
-const args = process.argv.slice(2);
-const pathIdx = args.indexOf("--path");
-const fmtIdx = args.indexOf("--format");
-const pathPrefix = pathIdx >= 0 ? args[pathIdx + 1] : "data/";
-const format = (fmtIdx >= 0 ? args[fmtIdx + 1] : "json") as "json" | "markdown";
+export const ABORT_RATIO = 0.5;
+// `typeof` guard: vitest imports this module as ESM (no __dirname) to test
+// the pure helpers; only the CLI path below ever reads ROOT.
+const ROOT =
+  typeof __dirname !== "undefined" ? resolve(__dirname, "..", "..") : process.cwd();
 
 interface Regression {
   file: string;
@@ -55,7 +60,7 @@ function sh(cmd: string): string {
   });
 }
 
-function countRows(text: string): number {
+export function countRows(text: string): number {
   try {
     const parsed = JSON.parse(text);
     if (Array.isArray(parsed)) return parsed.length;
@@ -68,94 +73,168 @@ function countRows(text: string): number {
   }
 }
 
-function beforeCount(file: string): number {
+/**
+ * Entry counts per `source` tag for a prereqs.json payload. Entries
+ * without a tag (section-derived aggregation) group under "aggregate".
+ */
+export function countBySource(text: string): Record<string, number> {
+  const counts: Record<string, number> = {};
   try {
-    return countRows(sh(`git show HEAD:${file}`));
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return counts;
+    }
+    for (const entry of Object.values(parsed)) {
+      const source =
+        entry && typeof entry === "object" && typeof (entry as { source?: unknown }).source === "string"
+          ? (entry as { source: string }).source
+          : "aggregate";
+      counts[source] = (counts[source] ?? 0) + 1;
+    }
   } catch {
-    return 0;
+    /* unparseable — treated as no groups */
+  }
+  return counts;
+}
+
+/**
+ * Per-source regressions between two prereqs.json payloads. A group that
+ * had at least `minGroup` entries before and retains under ABORT_RATIO of
+ * them is a regression — its scraper (or the aggregation input) broke,
+ * regardless of what the file-level total says. Tiny groups are skipped:
+ * a 4→1 blip shouldn't abort a whole state's cron tick.
+ */
+export function sourceRegressions(
+  file: string,
+  beforeText: string,
+  afterText: string,
+  minGroup = 20,
+): Regression[] {
+  const before = countBySource(beforeText);
+  const after = countBySource(afterText);
+  const out: Regression[] = [];
+  for (const [source, b] of Object.entries(before)) {
+    if (b < minGroup) continue;
+    const a = after[source] ?? 0;
+    const ratio = a / b;
+    if (ratio < ABORT_RATIO) {
+      out.push({
+        file: `${file} [source: ${source}]`,
+        before: b,
+        after: a,
+        ratio: `${(ratio * 100).toFixed(1)}%`,
+      });
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const pathIdx = args.indexOf("--path");
+  const fmtIdx = args.indexOf("--format");
+  const pathPrefix = pathIdx >= 0 ? args[pathIdx + 1] : "data/";
+  const format = (fmtIdx >= 0 ? args[fmtIdx + 1] : "json") as "json" | "markdown";
+
+  function beforeText(file: string): string {
+    try {
+      return sh(`git show HEAD:${file}`);
+    } catch {
+      return "";
+    }
+  }
+
+  function afterText(file: string): string {
+    const abs = resolve(ROOT, file);
+    if (!existsSync(abs)) return "";
+    return readFileSync(abs, "utf8");
+  }
+
+  const tracked = sh(`git ls-files ${pathPrefix}`)
+    .trim()
+    .split("\n")
+    .filter((f) => f.endsWith(".json"));
+
+  const untracked = sh(`git ls-files --others --exclude-standard ${pathPrefix}`)
+    .trim()
+    .split("\n")
+    .filter((f) => f.endsWith(".json"));
+
+  const files = Array.from(new Set([...tracked, ...untracked])).filter(Boolean);
+
+  const regressions: Regression[] = [];
+  const changedFiles: ChangedFile[] = [];
+
+  for (const file of files) {
+    const beforeRaw = beforeText(file);
+    const afterRaw = afterText(file);
+    const before = countRows(beforeRaw);
+    const after = countRows(afterRaw);
+    if (before === after && beforeRaw === afterRaw) continue;
+
+    if (before !== after) {
+      changedFiles.push({ file, before, after, delta: after - before });
+    }
+
+    // First-time-added file (before = 0) cannot regress.
+    if (before === 0) continue;
+
+    const ratio = after / before;
+    if (ratio < ABORT_RATIO) {
+      regressions.push({
+        file,
+        before,
+        after,
+        ratio: `${(ratio * 100).toFixed(1)}%`,
+      });
+    } else if (file.endsWith("prereqs.json")) {
+      regressions.push(...sourceRegressions(file, beforeRaw, afterRaw));
+    }
+  }
+
+  const broken = regressions.length > 0;
+  const summary = broken
+    ? `ABORT: ${regressions.length} file(s) dropped below ${(ABORT_RATIO * 100).toFixed(0)}% of prior row count.`
+    : changedFiles.length === 0
+      ? "No changes — scraper output identical to main."
+      : `${changedFiles.length} file(s) changed; all within acceptable range.`;
+
+  if (format === "markdown") {
+    const lines: string[] = [];
+    lines.push(`**${summary}**`, "");
+    if (broken) {
+      lines.push("## Regressions");
+      lines.push("| File | Before | After | Ratio |");
+      lines.push("|---|---:|---:|---:|");
+      for (const r of regressions) {
+        lines.push(`| \`${r.file}\` | ${r.before} | ${r.after} | ${r.ratio} |`);
+      }
+      lines.push("");
+    }
+    if (changedFiles.length > 0 && !broken) {
+      lines.push("## Changes");
+      lines.push("| File | Before | After | Δ |");
+      lines.push("|---|---:|---:|---:|");
+      for (const c of changedFiles.slice(0, 50)) {
+        const d = c.delta >= 0 ? `+${c.delta}` : `${c.delta}`;
+        lines.push(`| \`${c.file}\` | ${c.before} | ${c.after} | ${d} |`);
+      }
+      if (changedFiles.length > 50) {
+        lines.push(`| …and ${changedFiles.length - 50} more | | | |`);
+      }
+    }
+    console.log(lines.join("\n"));
+  } else {
+    console.log(
+      JSON.stringify(
+        { broken, changed: changedFiles.length, regressions, summary },
+        null,
+        2
+      )
+    );
   }
 }
 
-function afterCount(file: string): number {
-  const abs = resolve(ROOT, file);
-  if (!existsSync(abs)) return 0;
-  return countRows(readFileSync(abs, "utf8"));
-}
-
-const tracked = sh(`git ls-files ${pathPrefix}`)
-  .trim()
-  .split("\n")
-  .filter((f) => f.endsWith(".json"));
-
-const untracked = sh(`git ls-files --others --exclude-standard ${pathPrefix}`)
-  .trim()
-  .split("\n")
-  .filter((f) => f.endsWith(".json"));
-
-const files = Array.from(new Set([...tracked, ...untracked])).filter(Boolean);
-
-const regressions: Regression[] = [];
-const changedFiles: ChangedFile[] = [];
-
-for (const file of files) {
-  const before = beforeCount(file);
-  const after = afterCount(file);
-  if (before === after) continue;
-
-  changedFiles.push({ file, before, after, delta: after - before });
-
-  // First-time-added file (before = 0) cannot regress.
-  if (before === 0) continue;
-
-  const ratio = after / before;
-  if (ratio < ABORT_RATIO) {
-    regressions.push({
-      file,
-      before,
-      after,
-      ratio: `${(ratio * 100).toFixed(1)}%`,
-    });
-  }
-}
-
-const broken = regressions.length > 0;
-const summary = broken
-  ? `ABORT: ${regressions.length} file(s) dropped below ${(ABORT_RATIO * 100).toFixed(0)}% of prior row count.`
-  : changedFiles.length === 0
-    ? "No changes — scraper output identical to main."
-    : `${changedFiles.length} file(s) changed; all within acceptable range.`;
-
-if (format === "markdown") {
-  const lines: string[] = [];
-  lines.push(`**${summary}**`, "");
-  if (broken) {
-    lines.push("## Regressions");
-    lines.push("| File | Before | After | Ratio |");
-    lines.push("|---|---:|---:|---:|");
-    for (const r of regressions) {
-      lines.push(`| \`${r.file}\` | ${r.before} | ${r.after} | ${r.ratio} |`);
-    }
-    lines.push("");
-  }
-  if (changedFiles.length > 0 && !broken) {
-    lines.push("## Changes");
-    lines.push("| File | Before | After | Δ |");
-    lines.push("|---|---:|---:|---:|");
-    for (const c of changedFiles.slice(0, 50)) {
-      const d = c.delta >= 0 ? `+${c.delta}` : `${c.delta}`;
-      lines.push(`| \`${c.file}\` | ${c.before} | ${c.after} | ${d} |`);
-    }
-    if (changedFiles.length > 50) {
-      lines.push(`| …and ${changedFiles.length - 50} more | | | |`);
-    }
-  }
-  console.log(lines.join("\n"));
-} else {
-  console.log(
-    JSON.stringify(
-      { broken, changed: changedFiles.length, regressions, summary },
-      null,
-      2
-    )
-  );
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
 }


### PR DESCRIPTION
## What this changes

Users see nothing new directly — this stops the scheduled prereq scrape from quietly **deleting** prerequisite data the site already has. On 2026-06-07 the cron opened PRs that would have erased half of Massachusetts' prereq entries (1,946 → 1,020) and similar chunks of Texas and Connecticut; the semester planner's prereq chains for those courses would have silently stopped resolving. With this fix, that failure mode can't produce a mergeable PR anymore.

## The bug

The prereqs cron tick runs `aggregate-prereqs.ts <state>` for **every** state in the matrix ([scheduled-scrape-v2.yml:268](.github/workflows/scheduled-scrape-v2.yml)). For the 18 states whose `StateConfig` declares dedicated catalog prereq scrapers (MA, TX, CT, …), those scrapers *merge* their entries into `prereqs.json` (MA tags them `"source": "gcc"` / `"middlesex"`) — and the section-derived rebuild then **clobbered the whole file**. The existing 50% safety net didn't fire because the rebuild kept 52.4% of MA's rows: all 926 catalog entries deleted, gate satisfied, routine-looking PR opened (#1311; same signature on #1309 tx, #1314 ct). Violates CLAUDE.md invariant #4: a failed/absent scrape must never replace good data.

## The fix — three layers

| Layer | File | Behavior |
|---|---|---|
| Skip | `scripts/lib/aggregate-prereqs.ts` | States with scripted prereqs (registry-driven, `Array.isArray(scrapers.prereqs)`) are skipped with an explanatory log; `--force` overrides. Covers both workflow call sites (`<state>` and `--all`) with zero YAML changes. |
| Preserve | `scripts/lib/aggregate-prereqs.ts` | Rebuilds carry over `source`-tagged entries they can't re-derive from sections, using the scrapers' own `source:key` collision convention. Backstop for future hybrid states. |
| Detect | `scripts/lib/scrape-diff.ts` | For `prereqs.json`, the 50% abort gate now also applies **per source group** (untagged entries group as `aggregate`, groups <20 entries ignored). One input vanishing flags `broken` even when the file total stays above 50% — the workflow opens an issue instead of a PR. |

Both scripts gained an `import.meta.url` main guard (repo's existing idiom) so their pure helpers are importable by vitest.

## Verification

- 18 new tests (`aggregate-prereqs.test.ts`, `scrape-diff.test.ts`) — all pass; `tsc --noEmit` clean.
- Replayed the real incident: `npx tsx scripts/lib/aggregate-prereqs.ts ma` is now a no-op (kept 1,946 entries); overwrote `data/ma/prereqs.json` with the actual #1311 payload and `scrape-diff` reports `broken: true` with `[source: gcc] 360→0 (0.0%)` and `[source: middlesex] 566→0 (0.0%)`.
- Aggregate-from-courses states unaffected: `aggregate-prereqs.ts va` still rebuilds normally (374→292, matching open PR #1308 — that one is genuine course-data thinning, a separate question).

## Related open PRs

#1311 (ma), #1309 (tx), #1314 (ct) are products of this bug and should be **closed without merging**. The next prereqs cron tick after this lands will force-push their branches with correct output (scraper-merged file untouched by aggregation). DE and TN prereq PRs with the same signature were merged before this was caught — their next catalog scrape run will restore the lost entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)