### PR TITLE
mn: run prereqs scraper on the playwright runner

### DIFF
--- a/lib/states/mn/config.ts
+++ b/lib/states/mn/config.ts
@@ -90,8 +90,15 @@ const mnConfig: StateConfig = {
     ],
     prereqs: [
       {
+        // Mostly plain HTTP, but acquireWafCookies() launches headless
+        // Chromium when an Acalog catalog's AWS WAF challenge fires — so the
+        // cron job needs the Playwright browser (scheduled-scrape-v2 only
+        // runs `playwright install` when runner == "playwright"). With
+        // runner: "http" the launch failure is swallowed by retryFetch and
+        // the job "succeeds" writing 0 prereqs for the WAF-protected
+        // colleges (run 27089258314: century, dctc, inver-hills, saint-paul).
         scripts: ["scripts/mn/scrape-catalog-prereqs.ts"],
-        runner: "http",
+        runner: "playwright",
       },
     ],
     programs: [


### PR DESCRIPTION
## What this changes

**For someone using the site:** nothing visible immediately — but Minnesota prerequisite data stops silently rotting. Four MN colleges (Century, Dakota County Technical, Inver Hills, Saint Paul) currently get **0 prereqs** written every Sunday because their catalogs sit behind an AWS WAF challenge the cron runner can't solve. After this lands, the next Sunday prereqs run can solve the challenge and their prereq chains will populate in the semester planner again.

**Technically:** a one-line config fix. `scripts/mn/scrape-catalog-prereqs.ts` was declared with `runner: "http"` in `lib/states/mn/config.ts`, but its `acquireWafCookies()` launches headless Chromium (via Playwright) whenever an Acalog catalog serves an AWS WAF challenge. `scheduled-scrape-v2.yml` only runs `npx playwright install chromium --with-deps` when `matrix.runner == 'playwright'`, so the browser was never installed for this job. This PR flips the entry to `runner: "playwright"` and documents why in a comment at the site.

## Verified against the latest scheduled run

The most recent prereqs cron run ([27089258314](https://github.com/rohan-c0de/cc-coursemap/actions/runs/27089258314), Sun 2026-06-07) shows the failure is real — and *worse* than a crash, because it's silent:

- Job `scrape (mn-prereqs-0, mn, prereqs, http, …)` ran with **no** "Install Playwright" step and concluded **success**.
- The log contains **198** `WAF challenge … acquiring cookies via browser` lines but **zero** `WAF cookies acquired` lines — every `chromium.launch()` failed (missing browser), and the error is swallowed by `retryFetch`'s catch (the challenge is only re-solved on attempt 0; later attempts return the challenge HTML as if it were content).
- Result: `century-college: 0 prereqs`, `dakota-county-technical-college: 0 prereqs`, `inver-hills-community-college: 0 prereqs`, `saint-paul-college: 0 prereqs`, and `anoka-ramsey-community-college` degraded to 139 (only requests the WAF happened to let through). The unprotected SmartCatalogIQ colleges (Hennepin 787, Normandale 351) were unaffected.

## Local checks

- `npx tsx scripts/lib/scraper-matrix.ts --datatype prereqs` (exactly what the workflow's `plan` job runs) now emits `{"id": "mn-prereqs-0", …, "runner": "playwright"}`.
- `check:scrapers` passes (51 states × 4 datatypes accounted for).

## Known gap

This makes the browser available; it doesn't fix the swallow-and-continue behavior in `retryFetch` (a future failed cookie acquisition would still degrade silently rather than fail the job). That's a separate, behavioral change left out of this config-only fix.

https://claude.ai/code/session_015wc1bc58GHp3Qr3hUG1vVU

---
_Generated by [Claude Code](https://claude.ai/code/session_015wc1bc58GHp3Qr3hUG1vVU)_