### PR TITLE
fix: course-detail pages 504 in big states (CA/TX/NY/MI) — stop pulling the whole subject

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { loadInstitutions } from "@/lib/institutions";
-import { loadCourseByCode, loadCoursesBySubject } from "@/lib/courses";
+import { loadCourseByCode, loadSubjectCourseList } from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { getAllStates, isValidState, getStateConfig } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
@@ -239,10 +239,16 @@ export default async function CoursePage(props: PageProps) {
   const institutions = loadInstitutions(state);
   const currentTerm = await getCurrentTerm(state);
 
-  // Pull only this subject's rows once and split — used for both the target
-  // course's sections and the "Related courses" sidebar (same prefix).
-  const subjectSections = await loadCoursesBySubject(prefix, currentTerm, state);
-  const sections = subjectSections.filter((c) => c.course_number === number);
+  // Two cheap, indexed reads instead of pulling the whole subject's sections:
+  //  • this course's own sections via the (state,term,prefix,number) index
+  //    (loadCourseByCode — also already cached from generateMetadata above), and
+  //  • a tiny DISTINCT course list for the "Related courses" sidebar.
+  // A big subject in a big state (CA Fall ENGL = 9,120 wide rows) used to be
+  // pulled in full here, which tripped Vercel's 15s FUNCTION_INVOCATION_TIMEOUT.
+  const [sections, subjectCourses] = await Promise.all([
+    loadCourseByCode(prefix, number, currentTerm, state),
+    loadSubjectCourseList(prefix, currentTerm, state),
+  ]);
 
   if (sections.length === 0) {
     // The course code is well-formed and the state is valid — but no sections
@@ -252,9 +258,7 @@ export default async function CoursePage(props: PageProps) {
     // 404. Instead we render a real page with helpful next-steps links and
     // rely on the noindex meta in generateMetadata() to keep these out of
     // Google's index.
-    const relatedSubjectCourses = Array.from(
-      new Map(subjectSections.map((s) => [s.course_number, s])).values(),
-    )
+    const relatedSubjectCourses = [...subjectCourses]
       .sort((a, b) => a.course_number.localeCompare(b.course_number))
       .slice(0, 12);
     return (
@@ -345,9 +349,9 @@ export default async function CoursePage(props: PageProps) {
 
   // Related courses — same prefix, different number
   const relatedCourses = new Map<string, string>();
-  for (const c of subjectSections) {
+  for (const c of subjectCourses) {
     if (c.course_number !== number) {
-      const key = `${c.course_prefix}-${c.course_number}`;
+      const key = `${prefix}-${c.course_number}`;
       if (!relatedCourses.has(key)) {
         relatedCourses.set(key, c.course_title);
       }

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -556,6 +556,42 @@ export async function loadCourseByCode(
 }
 
 /**
+ * Distinct course list for one subject prefix — `{ course_number, course_title }`,
+ * one row per course number (not per section). Backs the lightweight "Related
+ * courses" sidebar on the course-detail page.
+ *
+ * Uses the `get_subject_course_list` RPC (migration 031) so we make ONE round
+ * trip returning a few hundred small rows instead of paginating the subject's
+ * full section set (a big subject like CA Fall ENGL is 9,120 wide rows — that
+ * full pull was the cause of the /{state}/course/* 504s). The course page gets
+ * its OWN sections from the indexed loadCourseByCode, so it never needs the
+ * whole subject anymore.
+ */
+export interface SubjectCourse {
+  course_number: string;
+  course_title: string;
+}
+
+export async function loadSubjectCourseList(
+  prefix: string,
+  term: string,
+  state: string
+): Promise<SubjectCourse[]> {
+  return cached(`subjectlist:${state}:${term}:${prefix}`, async () => {
+    const { data, error } = await supabase.rpc("get_subject_course_list", {
+      p_state: state,
+      p_term: term,
+      p_prefix: prefix,
+    });
+    if (error) {
+      console.error("loadSubjectCourseList error:", error.message);
+      return [];
+    }
+    return (data || []) as SubjectCourse[];
+  });
+}
+
+/**
  * Load all sections for one subject prefix across the state.
  * Targeted query — pulls only the rows for that prefix (typically 100–2000)
  * instead of the full state catalog. Used by the subject pSEO pages.

--- a/supabase/migrations/031_subject_course_list_rpc.sql
+++ b/supabase/migrations/031_subject_course_list_rpc.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- 031_subject_course_list_rpc.sql
+--
+-- Adds get_subject_course_list — a tiny DISTINCT-ON RPC backing the "Related
+-- courses" sidebar on the course-detail page (app/[state]/course/[code]).
+--
+-- Problem (the /ca/course/* 504s, 2026-06): the course page called
+-- loadCoursesBySubject() to get the whole subject's sections, then used them
+-- for only two things — the target course's own sections (already served fast
+-- by loadCourseByCode via the (state,term,course_prefix,course_number) index)
+-- and a list of OTHER course numbers in the same subject for a 12-link sidebar.
+-- For a big subject in a big state (CA Fall ENGL = 9,120 rows of 134,378 in the
+-- state×term partition) that pulled ~9k full-width rows across ~9 paginated
+-- round trips on every cold Vercel lambda — 15s+, tripping FUNCTION_INVOCATION
+-- _TIMEOUT. Same shape as the transfer-destinations fix in migration 016.
+--
+-- Fix: the sidebar only needs distinct (course_number, course_title). This RPC
+-- returns them in one round trip (~600 small rows, ~30ms) using DISTINCT ON,
+-- which the existing idx_courses_state_term_prefix_number index serves without
+-- a sort (it is already ordered by course_number within the prefix).
+--
+-- Execution: safe to run in a single transaction.
+-- Run via: Supabase Dashboard SQL Editor, or scripts/lib/run-migration.ts
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_subject_course_list(
+  p_state text,
+  p_term text,
+  p_prefix text
+)
+RETURNS TABLE(course_number text, course_title text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+PARALLEL SAFE
+AS $$
+  SELECT DISTINCT ON (c.course_number)
+    c.course_number,
+    c.course_title
+  FROM courses c
+  WHERE c.state = p_state
+    AND c.term = p_term
+    AND c.course_prefix = p_prefix
+  ORDER BY c.course_number, c.course_title
+$$;
+
+-- Anon + authenticated read it (same public-read posture as the courses table).
+GRANT EXECUTE ON FUNCTION get_subject_course_list(text, text, text) TO anon, authenticated;


### PR DESCRIPTION
## What changes for someone using the site

Course-detail pages — e.g. `/ca/course/engl-001a`, the page that shows every section of a course across all of a state's colleges plus its transfer credit — were **timing out and showing a raw "An error occurred with your deployment / FUNCTION_INVOCATION_TIMEOUT" error** in the largest states (California, Texas, New York, Michigan). A first-gen student following a link from a subject page hit a dead wall exactly where the transfer information lives. After this change those pages load in well under a second.

## What changed technically

The page was pulling the **entire subject** to render one course. For a big subject in a big state that's enormous: CA Fall 2026 `ENGL` is **9,120 sections** out of the state's 134,378 rows for that term. `loadCoursesBySubject()` fetched all 9,120 full-width rows (≈9 paginated Supabase round trips on every cold Vercel lambda) and then used them for only two things: this course's own ~170 sections, and a 12-link "Related courses" sidebar.

Now the page makes two cheap, indexed reads in parallel instead:
- **`loadCourseByCode`** for the sections — hits the existing `(state, term, course_prefix, course_number)` index (~170 rows, ~5 ms; verified by `EXPLAIN ANALYZE`), and it's already cached from `generateMetadata`.
- **`loadSubjectCourseList`** for the sidebar — a new `get_subject_course_list` RPC (**migration 031**) that does a `DISTINCT ON (course_number)` over the same prefix index, returning ~600 small rows (~30 ms) instead of 9,120 wide ones.

This is the same fix shape as migration 016 (transfer destinations): replace a paginated full-table pull that saturates the connection pool with one targeted query. `loadCoursesBySubject` is intentionally **kept** — the subject hub pages (`/{state}/subject/{prefix}`) still need the full section set and weren't timing out.

## Migration note

`supabase/migrations/031_subject_course_list_rpc.sql` — **already applied to production** (Project CC) via the Supabase MCP, so the repo file and prod are in sync. It's a pure function add (`SECURITY INVOKER`, granted to `anon`/`authenticated`), no data or schema change.

## Test plan

- `npm run typecheck` ✓ · `npm run build` ✓ (compiled successfully)
- `EXPLAIN ANALYZE` on prod: sections query 5 ms, related-courses RPC 31 ms (594 rows) — vs the old 9,120-row pull
- Local worktree dev server against prod data: `/ca/course/engl-001a` renders 200 with real sections + working Related sidebar; a cold-data course (`/ca/course/math-003a`) renders in **0.6 s**; the no-sections branch (`/ca/course/zzz-999`) renders "Not offered" correctly (not a 500)
- Post-merge: confirm `/ca/course/engl-001a`, `/tx/course/engl-1301`, `/ny/course/eng-101`, `/mi/course/eng-101` return 200 (they 504 today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
